### PR TITLE
Fix MetricSampleAggregator eviction

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregator.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregator.java
@@ -253,11 +253,11 @@ public class MetricSampleAggregator {
     if (_activeSnapshotWindow < 0) {
       return new MetricSampleAggregationResult(currentGeneration(), includeAllTopics);
     }
+    long requestedLowerBoundWindow = MonitorUtils.toSnapshotWindow(Math.max(from, 0), _snapshotWindowMs);
+    long requestedUpperBoundWindow = MonitorUtils.toSnapshotWindow(Math.max(to, 0), _snapshotWindowMs) - _snapshotWindowMs;
+    long mostRecentAvailableWindow;
+    long actualUpperBoundWindow;
     try {
-      long requestedLowerBoundWindow = MonitorUtils.toSnapshotWindow(Math.max(from, 0), _snapshotWindowMs);
-      long requestedUpperBoundWindow = MonitorUtils.toSnapshotWindow(Math.max(to, 0), _snapshotWindowMs) - _snapshotWindowMs;
-      long mostRecentAvailableWindow;
-      long actualUpperBoundWindow;
       // Synchronize with addSamples() here.
       synchronized (this) {
         // Disable the snapshot window eviction to avoid inconsistency of data.


### PR DESCRIPTION
There is a bug in MetricSampleAggregator that may result in the `_snapshotCollectionInProgress` counter to be negative, which will cause the aggregator not to evict the old snapshots windows.