### PR TITLE
Add Kafka-Assigner Even Rack-Aware Goal.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ subprojects {
     useJUnit {}
     testLogging {
       events "passed", "failed", "skipped"
+      exceptionFormat = 'full'
     }
     if (!project.hasProperty("maxParallelForks")) {
       maxParallelForks = Runtime.runtime.availableProcessors()

--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -88,7 +88,7 @@ disk.balance.threshold=1.1
 # The balance threshold for network inbound utilization
 network.inbound.balance.threshold=1.1
 
-# The balance threshold for network outbound utilizatoin
+# The balance threshold for network outbound utilization
 network.outbound.balance.threshold=1.1
 
 # The capacity threshold for CPU in percentage

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -247,7 +247,7 @@ public abstract class AbstractGoal implements Goal {
       return candidateBrokers;
     } else {
       List<Broker> eligibleBrokers = new ArrayList<>();
-      // When there is new brokers, we should only allow the replicas to be moved to the new brokers.
+      // When there are new brokers, we should only allow the replicas to be moved to the new brokers.
       candidateBrokers.forEach(b -> {
         if (b.isNew() || b == replica.originalBroker()) {
           eligibleBrokers.add(b);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerEvenRackAwareGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerEvenRackAwareGoal.java
@@ -1,0 +1,435 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ *
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner;
+
+import com.linkedin.kafka.cruisecontrol.analyzer.BalancingProposal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
+import com.linkedin.kafka.cruisecontrol.common.BalancingAction;
+import com.linkedin.kafka.cruisecontrol.exception.AnalysisInputException;
+import com.linkedin.kafka.cruisecontrol.exception.KafkaCruiseControlException;
+import com.linkedin.kafka.cruisecontrol.exception.ModelInputException;
+import com.linkedin.kafka.cruisecontrol.exception.OptimizationFailureException;
+import com.linkedin.kafka.cruisecontrol.model.Broker;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
+import com.linkedin.kafka.cruisecontrol.model.Partition;
+import com.linkedin.kafka.cruisecontrol.model.Replica;
+import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class KafkaAssignerEvenRackAwareGoal implements Goal {
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaAssignerEvenRackAwareGoal.class);
+  private Map<String, List<Partition>> _partitionsByTopic;
+  private Map<Integer, SortedSet<BrokerReplicaCount>> _healthyBrokerReplicaCountByPosition;
+
+  public KafkaAssignerEvenRackAwareGoal() {
+    _partitionsByTopic = null;
+    _healthyBrokerReplicaCountByPosition = new HashMap<>();
+  }
+
+  /**
+   * Optimize the given cluster model as needed for this goal.
+   *
+   * @param clusterModel   The state of the cluster.
+   * @param optimizedGoals Goals that have already been optimized. These goals cannot be violated.
+   * @param excludedTopics The topics that should be excluded from the optimization proposal.
+   * @return true if the goal is met after the optimization, throws an exceptions if the goal is not met.
+   */
+  @Override
+  public boolean optimize(ClusterModel clusterModel, Set<Goal> optimizedGoals, Set<String> excludedTopics)
+      throws KafkaCruiseControlException {
+    LOG.debug("Starting {} with excluded topics = {}", name(), excludedTopics);
+
+    if (!optimizedGoals.isEmpty()) {
+      throw new IllegalArgumentException(String.format("Goals %s cannot be optimized before %s.", optimizedGoals, name()));
+    }
+
+    ensureRackAwareSatisfiable(clusterModel, excludedTopics);
+
+    _partitionsByTopic = clusterModel.getPartitionsByTopic();
+    int maxReplicationFactor = clusterModel.maxReplicationFactor();
+    Map<String, Integer> replicationFactorByTopic = clusterModel.replicationFactorByTopic();
+
+    for (int i = 0; i < maxReplicationFactor; i++) {
+      SortedSet<BrokerReplicaCount> healthyBrokersByReplicaCount = new TreeSet<>();
+      clusterModel.healthyBrokers().stream().map(BrokerReplicaCount::new).forEach(healthyBrokersByReplicaCount::add);
+      _healthyBrokerReplicaCountByPosition.put(i, healthyBrokersByReplicaCount);
+    }
+
+    for (int position = 0; position < maxReplicationFactor; position++) {
+      for (Map.Entry<String, List<Partition>> entry : _partitionsByTopic.entrySet()) {
+        if (replicationFactorByTopic.get(entry.getKey()) < position + 1) {
+          // The topic replication factor is smaller than the position index.
+          continue;
+        }
+        for (Partition partition : entry.getValue()) {
+          if (shouldExclude(partition, position, excludedTopics)) {
+            continue;
+          }
+          // Apply the necessary move (if needed).
+          if (!maybeApplyMove(clusterModel, partition, position)) {
+            throw new OptimizationFailureException(
+                String.format("Unable to apply move for replica %s.", replicaInPositionFor(partition, position)));
+          }
+        }
+      }
+    }
+    ensureRackAware(clusterModel, excludedTopics);
+    return true;
+  }
+
+  /**
+   * Apply the move to the first eligible destination broker selected from _healthyBrokerReplicaCountByPosition for the
+   * relevant replica position.
+   *
+   * An eligible destination broker must reside in a rack that has no other replicas from the same partition, which has
+   * a position smaller than the given replicaPosition.
+   *
+   * If the destination broker has:
+   * (1) no other replica from the same partition, move the replica to there.
+   * (2) the current replica under consideration, do nothing.
+   * (3) a replica with a larger position, swap positions.
+   *
+   * @param clusterModel The state of the cluster.
+   * @param sourcePartition The partition whose replica might be moved.
+   * @param replicaPosition The position of the replica in the given partition.
+   * @return true if a move is applied, false otherwise.
+   */
+  private boolean maybeApplyMove(ClusterModel clusterModel, Partition sourcePartition, int replicaPosition)
+      throws AnalysisInputException, ModelInputException {
+    // Initialize ineligible broker rack ids based on rack-awareness.
+    Set<String> ineligibleBrokersRackIds = new HashSet<>();
+    for (int pos = 0; pos < replicaPosition; pos++) {
+      Replica replica = replicaInPositionFor(sourcePartition, pos);
+      ineligibleBrokersRackIds.add(replica.broker().rack().id());
+    }
+    // Find an eligible destination and apply the relevant move.
+    BrokerReplicaCount eligibleBrokerReplicaCount = null;
+    for (final Iterator<BrokerReplicaCount> it = _healthyBrokerReplicaCountByPosition.get(replicaPosition).iterator();
+         it.hasNext(); ) {
+      BrokerReplicaCount healthyBrokerReplicaCount = it.next();
+      if (ineligibleBrokersRackIds.contains(healthyBrokerReplicaCount.broker().rack().id())) {
+        continue;
+      }
+
+      // Get the replica in the destination broker (if any)
+      Replica destinationReplica = replicaInBrokerFor(sourcePartition, healthyBrokerReplicaCount.broker().id());
+      Broker destinationBroker = healthyBrokerReplicaCount.broker();
+      Replica sourceReplica = replicaInPositionFor(sourcePartition, replicaPosition);
+
+      if (destinationReplica == null) {
+        LOG.trace("Destination broker {} has no other replica from the same partition, move the replica {} to there.",
+                  destinationBroker, sourceReplica);
+        applyBalancingAction(clusterModel, sourceReplica, destinationBroker, BalancingAction.REPLICA_MOVEMENT);
+      } else if (destinationBroker.id() != sourceReplica.broker().id() && sourceReplica.broker().isAlive()) {
+        LOG.trace("Destination broker has a replica {} with a larger position than source replica {}, swap positions.",
+                  destinationReplica, sourceReplica);
+        if (replicaPosition == 0) {
+          // Transfer leadership.
+          applyBalancingAction(clusterModel, sourceReplica, destinationBroker, BalancingAction.LEADERSHIP_MOVEMENT);
+        } else {
+          // Swap followers.
+          int otherPos = followerPosition(sourcePartition, destinationBroker.id());
+          sourcePartition.swapFollowerPositions(replicaPosition - 1, otherPos - 1);
+        }
+      } else if (!sourceReplica.broker().isAlive()) {
+        LOG.trace("Source broker {} is dead and either the destination broker {} is the same as the source, or has a "
+                  + "replica from the same partition.", sourceReplica.broker(), destinationBroker);
+        // Unable apply any valid move.
+        continue;
+      }
+      // Increment the replica count on the destination.
+      eligibleBrokerReplicaCount = healthyBrokerReplicaCount;
+      it.remove();
+      break;
+    }
+
+    if (eligibleBrokerReplicaCount != null) {
+      // Success: Increment the replica count on the destination.
+      eligibleBrokerReplicaCount.incReplicaCount();
+      _healthyBrokerReplicaCountByPosition.get(replicaPosition).add(eligibleBrokerReplicaCount);
+      return true;
+    }
+    // Failure: Unable to apply any move.
+    return false;
+  }
+
+  /**
+   * Get the position of follower that is part of the given partition and reside in the broker with the given id.
+   *
+   * @param partition The partition that the follower is a part of.
+   * @param brokerId Id of the broker that the follower resides.
+   * @return the position of follower that is part of the given partition and reside in the broker with the given id.
+   */
+  private int followerPosition(Partition partition, int brokerId) {
+    int followerPos = 1;
+    for (Broker follower: partition.followerBrokers()) {
+      if (follower.id() == brokerId) {
+        return followerPos;
+      }
+      followerPos++;
+    }
+    throw new IllegalArgumentException(String.format("Partition %s has no follower on %d.", partition, brokerId));
+  }
+
+  /**
+   * Apply the given balancing action.
+   *
+   * @param clusterModel The state of the cluster
+   * @param sourceReplica The source replica to be moved or giving its leadership.
+   * @param destinationBroker The broker that will receive the source broker or its leadership.
+   * @param action The balancing action is either replica or leadership move.
+   */
+  private void applyBalancingAction(ClusterModel clusterModel,
+                                    Replica sourceReplica,
+                                    Broker destinationBroker,
+                                    BalancingAction action)
+      throws ModelInputException, AnalysisInputException {
+
+    if (action == BalancingAction.LEADERSHIP_MOVEMENT) {
+      clusterModel.relocateLeadership(sourceReplica.topicPartition(), sourceReplica.broker().id(), destinationBroker.id());
+    } else if (action == BalancingAction.REPLICA_MOVEMENT) {
+      clusterModel.relocateReplica(sourceReplica.topicPartition(), sourceReplica.broker().id(), destinationBroker.id());
+    }
+  }
+
+  /**
+   * Get replica of the given partition residing in the given position.
+   *
+   * @param sourcePartition Partition whose replica will be returned.
+   * @param position The position of replica in the partition, i.e. 0 means leader, 1 is the first follower, and so on.
+   */
+  private Replica replicaInPositionFor(Partition sourcePartition, int position) {
+    if (position == 0) {
+      return sourcePartition.leader();
+    }
+    return sourcePartition.followers().get(position - 1);
+  }
+
+  /**
+   * Get replica of the given partition residing in the broker with the given brokerId. If there is no replica of the
+   * given partition in the broker with the given brokerId, return null.
+   *
+   * @param sourcePartition Partition whose replica will be returned (if any).
+   * @param brokerId The id of the broker in which the replica resides (if any).
+   */
+  private Replica replicaInBrokerFor(Partition sourcePartition, int brokerId) {
+    if (sourcePartition.leader().broker().id() == brokerId) {
+      return sourcePartition.leader();
+    }
+
+    for (Replica replica : sourcePartition.followers()) {
+      if (replica.broker().id() == brokerId) {
+        return replica;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Check whether the replica should be excluded from the rebalance. A replica should be excluded if its topic
+   * is in the excluded topics set and its broker is still alive.
+   *
+   * @param partition The partition of replica to be checked.
+   * @param position The position of replica in the given partition.
+   * @param excludedTopics The excluded topics set.
+   * @return True if the replica should be excluded, false otherwise.
+   */
+  private boolean shouldExclude(Partition partition, int position, Set<String> excludedTopics) {
+    Replica replica = replicaInPositionFor(partition, position);
+    return excludedTopics.contains(replica.topicPartition().topic()) && replica.originalBroker().isAlive();
+  }
+
+  /**
+   * Sanity Check: There exists sufficient number of racks for achieving rack-awareness.
+   *
+   * @param clusterModel The state of the cluster.
+   * @param excludedTopics The topics that should be excluded from the optimization proposals.
+   */
+  private void ensureRackAwareSatisfiable(ClusterModel clusterModel, Set<String> excludedTopics)
+      throws OptimizationFailureException {
+    // Sanity Check: not enough racks to satisfy rack awareness.
+    int numHealthyRacks = clusterModel.numHealthyRacks();
+    if (!excludedTopics.isEmpty()) {
+      int maxReplicationFactorOfIncludedTopics = 1;
+      Map<String, Integer> replicationFactorByTopic = clusterModel.replicationFactorByTopic();
+
+      for (Map.Entry<String, Integer> replicationFactorByTopicEntry: replicationFactorByTopic.entrySet()) {
+        if (!excludedTopics.contains(replicationFactorByTopicEntry.getKey())) {
+          maxReplicationFactorOfIncludedTopics =
+              Math.max(maxReplicationFactorOfIncludedTopics, replicationFactorByTopicEntry.getValue());
+          if (maxReplicationFactorOfIncludedTopics > numHealthyRacks) {
+            throw new OptimizationFailureException("Insufficient number of racks to distribute included replicas.");
+          }
+        }
+      }
+    } else if (clusterModel.maxReplicationFactor() > numHealthyRacks) {
+      throw new OptimizationFailureException("Insufficient number of racks to distribute each replica.");
+    }
+  }
+
+  /**
+   * Sanity Check: Replicas are distributed in a rack-aware way.
+   *
+   * @param clusterModel The state of the cluster.
+   * @param excludedTopics The topics that should be excluded from the optimization proposals.
+   */
+  private void ensureRackAware(ClusterModel clusterModel, Set<String> excludedTopics)
+      throws OptimizationFailureException {
+    // Sanity check to confirm that the final distribution is rack aware.
+    for (Replica leader : clusterModel.leaderReplicas()) {
+      if (excludedTopics.contains(leader.topicPartition().topic())) {
+        continue;
+      }
+
+      Set<String> replicaBrokersRackIds = new HashSet<>();
+      Set<Broker> followerBrokers = new HashSet<>(clusterModel.partition(leader.topicPartition()).followerBrokers());
+
+      // Add rack Id of replicas.
+      for (Broker followerBroker : followerBrokers) {
+        String followerRackId = followerBroker.rack().id();
+        replicaBrokersRackIds.add(followerRackId);
+      }
+      replicaBrokersRackIds.add(leader.broker().rack().id());
+      if (replicaBrokersRackIds.size() != (followerBrokers.size() + 1)) {
+        throw new OptimizationFailureException("Optimization for goal " + name() + " failed for rack-awareness of "
+                                               + "partition " + leader.topicPartition());
+      }
+    }
+  }
+
+  /**
+   * Check whether the given proposal is acceptable by this goal. This goal is used to generate an initially balanced,
+   * rack-aware distribution. Hence, as long as the rack awareness is preserved, it is acceptable to break the
+   * distribution generated by this goal for the sake of satisfying the requirements of the other goals.
+   *
+   * @param proposal     Proposal to be checked for acceptance.
+   * @param clusterModel The state of the cluster.
+   * @return True if proposal is acceptable by this goal, false otherwise.
+   */
+  @Override
+  public boolean isProposalAcceptable(BalancingProposal proposal, ClusterModel clusterModel) {
+    if (proposal.balancingAction().equals(BalancingAction.REPLICA_MOVEMENT)) {
+      Replica sourceReplica = clusterModel.broker(proposal.sourceBrokerId()).replica(proposal.topicPartition());
+      Broker destinationBroker = clusterModel.broker(proposal.destinationBrokerId());
+
+      // Destination broker cannot be in a rack that violates rack awareness.
+      Set<Broker> partitionBrokers = clusterModel.partition(sourceReplica.topicPartition()).partitionBrokers();
+      partitionBrokers.remove(sourceReplica.broker());
+
+      // Remove brokers in partition broker racks except the brokers in replica broker rack.
+      for (Broker broker : partitionBrokers) {
+        if (broker.rack().brokers().contains(destinationBroker)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public ModelCompletenessRequirements clusterModelCompletenessRequirements() {
+    // We only need the latest snapshot and include all the topics.
+    return new ModelCompletenessRequirements(1, 0.0, true);
+  }
+
+  /**
+   * Get the name of this goal. Name of a goal provides an identification for the goal in human readable format.
+   */
+  @Override
+  public String name() {
+    return KafkaAssignerEvenRackAwareGoal.class.getSimpleName();
+  }
+
+  @Override
+  public ClusterModelStatsComparator clusterModelStatsComparator() {
+    return new EvenRackAwareGoalStatsComparator();
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    // No external config is used.
+  }
+
+  private static class EvenRackAwareGoalStatsComparator implements ClusterModelStatsComparator {
+
+    @Override
+    public int compare(ClusterModelStats stats1, ClusterModelStats stats2) {
+      // This goal does not care about stats. The optimization would have already failed if the goal is not met.
+      return 0;
+    }
+
+    @Override
+    public String explainLastComparison() {
+      return null;
+    }
+  }
+
+  /**
+   * A helper class for this goal to keep track of the number of replicas assigned to brokers at each position during
+   * the optimization process.
+   */
+  private static class BrokerReplicaCount implements Comparable<BrokerReplicaCount> {
+    private final Broker _broker;
+    private int _replicaCount;
+
+    BrokerReplicaCount(Broker broker) {
+      _broker = broker;
+      _replicaCount = 0;
+    }
+
+    public Broker broker() {
+      return _broker;
+    }
+
+    int replicaCount() {
+      return _replicaCount;
+    }
+
+    void incReplicaCount() {
+      _replicaCount++;
+    }
+
+    @Override
+    public int compareTo(BrokerReplicaCount o) {
+      if (_replicaCount > o.replicaCount()) {
+        return 1;
+      } else if (_replicaCount < o.replicaCount()) {
+        return -1;
+      } else {
+        return Integer.compare(_broker.id(), o.broker().id());
+      }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      BrokerReplicaCount that = (BrokerReplicaCount) o;
+      return _replicaCount == that._replicaCount && _broker.id() == that._broker.id();
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_broker.id(), _replicaCount);
+    }
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -187,6 +189,20 @@ public class ClusterModel implements Serializable {
    */
   public Partition partition(TopicPartition tp) {
     return _partitionsByTopicPartition.get(tp);
+  }
+
+  /**
+   * Get a map of partitions by topic names.
+   */
+  public SortedMap<String, List<Partition>> getPartitionsByTopic() {
+    SortedMap<String, List<Partition>> partitionsByTopic = new TreeMap<>();
+    for (String topicName: topics()) {
+      partitionsByTopic.put(topicName, new ArrayList<>());
+    }
+    for (Map.Entry<TopicPartition, Partition> entry: _partitionsByTopicPartition.entrySet()) {
+      partitionsByTopic.get(entry.getKey().topic()).add(entry.getValue());
+    }
+    return partitionsByTopic;
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Partition.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Partition.java
@@ -35,7 +35,7 @@ public class Partition implements Serializable {
   Partition(TopicPartition tp, Replica leader) throws ModelInputException {
     if (leader != null && !leader.isLeader()) {
       throw new ModelInputException("Inconsistent leadership information. Specified leader replica " + leader +
-          " is not marked as leader.");
+                                    " is not marked as leader.");
     }
     _tp = tp;
     _followers = new ArrayList<>();
@@ -49,16 +49,30 @@ public class Partition implements Serializable {
    * @throws ModelInputException
    */
   void addFollower(Replica follower) throws ModelInputException {
+    addFollower(-1, follower);
+  }
+
+  /**
+   * Add follower to the partition in the given index determining the follower position in replica list.
+   * @param index An index determining the follower position in replica list.
+   * @param follower Follower replica.
+   * @throws ModelInputException
+   */
+  private void addFollower(int index, Replica follower) throws ModelInputException {
     if (follower.isLeader()) {
       throw new ModelInputException("Inconsistent leadership information. Trying to add follower replica " +
-          follower + " while it is a leader.");
+                                    follower + " while it is a leader.");
     }
     if (!follower.topicPartition().equals(_tp)) {
       throw new ModelInputException("Inconsistent topic partition. Trying to add follower replica " + follower +
-          " to partition " + _tp + ".");
+                                    " to partition " + _tp + ".");
     }
     // Add follower to the list of followers.
-    _followers.add(follower);
+    if (index >= 0) {
+      _followers.add(index, follower);
+    } else {
+      _followers.add(follower);
+    }
   }
 
   /**
@@ -99,8 +113,22 @@ public class Partition implements Serializable {
   /**
    * Get the set of brokers that followers reside in.
    */
-  public Set<Broker> followerBrokers() {
-    return _followers.stream().map(Replica::broker).collect(Collectors.toSet());
+  public List<Broker> followerBrokers() {
+    return _followers.stream().map(Replica::broker).collect(Collectors.toList());
+  }
+
+  /**
+   * Given two follower indices in the follower list, swap their positions.
+   *
+   * @param followerIndex The index of the first follower to be swapped.
+   * @param otherFollowerIndex The index of the second follower to be swapped
+   */
+  public void swapFollowerPositions(int followerIndex, int otherFollowerIndex) {
+    Replica follower1 = _followers.get(followerIndex);
+    Replica follower2 = _followers.get(otherFollowerIndex);
+
+    _followers.set(otherFollowerIndex, follower1);
+    _followers.set(followerIndex, follower2);
   }
 
   /**
@@ -110,7 +138,7 @@ public class Partition implements Serializable {
     Set<Broker> partitionBrokers = new HashSet<>();
     // Add leader and follower brokers.
     partitionBrokers.add(_leader.broker());
-    partitionBrokers.addAll(_followers.stream().map(Replica::broker).collect(Collectors.toList()));
+    partitionBrokers.addAll(followerBrokers());
     return partitionBrokers;
   }
 
@@ -124,7 +152,7 @@ public class Partition implements Serializable {
       throws ModelInputException {
     if (!leader.isLeader()) {
       throw new ModelInputException("Inconsistent leadership information. Trying to set " + leader.broker() +
-          " as the leader for partition " + _tp + " while the replica is not marked as a leader.");
+                                    " as the leader for partition " + _tp + " while the replica is not marked as a leader.");
     }
     _leader = leader;
   }
@@ -139,9 +167,10 @@ public class Partition implements Serializable {
    */
   void relocateLeadership(Replica prospectiveLeader) throws ModelInputException {
     // Remove prospective leader from followers.
+    int followerPosition = _followers.indexOf(prospectiveLeader);
     _followers.remove(prospectiveLeader);
     // Make the old leader a follower.
-    addFollower(_leader);
+    addFollower(followerPosition, _leader);
     // Make the prospective leader the leader.
     _leader = prospectiveLeader;
   }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/ExcludedTopicsTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/ExcludedTopicsTest.java
@@ -67,7 +67,7 @@ public class ExcludedTopicsTest {
   @Parameters(name = "{1}-{0}")
   public static Collection<Object[]> data() throws Exception {
     Collection<Object[]> p = new ArrayList<>();
-    
+
     Set<String> noExclusion = Collections.emptySet();
     Set<String> excludeT1 = Collections.unmodifiableSet(Collections.singleton("T1"));
     Set<String> excludeAllTopics = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("T1", "T2")));
@@ -76,21 +76,21 @@ public class ExcludedTopicsTest {
 
     for (Class<? extends Goal> goalClass : Arrays.asList(RackAwareGoal.class, RackAwareCapacityGoal.class)) {
       // With excluded topics, rack aware satisfiable cluster, no dead brokers (No exception, No proposal, Expected to look optimized)
-      p.add(params(0, goalClass, excludeT1, null, rackAwareSatisfiable(), noDeadBroker, true));
+      p.add(params(0, goalClass, excludeT1, null, DeterministicCluster.rackAwareSatisfiable(), noDeadBroker, true));
       // With excluded topics, rack aware satisfiable cluster, one dead brokers (No exception, No proposal, Expected to look optimized)
-      p.add(params(1, goalClass, excludeT1, null, rackAwareSatisfiable(), deadBroker0, true));
+      p.add(params(1, goalClass, excludeT1, null, DeterministicCluster.rackAwareSatisfiable(), deadBroker0, true));
       // Without excluded topics, rack aware satisfiable cluster, no dead brokers (No exception, Proposal expected, Expected to look optimized)
-      p.add(params(2, goalClass, noExclusion, null, rackAwareSatisfiable(), noDeadBroker, true));
+      p.add(params(2, goalClass, noExclusion, null, DeterministicCluster.rackAwareSatisfiable(), noDeadBroker, true));
       // Without excluded topics, rack aware satisfiable cluster, one dead broker (No exception, Proposal expected, Expected to look optimized)
-      p.add(params(3, goalClass, noExclusion, null, rackAwareSatisfiable(), deadBroker0, true));
+      p.add(params(3, goalClass, noExclusion, null, DeterministicCluster.rackAwareSatisfiable(), deadBroker0, true));
       // With excluded topics, rack aware unsatisfiable cluster, no dead broker (No exception, No proposal, Expected to look optimized)
-      p.add(params(4, goalClass, excludeT1, null, rackAwareUnsatisfiable(), noDeadBroker, true));
+      p.add(params(4, goalClass, excludeT1, null, DeterministicCluster.rackAwareUnsatisfiable(), noDeadBroker, true));
       // With excluded topics, rack aware unsatisfiable cluster, one dead broker (Exception)
-      p.add(params(5, goalClass, excludeT1, AnalysisInputException.class, rackAwareUnsatisfiable(), deadBroker0, null));
+      p.add(params(5, goalClass, excludeT1, AnalysisInputException.class, DeterministicCluster.rackAwareUnsatisfiable(), deadBroker0, null));
       // Test: Without excluded topics, rack aware unsatisfiable cluster, no dead brokers (Exception expected)
-      p.add(params(6, goalClass, noExclusion, AnalysisInputException.class, rackAwareUnsatisfiable(), noDeadBroker, null));
-      // Test: Without excluded topics, rack aware unsatisfiable cluster, one dead broker (Exception expceted)
-      p.add(params(7, goalClass, noExclusion, AnalysisInputException.class, rackAwareUnsatisfiable(), deadBroker0, null));
+      p.add(params(6, goalClass, noExclusion, AnalysisInputException.class, DeterministicCluster.rackAwareUnsatisfiable(), noDeadBroker, null));
+      // Test: Without excluded topics, rack aware unsatisfiable cluster, one dead broker (Exception expected)
+      p.add(params(7, goalClass, noExclusion, AnalysisInputException.class, DeterministicCluster.rackAwareUnsatisfiable(), deadBroker0, null));
     }
 
     for (Class<? extends Goal> goalClass : Arrays.asList(CpuCapacityGoal.class,
@@ -98,10 +98,10 @@ public class ExcludedTopicsTest {
                                                          NetworkInboundCapacityGoal.class,
                                                          NetworkOutboundCapacityGoal.class,
                                                          ReplicaCapacityGoal.class)) {
-      // Test: With single excluded topic, satisfiable cluster, no dead brokers (No exception, No proposal 
+      // Test: With single excluded topic, satisfiable cluster, no dead brokers (No exception, No proposal
       // for excluded topic, Expected to look optimized)
       p.add(params(0, goalClass, excludeT1, null, unbalanced(), noDeadBroker, true));
-      // Test: With single excluded topic, satisfiable cluster, one dead brokers (No exception, No proposal 
+      // Test: With single excluded topic, satisfiable cluster, one dead brokers (No exception, No proposal
       // for excluded topic, Expected to look optimized)
       p.add(params(1, goalClass, excludeT1, null, unbalanced(), deadBroker0, true));
       // Test: With all topics excluded, no dead brokers, not satisfiable (Exception)
@@ -109,67 +109,67 @@ public class ExcludedTopicsTest {
       // Test: With all topics excluded, one dead brokers, not satisfiable, no exception.
       p.add(params(3, goalClass, excludeAllTopics, null, unbalanced(), deadBroker0, true));
     }
-    
+
     for (Class<? extends Goal> goalClass : Arrays.asList(DiskUsageDistributionGoal.class,
                                                          NetworkInboundUsageDistributionGoal.class,
                                                          NetworkOutboundUsageDistributionGoal.class,
                                                          CpuUsageDistributionGoal.class)) {
-      // Test: With single excluded topic, balance not satisfiable cluster, no dead broker (No exception, No proposal 
+      // Test: With single excluded topic, balance not satisfiable cluster, no dead broker (No exception, No proposal
       // for excluded topic, Not expected to look optimized)
       p.add(params(0, goalClass, excludeT1, null, unbalanced(), noDeadBroker, false));
-      // Test: With single excluded topic, balance not satisfiable cluster, no dead broker (No exception, No proposal 
+      // Test: With single excluded topic, balance not satisfiable cluster, no dead broker (No exception, No proposal
       // for excluded topic, Not expected to look optimized)
       p.add(params(1, goalClass, excludeT1, null, unbalanced(), deadBroker0, true));
-      // Test: With all topics excluded, no dead brokers, balance not satisfiable (No exception, No proposal for 
+      // Test: With all topics excluded, no dead brokers, balance not satisfiable (No exception, No proposal for
       // excluded topic, Not expected to look optimized)
       p.add(params(2, goalClass, excludeAllTopics, null, unbalanced(), noDeadBroker, false));
-      // Test: With all topics excluded, no dead brokers, balance not satisfiable (No exception, No proposal for 
+      // Test: With all topics excluded, no dead brokers, balance not satisfiable (No exception, No proposal for
       // excluded topic, Not expected to look optimized)
       p.add(params(3, goalClass, excludeAllTopics, null, unbalanced(), deadBroker0, true));
     }
 
-    // Test: With single excluded topic, balance not satisfiable cluster, no dead broker (No exception, No proposal 
+    // Test: With single excluded topic, balance not satisfiable cluster, no dead broker (No exception, No proposal
     // for excluded topic, Not expected to look optimized)
     p.add(params(0, LeaderBytesInDistributionGoal.class, excludeT1, null, unbalanced(), noDeadBroker, false));
-    // Test: With single excluded topic, balance not satisfiable cluster, no dead broker (No exception, No proposal 
+    // Test: With single excluded topic, balance not satisfiable cluster, no dead broker (No exception, No proposal
     // for excluded topic, Not expected to look optimized)
     p.add(params(1, LeaderBytesInDistributionGoal.class, excludeT1, null, unbalanced(), deadBroker0, false));
-    // Test: With all topics excluded, no dead brokers, balance not satisfiable (No exception, No proposal for 
+    // Test: With all topics excluded, no dead brokers, balance not satisfiable (No exception, No proposal for
     // excluded topic, Not expected to look optimized)
     p.add(params(2, LeaderBytesInDistributionGoal.class, excludeAllTopics, null, unbalanced(), noDeadBroker, false));
-    // Test: With all topics excluded, no dead brokers, balance not satisfiable (No exception, No proposal for 
+    // Test: With all topics excluded, no dead brokers, balance not satisfiable (No exception, No proposal for
     // excluded topic, Not expected to look optimized)
     p.add(params(3, LeaderBytesInDistributionGoal.class, excludeAllTopics, null, unbalanced(), deadBroker0, false));
 
-    // Test: With single excluded topic, balance satisfiable cluster, no dead brokers (No exception, No proposal 
+    // Test: With single excluded topic, balance satisfiable cluster, no dead brokers (No exception, No proposal
     // for excluded topic, Expected to look optimized)
     p.add(params(0, PotentialNwOutGoal.class, excludeT1, null, unbalanced(), noDeadBroker, true));
-    // Test: With single excluded topic, balance satisfiable cluster, one dead brokers (No exception, No proposal 
+    // Test: With single excluded topic, balance satisfiable cluster, one dead brokers (No exception, No proposal
     // for excluded topic, Expected to look optimized)
     p.add(params(1, PotentialNwOutGoal.class, excludeT1, null, unbalanced(), deadBroker0, true));
-    // Test: With all topics excluded, balance not satisfiable, no dead brokers (No exception, No proposal for 
+    // Test: With all topics excluded, balance not satisfiable, no dead brokers (No exception, No proposal for
     // excluded topic, Not expected to look optimized)
     p.add(params(2, PotentialNwOutGoal.class, excludeAllTopics, null, unbalanced(), noDeadBroker, false));
-    // Test: With all topics excluded, balance not satisfiable, one dead brokers (No exception, No proposal for 
+    // Test: With all topics excluded, balance not satisfiable, one dead brokers (No exception, No proposal for
     // excluded topic, expected to look optimized)
     p.add(params(3, PotentialNwOutGoal.class, excludeAllTopics, null, unbalanced(), deadBroker0, true));
 
     for (Class<? extends Goal> goalClass : Arrays.asList(TopicReplicaDistributionGoal.class,
                                                          ReplicaDistributionGoal.class)) {
-      // Test: With single excluded topic, satisfiable cluster, no dead broker (No exception, No proposal for 
+      // Test: With single excluded topic, satisfiable cluster, no dead broker (No exception, No proposal for
       // excluded topic, Expected to look optimized)
       p.add(params(0, goalClass, excludeT1, null, unbalanced(), noDeadBroker, true));
-      // Test: With single excluded topic, satisfiable cluster, one dead broker (No exception, No proposal for 
+      // Test: With single excluded topic, satisfiable cluster, one dead broker (No exception, No proposal for
       // excluded topic, Expected to look optimized)
       p.add(params(1, goalClass, excludeT1, null, unbalanced(), deadBroker0, true));
-      // Test: With all topics excluded, balance not satisfiable, no dead brokers (No exception, No proposal 
+      // Test: With all topics excluded, balance not satisfiable, no dead brokers (No exception, No proposal
       // for excluded topic, Expected to look optimized)
       p.add(params(2, goalClass, excludeAllTopics, null, unbalanced(), noDeadBroker, true));
-      // Test: With all topics excluded, balance not satisfiable, one dead brokers (No exception, No proposal 
+      // Test: With all topics excluded, balance not satisfiable, one dead brokers (No exception, No proposal
       // for excluded topic, Expected to look optimized)
       p.add(params(3, goalClass, excludeAllTopics, null, unbalanced(), deadBroker0, true));
     }
-    
+
     return p;
   }
 
@@ -191,10 +191,10 @@ public class ExcludedTopicsTest {
    * @param expectedToOptimize The expectation on whether the cluster state will be considered optimized or not.
    */
   public ExcludedTopicsTest(int testId,
-                            Goal goal, 
-                            Set<String> excludedTopics, 
+                            Goal goal,
+                            Set<String> excludedTopics,
                             Class<Throwable> exceptionClass,
-                            ClusterModel clusterModel, 
+                            ClusterModel clusterModel,
                             Boolean expectedToOptimize) {
     _testId = testId;
     _goal = goal;
@@ -206,8 +206,6 @@ public class ExcludedTopicsTest {
 
   @Test
   public void test() throws Exception {
-    System.out.println(String.format("Goal=%s, excludedTopics=%s, exceptionClass=%s, clusterModel=%s, expectedToOptimize=%s",
-                                     _goal, _excludedTopics, _exceptionClass, _clusterModel, _expectedToOptimize));
     if (_exceptionClass == null) {
       Map<TopicPartition, List<Integer>> initDistribution = _clusterModel.getReplicaDistribution();
 
@@ -224,7 +222,7 @@ public class ExcludedTopicsTest {
 
         boolean proposalHasTopic = false;
         for (BalancingProposal proposal : goalProposals) {
-          proposalHasTopic = _excludedTopics.contains(proposal.topic()) 
+          proposalHasTopic = _excludedTopics.contains(proposal.topic())
               && _clusterModel.broker(proposal.sourceBrokerId()).isAlive();
           if (proposalHasTopic) {
             break;
@@ -238,25 +236,25 @@ public class ExcludedTopicsTest {
           _goal.optimize(_clusterModel, Collections.emptySet(), _excludedTopics));
     }
   }
-  
+
   private static Object[] params(int tid,
                                  Class<? extends Goal> goalClass,
-                                 Collection<String> excludedTopics, 
-                                 Class<? extends Throwable> exceptionClass, 
-                                 ClusterModel clusterModel, 
-                                 Collection<Integer> deadBrokers, 
+                                 Collection<String> excludedTopics,
+                                 Class<? extends Throwable> exceptionClass,
+                                 ClusterModel clusterModel,
+                                 Collection<Integer> deadBrokers,
                                  Boolean expectedToOptimize) throws Exception {
     deadBrokers.forEach(id -> clusterModel.setBrokerState(id, Broker.State.DEAD));
     return new Object[]{tid, goal(goalClass), excludedTopics, exceptionClass, clusterModel, expectedToOptimize};
   }
-  
+
   private static Goal goal(Class<? extends Goal> goalClass) throws Exception {
     Properties props = CruiseControlUnitTestUtils.getCruiseControlProperties();
     props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(1L));
     BalancingConstraint balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
     balancingConstraint.setBalancePercentage(TestConstants.LOW_BALANCE_PERCENTAGE);
     balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);
-    
+
     try {
       Constructor<? extends Goal> constructor = goalClass.getDeclaredConstructor(BalancingConstraint.class);
       constructor.setAccessible(true);
@@ -269,9 +267,9 @@ public class ExcludedTopicsTest {
 
   // two racks, three brokers, two partitions, one replica.
   private static ClusterModel unbalanced() throws AnalysisInputException, ModelInputException {
-    
+
     List<Integer> orderedRackIdsOfBrokers = Arrays.asList(0, 0, 1);
-    ClusterModel cluster = DeterministicCluster.getHomogeneousDeterministicCluster(2, orderedRackIdsOfBrokers, 
+    ClusterModel cluster = DeterministicCluster.getHomogeneousDeterministicCluster(2, orderedRackIdsOfBrokers,
                                                                                    TestConstants.BROKER_CAPACITY);
 
     // Create topic partition.
@@ -293,37 +291,6 @@ public class ExcludedTopicsTest {
                                                               TestConstants.LARGE_BROKER_CAPACITY / 2,
                                                               TestConstants.MEDIUM_BROKER_CAPACITY / 2,
                                                               TestConstants.LARGE_BROKER_CAPACITY / 2));
-
-    return cluster;
-  }
-
-  // Two racks, three brokers, one partition, two replicas
-  private static ClusterModel rackAwareSatisfiable() throws AnalysisInputException, ModelInputException {
-    List<Integer> orderedRackIdsOfBrokers = Arrays.asList(0, 0, 1);
-    ClusterModel cluster = DeterministicCluster.getHomogeneousDeterministicCluster(2, orderedRackIdsOfBrokers, 
-                                                                                   TestConstants.BROKER_CAPACITY);
-
-    // Create topic partition.
-    TopicPartition pInfoT10 = new TopicPartition("T1", 0);
-
-    // Create replicas for topic: T1.
-    cluster.createReplica("0", 0, pInfoT10, true);
-    cluster.createReplica("0", 1, pInfoT10, false);
-
-    // Create snapshots and push them to the cluster.
-    cluster.pushLatestSnapshot("0", 0, pInfoT10, new Snapshot(1L, 100.0, 100.0, 130.0, 75.0));
-    cluster.pushLatestSnapshot("0", 1, pInfoT10, new Snapshot(1L, 5.0, 100.0, 0.0, 75.0));
-
-    return cluster;
-  }
-
-  // two racks, three brokers, one partition, three replicas.
-  private static ClusterModel rackAwareUnsatisfiable() throws AnalysisInputException, ModelInputException {
-    ClusterModel cluster = rackAwareSatisfiable();
-    TopicPartition pInfoT10 = new TopicPartition("T1", 0);
-
-    cluster.createReplica("1", 2, pInfoT10, false);
-    cluster.pushLatestSnapshot("1", 2, pInfoT10, new Snapshot(1L, 100.0, 100.0, 130.0, 75.0));
 
     return cluster;
   }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomSelfHealingTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomSelfHealingTest.java
@@ -53,7 +53,7 @@ public class RandomSelfHealingTest {
    *
    * @return Parameters for the {@link OptimizationVerifier}.
    */
-  @Parameters
+  @Parameters(name = "{2}-{0}")
   public static Collection<Object[]> data() throws AnalysisInputException {
     Collection<Object[]> params = new ArrayList<>();
 
@@ -83,12 +83,13 @@ public class RandomSelfHealingTest {
     // Test: Single Goal.
     Map<ClusterProperty, Number> singleDeadBroker = new HashMap<>();
     singleDeadBroker.put(ClusterProperty.NUM_DEAD_BROKERS, 1);
+    int testId = 0;
     for (Map.Entry<Integer, String> entry : goalNameByPriority.entrySet()) {
-      Object[] singleDeadSingleSoftParams = {singleDeadBroker, Collections.singletonMap(entry.getKey(),
+      Object[] singleDeadSingleSoftParams = {testId++, singleDeadBroker, Collections.singletonMap(entry.getKey(),
           entry.getValue()), balancingConstraint, Collections.emptySet()};
       params.add(singleDeadSingleSoftParams);
-      Object[] singleDeadSingleSoftParamsWithExcludedTopics = 
-          {singleDeadBroker, Collections.singletonMap(entry.getKey(), entry.getValue()), balancingConstraint, 
+      Object[] singleDeadSingleSoftParamsWithExcludedTopics =
+          {testId++, singleDeadBroker, Collections.singletonMap(entry.getKey(), entry.getValue()), balancingConstraint,
           Collections.singleton("T0")};
       params.add(singleDeadSingleSoftParamsWithExcludedTopics);
     }
@@ -98,11 +99,11 @@ public class RandomSelfHealingTest {
     balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);
 
     // Test: All Goals.
-    Object[] singleDeadMultiAllGoalsParams = 
-        {singleDeadBroker, goalNameByPriority, balancingConstraint, Collections.emptySet()};
+    Object[] singleDeadMultiAllGoalsParams =
+        {testId++, singleDeadBroker, goalNameByPriority, balancingConstraint, Collections.emptySet()};
     params.add(singleDeadMultiAllGoalsParams);
-    Object[] singleDeadMultiAllGoalsParamsWithExcludedTopics = 
-        {singleDeadBroker, goalNameByPriority, balancingConstraint, Collections.singleton("T0")};
+    Object[] singleDeadMultiAllGoalsParamsWithExcludedTopics =
+        {testId++, singleDeadBroker, goalNameByPriority, balancingConstraint, Collections.singleton("T0")};
     params.add(singleDeadMultiAllGoalsParamsWithExcludedTopics);
 
     // -- TEST DECK #2: MULTIPLE DEAD BROKERS.
@@ -110,26 +111,27 @@ public class RandomSelfHealingTest {
     Map<ClusterProperty, Number> multipleDeadBrokers = new HashMap<>();
     multipleDeadBrokers.put(ClusterProperty.NUM_DEAD_BROKERS, 5);
     for (Map.Entry<Integer, String> entry : goalNameByPriority.entrySet()) {
-      Object[] multiDeadSingleSoftParams = 
-          {multipleDeadBrokers, Collections.singletonMap(entry.getKey(), entry.getValue()), balancingConstraint, 
+      Object[] multiDeadSingleSoftParams =
+          {testId++, multipleDeadBrokers, Collections.singletonMap(entry.getKey(), entry.getValue()), balancingConstraint,
           Collections.emptySet()};
       params.add(multiDeadSingleSoftParams);
       Object[] multiDeadSingleSoftParamsWithExcludedTopics =
-          {multipleDeadBrokers, Collections.singletonMap(entry.getKey(), entry.getValue()), balancingConstraint,
+          {testId++, multipleDeadBrokers, Collections.singletonMap(entry.getKey(), entry.getValue()), balancingConstraint,
               Collections.singleton("T0")};
       params.add(multiDeadSingleSoftParamsWithExcludedTopics);
     }
     // Test: All Goals.
-    Object[] multiDeadMultiAllGoalsParams = 
-        {multipleDeadBrokers, goalNameByPriority, balancingConstraint, Collections.emptySet()};
+    Object[] multiDeadMultiAllGoalsParams =
+        {testId++, multipleDeadBrokers, goalNameByPriority, balancingConstraint, Collections.emptySet()};
     params.add(multiDeadMultiAllGoalsParams);
-    Object[] multiDeadMultiAllGoalsParamsWithExcludedTopics = 
-        {multipleDeadBrokers, goalNameByPriority, balancingConstraint, Collections.singleton("T0")};
+    Object[] multiDeadMultiAllGoalsParamsWithExcludedTopics =
+        {testId++, multipleDeadBrokers, goalNameByPriority, balancingConstraint, Collections.singleton("T0")};
     params.add(multiDeadMultiAllGoalsParamsWithExcludedTopics);
-    
+
     return params;
   }
 
+  private int _testId;
   private Map<ClusterProperty, Number> _modifiedProperties;
   private Map<Integer, String> _goalNameByPriority;
   private BalancingConstraint _balancingConstraint;
@@ -138,13 +140,18 @@ public class RandomSelfHealingTest {
   /**
    * Constructor of Self Healing Test.
    *
+   * @param testId Test id.
    * @param modifiedProperties Modified cluster properties over the {@link TestConstants#BASE_PROPERTIES}.
    * @param goalNameByPriority Goal name by priority.
+   * @param balancingConstraint Balancing constraint.
+   * @param excludedTopics Excluded topics.
    */
-  public RandomSelfHealingTest(Map<ClusterProperty, Number> modifiedProperties,
+  public RandomSelfHealingTest(int testId,
+                               Map<ClusterProperty, Number> modifiedProperties,
                                Map<Integer, String> goalNameByPriority,
                                BalancingConstraint balancingConstraint,
                                Collection<String> excludedTopics) {
+    _testId = testId;
     _modifiedProperties = modifiedProperties;
     _goalNameByPriority = goalNameByPriority;
     _balancingConstraint = balancingConstraint;

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDeterministicClusterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDeterministicClusterTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner;
+
+    import com.linkedin.kafka.cruisecontrol.common.DeterministicCluster;
+    import com.linkedin.kafka.cruisecontrol.common.TestConstants;
+    import com.linkedin.kafka.cruisecontrol.exception.OptimizationFailureException;
+    import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+
+    import java.util.Collection;
+    import java.util.HashMap;
+    import java.util.Map;
+    import java.util.ArrayList;
+    import org.junit.Rule;
+    import org.junit.Test;
+    import org.junit.rules.ExpectedException;
+    import org.junit.runner.RunWith;
+    import org.junit.runners.Parameterized;
+
+    import static com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerOptimizationVerifier.executeGoalsFor;
+    import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Unit test for testing with various deterministic clusters.
+ */
+@RunWith(Parameterized.class)
+public class KafkaAssignerDeterministicClusterTest {
+  private int _testId;
+  private ClusterModel _cluster;
+  private Map<Integer, String> _goalNameByPriority;
+  private Class<Throwable> _exceptionClass;
+
+  /**
+   * Constructor for Deterministic Cluster Test.
+   *
+   * @param cluster             The state of the cluster.
+   * @param goalNameByPriority  Name of goals by the order of execution priority.
+   */
+  public KafkaAssignerDeterministicClusterTest(int testId,
+                                               ClusterModel cluster,
+                                               Map<Integer, String> goalNameByPriority,
+                                               Class<Throwable> exceptionClass) {
+    _testId = testId;
+    _cluster = cluster;
+    _goalNameByPriority = goalNameByPriority;
+    _exceptionClass = exceptionClass;
+  }
+
+  @Rule
+  public ExpectedException expected = ExpectedException.none();
+
+  @Parameterized.Parameters(name = "{2}-{0}")
+  public static Collection<Object[]> data() throws Exception {
+    Collection<Object[]> p = new ArrayList<>();
+
+    Map<Integer, String> goalNameByPriority = new HashMap<>();
+    goalNameByPriority.put(1, KafkaAssignerEvenRackAwareGoal.class.getName());
+
+    int testId = 0;
+    // Small cluster.
+    p.add(params(testId++, DeterministicCluster.smallClusterModel(TestConstants.BROKER_CAPACITY), goalNameByPriority, null));
+    // Medium cluster.
+    p.add(params(testId++, DeterministicCluster.mediumClusterModel(TestConstants.BROKER_CAPACITY), goalNameByPriority, null));
+    // Rack-aware satisfiable.
+    p.add(params(testId++, DeterministicCluster.rackAwareSatisfiable(), goalNameByPriority, null));
+    // Rack-aware unsatisfiable.
+    p.add(params(testId++, DeterministicCluster.rackAwareUnsatisfiable(), goalNameByPriority, OptimizationFailureException.class));
+
+    return p;
+  }
+
+  private static Object[] params(int testId,
+                                 ClusterModel cluster,
+                                 Map<Integer, String> goalNameByPriority,
+                                 Class<? extends Throwable> exceptionClass) throws Exception {
+    return new Object[]{testId, cluster, goalNameByPriority, exceptionClass};
+  }
+
+  @Test
+  public void test() throws Exception {
+    if (_exceptionClass != null) {
+      expected.expect(_exceptionClass);
+    }
+
+    assertTrue("Deterministic Cluster Test failed to optimize goals.",
+               executeGoalsFor(_cluster, _goalNameByPriority).violatedGoalsAfterOptimization().isEmpty());
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerExcludedTopicsTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerExcludedTopicsTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner;
+
+    import com.linkedin.kafka.cruisecontrol.analyzer.AnalyzerUtils;
+    import com.linkedin.kafka.cruisecontrol.analyzer.BalancingProposal;
+    import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
+    import com.linkedin.kafka.cruisecontrol.common.DeterministicCluster;
+    import com.linkedin.kafka.cruisecontrol.exception.OptimizationFailureException;
+    import com.linkedin.kafka.cruisecontrol.model.Broker;
+    import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+
+    import java.util.ArrayList;
+    import java.util.Collection;
+    import java.util.Collections;
+    import java.util.List;
+    import java.util.Map;
+    import java.util.Set;
+    import org.apache.kafka.common.TopicPartition;
+    import org.junit.Rule;
+    import org.junit.Test;
+    import org.junit.rules.ExpectedException;
+    import org.junit.runner.RunWith;
+    import org.junit.runners.Parameterized;
+    import org.junit.runners.Parameterized.Parameters;
+
+    import static org.junit.Assert.*;
+
+
+/**
+ * Unit test for testing goals with excluded topics under fixed cluster properties.
+ */
+@RunWith(Parameterized.class)
+public class KafkaAssignerExcludedTopicsTest {
+
+  @Rule
+  public ExpectedException expected = ExpectedException.none();
+
+  @Parameters(name = "{1}-{0}")
+  public static Collection<Object[]> data() throws Exception {
+    Collection<Object[]> p = new ArrayList<>();
+
+    Set<String> noExclusion = Collections.emptySet();
+    Set<String> excludeT1 = Collections.unmodifiableSet(Collections.singleton("T1"));
+    Set<Integer> noDeadBroker = Collections.emptySet();
+    Set<Integer> deadBroker0 = Collections.unmodifiableSet(Collections.singleton(0));
+
+    int testId = 0;
+    // With excluded topics, rack aware satisfiable cluster, no dead brokers (No exception, No proposal, Expected to look optimized)
+    p.add(params(testId++, KafkaAssignerEvenRackAwareGoal.class, excludeT1, null,
+                 DeterministicCluster.rackAwareSatisfiable(), noDeadBroker, true));
+    // With excluded topics, rack aware satisfiable cluster, one dead brokers (No exception, No proposal, Expected to look optimized)
+    p.add(params(testId++, KafkaAssignerEvenRackAwareGoal.class, excludeT1, null,
+                 DeterministicCluster.rackAwareSatisfiable(), deadBroker0, true));
+    // Without excluded topics, rack aware satisfiable cluster, no dead brokers (No exception, Proposal expected, Expected to look optimized)
+    p.add(params(testId++, KafkaAssignerEvenRackAwareGoal.class, noExclusion, null,
+                 DeterministicCluster.rackAwareSatisfiable(), noDeadBroker, true));
+    // Without excluded topics, rack aware satisfiable cluster, one dead broker (No exception, Proposal expected, Expected to look optimized)
+    p.add(params(testId++, KafkaAssignerEvenRackAwareGoal.class, noExclusion, null,
+                 DeterministicCluster.rackAwareSatisfiable(), deadBroker0, true));
+    // With excluded topics, rack aware unsatisfiable cluster, no dead broker (No exception, No proposal, Expected to look optimized)
+    p.add(params(testId++, KafkaAssignerEvenRackAwareGoal.class, excludeT1, null,
+                 DeterministicCluster.rackAwareUnsatisfiable(), noDeadBroker, true));
+    // With excluded topics, rack aware unsatisfiable cluster, one dead broker (Exception)
+    p.add(params(testId++, KafkaAssignerEvenRackAwareGoal.class, excludeT1, OptimizationFailureException.class,
+                 DeterministicCluster.rackAwareUnsatisfiable(), deadBroker0, null));
+    // Test: Without excluded topics, rack aware unsatisfiable cluster, no dead brokers (Exception expected)
+    p.add(params(testId++, KafkaAssignerEvenRackAwareGoal.class, noExclusion, OptimizationFailureException.class,
+                 DeterministicCluster.rackAwareUnsatisfiable(), noDeadBroker, null));
+    // Test: Without excluded topics, rack aware unsatisfiable cluster, one dead broker (Exception expected)
+    p.add(params(testId++, KafkaAssignerEvenRackAwareGoal.class, noExclusion, OptimizationFailureException.class,
+                 DeterministicCluster.rackAwareUnsatisfiable(), deadBroker0, null));
+
+    return p;
+  }
+
+  private int _testId;
+  private Goal _goal;
+  private Set<String> _excludedTopics;
+  private Class<Throwable> _exceptionClass;
+  private ClusterModel _clusterModel;
+  private Boolean _expectedToOptimize;
+
+  /**
+   * Constructor of Kafka Assigner Excluded Topics Test.
+   *
+   * @param goal Goal to be tested.
+   * @param excludedTopics Topics to be excluded from the goal.
+   * @param exceptionClass Expected exception class (if any).
+   * @param clusterModel Cluster model to be used for the test.
+   * @param expectedToOptimize The expectation on whether the cluster state will be considered optimized or not.
+   */
+  public KafkaAssignerExcludedTopicsTest(int testId,
+                                         Goal goal,
+                                         Set<String> excludedTopics,
+                                         Class<Throwable> exceptionClass,
+                                         ClusterModel clusterModel,
+                                         Boolean expectedToOptimize) {
+    _testId = testId;
+    _goal = goal;
+    _excludedTopics = excludedTopics;
+    _exceptionClass = exceptionClass;
+    _clusterModel = clusterModel;
+    _expectedToOptimize = expectedToOptimize;
+  }
+
+  @Test
+  public void test() throws Exception {
+    if (_exceptionClass == null) {
+      Map<TopicPartition, List<Integer>> initDistribution = _clusterModel.getReplicaDistribution();
+
+      if (_expectedToOptimize) {
+        assertTrue("Excluded Topics Test failed to optimize " + _goal.name() + " with excluded topics.",
+                   _goal.optimize(_clusterModel, Collections.emptySet(), _excludedTopics));
+      } else {
+        assertTrue("Excluded Topics Test optimized " + _goal.name() + " with excluded topics " + _excludedTopics,
+                   !_goal.optimize(_clusterModel, Collections.emptySet(), _excludedTopics));
+      }
+      // Generated proposals cannot have the excluded topic.
+      if (!_excludedTopics.isEmpty()) {
+        Set<BalancingProposal> goalProposals = AnalyzerUtils.getDiff(initDistribution, _clusterModel);
+
+        boolean proposalHasTopic = false;
+        for (BalancingProposal proposal : goalProposals) {
+          proposalHasTopic = _excludedTopics.contains(proposal.topic())
+                             && _clusterModel.broker(proposal.sourceBrokerId()).isAlive();
+          if (proposalHasTopic) {
+            break;
+          }
+        }
+        assertTrue("Excluded topic partitions are included in proposals.", !proposalHasTopic);
+      }
+    } else {
+      expected.expect(_exceptionClass);
+      assertTrue("Excluded Topics Test failed to optimize with excluded topics.",
+                 _goal.optimize(_clusterModel, Collections.emptySet(), _excludedTopics));
+    }
+  }
+
+  private static Object[] params(int tid,
+                                 Class<? extends Goal> goalClass,
+                                 Collection<String> excludedTopics,
+                                 Class<? extends Throwable> exceptionClass,
+                                 ClusterModel clusterModel,
+                                 Collection<Integer> deadBrokers,
+                                 Boolean expectedToOptimize) throws Exception {
+    deadBrokers.forEach(id -> clusterModel.setBrokerState(id, Broker.State.DEAD));
+    return new Object[]{tid, goalClass.newInstance(), excludedTopics, exceptionClass, clusterModel, expectedToOptimize};
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerOptimizationVerifier.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerOptimizationVerifier.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ *
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner;
+
+import com.codahale.metrics.MetricRegistry;
+import com.linkedin.kafka.cruisecontrol.CruiseControlUnitTestUtils;
+import com.linkedin.kafka.cruisecontrol.analyzer.GoalOptimizer;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import java.util.SortedMap;
+import java.util.StringJoiner;
+import java.util.TreeMap;
+import org.apache.kafka.common.utils.SystemTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+class KafkaAssignerOptimizationVerifier {
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaAssignerOptimizationVerifier.class);
+
+  private KafkaAssignerOptimizationVerifier() {
+  }
+
+  static GoalOptimizer.OptimizerResult executeGoalsFor(ClusterModel clusterModel,
+                                                       Map<Integer, String> goalNameByPriority) throws Exception {
+    return executeGoalsFor(clusterModel, goalNameByPriority, Collections.emptySet());
+  }
+
+  static GoalOptimizer.OptimizerResult executeGoalsFor(ClusterModel clusterModel,
+                                                       Map<Integer, String> goalNameByPriority,
+                                                       Collection<String> excludedTopics)
+      throws Exception {
+    // Set goals by their priority.
+    SortedMap<Integer, Goal> goalByPriority = new TreeMap<>();
+    for (Map.Entry<Integer, String> goalEntry : goalNameByPriority.entrySet()) {
+      Integer priority = goalEntry.getKey();
+      String goalClassName = goalEntry.getValue();
+
+      Class<? extends Goal> goalClass = (Class<? extends Goal>) Class.forName(goalClassName);
+      goalByPriority.put(priority, goalClass.newInstance());
+    }
+
+    // Generate the goalOptimizer and optimize given goals.
+    long startTime = System.currentTimeMillis();
+    Properties props = CruiseControlUnitTestUtils.getCruiseControlProperties();
+    StringJoiner stringJoiner = new StringJoiner(",");
+    excludedTopics.forEach(stringJoiner::add);
+    props.setProperty(KafkaCruiseControlConfig.TOPICS_EXCLUDED_FROM_PARTITION_MOVEMENT_CONFIG, stringJoiner.toString());
+    GoalOptimizer goalOptimizer = new GoalOptimizer(new KafkaCruiseControlConfig(props),
+                                                    null,
+                                                    new SystemTime(),
+                                                    new MetricRegistry());
+    GoalOptimizer.OptimizerResult optimizerResult = goalOptimizer.optimizations(clusterModel, goalByPriority);
+    LOG.trace("Took {} ms to execute {} to generate {} proposals.", System.currentTimeMillis() - startTime,
+              goalByPriority, optimizerResult.goalProposals().size());
+
+    return optimizerResult;
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerRandomClusterExpDistNewBrokerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerRandomClusterExpDistNewBrokerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ *
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner;
+
+    import com.linkedin.kafka.cruisecontrol.common.ClusterProperty;
+    import com.linkedin.kafka.cruisecontrol.common.TestConstants;
+    import java.util.Collection;
+    import java.util.Map;
+    import org.junit.Test;
+    import org.junit.runner.RunWith;
+    import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class KafkaAssignerRandomClusterExpDistNewBrokerTest extends KafkaAssignerRandomClusterTest {
+
+  @Parameterized.Parameters(name = "{2}-{0}")
+  public static Collection<Object[]> data() throws Exception {
+    return KafkaAssignerRandomClusterTest.data(TestConstants.Distribution.EXPONENTIAL);
+  }
+
+  /**
+   * Constructor of Random Cluster Test.
+   *
+   * @param testId Test id.
+   * @param modifiedProperties  Modified cluster properties over the {@link TestConstants#BASE_PROPERTIES}.
+   * @param goalNameByPriority  Goal name by priority.
+   * @param replicaDistribution Distribution of replicas in the test cluster.
+   */
+  public KafkaAssignerRandomClusterExpDistNewBrokerTest(int testId,
+                                                        Map<ClusterProperty, Number> modifiedProperties,
+                                                        Map<Integer, String> goalNameByPriority,
+                                                        TestConstants.Distribution replicaDistribution) {
+    super(testId, modifiedProperties, goalNameByPriority, replicaDistribution);
+  }
+
+  @Test
+  public void testNewBrokers() throws Exception {
+    super.testNewBrokers();
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerRandomClusterExpDistRebalanceTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerRandomClusterExpDistRebalanceTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ *
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner;
+
+    import com.linkedin.kafka.cruisecontrol.common.ClusterProperty;
+    import com.linkedin.kafka.cruisecontrol.common.TestConstants;
+    import java.util.Collection;
+    import java.util.Map;
+    import org.junit.Test;
+    import org.junit.runner.RunWith;
+    import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class KafkaAssignerRandomClusterExpDistRebalanceTest extends KafkaAssignerRandomClusterTest {
+
+  @Parameterized.Parameters(name = "{2}-{0}")
+  public static Collection<Object[]> data() throws Exception {
+    return KafkaAssignerRandomClusterTest.data(TestConstants.Distribution.EXPONENTIAL);
+  }
+
+  /**
+   * Constructor of Random Cluster Test.
+   *
+   * @param testId Test id.
+   * @param modifiedProperties  Modified cluster properties over the {@link TestConstants#BASE_PROPERTIES}.
+   * @param goalNameByPriority  Goal name by priority.
+   * @param replicaDistribution Distribution of replicas in the test cluster.
+   */
+  public KafkaAssignerRandomClusterExpDistRebalanceTest(int testId,
+                                                        Map<ClusterProperty, Number> modifiedProperties,
+                                                        Map<Integer, String> goalNameByPriority,
+                                                        TestConstants.Distribution replicaDistribution) {
+    super(testId, modifiedProperties, goalNameByPriority, replicaDistribution);
+  }
+
+  @Test
+  public void testRebalance() throws Exception {
+    super.testRebalance();
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerRandomClusterLinearDistNewBrokerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerRandomClusterLinearDistNewBrokerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ *
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner;
+
+    import com.linkedin.kafka.cruisecontrol.common.ClusterProperty;
+    import com.linkedin.kafka.cruisecontrol.common.TestConstants;
+    import java.util.Collection;
+    import java.util.Map;
+    import org.junit.Test;
+    import org.junit.runner.RunWith;
+    import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class KafkaAssignerRandomClusterLinearDistNewBrokerTest extends KafkaAssignerRandomClusterTest {
+
+  @Parameterized.Parameters(name = "{2}-{0}")
+  public static Collection<Object[]> data() throws Exception {
+    return KafkaAssignerRandomClusterTest.data(TestConstants.Distribution.LINEAR);
+  }
+
+  /**
+   * Constructor of Random Cluster Test.
+   *
+   * @param testId Test id.
+   * @param modifiedProperties  Modified cluster properties over the {@link TestConstants#BASE_PROPERTIES}.
+   * @param goalNameByPriority  Goal name by priority.
+   * @param replicaDistribution Distribution of replicas in the test cluster.
+   */
+  public KafkaAssignerRandomClusterLinearDistNewBrokerTest(int testId,
+                                                           Map<ClusterProperty, Number> modifiedProperties,
+                                                           Map<Integer, String> goalNameByPriority,
+                                                           TestConstants.Distribution replicaDistribution) {
+    super(testId, modifiedProperties, goalNameByPriority, replicaDistribution);
+  }
+
+  @Test
+  public void testNewBrokers() throws Exception {
+    super.testNewBrokers();
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerRandomClusterLinearDistRebalanceTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerRandomClusterLinearDistRebalanceTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ *
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner;
+
+    import com.linkedin.kafka.cruisecontrol.common.ClusterProperty;
+    import com.linkedin.kafka.cruisecontrol.common.TestConstants;
+    import java.util.Collection;
+    import java.util.Map;
+    import org.junit.Test;
+    import org.junit.runner.RunWith;
+    import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class KafkaAssignerRandomClusterLinearDistRebalanceTest extends KafkaAssignerRandomClusterTest {
+
+  @Parameterized.Parameters(name = "{2}-{0}")
+  public static Collection<Object[]> data() throws Exception {
+    return KafkaAssignerRandomClusterTest.data(TestConstants.Distribution.LINEAR);
+  }
+
+  /**
+   * Constructor of Random Cluster Test.
+   *
+   * @param testId Test id.
+   * @param modifiedProperties  Modified cluster properties over the {@link TestConstants#BASE_PROPERTIES}.
+   * @param goalNameByPriority  Goal name by priority.
+   * @param replicaDistribution Distribution of replicas in the test cluster.
+   */
+  public KafkaAssignerRandomClusterLinearDistRebalanceTest(int testId,
+                                                           Map<ClusterProperty, Number> modifiedProperties,
+                                                           Map<Integer, String> goalNameByPriority,
+                                                           TestConstants.Distribution replicaDistribution) {
+    super(testId, modifiedProperties, goalNameByPriority, replicaDistribution);
+  }
+
+  @Test
+  public void testRebalance() throws Exception {
+    super.testRebalance();
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerRandomClusterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerRandomClusterTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner;
+
+    import com.linkedin.kafka.cruisecontrol.common.ClusterProperty;
+    import com.linkedin.kafka.cruisecontrol.common.RandomCluster;
+    import com.linkedin.kafka.cruisecontrol.common.TestConstants;
+    import com.linkedin.kafka.cruisecontrol.model.Broker;
+    import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+
+    import com.linkedin.kafka.cruisecontrol.monitor.ModelGeneration;
+    import java.util.ArrayList;
+    import java.util.Collection;
+    import java.util.HashMap;
+    import java.util.List;
+    import java.util.Map;
+
+    import com.linkedin.kafka.cruisecontrol.model.Replica;
+    import com.linkedin.kafka.cruisecontrol.monitor.sampling.Snapshot;
+    import org.slf4j.Logger;
+    import org.slf4j.LoggerFactory;
+
+    import static com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerOptimizationVerifier.executeGoalsFor;
+    import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Unit test for testing with different clusters properties and fixed goals.
+ */
+public class KafkaAssignerRandomClusterTest {
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaAssignerRandomClusterTest.class);
+
+  public static Collection<Object[]> data(TestConstants.Distribution distribution) throws Exception {
+    Collection<Object[]> p = new ArrayList<>();
+
+    Map<Integer, String> goalNameByPriority = new HashMap<>();
+    goalNameByPriority.put(1, KafkaAssignerEvenRackAwareGoal.class.getName());
+
+    int testId = 0;
+    Map<ClusterProperty, Number> modifiedProperties;
+    // Test: Increase Broker Count
+    for (int i = 1; i <= 6; i++) {
+      modifiedProperties = new HashMap<>();
+      modifiedProperties.put(ClusterProperty.NUM_BROKERS, 20 + i * 20);
+      p.add(params(testId++, modifiedProperties, goalNameByPriority, distribution));
+    }
+
+    // Test: Increase Replica Count
+    for (int i = 7; i <= 12; i++) {
+      modifiedProperties = new HashMap<>();
+      modifiedProperties.put(ClusterProperty.NUM_REPLICAS, 50001 + (i - 7) * 5001);
+      p.add(params(testId++, modifiedProperties, goalNameByPriority, distribution));
+    }
+    // Test: Increase Topic Count
+    for (int i = 13; i <= 18; i++) {
+      modifiedProperties = new HashMap<>();
+      modifiedProperties.put(ClusterProperty.NUM_TOPICS, 3000 + (i - 13) * 1000);
+      p.add(params(testId++, modifiedProperties, goalNameByPriority, distribution));
+    }
+    // Test: Increase Replication Count
+    for (int i = 19; i <= 24; i++) {
+      modifiedProperties = new HashMap<>();
+      modifiedProperties.put(ClusterProperty.NUM_REPLICAS, 50000 - (50000 % (i - 16)));
+      modifiedProperties.put(ClusterProperty.MIN_REPLICATION, (i - 16));
+      modifiedProperties.put(ClusterProperty.MAX_REPLICATION, (i - 16));
+      p.add(params(testId++, modifiedProperties, goalNameByPriority, distribution));
+    }
+
+    return p;
+  }
+
+  private int _testId;
+  private Map<ClusterProperty, Number> _modifiedProperties;
+  private Map<Integer, String> _goalNameByPriority;
+  private TestConstants.Distribution _replicaDistribution;
+
+  /**
+   * Constructor of Random Cluster Test.
+   *
+   * @param testId Test id.
+   * @param modifiedProperties  Modified cluster properties over the {@link TestConstants#BASE_PROPERTIES}.
+   * @param goalNameByPriority  Goal name by priority.
+   * @param replicaDistribution Distribution of replicas in the test cluster.
+   */
+  public KafkaAssignerRandomClusterTest(int testId,
+                                        Map<ClusterProperty, Number> modifiedProperties,
+                                        Map<Integer, String> goalNameByPriority,
+                                        TestConstants.Distribution replicaDistribution) {
+    _testId = testId;
+    _modifiedProperties = modifiedProperties;
+    _goalNameByPriority = goalNameByPriority;
+    _replicaDistribution = replicaDistribution;
+  }
+
+  private static Object[] params(int testId,
+                                 Map<ClusterProperty, Number> modifiedProperties,
+                                 Map<Integer, String> goalNameByPriority,
+                                 TestConstants.Distribution replicaDistribution) throws Exception {
+    return new Object[]{testId, modifiedProperties, goalNameByPriority, replicaDistribution};
+  }
+
+  public void testRebalance() throws Exception {
+    // Create cluster properties by applying modified properties to base properties.
+    Map<ClusterProperty, Number> clusterProperties = new HashMap<>(TestConstants.BASE_PROPERTIES);
+    clusterProperties.putAll(_modifiedProperties);
+
+    LOG.debug("Replica distribution: {}.", _replicaDistribution);
+    ClusterModel clusterModel = RandomCluster.generate(clusterProperties);
+    RandomCluster.populate(clusterModel, clusterProperties, _replicaDistribution);
+
+    assertTrue("Random Cluster Test failed to improve the existing state.",
+               executeGoalsFor(clusterModel, _goalNameByPriority).violatedGoalsAfterOptimization().isEmpty());
+  }
+
+  /**
+   * This test first creates a random cluster, balance it. Then add two new brokers, balance the cluster again.
+   */
+  public void testNewBrokers() throws Exception {
+    // Create cluster properties by applying modified properties to base properties.
+    Map<ClusterProperty, Number> clusterProperties = new HashMap<>(TestConstants.BASE_PROPERTIES);
+    clusterProperties.putAll(_modifiedProperties);
+
+    LOG.debug("Replica distribution: {}.", _replicaDistribution);
+    ClusterModel clusterModel = RandomCluster.generate(clusterProperties);
+    RandomCluster.populate(clusterModel, clusterProperties, _replicaDistribution);
+
+    assertTrue("Random Cluster Test failed to improve the existing state.",
+               executeGoalsFor(clusterModel, _goalNameByPriority).violatedGoalsAfterOptimization().isEmpty());
+
+    ClusterModel clusterWithNewBroker = new ClusterModel(new ModelGeneration(0, 0L), 1.0);
+    for (Broker b : clusterModel.brokers()) {
+      clusterWithNewBroker.createRack(b.rack().id());
+      clusterWithNewBroker.createBroker(b.rack().id(), Integer.toString(b.id()), b.id(), TestConstants.BROKER_CAPACITY);
+      for (Replica replica : b.replicas()) {
+        clusterWithNewBroker.createReplica(b.rack().id(), b.id(), replica.topicPartition(), replica.isLeader());
+      }
+    }
+
+    for (Broker b : clusterModel.brokers()) {
+      for (Replica replica : b.replicas()) {
+        List<Snapshot> snapshots =
+            clusterModel.broker(b.id()).replica(replica.topicPartition()).load().snapshotsByTime();
+        for (Snapshot snapshot : snapshots) {
+          clusterWithNewBroker.pushLatestSnapshot(b.rack().id(), b.id(), replica.topicPartition(), snapshot);
+        }
+      }
+    }
+
+    for (int i = 1; i < 3; i++) {
+      clusterWithNewBroker.createBroker(Integer.toString(i),
+                                        Integer.toString(i + clusterModel.brokers().size()),
+                                        i + clusterModel.brokers().size(),
+                                        TestConstants.BROKER_CAPACITY);
+      clusterWithNewBroker.setBrokerState(i + clusterModel.brokers().size(), Broker.State.NEW);
+    }
+
+    assertTrue("Random Cluster Test failed to improve the existing state.",
+               executeGoalsFor(clusterWithNewBroker, _goalNameByPriority).violatedGoalsAfterOptimization().isEmpty());
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerRandomClusterUniformDistNewBrokerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerRandomClusterUniformDistNewBrokerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ *
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner;
+
+    import com.linkedin.kafka.cruisecontrol.common.ClusterProperty;
+    import com.linkedin.kafka.cruisecontrol.common.TestConstants;
+    import java.util.Collection;
+    import java.util.Map;
+    import org.junit.Test;
+    import org.junit.runner.RunWith;
+    import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class KafkaAssignerRandomClusterUniformDistNewBrokerTest extends KafkaAssignerRandomClusterTest {
+
+  @Parameterized.Parameters(name = "{2}-{0}")
+  public static Collection<Object[]> data() throws Exception {
+    return KafkaAssignerRandomClusterTest.data(TestConstants.Distribution.UNIFORM);
+  }
+
+  /**
+   * Constructor of Random Cluster Test.
+   *
+   * @param testId Test id.
+   * @param modifiedProperties  Modified cluster properties over the {@link TestConstants#BASE_PROPERTIES}.
+   * @param goalNameByPriority  Goal name by priority.
+   * @param replicaDistribution Distribution of replicas in the test cluster.
+   */
+  public KafkaAssignerRandomClusterUniformDistNewBrokerTest(int testId,
+                                                            Map<ClusterProperty, Number> modifiedProperties,
+                                                            Map<Integer, String> goalNameByPriority,
+                                                            TestConstants.Distribution replicaDistribution) {
+    super(testId, modifiedProperties, goalNameByPriority, replicaDistribution);
+  }
+
+  @Test
+  public void testNewBrokers() throws Exception {
+    super.testNewBrokers();
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerRandomClusterUniformDistRebalanceTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerRandomClusterUniformDistRebalanceTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ *
+ */
+
+    package com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner;
+
+    import com.linkedin.kafka.cruisecontrol.common.ClusterProperty;
+    import com.linkedin.kafka.cruisecontrol.common.TestConstants;
+    import java.util.Collection;
+    import java.util.Map;
+    import org.junit.Test;
+    import org.junit.runner.RunWith;
+    import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class KafkaAssignerRandomClusterUniformDistRebalanceTest extends KafkaAssignerRandomClusterTest {
+
+  @Parameterized.Parameters(name = "{2}-{0}")
+  public static Collection<Object[]> data() throws Exception {
+    return KafkaAssignerRandomClusterTest.data(TestConstants.Distribution.UNIFORM);
+  }
+
+  /**
+   * Constructor of Random Cluster Test.
+   * @param testId Test id.
+   * @param modifiedProperties  Modified cluster properties over the {@link TestConstants#BASE_PROPERTIES}.
+   * @param goalNameByPriority  Goal name by priority.
+   * @param replicaDistribution Distribution of replicas in the test cluster.
+   */
+  public KafkaAssignerRandomClusterUniformDistRebalanceTest(int testId,
+                                                            Map<ClusterProperty, Number> modifiedProperties,
+                                                            Map<Integer, String> goalNameByPriority,
+                                                            TestConstants.Distribution replicaDistribution) {
+    super(testId, modifiedProperties, goalNameByPriority, replicaDistribution);
+  }
+
+  @Test
+  public void testRebalance() throws Exception {
+    super.testRebalance();
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerRandomSelfHealingTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerRandomSelfHealingTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner;
+
+    import com.linkedin.kafka.cruisecontrol.common.ClusterProperty;
+    import com.linkedin.kafka.cruisecontrol.common.RandomCluster;
+    import com.linkedin.kafka.cruisecontrol.common.TestConstants;
+    import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+
+    import java.util.ArrayList;
+    import java.util.Collection;
+    import java.util.Collections;
+    import java.util.HashMap;
+    import java.util.HashSet;
+    import java.util.Map;
+
+    import java.util.Set;
+    import org.junit.Test;
+    import org.junit.runner.RunWith;
+    import org.junit.runners.Parameterized;
+    import org.junit.runners.Parameterized.Parameters;
+    import org.slf4j.Logger;
+    import org.slf4j.LoggerFactory;
+
+    import static com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerOptimizationVerifier.executeGoalsFor;
+    import static org.junit.Assert.assertTrue;
+
+
+@RunWith(Parameterized.class)
+public class KafkaAssignerRandomSelfHealingTest {
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaAssignerRandomSelfHealingTest.class);
+
+  @Parameters(name = "{2}-{0}")
+  public static Collection<Object[]> data() throws Exception {
+    Collection<Object[]> p = new ArrayList<>();
+
+    Map<Integer, String> goalNameByPriority = new HashMap<>();
+    goalNameByPriority.put(1, KafkaAssignerEvenRackAwareGoal.class.getName());
+
+    // -- TEST DECK #1: SINGLE DEAD BROKER.
+    // Test: Single Goal.
+    Map<ClusterProperty, Number> singleDeadBroker = new HashMap<>();
+    singleDeadBroker.put(ClusterProperty.NUM_DEAD_BROKERS, 1);
+    int testId = 0;
+    for (Map.Entry<Integer, String> entry : goalNameByPriority.entrySet()) {
+      p.add(params(testId++, singleDeadBroker, Collections.singletonMap(entry.getKey(), entry.getValue()), Collections.emptySet()));
+      p.add(params(testId++, singleDeadBroker, Collections.singletonMap(entry.getKey(), entry.getValue()), Collections.singleton("T0")));
+    }
+
+    // Test: All Goals.
+    p.add(params(testId++, singleDeadBroker, goalNameByPriority, Collections.emptySet()));
+    p.add(params(testId++, singleDeadBroker, goalNameByPriority, Collections.singleton("T0")));
+
+    // -- TEST DECK #2: MULTIPLE DEAD BROKERS.
+    // Test: Single Goal.
+    Map<ClusterProperty, Number> multipleDeadBrokers = new HashMap<>();
+    multipleDeadBrokers.put(ClusterProperty.NUM_DEAD_BROKERS, 5);
+    for (Map.Entry<Integer, String> entry : goalNameByPriority.entrySet()) {
+      p.add(params(testId++, multipleDeadBrokers, Collections.singletonMap(entry.getKey(), entry.getValue()), Collections.emptySet()));
+      p.add(params(testId++, multipleDeadBrokers, Collections.singletonMap(entry.getKey(), entry.getValue()), Collections.singleton("T0")));
+    }
+    // Test: All Goals.
+    p.add(params(testId++, multipleDeadBrokers, goalNameByPriority, Collections.emptySet()));
+    p.add(params(testId++, multipleDeadBrokers, goalNameByPriority, Collections.singleton("T0")));
+
+    return p;
+  }
+
+  private int _testId;
+  private Map<ClusterProperty, Number> _modifiedProperties;
+  private Map<Integer, String> _goalNameByPriority;
+  private Set<String> _excludedTopics;
+
+  /**
+   * Constructor of Self Healing Test.
+   *
+   * @param testId Test id.
+   * @param modifiedProperties Modified cluster properties over the {@link TestConstants#BASE_PROPERTIES}.
+   * @param goalNameByPriority Goal name by priority.
+   * @param excludedTopics Excluded topics.
+   */
+  public KafkaAssignerRandomSelfHealingTest(int testId,
+                                            Map<ClusterProperty, Number> modifiedProperties,
+                                            Map<Integer, String> goalNameByPriority,
+                                            Collection<String> excludedTopics) {
+    _testId = testId;
+    _modifiedProperties = modifiedProperties;
+    _goalNameByPriority = goalNameByPriority;
+    _excludedTopics = new HashSet<>(excludedTopics);
+  }
+
+  private static Object[] params(int testId,
+                                 Map<ClusterProperty, Number> modifiedProperties,
+                                 Map<Integer, String> goalNameByPriority,
+                                 Collection<String> excludedTopics) throws Exception {
+    return new Object[]{testId, modifiedProperties, goalNameByPriority, excludedTopics};
+  }
+
+  @Test
+  public void test() throws Exception {
+    // Create cluster properties by applying modified properties to base properties.
+    Map<ClusterProperty, Number> clusterProperties = new HashMap<>(TestConstants.BASE_PROPERTIES);
+    clusterProperties.putAll(_modifiedProperties);
+
+    LOG.debug("Replica distribution: {}.", TestConstants.Distribution.UNIFORM);
+    ClusterModel clusterModel = RandomCluster.generate(clusterProperties);
+    RandomCluster.populate(clusterModel, clusterProperties, TestConstants.Distribution.UNIFORM, true);
+
+    assertTrue("Self Healing Test failed to improve the existing state.",
+               executeGoalsFor(clusterModel, _goalNameByPriority, _excludedTopics).violatedGoalsAfterOptimization().isEmpty());
+
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/DeterministicCluster.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/DeterministicCluster.java
@@ -23,6 +23,37 @@ public class DeterministicCluster {
 
   }
 
+  // Two racks, three brokers, one partition, two replicas
+  public static ClusterModel rackAwareSatisfiable() throws AnalysisInputException, ModelInputException {
+    List<Integer> orderedRackIdsOfBrokers = Arrays.asList(0, 0, 1);
+    ClusterModel cluster = DeterministicCluster.getHomogeneousDeterministicCluster(2, orderedRackIdsOfBrokers,
+                                                                                   TestConstants.BROKER_CAPACITY);
+
+    // Create topic partition.
+    TopicPartition pInfoT10 = new TopicPartition("T1", 0);
+
+    // Create replicas for topic: T1.
+    cluster.createReplica("0", 0, pInfoT10, true);
+    cluster.createReplica("0", 1, pInfoT10, false);
+
+    // Create snapshots and push them to the cluster.
+    cluster.pushLatestSnapshot("0", 0, pInfoT10, new Snapshot(1L, 100.0, 100.0, 130.0, 75.0));
+    cluster.pushLatestSnapshot("0", 1, pInfoT10, new Snapshot(1L, 5.0, 100.0, 0.0, 75.0));
+
+    return cluster;
+  }
+
+  // two racks, three brokers, one partition, three replicas.
+  public static ClusterModel rackAwareUnsatisfiable() throws AnalysisInputException, ModelInputException {
+    ClusterModel cluster = rackAwareSatisfiable();
+    TopicPartition pInfoT10 = new TopicPartition("T1", 0);
+
+    cluster.createReplica("1", 2, pInfoT10, false);
+    cluster.pushLatestSnapshot("1", 2, pInfoT10, new Snapshot(1L, 100.0, 100.0, 130.0, 75.0));
+
+    return cluster;
+  }
+
   /**
    * Generates a small scale cluster.
    * <p>


### PR DESCRIPTION
* Add a goal that combines the even balancing action of kafka-assigner and rack-awareness. 
* Fix self-healing bug in ReplicaCapacityGoal.
* Enable printing the stack trace of a failed test without waiting until all the tests are completed.