### PR TITLE
Avoid holding the lock for too long when running goal violation detection

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -693,7 +693,7 @@ public class LoadMonitor {
   }
 
   public class AutoCloseableSemaphore implements AutoCloseable {
-    private AtomicBoolean _closed = new AtomicBoolean();
+    private AtomicBoolean _closed = new AtomicBoolean(false);
     @Override
     public void close() throws Exception {
       if (_closed.compareAndSet(false, true)) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -692,10 +692,13 @@ public class LoadMonitor {
   }
 
   public class AutoCloseableSemaphore implements AutoCloseable {
+    private boolean closed = false;
     @Override
     public void close() throws Exception {
-      _clusterModelSemaphore.release();
-      _acquiredClusterModelSemaphore.set(false);
+      if (!closed) {
+        _clusterModelSemaphore.release();
+        _acquiredClusterModelSemaphore.set(false);
+      }
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
@@ -692,10 +693,10 @@ public class LoadMonitor {
   }
 
   public class AutoCloseableSemaphore implements AutoCloseable {
-    private boolean closed = false;
+    private AtomicBoolean _closed = new AtomicBoolean();
     @Override
     public void close() throws Exception {
-      if (!closed) {
+      if (_closed.compareAndSet(false, true)) {
         _clusterModelSemaphore.release();
         _acquiredClusterModelSemaphore.set(false);
       }


### PR DESCRIPTION
We are having more and more goals now. We are holding the lock for too long. This patch release the lock between each goal to avoid holding it for all the goals.