### PR TITLE
Fix broken path in Cruise Control start script to copy jars.

### DIFF
--- a/kafka-cruise-control-start.sh
+++ b/kafka-cruise-control-start.sh
@@ -23,7 +23,7 @@ copyJars() {
   jars=(${files//,/ })
   for usrJar in ${jars[@]};
   do
-    cp $usrJar "$base_dir"/build/dependant-libs/
+    cp $usrJar "$base_dir"/cruise-control/build/dependant-libs/
   done
 }
 


### PR DESCRIPTION
Fixes the issue https://github.com/linkedin/cruise-control/issues/91.