### PR TITLE
Change comparison epsilon percent to 0.1% for large clusters.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/Resource.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/Resource.java
@@ -15,7 +15,7 @@ public enum Resource {
   NW_OUT("networkOutbound", 2, true, 10),
   DISK("disk", 3, false, 100);
 
-  private static final double EPSILON_PERCENT = 1E-4;
+  private static final double EPSILON_PERCENT = 1E-3;
   private final String _resource;
   private final int _id;
   private final boolean _isHostResource;


### PR DESCRIPTION
We see sometimes the cluster model sanity check fails on the large clusters. This is caused by double/float conversion. When there are a lot conversions, the precision error accumulates. Change the epsilon percent from 0.01% to 0.1% to avoid fail the sanity check. 