### PR TITLE
Disable self-healing by default in the SelfHealingNotifier.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
@@ -138,7 +138,7 @@ public class GoalOptimizer implements Runnable {
                       + "Cached generation: {}", _bestProposal.modelGeneration());
       }
       long deadline = _time.milliseconds() + sleepTime;
-      while (!_shutdown && _time.milliseconds() < deadline && (_bestProposal == null || validCachedProposal())) {
+      while (!_shutdown && _time.milliseconds() < deadline) {
         try {
           Thread.sleep(deadline - _time.milliseconds());
         } catch (InterruptedException e) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SelfHealingNotifier.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SelfHealingNotifier.java
@@ -113,6 +113,6 @@ public class SelfHealingNotifier implements AnomalyNotifier {
                                                        _brokerFailureAlertThresholdMs, _selfHealingThresholdMs));
     }
     String selfHealingEnabledString = (String) config.get(SELF_HEALING_ENABLED_CONFIG);
-    _selfHealingEnabled = selfHealingEnabledString == null || Boolean.parseBoolean(selfHealingEnabledString);
+    _selfHealingEnabled = selfHealingEnabledString != null && Boolean.parseBoolean(selfHealingEnabledString);
   }
 }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SelfHealingNotifierTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SelfHealingNotifierTest.java
@@ -30,7 +30,7 @@ public class SelfHealingNotifierTest {
     final long startTime = 500L;
     Time mockTime = new MockTime(0, startTime, TimeUnit.NANOSECONDS.convert(startTime, TimeUnit.MILLISECONDS));
     TestingBrokerFailureAutoFixNotifier anomalyNotifier = new TestingBrokerFailureAutoFixNotifier(mockTime);
-    anomalyNotifier.configure(Collections.emptyMap());
+    anomalyNotifier.configure(Collections.singletonMap(SelfHealingNotifier.SELF_HEALING_ENABLED_CONFIG, "true"));
 
     Map<Integer, Long> failedBrokers = new HashMap<>();
     failedBrokers.put(1, failureTime1);


### PR DESCRIPTION
Also fix potential frequent logging in GoalOptimizer.