### PR TITLE
Improve MetricSampleAggregator and sanity check stability

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUtils.java
@@ -143,6 +143,19 @@ public class AnalyzerUtils {
    *
    * @param d1 The first {@code double} to compare.
    * @param d2 The second {@code double} to compare.
+   * @param resource the resource the current comparison is for.
+   * @return 1 if first > second, -1 if first < second, 0 otherwise.
+   */
+  public static int compare(double d1, double d2, Resource resource) {
+    double epsilon = resource.epsilon(d1, d2);
+    return compare(d1, d2, epsilon);
+  }
+
+  /**
+   * Compare the given values. Return 1 if first > second, -1 if first < second, 0 otherwise.
+   *
+   * @param d1 The first {@code double} to compare.
+   * @param d2 The second {@code double} to compare.
    * @return 1 if first > second, -1 if first < second, 0 otherwise.
    */
   public static int compare(double d1, double d2, double epsilon) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/Resource.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/Resource.java
@@ -15,6 +15,7 @@ public enum Resource {
   NW_OUT("networkOutbound", 2, true, 10),
   DISK("disk", 3, false, 100);
 
+  private static final double EPSILON_PERCENT = 1E-4;
   private final String _resource;
   private final int _id;
   private final boolean _isHostResource;
@@ -49,8 +50,8 @@ public enum Resource {
     return _isHostResource;
   }
 
-  public double epsilon() {
-    return _epsilon;
+  public double epsilon(double value1, double value2) {
+    return Math.max(_epsilon, EPSILON_PERCENT * (value1 + value2) / 2);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -715,7 +715,7 @@ public class ClusterModel implements Serializable {
         for (Replica replica : broker.replicas()) {
           sumOfReplicaUtilization += replica.load().expectedUtilizationFor(resource);
         }
-        if (AnalyzerUtils.compare(sumOfReplicaUtilization, broker.load().expectedUtilizationFor(resource), resource.epsilon()) != 0) {
+        if (AnalyzerUtils.compare(sumOfReplicaUtilization, broker.load().expectedUtilizationFor(resource), resource) != 0) {
           throw new ModelInputException(prologueErrorMsg + " Broker utilization for " + resource + " is "
               + "different from the total replica utilization in the broker with id: " + broker.id()
               + ". Sum of the replica utilization: " + sumOfReplicaUtilization + ", broker utilization: "
@@ -736,7 +736,7 @@ public class ClusterModel implements Serializable {
             sumOfBrokerUtilization += broker.load().expectedUtilizationFor(resource);
           }
           Double hostUtilization = host.load().expectedUtilizationFor(resource);
-          if (AnalyzerUtils.compare(sumOfBrokerUtilization, hostUtilization, resource.epsilon()) != 0) {
+          if (AnalyzerUtils.compare(sumOfBrokerUtilization, hostUtilization, resource) != 0) {
             throw new ModelInputException(prologueErrorMsg + " Host utilization for " + resource + " is "
                                               + "different from the total broker utilization in the host : " + host.name()
                                               + ". Sum of the brokers: " + sumOfBrokerUtilization + ", host utilization: " + hostUtilization);
@@ -751,7 +751,7 @@ public class ClusterModel implements Serializable {
         double sumOfHostsUtil = entry.getValue();
         sumOfRackUtilizationByResource.putIfAbsent(resource, 0.0);
         Double rackUtilization = rack.load().expectedUtilizationFor(resource);
-        if (AnalyzerUtils.compare(rackUtilization, sumOfHostsUtil, resource.epsilon()) != 0) {
+        if (AnalyzerUtils.compare(rackUtilization, sumOfHostsUtil, resource) != 0) {
           throw new ModelInputException(prologueErrorMsg + " Rack utilization for " + resource + " is "
                                             + "different from the total host utilization in rack" + rack.id()
                                             + " . Sum of the hosts: " + sumOfHostsUtil + ", rack utilization: "
@@ -765,7 +765,7 @@ public class ClusterModel implements Serializable {
     for (Map.Entry<Resource, Double> entry : sumOfRackUtilizationByResource.entrySet()) {
       Resource resource = entry.getKey();
       double sumOfRackUtil = entry.getValue();
-      if (AnalyzerUtils.compare(_load.expectedUtilizationFor(resource), sumOfRackUtil, resource.epsilon()) != 0) {
+      if (AnalyzerUtils.compare(_load.expectedUtilizationFor(resource), sumOfRackUtil, resource) != 0) {
         throw new ModelInputException(prologueErrorMsg + " Cluster utilization for " + resource + " is "
             + "different from the total rack utilization in the cluster. Sum of the racks: "
             + sumOfRackUtil + ", cluster utilization: " + _load.expectedUtilizationFor(resource));
@@ -781,7 +781,7 @@ public class ClusterModel implements Serializable {
       }
       if (AnalyzerUtils.compare(sumOfLeaderOfReplicaUtilization,
                                 _potentialLeadershipLoadByBrokerId.get(broker.id()).expectedUtilizationFor(Resource.NW_OUT),
-                                Resource.NW_OUT.epsilon()) != 0) {
+                                Resource.NW_OUT) != 0) {
         throw new ModelInputException(prologueErrorMsg + " Leadership utilization for " + Resource.NW_OUT
             + " is different from the total utilization leader of replicas in the broker with id: "
             + broker.id() + " Expected: " + sumOfLeaderOfReplicaUtilization + " Received: "
@@ -794,7 +794,7 @@ public class ClusterModel implements Serializable {
         }
         double leaderSum = broker.leaderReplicas().stream().mapToDouble(r -> r.load().expectedUtilizationFor(resource)).sum();
         double cachedLoad = broker.leadershipLoad().expectedUtilizationFor(resource);
-        if (AnalyzerUtils.compare(leaderSum, cachedLoad, resource.epsilon()) != 0) {
+        if (AnalyzerUtils.compare(leaderSum, cachedLoad, resource) != 0) {
           throw new ModelInputException(prologueErrorMsg + " Leadership load for resource " + resource + " is " +
             cachedLoad + " but recomputed sum is " + leaderSum + ".");
         }


### PR DESCRIPTION
The patch does the following:
1. check whether old windows should be evicted on every sampling instead of waiting for the next window to be rolled out.
2. Use a adaptive epsilon in the double comparison. This avoids false failure on the big disk utilization.