### PR TITLE
Support for setting cleanup policy for CC generated topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,21 @@ to a Kafka topic.
     * Modify Kafka server configuration to set `metric.reporters` to 
     `com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter`. For Apache Kafka, server properties
     are located at `./config/server.properties`.
-    * Start ZooKeeper and Kafka server.
-1. Modify config/cruisecontrol.properties to 
+    * If the default broker cleanup policy is `compact`, make sure that the topic to which Cruise Control metrics 
+    reporter should send messages is created with the `delete` cleanup policy -- the default metrics reporter topic is
+    `__CruiseControlMetrics`.
+1. Start ZooKeeper and Kafka server.
+2. Modify config/cruisecontrol.properties to 
     * fill in `bootstrap.servers` and `zookeeper.connect` to the Kafka cluster to be monitored.
     * set `metric.sampler.class` to your implementation (the default sampler class is CruiseControlMetricsReporterSampler) 
     * set `sample.store.class` to your implementation if necessary (the default SampleStore is KafkaSampleStore)
-2. Run the following command 
+3. Run the following command 
     ```
     ./gradlew jar copyDependantLibs
     ./kafka-cruise-control-start.sh [-jars PATH_TO_YOUR_JAR_1,PATH_TO_YOUR_JAR_2] config/cruisecontrol.properties [port]
     ```
     JAR files correspond to your applications and `port` enables customizing the Cruise Control port number (default: 9090).
-3. visit http://localhost:9090/kafkacruisecontrol/state or http://localhost:\[port\]/kafkacruisecontrol/state if 
+4. visit http://localhost:9090/kafkacruisecontrol/state or http://localhost:\[port\]/kafkacruisecontrol/state if 
 you specified the port when starting Cruise Control. 
 
 **Note**: 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
@@ -56,6 +56,7 @@ public class KafkaSampleStore implements SampleStore {
   public static final String NUM_SAMPLE_LOADING_THREADS = "num.sample.loading.threads";
   protected static final String PRODUCER_CLIENT_ID = "KafkaCruiseControlSampleStoreProducer";
   protected static final String CONSUMER_CLIENT_ID = "KafkaCruiseControlSampleStoreConsumer";
+  private static final String DEFAULT_CLEANUP_POLICY = "delete";
   // Keep additional snapshot windows in case some of the windows do not have enough samples.
   private static final int ADDITIONAL_SNAPSHOT_WINDOW_TO_RETAIN_FACTOR = 2;
   private static final ConsumerRecords<byte[], byte[]> SHUTDOWN_RECORDS = new ConsumerRecords<>(Collections.emptyMap());
@@ -129,6 +130,7 @@ public class KafkaSampleStore implements SampleStore {
     long retentionMs = (numSnapshotWindows * ADDITIONAL_SNAPSHOT_WINDOW_TO_RETAIN_FACTOR) * snapshotWindowMs;
     Properties props = new Properties();
     props.setProperty(LogConfig.RetentionMsProp(), Long.toString(retentionMs));
+    props.setProperty(LogConfig.CleanupPolicyProp(), DEFAULT_CLEANUP_POLICY);
     int replicationFactor = Math.min(2, zkUtils.getAllBrokersInCluster().size());
     if (!topics.containsKey(_partitionMetricSampleStoreTopic)) {
       AdminUtils.createTopic(zkUtils, _partitionMetricSampleStoreTopic, 32, replicationFactor, props, RackAwareMode.Safe$.MODULE$);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
@@ -60,6 +60,7 @@ public class LoadMonitorTest {
   private static final int NUM_SNAPSHOT_WINDOWS = 2;
   private static final int MIN_SAMPLES_PER_SNAPSHOT_WINDOW = 4;
   private static final long SNAPSHOT_WINDOW_MS = 1000;
+  private static final String DEFAULT_CLEANUP_POLICY = "delete";
 
   private final Time _time = new MockTime(0);
 
@@ -403,6 +404,7 @@ public class LoadMonitorTest {
     props.put(KafkaCruiseControlConfig.MIN_SAMPLES_PER_LOAD_SNAPSHOT_CONFIG,
               Integer.toString(MIN_SAMPLES_PER_SNAPSHOT_WINDOW));
     props.put(KafkaCruiseControlConfig.LOAD_SNAPSHOT_WINDOW_MS_CONFIG, Long.toString(SNAPSHOT_WINDOW_MS));
+    props.put("cleanup.policy", DEFAULT_CLEANUP_POLICY);
     props.put(KafkaCruiseControlConfig.SAMPLE_STORE_CLASS_CONFIG, NoopSampleStore.class.getName());
     KafkaCruiseControlConfig config = new KafkaCruiseControlConfig(props);
     LoadMonitor loadMonitor = new LoadMonitor(config, mockMetadataClient, _time, new MetricRegistry());


### PR DESCRIPTION
Currently CC does not set the cleanup policy for the topics that it creates – i.e. __KafkaCruiseControlModelTrainingSamples, __KafkaCruiseControlPartitionMetricSamples.
This patch aims to set the value of this config to `delete` inside CC.

This patch fixes the following issue: https://github.com/linkedin/cruise-control/issues/76