### PR TITLE
Add an identity map for TopicPartition in the metric aggregator to reduce memory consumption

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
@@ -98,6 +98,8 @@ public class GoalViolationDetector implements Runnable {
           LOG.debug("Detecting if {} is violated.", entry.getValue().name());
           // Because the model generation could be slow, We only get new cluster model if needed.
           if (newModelNeeded) {
+            // Make cluster model null before generating a new cluster model so the current one can be GCed.
+            clusterModel = null;
             clusterModel = _loadMonitor.clusterModel(now, goal.clusterModelCompletenessRequirements());
             // The anomaly detector have to include all the topics in order to detect the rack awareness issue.
             newModelNeeded = false;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/MetricCompletenessChecker.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/MetricCompletenessChecker.java
@@ -113,8 +113,8 @@ public class MetricCompletenessChecker {
   /**
    * Update the valid partition number of a topic for a window.
    */
-  void updatePartitionCompleteness(MetricSampleAggregator aggregator, 
-                                   long window, 
+  void updatePartitionCompleteness(MetricSampleAggregator aggregator,
+                                   long window,
                                    TopicPartition tp) {
     _activeSnapshotWindow = aggregator.activeSnapshotWindow();
     _validPartitionsPerTopicByWindows.computeIfAbsent(window, w -> new ConcurrentHashMap<>())
@@ -122,7 +122,7 @@ public class MetricCompletenessChecker {
                                        Set<Integer> s = set == null ? new HashSet<>() : set;
                                        MetricSampleAggregationResult.Imputation imputation = aggregator.validatePartitions(window, tp);
                                        if (imputation != MetricSampleAggregationResult.Imputation.NO_VALID_IMPUTATION) {
-                                         LOG.debug("Added partition {} to valid partition set for window {} with imputation {}", 
+                                         LOG.debug("Added partition {} to valid partition set for window {} with imputation {}",
                                                    tp, window, imputation);
                                          synchronized (s) {
                                            s.add(tp.partition());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregator.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregator.java
@@ -60,6 +60,7 @@ public class MetricSampleAggregator {
   private final int _numSnapshots;
   private final int _numSnapshotsToKeep;
   private final long _snapshotWindowMs;
+  private final ConcurrentHashMap<TopicPartition, TopicPartition> _identityPartitionMap;
   private final ConcurrentNavigableMap<Long, Map<TopicPartition, AggregatedMetrics>> _windowedAggregatedPartitionMetrics;
   private final Metadata _metadata;
   private final int _minSamplesPerSnapshot;
@@ -102,6 +103,7 @@ public class MetricSampleAggregator {
     _cachedAggregationResultWindow = -1L;
     _aggregationResultGeneration = new AtomicLong(0);
     _latestBrokerMetrics = new ConcurrentHashMap<>();
+    _identityPartitionMap = new ConcurrentHashMap<>();
   }
 
   public void updateBrokerMetricSample(BrokerMetricSample brokerMetricSample) {
@@ -161,7 +163,9 @@ public class MetricSampleAggregator {
     }
     maybeEvictOldSnapshots();
     AggregatedMetrics aggMetrics =
-        snapshotsByPartition.computeIfAbsent(sample.topicPartition(), topicPartition -> new AggregatedMetrics());
+        snapshotsByPartition.computeIfAbsent(_identityPartitionMap.computeIfAbsent(sample.topicPartition(),
+                                                                                   topicPartition -> topicPartition),
+                                             topicPartition -> new AggregatedMetrics());
     aggMetrics.addSample(sample);
     if (updateCompletenessCache) {
       _metricCompletenessChecker.updatePartitionCompleteness(this, snapshotWindow, sample.topicPartition());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregator.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregator.java
@@ -168,7 +168,8 @@ public class MetricSampleAggregator {
                                              topicPartition -> new AggregatedMetrics());
     aggMetrics.addSample(sample);
     if (updateCompletenessCache) {
-      _metricCompletenessChecker.updatePartitionCompleteness(this, snapshotWindow, sample.topicPartition());
+      _metricCompletenessChecker.updatePartitionCompleteness(this, snapshotWindow,
+                                                             _identityPartitionMap.get(sample.topicPartition()));
     }
     // If we are inserting metric samples into some past windows, invalidate the aggregation result cache and
     // bump up aggregation result generation.


### PR DESCRIPTION
MetricSampleAggregator has a ConcurrentHashMap for each snapshot window. Currently the key in those ConcurrentHashMaps are different TopicPartition instances for the same partition, which takes a lot of memory. This patch uses an identity map to ensure that there is only one TopicPartition instance for the same partition.