### PR TITLE
Make the RackAwareCapacityGoal more robust. Fix cruisecontrol.properties.

### DIFF
--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -156,7 +156,7 @@ execution.progress.check.interval.ms=10000
 # =======================================
 
 # The goal violation notifier class
-goal.violation.notifier.class=com.linkedin.kafka.cruisecontrol.detector.notifier.SelfHealingNotifier
+anomaly.notifier.class=com.linkedin.kafka.cruisecontrol.detector.notifier.SelfHealingNotifier
 
 # The anomaly detection interval
 anomaly.detection.interval.ms=10000

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareCapacityGoal.java
@@ -184,14 +184,6 @@ public class RackAwareCapacityGoal extends AbstractGoal {
           throw new AnalysisInputException("Healthy brokers fail to satisfy rack-awareness.");
         }
       }
-      for (Resource resource : _balancingConstraint.resources()) {
-        for (Broker broker : clusterModel.healthyBrokers()) {
-          if (isUtilizationAboveLimit(resource, broker)) {
-            throw new AnalysisInputException(String.format("%s utilization of healthy broker %d is already beyond "
-                                                               + "the capacity limit.", resource, broker.id()));
-          }
-        }
-      }
     }
     // Sanity Check #2. -- i.e. not enough resources.
     Load recentClusterLoad = clusterModel.load();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -17,8 +17,7 @@ import com.linkedin.kafka.cruisecontrol.detector.notifier.NoopNotifier;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.CruiseControlMetricsReporterSampler;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.DefaultMetricSamplerPartitionAssignor;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.KafkaSampleStore;
-import java.util.Arrays;
-import joptsimple.internal.Strings;
+import java.util.StringJoiner;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -635,15 +634,16 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 EXECUTION_PROGRESS_CHECK_INTERVAL_MS_DOC)
         .define(GOALS_CONFIG,
                 ConfigDef.Type.LIST,
-                Strings.join(Arrays.asList(RackAwareCapacityGoal.class.getName(),
-                                           PotentialNwOutGoal.class.getName(),
-                                           DiskUsageDistributionGoal.class.getName(),
-                                           NetworkInboundUsageDistributionGoal.class.getName(),
-                                           NetworkOutboundUsageDistributionGoal.class.getName(),
-                                           CpuUsageDistributionGoal.class.getName(),
-                                           LeaderBytesInDistributionGoals.class.getName(),
-                                           TopicReplicaDistributionGoal.class.getName(),
-                                           ReplicaDistributionGoal.class.getName()), ","),
+                new StringJoiner(",")
+                    .add(RackAwareCapacityGoal.class.getName())
+                    .add(PotentialNwOutGoal.class.getName())
+                    .add(DiskUsageDistributionGoal.class.getName())
+                    .add(NetworkInboundUsageDistributionGoal.class.getName())
+                    .add(NetworkOutboundUsageDistributionGoal.class.getName())
+                    .add(CpuUsageDistributionGoal.class.getName())
+                    .add(LeaderBytesInDistributionGoals.class.getName())
+                    .add(TopicReplicaDistributionGoal.class.getName())
+                    .add(ReplicaDistributionGoal.class.getName()).toString(),
                 ConfigDef.Importance.HIGH,
                 GOALS_DOC)
         .define(ANOMALY_NOTIFIER_CLASS_CONFIG,
@@ -657,15 +657,16 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 ANOMALY_DETECTION_INTERVAL_MS_DOC)
         .define(ANOMALY_DETECTION_GOALS_CONFIG,
                 ConfigDef.Type.LIST,
-                Strings.join(Arrays.asList(RackAwareCapacityGoal.class.getName(),
-                                           PotentialNwOutGoal.class.getName(),
-                                           DiskUsageDistributionGoal.class.getName(),
-                                           NetworkInboundUsageDistributionGoal.class.getName(),
-                                           NetworkOutboundUsageDistributionGoal.class.getName(),
-                                           CpuUsageDistributionGoal.class.getName(),
-                                           LeaderBytesInDistributionGoals.class.getName(),
-                                           TopicReplicaDistributionGoal.class.getName(),
-                                           ReplicaDistributionGoal.class.getName()), ","),
+                new StringJoiner(",")
+                    .add(RackAwareCapacityGoal.class.getName())
+                    .add(PotentialNwOutGoal.class.getName())
+                    .add(DiskUsageDistributionGoal.class.getName())
+                    .add(NetworkInboundUsageDistributionGoal.class.getName())
+                    .add(NetworkOutboundUsageDistributionGoal.class.getName())
+                    .add(CpuUsageDistributionGoal.class.getName())
+                    .add(LeaderBytesInDistributionGoals.class.getName())
+                    .add(TopicReplicaDistributionGoal.class.getName())
+                    .add(ReplicaDistributionGoal.class.getName()).toString(),
                 ConfigDef.Importance.MEDIUM,
                 ANOMALY_DETECTION_GOALS_DOC)
         .define(FAILED_BROKERS_ZK_PATH_CONFIG,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -581,8 +581,9 @@ public class LoadMonitor {
       for (Node replica : partitionInfo.replicas()) {
         boolean isLeader = partitionInfo.leader() != null && replica.id() == partitionInfo.leader().id();
         String rack = getRackHandleNull(replica);
-        // If broker is dead, do not call resolver to get the capacity.
-        Map<Resource, Double> brokerCapacity = kafkaCluster.nodeById(replica.id()) == null ? deadBrokerCapacity() :
+        // Note that we assume the capacity resolver can still return the broker capacity even if the broker
+        // is dead. We need this to get the host resource capacity.
+        Map<Resource, Double> brokerCapacity =
             _brokerCapacityConfigResolver.capacityForBroker(rack, replica.host(), replica.id());
         clusterModel.createReplicaHandleDeadBroker(rack, replica.id(), tp, isLeader, brokerCapacity);
         // Push the load snapshot to the replica one by one.


### PR DESCRIPTION
1. Removed a sanity check on the RackAwareCapacityGoal. As long as the end result meets the goal, we should let the goal to run.
2. Fixed a configuration in the cruisecontrol.properties.
3. Revert back to always call capacity resolver even if the broker is dead. Because the host level resource capacity relies on the per broker resource capacity as of now.
