### PR TITLE
Fix the flaky RandomGoalTest

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderBytesInDistributionGoals.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderBytesInDistributionGoals.java
@@ -209,8 +209,8 @@ public class LeaderBytesInDistributionGoals extends AbstractGoal {
 
       double[] stat2 = stats2.utilizationMatrix()[RawAndDerivedResource.LEADER_NW_IN.ordinal()];
       double variance1 = new Variance().evaluate(stat1);
-      double variance2 = new Variance().evaluate(stat2, meanPreLeaderBytesIn);
-      int result = AnalyzerUtils.compare(variance2, variance1, EPSILON);
+      double variance2 = new Variance().evaluate(stat2);
+      int result = AnalyzerUtils.compare(Math.sqrt(variance2), Math.sqrt(variance1), Resource.NW_IN);
       if (result < 0) {
         _reasonForLastNegativeResult = String.format("Violated leader bytes in balancing. preVariance: %.3f "
                                                          + "postVariance: %.3f.", variance2, variance1);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderBytesInDistributionGoals.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderBytesInDistributionGoals.java
@@ -31,8 +31,6 @@ import org.apache.commons.math3.stat.descriptive.moment.Variance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.linkedin.kafka.cruisecontrol.analyzer.AnalyzerUtils.EPSILON;
-
 
 /**
  * Soft goal to distribute leader bytes evenly.


### PR DESCRIPTION
The test was failing because the float to double conversion. If we move a little tiny thing from one broker to another. The variance may be actually become worse due to the float to double conversion. Change the test to compare the sqrt of variance and use the NW_IN epsilon. Ran the test over 100 times and it seems to work.