### PR TITLE
Clarify naming in servlet responses.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/ModelCompletenessRequirements.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/ModelCompletenessRequirements.java
@@ -118,7 +118,7 @@ public class ModelCompletenessRequirements {
 
   @Override
   public String toString() {
-    return String.format("(requiredNumSnapshots=%d, minMonitoredPartitionPercentage=%.3f, includedAllTopics=%s)",
+    return String.format("(requiredNumWindows=%d, minMonitoredPartitionPercentage=%.3f, includedAllTopics=%s)",
                          _minRequiredNumSnapshotWindows, _minMonitoredPartitionsPercentage, _includeAllTopics);
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -734,7 +734,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
         return "(FIXED)";
       }
     } else {
-      return "";
+      return "(NO-ACTION)";
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
@@ -56,8 +56,8 @@ class KafkaCruiseControlServletUtils {
       }
     }
     return String.format("%n%nThe optimization proposal has %d replica(%d MB) movements and %d leadership movements "
-                             + "based on the cluster model with %d recent snapshot windows and %.3f%% valid monitored "
-                             + "partitions", numReplicaMovements, dataToMove, numLeaderMovements,
+                             + "based on the cluster model with %d recent snapshot windows and %.3f%% of the partitions "
+                             + "covered.", numReplicaMovements, dataToMove, numLeaderMovements,
                          result.clusterModelStats().numSnapshotWindows(),
                          result.clusterModelStats().monitoredPartitionsPercentage() * 100);
   }


### PR DESCRIPTION
* Fix `proposals` response to clarify the covered partitions and satisfied goals with no proposal generation.
* Fix `verbose state` response to clarify required number of windows.