### PR TITLE
Disable Debug mode by default

### DIFF
--- a/kafka-cruise-control-start.sh
+++ b/kafka-cruise-control-start.sh
@@ -100,7 +100,7 @@ if [ -z "$KAFKA_OPTS" ]; then
 fi
 
 # Set Debug options if enabled
-#if [ "x$KAFKA_DEBUG" != "x" ]; then
+if [ "x$KAFKA_DEBUG" != "x" ]; then
 
     # Use default ports
     DEFAULT_JAVA_DEBUG_PORT="5005"
@@ -117,7 +117,7 @@ fi
 
     echo "Enabling Java debug options: $JAVA_DEBUG_OPTS"
     KAFKA_OPTS="$JAVA_DEBUG_OPTS $KAFKA_OPTS"
-#fi
+fi
 
 # Which java to use
 if [ -z "$JAVA_HOME" ]; then


### PR DESCRIPTION
Debug must be explicitly enabled by `KAFKA_DEBUG ` environment variable. Most likely this has been mistakenly enabled by https://github.com/linkedin/cruise-control/commit/de2b67275bee8af48068ded446efcb2aa580c6e2