### PR TITLE
Add seeds for random load generation.

### DIFF
--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/RandomCluster.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/RandomCluster.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.kafka.common.TopicPartition;
 
@@ -170,8 +169,9 @@ public class RandomCluster {
     }
     // Create replicas and set their distribution
     int replicaIndex = 0;
+    int topicIndex = 0;
     for (TopicMetadata datum : metadata) {
-      double topicPopularity = exponentialRandom(1.0);
+      double topicPopularity = exponentialRandom(1.0, TestConstants.TOPIC_POPULARITY_SEED + topicIndex++);
       String topic = datum.topic();
       for (int i = 1; i <= datum.numTopicLeaders(); i++) {
         Set<Integer> replicaBrokerIds = new HashSet<>();
@@ -242,15 +242,19 @@ public class RandomCluster {
           // Set leadership properties and replica load.
           Map<Resource, Double> utilizationByResource = new HashMap<>();
           utilizationByResource.put(Resource.CPU,
-              exponentialRandom(properties.get(ClusterProperty.MEAN_CPU).doubleValue() * topicPopularity));
+              exponentialRandom(properties.get(ClusterProperty.MEAN_CPU).doubleValue() * topicPopularity,
+                  TestConstants.UTILIZATION_SEEDS_BY_RESOURCE.get(Resource.CPU) + replicaIndex));
           utilizationByResource.put(Resource.NW_IN,
-              exponentialRandom(properties.get(ClusterProperty.MEAN_NW_IN).doubleValue() * topicPopularity));
+              exponentialRandom(properties.get(ClusterProperty.MEAN_NW_IN).doubleValue() * topicPopularity,
+                  TestConstants.UTILIZATION_SEEDS_BY_RESOURCE.get(Resource.NW_IN) + replicaIndex));
           utilizationByResource.put(Resource.DISK,
-              exponentialRandom(properties.get(ClusterProperty.MEAN_DISK).doubleValue() * topicPopularity));
+              exponentialRandom(properties.get(ClusterProperty.MEAN_DISK).doubleValue() * topicPopularity,
+                  TestConstants.UTILIZATION_SEEDS_BY_RESOURCE.get(Resource.DISK) + replicaIndex));
 
           if (j == 1) {
             utilizationByResource.put(Resource.NW_OUT,
-                exponentialRandom(properties.get(ClusterProperty.MEAN_NW_OUT).doubleValue() * topicPopularity));
+                exponentialRandom(properties.get(ClusterProperty.MEAN_NW_OUT).doubleValue() * topicPopularity,
+                    TestConstants.UTILIZATION_SEEDS_BY_RESOURCE.get(Resource.NW_OUT) + replicaIndex));
             cluster.createReplica(cluster.broker(randomBrokerId).rack().id(), randomBrokerId, pInfo, true);
           } else {
             utilizationByResource.put(Resource.NW_OUT, 0.0);
@@ -287,13 +291,14 @@ public class RandomCluster {
   }
 
   /**
-   * Generated an exponentially random double with the given mean value.
+   * Generated an exponentially random double with the given mean value using the seed.
    *
    * @param mean Mean value of the exponentially random distribution.
+   * @param seed Seed for the random number generator.
    * @return An exponential random number.
    */
-  private static double exponentialRandom(double mean) {
-    return Math.log(1.0 - ThreadLocalRandom.current().nextDouble()) * (-mean);
+  private static double exponentialRandom(double mean, long seed) {
+    return Math.log(1.0 - (new Random(seed)).nextDouble()) * (-mean);
   }
 
   /**

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/TestConstants.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/TestConstants.java
@@ -19,6 +19,17 @@ public class TestConstants {
   static final long REPLICATION_SEED = 5234;
   static final long LEADER_SEED = 72033;
   static final long REPLICA_ASSIGNMENT_SEED = 1240;
+  static final long TOPIC_POPULARITY_SEED = 7234;
+  static final Map<Resource, Long> UTILIZATION_SEED_BY_RESOURCE;
+  static {
+    Map<Resource, Long> utilizationSeedByResource = new HashMap<>();
+    utilizationSeedByResource.put(Resource.CPU, 100000L);
+    utilizationSeedByResource.put(Resource.DISK, 300000L);
+    utilizationSeedByResource.put(Resource.NW_IN, 500000L);
+    utilizationSeedByResource.put(Resource.NW_OUT, 700000L);
+    UTILIZATION_SEED_BY_RESOURCE = Collections.unmodifiableMap(utilizationSeedByResource);
+  }
+
   public static final double LOW_BALANCE_PERCENTAGE = 1.05;
   public static final double MEDIUM_BALANCE_PERCENTAGE = 1.25;
   public static final double HIGH_BALANCE_PERCENTAGE = 1.65;


### PR DESCRIPTION
The repeated tests of CC may generate clusters with varying load at each execution due to missing resource utilization seeds in random cluster generation.
This patch stabilizes the random load generation by providing predetermined seeds.