### PR TITLE
Add Replica Capacity Goal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The default Sample Store implementation produces metric samples back to Kafka.
 The goals in Cruise Control are pluggable with different priorities. The default goals in order of decreasing priority are:
  * **RackAwareGoal** - Ensures that all replicas of each partition are assigned in a rack aware manner -- i.e. no more than one replica of 
  each partition resides in the same rack.
+ * **ReplicaCapacityGoal** - Ensures that the maximum number of replicas per broker is under the specified maximum limit.
  * **CpuCapacityGoal** - Ensures that CPU utilization of each broker is below a given threshold.
  * **DiskCapacityGoal** - Ensures that Disk space usage of each broker is below a given threshold.
  * **NetworkInboundCapacityGoal** - Ensures that inbound network utilization of each broker is below a given threshold.

--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -74,7 +74,7 @@ capacity.config.file=config/capacity.json
 # =======================================
 
 # The list of goals to optimize the Kafka cluster for
-goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal
+goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal
 
 # The minimum percentage of well monitored partitions out of all the partitions
 min.monitored.partition.percentage=0.95
@@ -121,6 +121,9 @@ max.proposal.candidates=10
 # How often should the cached proposal be expired and recalculated if necessary
 proposal.expiration.ms=60000
 
+# The maximum number of replicas that can reside on a broker at any given time.
+max.replicas.per.broker=10000
+
 # The number of threads to use for proposal candidate precomputing.
 num.proposal.precompute.threads=1
 
@@ -150,7 +153,7 @@ anomaly.notifier.class=com.linkedin.kafka.cruisecontrol.detector.notifier.SelfHe
 anomaly.detection.interval.ms=10000
 
 # The goal violation to detect.
-anomaly.detection.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal
+anomaly.detection.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal
 
 # The zk path to store failed broker information.
 failed.brokers.zk.path=/CruiseControlBrokerList

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/BalancingConstraint.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/BalancingConstraint.java
@@ -25,11 +25,13 @@ public class BalancingConstraint {
   private final Map<Resource, Double> _balancePercentage;
   private final Map<Resource, Double> _capacityThreshold;
   private final Map<Resource, Double> _lowUtilizationThreshold;
+  private final Long _maxReplicasPerBroker;
 
   /**
    * Constructor for Balancing Constraint.
    * (1) Sets resources in descending order of balancing priority.
-   * (2) Initializes balance percentage and capacity threshold with corresponding default values.
+   * (2) Initializes balance percentages, capacity thresholds, and the maximum number of replicas per broker with the
+   * corresponding default values.
    */
   public BalancingConstraint(KafkaCruiseControlConfig config) {
     _resources = Collections.unmodifiableList(Arrays.asList(Resource.DISK, Resource.NW_IN, Resource.NW_OUT, Resource.CPU));
@@ -52,6 +54,8 @@ public class BalancingConstraint {
     _lowUtilizationThreshold.put(Resource.CPU, config.getDouble(KafkaCruiseControlConfig.CPU_LOW_UTILIZATION_THRESHOLD_CONFIG));
     _lowUtilizationThreshold.put(Resource.NW_IN, config.getDouble(KafkaCruiseControlConfig.NETWORK_INBOUND_LOW_UTILIZATION_THRESHOLD_CONFIG));
     _lowUtilizationThreshold.put(Resource.NW_OUT, config.getDouble(KafkaCruiseControlConfig.NETWORK_OUTBOUND_LOW_UTILIZATION_THRESHOLD_CONFIG));
+    // Set default value for the maximum number of replicas per broker.
+    _maxReplicasPerBroker = config.getLong(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG);
   }
 
   Properties setProps(Properties props) {
@@ -69,6 +73,8 @@ public class BalancingConstraint {
     props.put(KafkaCruiseControlConfig.CPU_LOW_UTILIZATION_THRESHOLD_CONFIG, _lowUtilizationThreshold.get(Resource.CPU).toString());
     props.put(KafkaCruiseControlConfig.NETWORK_INBOUND_LOW_UTILIZATION_THRESHOLD_CONFIG, _lowUtilizationThreshold.get(Resource.NW_IN).toString());
     props.put(KafkaCruiseControlConfig.NETWORK_OUTBOUND_LOW_UTILIZATION_THRESHOLD_CONFIG, _lowUtilizationThreshold.get(Resource.NW_OUT).toString());
+
+    props.put(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, _maxReplicasPerBroker.toString());
     return props;
   }
 
@@ -77,6 +83,13 @@ public class BalancingConstraint {
    */
   public List<Resource> resources() {
     return _resources;
+  }
+
+  /**
+   * Get maximum number of replicas per broker.
+   */
+  public Long maxReplicasPerBroker() {
+    return _maxReplicasPerBroker;
   }
 
   /**
@@ -166,10 +179,11 @@ public class BalancingConstraint {
   public String toString() {
     return String.format("<BalancingConstraint cpuBalancePercentage=\"%.4f\" diskBalancePercentage=\"%.4f\" " +
             "inboundNwBalancePercentage=\"%.4f\" outboundNwBalancePercentage=\"%.4f\" cpuCapacityThreshold=\"%.4f\" "
-            + "diskCapacityThreshold=\"%.4f\" inboundNwCapacityThreshold=\"%.4f\" outboundNwCapacityThreshold=\"%.4f\">"
-            + "%n</BalancingConstraint>%n", _balancePercentage.get(Resource.CPU), _balancePercentage.get(Resource.DISK),
+            + "diskCapacityThreshold=\"%.4f\" inboundNwCapacityThreshold=\"%.4f\" outboundNwCapacityThreshold=\"%.4f\""
+            + " maxReplicasPerBroker=\"%d\">%n</BalancingConstraint>%n",
+        _balancePercentage.get(Resource.CPU), _balancePercentage.get(Resource.DISK),
         _balancePercentage.get(Resource.NW_IN), _balancePercentage.get(Resource.NW_OUT),
         _capacityThreshold.get(Resource.CPU), _capacityThreshold.get(Resource.DISK),
-        _capacityThreshold.get(Resource.NW_IN), _capacityThreshold.get(Resource.NW_OUT));
+        _capacityThreshold.get(Resource.NW_IN), _capacityThreshold.get(Resource.NW_OUT), _maxReplicasPerBroker);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -164,7 +164,7 @@ public abstract class AbstractGoal implements Goal {
                                              ClusterModel clusterModel,
                                              Set<Goal> optimizedGoals,
                                              Set<String> excludedTopics)
-      throws AnalysisInputException, ModelInputException;
+      throws AnalysisInputException, ModelInputException, OptimizationFailureException;
 
   /**
    * Attempt to apply the given balancing action to the given replica in the given cluster. The application

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
@@ -206,8 +206,12 @@ public class ReplicaCapacityGoal extends AbstractGoal {
       }
 
       // The goal requirements are violated. Move replica to an available broker.
-      maybeApplyBalancingAction(clusterModel, replica, replicaCapacityEligibleBrokers(replica, clusterModel),
+      SortedSet<Broker> replicaCapacityEligibleBrokers = replicaCapacityEligibleBrokers(replica, clusterModel);
+      Broker b = maybeApplyBalancingAction(clusterModel, replica, replicaCapacityEligibleBrokers,
           BalancingAction.REPLICA_MOVEMENT, optimizedGoals);
+      if (b == null) {
+        LOG.debug("Failed to move replica {} to any broker in {}", replica, replicaCapacityEligibleBrokers);
+      }
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ *
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.goals;
+
+import com.linkedin.kafka.cruisecontrol.analyzer.AnalyzerUtils;
+import com.linkedin.kafka.cruisecontrol.analyzer.BalancingConstraint;
+import com.linkedin.kafka.cruisecontrol.analyzer.BalancingProposal;
+import com.linkedin.kafka.cruisecontrol.common.BalancingAction;
+import com.linkedin.kafka.cruisecontrol.exception.AnalysisInputException;
+import com.linkedin.kafka.cruisecontrol.exception.ModelInputException;
+import com.linkedin.kafka.cruisecontrol.exception.OptimizationFailureException;
+import com.linkedin.kafka.cruisecontrol.model.Broker;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
+import com.linkedin.kafka.cruisecontrol.model.Replica;
+import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Class for achieving the following hard goal:
+ * HARD GOAL: Generate replica movement proposals to ensure that each broker has less than the given number of replicas.
+ */
+public class ReplicaCapacityGoal extends AbstractGoal {
+  private static final Logger LOG = LoggerFactory.getLogger(ReplicaCapacityGoal.class);
+
+  /**
+   * Constructor for Replica Capacity Goal.
+   */
+  public ReplicaCapacityGoal() {
+
+  }
+
+  /**
+   * Package private for unit test.
+   */
+  ReplicaCapacityGoal(BalancingConstraint constraint) {
+    _balancingConstraint = constraint;
+  }
+
+  /**
+   * Check whether given proposal is acceptable by this goal. A proposal is acceptable by a goal if it satisfies
+   * requirements of the goal. Requirements(hard goal): replica capacity goal.
+   *
+   * @param proposal     Proposal to be checked for acceptance.
+   * @param clusterModel The state of the cluster.
+   * @return True if proposal is acceptable by this goal, false otherwise.
+   */
+  @Override
+  public boolean isProposalAcceptable(BalancingProposal proposal, ClusterModel clusterModel) {
+    if (proposal.balancingAction().equals(BalancingAction.REPLICA_MOVEMENT) ||
+        proposal.balancingAction().equals(BalancingAction.REPLICA_ADDITION)) {
+      Broker destinationBroker = clusterModel.broker(proposal.destinationBrokerId());
+      if (destinationBroker.replicas().size() >= _balancingConstraint.maxReplicasPerBroker()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public ClusterModelStatsComparator clusterModelStatsComparator() {
+    return new ReplicaCapacityGoalStatsComparator();
+  }
+
+  @Override
+  public ModelCompletenessRequirements clusterModelCompletenessRequirements() {
+    return new ModelCompletenessRequirements(1, 0.0, true);
+  }
+
+  @Override
+  public String name() {
+    return ReplicaCapacityGoal.class.getSimpleName();
+  }
+
+  /**
+   * This is a hard goal; hence, the proposals are not limited to dead broker replicas in case of self-healing.
+   * Get brokers that the rebalance process will go over to apply balancing actions to replicas they contain.
+   *
+   * @param clusterModel The state of the cluster.
+   * @return A collection of brokers that the rebalance process will go over to apply balancing actions to replicas
+   * they contain.
+   */
+  @Override
+  protected Collection<Broker> brokersToBalance(ClusterModel clusterModel) {
+    return clusterModel.brokers();
+  }
+
+  /**
+   * This is a hard goal; hence, the proposals are not limited to dead broker replicas in case of self-healing.
+   * Sanity Check: Each node has sufficient number of replicas that can be moved to satisfy the replica capacity goal.
+   *
+   *  @param clusterModel The state of the cluster.
+   * @param excludedTopics The topics that should be excluded from the optimization proposals.
+   */
+  @Override
+  protected void initGoalState(ClusterModel clusterModel, Set<String> excludedTopics)
+      throws AnalysisInputException, ModelInputException {
+    List<String> topicsToRebalance = new ArrayList<>(clusterModel.topics());
+    topicsToRebalance.removeAll(excludedTopics);
+    if (topicsToRebalance.isEmpty()) {
+      LOG.warn("All topics are excluded from {}.", name());
+    }
+
+    // Sanity check: excluded topic replicas in a broker cannot exceed the max number of allowed replicas per broker.
+    int totalReplicasInCluster = 0;
+    for (Broker broker : brokersToBalance(clusterModel)) {
+      int excludedReplicasInBroker = 0;
+      for (String topic : excludedTopics) {
+        excludedReplicasInBroker += broker.replicasOfTopicInBroker(topic).size();
+      }
+
+      if (excludedReplicasInBroker > _balancingConstraint.maxReplicasPerBroker()) {
+        throw new AnalysisInputException(String.format("Replicas of excluded topics in broker: %d exceeds the maximum "
+            + "allowed number of replicas: %d.", excludedReplicasInBroker, _balancingConstraint.maxReplicasPerBroker()));
+      }
+      // Calculate total number of replicas for the next sanity check.
+      totalReplicasInCluster += broker.replicas().size();
+    }
+
+    // Sanity check: total replicas in the cluster cannot be more than the allowed replicas in the cluster.
+    long maxReplicasInCluster = _balancingConstraint.maxReplicasPerBroker() * clusterModel.brokers().size();
+    if (totalReplicasInCluster > maxReplicasInCluster) {
+      throw new AnalysisInputException(String.format("Total replicas in cluster: %d exceeds the maximum allowed "
+          + "replicas in cluster: %d.", totalReplicasInCluster, maxReplicasInCluster));
+    }
+  }
+
+  /**
+   * Check if requirements of this goal are not violated if this proposal is applied to the given cluster state,
+   * false otherwise.
+   *
+   * @param clusterModel The state of the cluster.
+   * @param proposal     Proposal containing information about
+   * @return True if requirements of this goal are not violated if this proposal is applied to the given cluster state,
+   * false otherwise.
+   */
+  @Override
+  protected boolean selfSatisfied(ClusterModel clusterModel, BalancingProposal proposal) {
+    if (proposal.balancingAction() != BalancingAction.REPLICA_MOVEMENT) {
+      throw new IllegalStateException("Found balancing action " + proposal.balancingAction() +
+          " but expected replica movement.");
+    }
+    Broker destinationBroker = clusterModel.broker(proposal.destinationBrokerId());
+    if (destinationBroker.replicas().size() >= _balancingConstraint.maxReplicasPerBroker()) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Update goal state after one round of self-healing / rebalance.
+   *
+   *  @param clusterModel The state of the cluster.
+   * @param excludedTopics The topics that should be excluded from the optimization proposal.
+   */
+  @Override
+  protected void updateGoalState(ClusterModel clusterModel, Set<String> excludedTopics)
+      throws AnalysisInputException, OptimizationFailureException {
+    // One pass is sufficient to satisfy or alert impossibility of this goal.
+    // Sanity check to confirm that the final distribution has less than the allowed number of replicas per broker.
+    ensureReplicaCapacitySatisfied(clusterModel);
+    // Sanity check: No self-healing eligible replica should remain at a decommissioned broker.
+    AnalyzerUtils.ensureNoReplicaOnDeadBrokers(clusterModel);
+    finish();
+  }
+
+  /**
+   * Sanity check: Ensure that the replica capacity per broker is not exceeded.
+   *
+   * @param clusterModel The cluster model.
+   */
+  private void ensureReplicaCapacitySatisfied(ClusterModel clusterModel) {
+    for (Broker broker : brokersToBalance(clusterModel)) {
+      int numBrokerReplicas = broker.replicas().size();
+      if (numBrokerReplicas > _balancingConstraint.maxReplicasPerBroker()) {
+        throw new IllegalStateException(String.format("Replicas in broker: %d exceeds the maximum allowed number of "
+            + "replicas: %d.", numBrokerReplicas, _balancingConstraint.maxReplicasPerBroker()));
+      }
+    }
+  }
+
+  /**
+   * Rebalance the given broker without violating the constraints of the current goal and optimized goals.
+   *  @param broker         Broker to be balanced.
+   * @param clusterModel   The state of the cluster.
+
+   * @param optimizedGoals Optimized goals.
+
+   * @param excludedTopics The topics that should be excluded from the optimization proposals.
+   */
+  @Override
+  protected void rebalanceForBroker(Broker broker, ClusterModel clusterModel, Set<Goal> optimizedGoals,
+      Set<String> excludedTopics) throws AnalysisInputException, ModelInputException {
+    LOG.debug("balancing broker {}, optimized goals = {}", broker, optimizedGoals);
+    int numBrokerReplicas = broker.replicas().size();
+    for (Replica replica : new ArrayList<>(broker.replicas())) {
+      if ((broker.isAlive() && numBrokerReplicas <= _balancingConstraint.maxReplicasPerBroker())
+          || excludedTopics.contains(replica.topicPartition().topic())) {
+        continue;
+      }
+
+      // The goal requirements are violated. Move replica to an available broker.
+      if (maybeApplyBalancingAction(clusterModel, replica, replicaCapacityEligibleBrokers(replica, clusterModel),
+          BalancingAction.REPLICA_MOVEMENT, optimizedGoals) == null) {
+        throw new AnalysisInputException("Violated replica capacity requirement for broker with id " + broker.id() + ".");
+      }
+    }
+    if (!broker.isAlive() && broker.replicas().size() > 0) {
+      throw new AnalysisInputException("THERE ARE REPLICAS ON DEAD BROKER");
+    }
+  }
+
+  /**
+   * Get a list of replica capacity eligible brokers for the given replica in the given cluster. A broker is eligible
+   * for a given replica if the broker contains less than allowed maximum number of replicas.
+   *
+   * @param replica      Replica for which a set of replica capacity eligible brokers are requested.
+   * @param clusterModel The state of the cluster.
+   * @return A list of replica capacity eligible brokers for the given replica in the given cluster.
+   */
+  private List<Broker> replicaCapacityEligibleBrokers(Replica replica, ClusterModel clusterModel) {
+    // Populate partition rack ids.
+    List<Broker> eligibleBrokers = new ArrayList<>();
+    int sourceBrokerId = replica.broker().id();
+
+    for (Broker broker : clusterModel.healthyBrokers()) {
+      if (broker.replicas().size() < _balancingConstraint.maxReplicasPerBroker() && broker.id() != sourceBrokerId) {
+        eligibleBrokers.add(broker);
+      }
+    }
+
+    // Sort brokers from the least to most replica holder.
+    Collections.sort(eligibleBrokers,
+        (o1, o2) -> Integer.compare(o1.replicas().size(), o2.replicas().size()));
+
+    // Return eligible brokers.
+    return eligibleBrokers;
+  }
+
+  private static class ReplicaCapacityGoalStatsComparator implements ClusterModelStatsComparator {
+
+    @Override
+    public int compare(ClusterModelStats stats1, ClusterModelStats stats2) {
+      // This goal do not care about stats. The optimization would have already failed if the goal is not met.
+      return 0;
+    }
+
+    @Override
+    public String explainLastComparison() {
+      return null;
+    }
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -15,6 +15,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGo
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.detector.notifier.NoopNotifier;
@@ -322,6 +323,14 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
       + "will continuously compute the proposal candidates.";
 
   /**
+   * <code>max.replicas.per.broker</code>
+   */
+  public static final String MAX_REPLICAS_PER_BROKER_CONFIG = "max.replicas.per.broker";
+  private static final String MAX_REPLICAS_PER_BROKER_DOC = "The maximum number of replicas allowed to reside on a "
+      + "broker. The analyzer will enforce a hard goal that the number of replica on a broker cannot be higher than "
+      + "this config.";
+
+  /**
    * <code>num.proposal.precompute.threads</code>
    */
   public static final String NUM_PROPOSAL_PRECOMPUTE_THREADS_CONFIG = "num.proposal.precompute.threads";
@@ -615,6 +624,12 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 atLeast(0),
                 ConfigDef.Importance.MEDIUM,
                 PROPOSAL_EXPIRATION_MS_DOC)
+        .define(MAX_REPLICAS_PER_BROKER_CONFIG,
+            ConfigDef.Type.LONG,
+            10000,
+            atLeast(0),
+            ConfigDef.Importance.MEDIUM,
+            MAX_REPLICAS_PER_BROKER_DOC)
         .define(NUM_PROPOSAL_PRECOMPUTE_THREADS_CONFIG,
                 ConfigDef.Type.INT,
                 1,
@@ -644,6 +659,7 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 ConfigDef.Type.LIST,
                 new StringJoiner(",")
                     .add(RackAwareGoal.class.getName())
+                    .add(ReplicaCapacityGoal.class.getName())
                     .add(CpuCapacityGoal.class.getName())
                     .add(DiskCapacityGoal.class.getName())
                     .add(NetworkInboundCapacityGoal.class.getName())
@@ -671,6 +687,7 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 ConfigDef.Type.LIST,
                 new StringJoiner(",")
                     .add(RackAwareGoal.class.getName())
+                    .add(ReplicaCapacityGoal.class.getName())
                     .add(CpuCapacityGoal.class.getName())
                     .add(DiskCapacityGoal.class.getName())
                     .add(NetworkInboundCapacityGoal.class.getName())

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/DeterministicClusterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/DeterministicClusterTest.java
@@ -15,6 +15,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGo
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
@@ -27,6 +28,7 @@ import com.linkedin.kafka.cruisecontrol.exception.ModelInputException;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import com.linkedin.kafka.cruisecontrol.model.Load;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -70,8 +72,7 @@ public class DeterministicClusterTest {
    * @return Parameters for the {@link OptimizationVerifier}.
    */
   @Parameterized.Parameters
-  public static Collection<Object[]> data()
-      throws AnalysisInputException, ModelInputException {
+  public static Collection<Object[]> data() throws AnalysisInputException, ModelInputException, IOException {
     Collection<Object[]> params = new ArrayList<>();
 
     int numSnapshots = 2;
@@ -83,21 +84,24 @@ public class DeterministicClusterTest {
 
     Map<Integer, String> goalNameByPriority = new HashMap<>();
     goalNameByPriority.put(1, RackAwareGoal.class.getName());
-    goalNameByPriority.put(2, CpuCapacityGoal.class.getName());
-    goalNameByPriority.put(3, DiskCapacityGoal.class.getName());
-    goalNameByPriority.put(4, NetworkInboundCapacityGoal.class.getName());
-    goalNameByPriority.put(5, NetworkOutboundCapacityGoal.class.getName());
-    goalNameByPriority.put(6, PotentialNwOutGoal.class.getName());
-    goalNameByPriority.put(7, TopicReplicaDistributionGoal.class.getName());
-    goalNameByPriority.put(8, DiskUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(9, NetworkInboundUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(10, NetworkOutboundUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(11, CpuUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(12, LeaderBytesInDistributionGoal.class.getName());
-    goalNameByPriority.put(13, ReplicaDistributionGoal.class.getName());
+    goalNameByPriority.put(2, ReplicaCapacityGoal.class.getName());
+    goalNameByPriority.put(3, CpuCapacityGoal.class.getName());
+    goalNameByPriority.put(4, DiskCapacityGoal.class.getName());
+    goalNameByPriority.put(5, NetworkInboundCapacityGoal.class.getName());
+    goalNameByPriority.put(6, NetworkOutboundCapacityGoal.class.getName());
+    goalNameByPriority.put(7, PotentialNwOutGoal.class.getName());
+    goalNameByPriority.put(8, TopicReplicaDistributionGoal.class.getName());
+    goalNameByPriority.put(9, DiskUsageDistributionGoal.class.getName());
+    goalNameByPriority.put(10, NetworkInboundUsageDistributionGoal.class.getName());
+    goalNameByPriority.put(11, NetworkOutboundUsageDistributionGoal.class.getName());
+    goalNameByPriority.put(12, CpuUsageDistributionGoal.class.getName());
+    goalNameByPriority.put(13, LeaderBytesInDistributionGoal.class.getName());
+    goalNameByPriority.put(14, ReplicaDistributionGoal.class.getName());
 
-    BalancingConstraint balancingConstraint =
-        new BalancingConstraint(new KafkaCruiseControlConfig(CruiseControlUnitTestUtils.getCruiseControlProperties()));
+
+    Properties props = CruiseControlUnitTestUtils.getCruiseControlProperties();
+    props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(6L));
+    BalancingConstraint balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
 
     // ----------##TEST: BALANCE PERCENTAGES.
     balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/DeterministicClusterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/DeterministicClusterTest.java
@@ -28,7 +28,6 @@ import com.linkedin.kafka.cruisecontrol.exception.ModelInputException;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import com.linkedin.kafka.cruisecontrol.model.Load;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -72,7 +71,7 @@ public class DeterministicClusterTest {
    * @return Parameters for the {@link OptimizationVerifier}.
    */
   @Parameterized.Parameters
-  public static Collection<Object[]> data() throws AnalysisInputException, ModelInputException, IOException {
+  public static Collection<Object[]> data() throws AnalysisInputException, ModelInputException {
     Collection<Object[]> params = new ArrayList<>();
 
     int numSnapshots = 2;

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/ExcludedTopicsTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/ExcludedTopicsTest.java
@@ -18,6 +18,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistr
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareCapacityGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.common.DeterministicCluster;
@@ -34,6 +35,7 @@ import java.util.HashSet;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Rule;
@@ -65,6 +67,7 @@ public class ExcludedTopicsTest {
     Set<String> goalNames = new HashSet<>();
     goalNames.add(RackAwareGoal.class.getName());
     goalNames.add(RackAwareCapacityGoal.class.getName());
+    goalNames.add(ReplicaCapacityGoal.class.getName());
     goalNames.add(CpuCapacityGoal.class.getName());
     goalNames.add(DiskCapacityGoal.class.getName());
     goalNames.add(NetworkInboundCapacityGoal.class.getName());
@@ -78,10 +81,9 @@ public class ExcludedTopicsTest {
     goalNames.add(LeaderBytesInDistributionGoal.class.getName());
     goalNames.add(ReplicaDistributionGoal.class.getName());
 
-    KafkaCruiseControlConfig config =
-        new KafkaCruiseControlConfig(CruiseControlUnitTestUtils.getCruiseControlProperties());
-
-    BalancingConstraint balancingConstraint = new BalancingConstraint(config);
+    Properties props = CruiseControlUnitTestUtils.getCruiseControlProperties();
+    props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(1L));
+    BalancingConstraint balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
     balancingConstraint.setBalancePercentage(TestConstants.LOW_BALANCE_PERCENTAGE);
     balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);
 
@@ -120,7 +122,8 @@ public class ExcludedTopicsTest {
       } else if (goalName.equals(CpuCapacityGoal.class.getName()) ||
                  goalName.equals(DiskCapacityGoal.class.getName()) ||
                  goalName.equals(NetworkInboundCapacityGoal.class.getName()) ||
-                 goalName.equals(NetworkOutboundCapacityGoal.class.getName())) {
+                 goalName.equals(NetworkOutboundCapacityGoal.class.getName()) ||
+                 goalName.equals(ReplicaCapacityGoal.class.getName())) {
 
         // Test: With single excluded topic, satisfiable cluster (No exception, No proposal for excluded topic,
         // Expected to look optimized)
@@ -164,7 +167,7 @@ public class ExcludedTopicsTest {
         Object[] withAllExcludedTopicTestParams = {goal, clusterModel.topics(), null, clusterModel, false};
         params.add(withAllExcludedTopicTestParams);
       } else if (goalName.equals(TopicReplicaDistributionGoal.class.getName()) ||
-          goalName.equals(ReplicaDistributionGoal.class.getName())) {
+                 goalName.equals(ReplicaDistributionGoal.class.getName())) {
 
         // Test: With single excluded topic, satisfiable cluster (No exception, No proposal for excluded topic,
         // Expected to look optimized)

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
@@ -16,6 +16,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGo
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
@@ -35,6 +36,7 @@ import java.util.Map;
 
 import com.linkedin.kafka.cruisecontrol.model.Replica;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.Snapshot;
+import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,22 +60,23 @@ public class RandomClusterTest {
 
     Map<Integer, String> goalNameByPriority = new HashMap<>();
     goalNameByPriority.put(1, RackAwareGoal.class.getName());
-    goalNameByPriority.put(2, CpuCapacityGoal.class.getName());
-    goalNameByPriority.put(3, DiskCapacityGoal.class.getName());
-    goalNameByPriority.put(4, NetworkInboundCapacityGoal.class.getName());
-    goalNameByPriority.put(5, NetworkOutboundCapacityGoal.class.getName());
-    goalNameByPriority.put(6, PotentialNwOutGoal.class.getName());
-    goalNameByPriority.put(7, TopicReplicaDistributionGoal.class.getName());
-    goalNameByPriority.put(8, DiskUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(9, NetworkInboundUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(10, NetworkOutboundUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(11, CpuUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(12, LeaderBytesInDistributionGoal.class.getName());
-    goalNameByPriority.put(13, ReplicaDistributionGoal.class.getName());
+    goalNameByPriority.put(2, ReplicaCapacityGoal.class.getName());
+    goalNameByPriority.put(3, CpuCapacityGoal.class.getName());
+    goalNameByPriority.put(4, DiskCapacityGoal.class.getName());
+    goalNameByPriority.put(5, NetworkInboundCapacityGoal.class.getName());
+    goalNameByPriority.put(6, NetworkOutboundCapacityGoal.class.getName());
+    goalNameByPriority.put(7, PotentialNwOutGoal.class.getName());
+    goalNameByPriority.put(8, TopicReplicaDistributionGoal.class.getName());
+    goalNameByPriority.put(9, DiskUsageDistributionGoal.class.getName());
+    goalNameByPriority.put(10, NetworkInboundUsageDistributionGoal.class.getName());
+    goalNameByPriority.put(11, NetworkOutboundUsageDistributionGoal.class.getName());
+    goalNameByPriority.put(12, CpuUsageDistributionGoal.class.getName());
+    goalNameByPriority.put(13, LeaderBytesInDistributionGoal.class.getName());
+    goalNameByPriority.put(14, ReplicaDistributionGoal.class.getName());
 
-    KafkaCruiseControlConfig config =
-        new KafkaCruiseControlConfig(CruiseControlUnitTestUtils.getCruiseControlProperties());
-    BalancingConstraint balancingConstraint = new BalancingConstraint(config);
+    Properties props = CruiseControlUnitTestUtils.getCruiseControlProperties();
+    props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(1500L));
+    BalancingConstraint balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
     balancingConstraint.setBalancePercentage(TestConstants.LOW_BALANCE_PERCENTAGE);
     balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);
 
@@ -85,7 +88,12 @@ public class RandomClusterTest {
       Object[] brokerCountParams = {modifiedProperties, goalNameByPriority, distribution, balancingConstraint};
       params.add(brokerCountParams);
     }
+
     // Test: Increase Replica Count
+    props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(4000L));
+    balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
+    balancingConstraint.setBalancePercentage(TestConstants.LOW_BALANCE_PERCENTAGE);
+    balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);
     for (int i = 7; i <= 12; i++) {
       modifiedProperties = new HashMap<>();
       modifiedProperties.put(ClusterProperty.NUM_REPLICAS, 50001 + (i - 7) * 5001);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
@@ -90,7 +90,7 @@ public class RandomClusterTest {
     }
 
     // Test: Increase Replica Count
-    props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(4000L));
+    props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(3000L));
     balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
     balancingConstraint.setBalancePercentage(TestConstants.LOW_BALANCE_PERCENTAGE);
     balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomGoalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomGoalTest.java
@@ -16,6 +16,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGo
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
@@ -31,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import java.util.Properties;
 import java.util.Random;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,22 +65,23 @@ public class RandomGoalTest {
 
     Map<Integer, String> goalNameByPriority = new HashMap<>();
     goalNameByPriority.put(1, RackAwareGoal.class.getName());
-    goalNameByPriority.put(2, CpuCapacityGoal.class.getName());
-    goalNameByPriority.put(3, DiskCapacityGoal.class.getName());
-    goalNameByPriority.put(4, NetworkInboundCapacityGoal.class.getName());
-    goalNameByPriority.put(5, NetworkOutboundCapacityGoal.class.getName());
-    goalNameByPriority.put(6, PotentialNwOutGoal.class.getName());
-    goalNameByPriority.put(7, TopicReplicaDistributionGoal.class.getName());
-    goalNameByPriority.put(8, DiskUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(9, NetworkInboundUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(10, NetworkOutboundUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(11, CpuUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(12, LeaderBytesInDistributionGoal.class.getName());
-    goalNameByPriority.put(13, ReplicaDistributionGoal.class.getName());
+    goalNameByPriority.put(2, ReplicaCapacityGoal.class.getName());
+    goalNameByPriority.put(3, CpuCapacityGoal.class.getName());
+    goalNameByPriority.put(4, DiskCapacityGoal.class.getName());
+    goalNameByPriority.put(5, NetworkInboundCapacityGoal.class.getName());
+    goalNameByPriority.put(6, NetworkOutboundCapacityGoal.class.getName());
+    goalNameByPriority.put(7, PotentialNwOutGoal.class.getName());
+    goalNameByPriority.put(8, TopicReplicaDistributionGoal.class.getName());
+    goalNameByPriority.put(9, DiskUsageDistributionGoal.class.getName());
+    goalNameByPriority.put(10, NetworkInboundUsageDistributionGoal.class.getName());
+    goalNameByPriority.put(11, NetworkOutboundUsageDistributionGoal.class.getName());
+    goalNameByPriority.put(12, CpuUsageDistributionGoal.class.getName());
+    goalNameByPriority.put(13, LeaderBytesInDistributionGoal.class.getName());
+    goalNameByPriority.put(14, ReplicaDistributionGoal.class.getName());
 
-    KafkaCruiseControlConfig config =
-        new KafkaCruiseControlConfig(CruiseControlUnitTestUtils.getCruiseControlProperties());
-    BalancingConstraint balancingConstraint = new BalancingConstraint(config);
+    Properties props = CruiseControlUnitTestUtils.getCruiseControlProperties();
+    props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(1500L));
+    BalancingConstraint balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
     balancingConstraint.setBalancePercentage(TestConstants.LOW_BALANCE_PERCENTAGE);
     balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);
 
@@ -119,6 +122,7 @@ public class RandomGoalTest {
     // Test shuffled soft goals.
     List<String> shuffledSoftGoalNames = new ArrayList<>(goalNameByPriority.values());
     shuffledSoftGoalNames.remove(RackAwareGoal.class.getName());    // Remove the hard goal.
+    shuffledSoftGoalNames.remove(ReplicaCapacityGoal.class.getName());    // Remove the hard goal.
     shuffledSoftGoalNames.remove(CpuCapacityGoal.class.getName());    // Remove the hard goal.
     shuffledSoftGoalNames.remove(DiskCapacityGoal.class.getName());    // Remove the hard goal.
     shuffledSoftGoalNames.remove(NetworkInboundCapacityGoal.class.getName());    // Remove the hard goal.

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomSelfHealingTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomSelfHealingTest.java
@@ -86,7 +86,7 @@ public class RandomSelfHealingTest {
           entry.getValue()), balancingConstraint};
       params.add(singleDeadSingleSoftParams);
     }
-    props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(10000L));
+    props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(5000L));
     balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
     balancingConstraint.setBalancePercentage(TestConstants.LOW_BALANCE_PERCENTAGE);
     balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomSelfHealingTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomSelfHealingTest.java
@@ -15,6 +15,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGo
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
@@ -30,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import java.util.Properties;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -55,21 +57,23 @@ public class RandomSelfHealingTest {
 
     Map<Integer, String> goalNameByPriority = new HashMap<>();
     goalNameByPriority.put(1, RackAwareGoal.class.getName());
-    goalNameByPriority.put(2, CpuCapacityGoal.class.getName());
-    goalNameByPriority.put(2, DiskCapacityGoal.class.getName());
-    goalNameByPriority.put(2, NetworkInboundCapacityGoal.class.getName());
-    goalNameByPriority.put(2, NetworkOutboundCapacityGoal.class.getName());
-    goalNameByPriority.put(3, PotentialNwOutGoal.class.getName());
-    goalNameByPriority.put(4, DiskUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(5, NetworkInboundUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(6, NetworkOutboundUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(7, CpuUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(8, TopicReplicaDistributionGoal.class.getName());
-    goalNameByPriority.put(9, ReplicaDistributionGoal.class.getName());
+    goalNameByPriority.put(2, ReplicaCapacityGoal.class.getName());
+    goalNameByPriority.put(3, CpuCapacityGoal.class.getName());
+    goalNameByPriority.put(4, DiskCapacityGoal.class.getName());
+    goalNameByPriority.put(5, NetworkInboundCapacityGoal.class.getName());
+    goalNameByPriority.put(6, NetworkOutboundCapacityGoal.class.getName());
+    goalNameByPriority.put(7, PotentialNwOutGoal.class.getName());
+    goalNameByPriority.put(8, DiskUsageDistributionGoal.class.getName());
+    goalNameByPriority.put(9, NetworkInboundUsageDistributionGoal.class.getName());
+    goalNameByPriority.put(10, NetworkOutboundUsageDistributionGoal.class.getName());
+    goalNameByPriority.put(11, CpuUsageDistributionGoal.class.getName());
+    goalNameByPriority.put(12, TopicReplicaDistributionGoal.class.getName());
+    goalNameByPriority.put(13, ReplicaDistributionGoal.class.getName());
 
-    KafkaCruiseControlConfig config =
-        new KafkaCruiseControlConfig(CruiseControlUnitTestUtils.getCruiseControlProperties());
-    BalancingConstraint balancingConstraint = new BalancingConstraint(config);
+
+    Properties props = CruiseControlUnitTestUtils.getCruiseControlProperties();
+    props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(2000L));
+    BalancingConstraint balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
     balancingConstraint.setBalancePercentage(TestConstants.LOW_BALANCE_PERCENTAGE);
     balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);
 
@@ -82,6 +86,11 @@ public class RandomSelfHealingTest {
           entry.getValue()), balancingConstraint};
       params.add(singleDeadSingleSoftParams);
     }
+    props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(10000L));
+    balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
+    balancingConstraint.setBalancePercentage(TestConstants.LOW_BALANCE_PERCENTAGE);
+    balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);
+
     // Test: All Goals.
     Object[] singleDeadMultiAllGoalsParams = {singleDeadBroker, goalNameByPriority, balancingConstraint};
     params.add(singleDeadMultiAllGoalsParams);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/CaseInsensitiveGoalConfigTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/CaseInsensitiveGoalConfigTest.java
@@ -44,6 +44,7 @@ public class CaseInsensitiveGoalConfigTest {
     caseInsensitiveGoalProps.putAll(sharedProps);
     caseInsensitiveGoalProps.setProperty(KafkaCruiseControlConfig.GOALS_CONFIG,
         "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,"
+            + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,"
             + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,"
             + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,"
             + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,"


### PR DESCRIPTION
_ReplicaCapacityGoal_ is a hard goal.
It ensures that the maximum number of replicas per broker is under the specified maximum limit controlled by `max.replicas.per.broker`