### PR TITLE
Clean up the executor logic and wait for the tasks to finish during stop.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerEvenRackAwareGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerEvenRackAwareGoal.java
@@ -267,26 +267,6 @@ public class KafkaAssignerEvenRackAwareGoal implements Goal {
   }
 
   /**
-   * Get replica of the given partition residing in the broker with the given brokerId. If there is no replica of the
-   * given partition in the broker with the given brokerId, return null.
-   *
-   * @param partition Partition whose replica will be returned (if any).
-   * @param brokerId The id of the broker in which the replica resides (if any).
-   */
-  private Replica replicaInBrokerFor(Partition partition, int brokerId) {
-    if (partition.leader().broker().id() == brokerId) {
-      return partition.leader();
-    }
-
-    for (Replica replica : partition.followers()) {
-      if (replica.broker().id() == brokerId) {
-        return replica;
-      }
-    }
-    return null;
-  }
-
-  /**
    * Check whether the replica should be excluded from the rebalance. A replica should be excluded if its topic
    * is in the excluded topics set and its broker is still alive.
    *

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerEvenRackAwareGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerEvenRackAwareGoal.java
@@ -112,7 +112,7 @@ public class KafkaAssignerEvenRackAwareGoal implements Goal {
     for (int position = 0; position < maxReplicationFactor; position++) {
       for (Map.Entry<String, List<Partition>> entry : _partitionsByTopic.entrySet()) {
         for (Partition partition : entry.getValue()) {
-          if (partition.replicas().size() <=  position) {
+          if (partition.replicas().size() <= position) {
             continue;
           }
           if (shouldExclude(partition, position, excludedTopics)) {
@@ -263,9 +263,6 @@ public class KafkaAssignerEvenRackAwareGoal implements Goal {
    * @param position The position of replica in the partition, i.e. 0 means leader, 1 is the first follower, and so on.
    */
   private Replica replicaAtPosition(Partition sourcePartition, int position) {
-    if (position == 0) {
-      return sourcePartition.leader();
-    }
     return sourcePartition.replicas().get(position);
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -647,7 +647,7 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
         .define(ZOOKEEPER_CONNECT_CONFIG, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, ZOOKEEPER_CONNECT_DOC)
         .define(NUM_CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER_CONFIG,
                 ConfigDef.Type.INT,
-                10,
+                1,
                 atLeast(1),
                 ConfigDef.Importance.MEDIUM,
                 NUM_CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER_DOC)

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTask.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTask.java
@@ -17,18 +17,18 @@ import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTask.State.*;
 
 /**
  * A class that wraps the execution information of a balancing proposal
- * 
+ *
  * The task state machine is the following:
- * 
+ *
  * <pre>
  * PENDING ---> IN_PROGRESS ------------> COMPLETED
- *                  |           
- *                  |           
+ *                  |
+ *                  |
  *                  |----> ABORTING ----> ABORTED
  *                  |          |
  *                  |          v
  *                  |-------------------> DEAD
- *                  
+ *
  * A newly created task is in <tt>PENDING</tt> state.
  * A <tt>PENDING</tt> task becomes <tt>IN_PROGRESS</tt> when it is drained from the {@link ExecutionTaskPlanner}
  * An <tt>IN_PROGRESS</tt> task becomes <tt>COMPLETED</tt> if the execution is done without error.
@@ -45,7 +45,7 @@ public class ExecutionTask implements Comparable<ExecutionTask> {
   // The corresponding balancing proposal of this task.
   public final BalancingProposal proposal;
   private volatile State _state;
-  
+
   static {
     VALID_TRANSFER.put(PENDING, new HashSet<>(Collections.singleton(IN_PROGRESS)));
     VALID_TRANSFER.put(IN_PROGRESS, new HashSet<>(Arrays.asList(ABORTING, DEAD, COMPLETED)));
@@ -54,7 +54,7 @@ public class ExecutionTask implements Comparable<ExecutionTask> {
     VALID_TRANSFER.put(DEAD, Collections.emptySet());
     VALID_TRANSFER.put(ABORTED, Collections.emptySet());
   }
-  
+
   public ExecutionTask(long executionId, BalancingProposal proposal) {
     this.executionId = executionId;
     this.proposal = proposal;
@@ -158,7 +158,7 @@ public class ExecutionTask implements Comparable<ExecutionTask> {
     executionStatsMap.put("proposal", proposal.getJsonStructure());
     return executionStatsMap;
   }
-  
+
   private void ensureValidTransfer(State targetState) {
     if (!canTransferToState(targetState)) {
       throw new IllegalStateException("Cannot mark a task in " + _state + " to" + targetState + "state. The "

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskTracker.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskTracker.java
@@ -18,7 +18,7 @@ import java.util.Set;
 public class ExecutionTaskTracker {
   // Dead tasks indicate cancelled/killed executions affecting the original state before the balancing action execution.
   private final Map<BalancingAction, Set<ExecutionTask>> _deadTasks;
-  // Aborting tasks due to cancelled balancing actions not affecting the state before the execution of balancing 
+  // Aborting tasks due to cancelled balancing actions not affecting the state before the execution of balancing
   // action.
   private final Map<BalancingAction, Set<ExecutionTask>> _abortingTasks;
   // Tasks that have been successfully aborted.
@@ -109,7 +109,8 @@ public class ExecutionTaskTracker {
    */
   public boolean hasTaskInProgress() {
     for (BalancingAction balancingAction : BalancingAction.cachedValues()) {
-      if (!_inProgressTasks.get(balancingAction).isEmpty()) {
+      if (!_inProgressTasks.get(balancingAction).isEmpty()
+          || !_abortingTasks.get(balancingAction).isEmpty()) {
         return true;
       }
     }
@@ -179,7 +180,7 @@ public class ExecutionTaskTracker {
   public int numDeadReplicaDeletion() {
     return _deadTasks.get(BalancingAction.REPLICA_DELETION).size();
   }
-  
+
   public int numAbortingReplicaMove() {
     return _abortingTasks.get(BalancingAction.REPLICA_MOVEMENT).size();
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorState.java
@@ -17,7 +17,7 @@ public class ExecutorState {
     EXECUTION_STARTED,
     REPLICA_MOVEMENT_TASK_IN_PROGRESS,
     LEADER_MOVEMENT_TASK_IN_PROGRESS,
-    STOPPING
+    STOPPING_EXECUTION
   }
 
   private final State _state;
@@ -113,7 +113,7 @@ public class ExecutorState {
                                        Set<ExecutionTask> deadParitionMovements,
                                        long remainingDataToMoveInMB,
                                        long finishedDataMovementInMB) {
-    return new ExecutorState(State.STOPPING,
+    return new ExecutorState(State.STOPPING_EXECUTION,
                              finishedPartitionMovements,
                              pendingPartitionMovements,
                              inProgressPartitionMovements,
@@ -177,7 +177,7 @@ public class ExecutorState {
         execState.put("state", _state);
         break;
       case REPLICA_MOVEMENT_TASK_IN_PROGRESS:
-      case STOPPING:
+      case STOPPING_EXECUTION:
         execState.put("state", _state);
         execState.put("numTotalPartitions", numTotalPartitionMovements());
         execState.put("totalDataToMove", totalDataToMoveInMB());
@@ -185,6 +185,7 @@ public class ExecutorState {
         execState.put("finishedDataMovement", _finishedDataMovementInMB);
         execState.put("abortingPartitions", _abortingPartitionMovements);
         execState.put("abortedPartitions", _abortedPartitionMovements);
+        execState.put("deadPartitions", _deadPartitionMovements);
         break;
       default:
         execState.put("state", _state);
@@ -203,7 +204,7 @@ public class ExecutorState {
         return String.format("{state: %s}", _state);
 
       case REPLICA_MOVEMENT_TASK_IN_PROGRESS:
-      case STOPPING:
+      case STOPPING_EXECUTION:
         return String.format("{state: %s, in-progress/aborting partitions: %d/%d, completed/total bytes(MB): %d/%d, "
                                  + "finished/aborted/dead/total partitions: %d/%d/%d/%d}",
                              _state, _inProgressPartitionMovements.size(), _abortingPartitionMovements.size(),

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorState.java
@@ -16,13 +16,17 @@ public class ExecutorState {
     NO_TASK_IN_PROGRESS,
     EXECUTION_STARTED,
     REPLICA_MOVEMENT_TASK_IN_PROGRESS,
-    LEADER_MOVEMENT_TASK_IN_PROGRESS;
+    LEADER_MOVEMENT_TASK_IN_PROGRESS,
+    STOPPING
   }
 
   private final State _state;
   private final Set<ExecutionTask> _pendingPartitionMovements;
   private final int _numFinishedPartitionMovements;
   private final Set<ExecutionTask> _inProgressPartitionMovements;
+  private final Set<ExecutionTask> _abortingPartitionMovements;
+  private final Set<ExecutionTask> _abortedPartitionMovements;
+  private final Set<ExecutionTask> _deadPartitionMovements;
   private final long _remainingDataToMoveInMB;
   private final long _finishedDataMovementInMB;
 
@@ -30,6 +34,9 @@ public class ExecutorState {
                         int numFinishedPartitionMovements,
                         Set<ExecutionTask> pendingPartitionMovements,
                         Set<ExecutionTask> inProgressPartitionMovements,
+                        Set<ExecutionTask> abortingPartitionMovements,
+                        Set<ExecutionTask> abortedPartitionMovements,
+                        Set<ExecutionTask> deadPartitionMovements,
                         long remainingDataToMoveInMB,
                         long finishedDataMovementInMB) {
     _state = state;
@@ -38,11 +45,17 @@ public class ExecutorState {
     _numFinishedPartitionMovements = numFinishedPartitionMovements;
     _remainingDataToMoveInMB = remainingDataToMoveInMB;
     _finishedDataMovementInMB = finishedDataMovementInMB;
+    _abortingPartitionMovements = abortingPartitionMovements;
+    _abortedPartitionMovements = abortedPartitionMovements;
+    _deadPartitionMovements = deadPartitionMovements;
   }
 
   public static ExecutorState noTaskInProgress() {
     return new ExecutorState(State.NO_TASK_IN_PROGRESS,
                              0,
+                             Collections.emptySet(),
+                             Collections.emptySet(),
+                             Collections.emptySet(),
                              Collections.emptySet(),
                              Collections.emptySet(),
                              0L,
@@ -54,6 +67,9 @@ public class ExecutorState {
                              0,
                              Collections.emptySet(),
                              Collections.emptySet(),
+                             Collections.emptySet(),
+                             Collections.emptySet(),
+                             Collections.emptySet(),
                              0L,
                              0L);
   }
@@ -61,12 +77,18 @@ public class ExecutorState {
   public static ExecutorState replicaMovementInProgress(int finishedPartitionMovements,
                                                         Set<ExecutionTask> pendingPartitionMovements,
                                                         Set<ExecutionTask> inProgressPartitionMovements,
+                                                        Set<ExecutionTask> abortingPartitionMovements,
+                                                        Set<ExecutionTask> abortedPartitionMovements,
+                                                        Set<ExecutionTask> deadPartitionMovements,
                                                         long remainingDataToMoveInMB,
                                                         long finishedDataMovementInMB) {
     return new ExecutorState(State.REPLICA_MOVEMENT_TASK_IN_PROGRESS,
                              finishedPartitionMovements,
                              pendingPartitionMovements,
                              inProgressPartitionMovements,
+                             abortingPartitionMovements,
+                             abortedPartitionMovements,
+                             deadPartitionMovements,
                              remainingDataToMoveInMB,
                              finishedDataMovementInMB);
   }
@@ -76,8 +98,30 @@ public class ExecutorState {
                              0,
                              Collections.emptySet(),
                              Collections.emptySet(),
+                             Collections.emptySet(),
+                             Collections.emptySet(),
+                             Collections.emptySet(),
                              0L,
                              0L);
+  }
+
+  public static ExecutorState stopping(int finishedPartitionMovements,
+                                       Set<ExecutionTask> pendingPartitionMovements,
+                                       Set<ExecutionTask> inProgressPartitionMovements,
+                                       Set<ExecutionTask> abortingPartitionMovements,
+                                       Set<ExecutionTask> abortedPartitionMovements,
+                                       Set<ExecutionTask> deadParitionMovements,
+                                       long remainingDataToMoveInMB,
+                                       long finishedDataMovementInMB) {
+    return new ExecutorState(State.STOPPING,
+                             finishedPartitionMovements,
+                             pendingPartitionMovements,
+                             inProgressPartitionMovements,
+                             abortingPartitionMovements,
+                             abortedPartitionMovements,
+                             deadParitionMovements,
+                             remainingDataToMoveInMB,
+                             finishedDataMovementInMB);
   }
 
   public State state() {
@@ -87,7 +131,9 @@ public class ExecutorState {
   public int numTotalPartitionMovements() {
     return _pendingPartitionMovements.size()
         + _inProgressPartitionMovements.size()
-        + _numFinishedPartitionMovements;
+        + _numFinishedPartitionMovements
+        + _abortingPartitionMovements.size()
+        + _abortedPartitionMovements.size();
   }
 
   public long totalDataToMoveInMB() {
@@ -106,6 +152,18 @@ public class ExecutorState {
     return _inProgressPartitionMovements;
   }
 
+  public Set<ExecutionTask> abortingPartitionMovements() {
+    return _abortingPartitionMovements;
+  }
+
+  public Set<ExecutionTask> abortedPartitionMovements() {
+    return _abortedPartitionMovements;
+  }
+
+  public Set<ExecutionTask> deadPartitionMovements() {
+    return _deadPartitionMovements;
+  }
+
   /*
    * Return an object that can be further used
    * to encode into JSON
@@ -119,11 +177,14 @@ public class ExecutorState {
         execState.put("state", _state);
         break;
       case REPLICA_MOVEMENT_TASK_IN_PROGRESS:
+      case STOPPING:
         execState.put("state", _state);
         execState.put("numTotalPartitions", numTotalPartitionMovements());
         execState.put("totalDataToMove", totalDataToMoveInMB());
         execState.put("numFinishedPartitions", _numFinishedPartitionMovements);
         execState.put("finishedDataMovement", _finishedDataMovementInMB);
+        execState.put("abortingPartitions", _abortingPartitionMovements);
+        execState.put("abortedPartitions", _abortedPartitionMovements);
         break;
       default:
         execState.put("state", _state);
@@ -142,9 +203,13 @@ public class ExecutorState {
         return String.format("{state: %s}", _state);
 
       case REPLICA_MOVEMENT_TASK_IN_PROGRESS:
-        return String.format("{state: %s, total partitions(MB): %d/%d, finished partitions: %d/%d}",
-                             _state, _finishedDataMovementInMB, totalDataToMoveInMB(),
-                             _numFinishedPartitionMovements, numTotalPartitionMovements());
+      case STOPPING:
+        return String.format("{state: %s, in-progress/aborting partitions: %d/%d, completed/total bytes(MB): %d/%d, "
+                                 + "finished/aborted/dead/total partitions: %d/%d/%d/%d}",
+                             _state, _inProgressPartitionMovements.size(), _abortingPartitionMovements.size(),
+                             _finishedDataMovementInMB, totalDataToMoveInMB(), _numFinishedPartitionMovements,
+                             _abortedPartitionMovements.size(), _deadPartitionMovements.size(),
+                             numTotalPartitionMovements());
       default:
         throw new IllegalStateException("This should never happen");
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -895,7 +895,7 @@ public class ClusterModel implements Serializable {
           brokerStats.addSingleBrokerStats(broker.host().name(),
                                            broker.id(),
                                            broker.getState(),
-                                           broker.load().expectedUtilizationFor(Resource.DISK),
+                                           broker.replicas().isEmpty() ? 0 : broker.load().expectedUtilizationFor(Resource.DISK),
                                            broker.load().expectedUtilizationFor(Resource.CPU),
                                            leaderBytesInRate,
                                            broker.load().expectedUtilizationFor(Resource.NW_IN) - leaderBytesInRate,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -813,7 +813,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
         }
         ExecutorState.State executorState = state.executorState().state();
         if (executorState == ExecutorState.State.REPLICA_MOVEMENT_TASK_IN_PROGRESS
-            || executorState == ExecutorState.State.STOPPING) {
+            || executorState == ExecutorState.State.STOPPING_EXECUTION) {
           out.write(String.format("%n%nIn progress partition movements:%n").getBytes(StandardCharsets.UTF_8));
           for (ExecutionTask task : state.executorState().inProgressPartitionMovements()) {
             out.write(String.format("%s%n", task).getBytes(StandardCharsets.UTF_8));
@@ -831,7 +831,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
             out.write(String.format("%s%n", task).getBytes(StandardCharsets.UTF_8));
           }
           out.write(String.format("%n%n%s partition movements:%n",
-                                  executorState == ExecutorState.State.STOPPING ? "Cancelled" : "Pending")
+                                  executorState == ExecutorState.State.STOPPING_EXECUTION ? "Cancelled" : "Pending")
                         .getBytes(StandardCharsets.UTF_8));
           for (ExecutionTask task : state.executorState().pendingPartitionMovements()) {
             out.write(String.format("%s%n", task).getBytes(StandardCharsets.UTF_8));

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -811,12 +811,28 @@ public class KafkaCruiseControlServlet extends HttpServlet {
           out.write(String.format("%50s, %s, %s%n", goal.getClass().getSimpleName(), goal.clusterModelCompletenessRequirements(),
               entry.getValue() ? "Ready" : "NotReady").getBytes(StandardCharsets.UTF_8));
         }
-        if (state.executorState().state() == ExecutorState.State.REPLICA_MOVEMENT_TASK_IN_PROGRESS) {
+        ExecutorState.State executorState = state.executorState().state();
+        if (executorState == ExecutorState.State.REPLICA_MOVEMENT_TASK_IN_PROGRESS
+            || executorState == ExecutorState.State.STOPPING) {
           out.write(String.format("%n%nIn progress partition movements:%n").getBytes(StandardCharsets.UTF_8));
           for (ExecutionTask task : state.executorState().inProgressPartitionMovements()) {
             out.write(String.format("%s%n", task).getBytes(StandardCharsets.UTF_8));
           }
-          out.write(String.format("%n%nPending partition movements:%n").getBytes(StandardCharsets.UTF_8));
+          out.write(String.format("%n%nAborting partition movements:%n").getBytes(StandardCharsets.UTF_8));
+          for (ExecutionTask task : state.executorState().abortingPartitionMovements()) {
+            out.write(String.format("%s%n", task).getBytes(StandardCharsets.UTF_8));
+          }
+          out.write(String.format("%n%nAborted partition movements:%n").getBytes(StandardCharsets.UTF_8));
+          for (ExecutionTask task : state.executorState().abortedPartitionMovements()) {
+            out.write(String.format("%s%n", task).getBytes(StandardCharsets.UTF_8));
+          }
+          out.write(String.format("%n%nDead partition movements:%n").getBytes(StandardCharsets.UTF_8));
+          for (ExecutionTask task : state.executorState().deadPartitionMovements()) {
+            out.write(String.format("%s%n", task).getBytes(StandardCharsets.UTF_8));
+          }
+          out.write(String.format("%n%n%s partition movements:%n",
+                                  executorState == ExecutorState.State.STOPPING ? "Cancelled" : "Pending")
+                        .getBytes(StandardCharsets.UTF_8));
           for (ExecutionTask task : state.executorState().pendingPartitionMovements()) {
             out.write(String.format("%s%n", task).getBytes(StandardCharsets.UTF_8));
           }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -121,9 +121,9 @@ public class AnomalyDetectorTest {
     // The following state are used to test the delayed check when executor is busy.
     EasyMock.expect(mockKafkaCruiseControl.state(EasyMock.anyObject()))
             .andReturn(new KafkaCruiseControlState(ExecutorState.noTaskInProgress(), null, null));
-    EasyMock.expect(mockKafkaCruiseControl.rebalance(EasyMock.eq(Collections.emptyList()), 
-                                                     EasyMock.eq(false), 
-                                                     EasyMock.eq(null), 
+    EasyMock.expect(mockKafkaCruiseControl.rebalance(EasyMock.eq(Collections.emptyList()),
+                                                     EasyMock.eq(false),
+                                                     EasyMock.eq(null),
                                                      EasyMock.anyObject(OperationProgress.class)))
             .andReturn(null);
 
@@ -180,8 +180,14 @@ public class AnomalyDetectorTest {
     // The following state are used to test the delayed check when executor is busy.
     EasyMock.expect(mockKafkaCruiseControl.state(EasyMock.anyObject()))
             .andReturn(new KafkaCruiseControlState(
-                ExecutorState.replicaMovementInProgress(1, Collections.emptySet(), Collections.emptySet(),
-                                                        1, 1),
+                ExecutorState.replicaMovementInProgress(1,
+                                                        Collections.emptySet(),
+                                                        Collections.emptySet(),
+                                                        Collections.emptySet(),
+                                                        Collections.emptySet(),
+                                                        Collections.emptySet(),
+                                                        1,
+                                                        1),
                 null, null));
 
     EasyMock.replay(mockAnomalyNotifier);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -146,7 +146,9 @@ public class ExecutorTest extends AbstractKafkaIntegrationTestHarness {
     Collection<BalancingProposal> proposalsToExecute = Arrays.asList(proposal0, proposal1);
     executeAndVerifyProposals(zkUtils, proposalsToExecute, Collections.emptyList());
 
-    assertEquals(Collections.singletonList(initialLeader0), ExecutorUtils.newAssignmentForPartition(zkUtils, tp0));
+    // We are not doing the rollback.
+    assertEquals(Collections.singletonList(initialLeader0 == 0 ? 1 : 0),
+                 ExecutorUtils.newAssignmentForPartition(zkUtils, tp0));
   }
 
   private void executeAndVerifyProposals(ZkUtils zkUtils,

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -149,6 +149,7 @@ public class ExecutorTest extends AbstractKafkaIntegrationTestHarness {
     // We are not doing the rollback.
     assertEquals(Collections.singletonList(initialLeader0 == 0 ? 1 : 0),
                  ExecutorUtils.newAssignmentForPartition(zkUtils, tp0));
+    assertEquals(initialLeader0, zkUtils.getLeaderForPartition(topic1, partition).get());
   }
 
   private void executeAndVerifyProposals(ZkUtils zkUtils,

--- a/cruise-control/src/test/resources/log4j.properties
+++ b/cruise-control/src/test/resources/log4j.properties
@@ -6,8 +6,8 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 log4j.logger.org.apache.kafka.clients.Metadata=ERROR
-log4j.logger.kafka.controller=INFO
+log4j.logger.kafka.controller=ERROR
 # zkclient can be verbose, during debugging it is common to adjust is separately
 log4j.logger.org.I0Itec.zkclient.ZkClient=WARN
 log4j.logger.org.apache.zookeeper=WARN
-log4j.logger.com.linkedin.kafka.cruisecontrol.executor.Executor=INFO
+log4j.logger.com.linkedin.kafka=ERROR

--- a/cruise-control/src/test/resources/log4j.properties
+++ b/cruise-control/src/test/resources/log4j.properties
@@ -6,8 +6,8 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 log4j.logger.org.apache.kafka.clients.Metadata=ERROR
-log4j.logger.kafka=ERROR
+log4j.logger.kafka.controller=INFO
 # zkclient can be verbose, during debugging it is common to adjust is separately
 log4j.logger.org.I0Itec.zkclient.ZkClient=WARN
 log4j.logger.org.apache.zookeeper=WARN
-log4j.logger.com.linkedin.kafka.cruisecontrol=ERROR
+log4j.logger.com.linkedin.kafka.cruisecontrol.executor.Executor=INFO


### PR DESCRIPTION
Change the executor to wait for the tasks to finish during manual stop.
The rollback can not be done until KAFKA-6304 is in place.