### PR TITLE
Handle anomaly detector goal fix exception.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -410,7 +410,7 @@ public class KafkaCruiseControl {
   /**
    * Get a goals by priority based on the goal list.
    */
-  private Map<Integer, Goal> goalsByPriority(List<String> goals) {
+  public Map<Integer, Goal> goalsByPriority(List<String> goals) {
     if (goals == null || goals.isEmpty()) {
       return AnalyzerUtils.getGoalMapByPriority(_config);
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -408,9 +408,19 @@ public class KafkaCruiseControl {
   }
 
   /**
+   * Check if the given goals meet the completeness requirements.
+   *
+   * @param goalNames Goal names (and empty list of names indicates all goals).
+   */
+  public boolean meetCompletenessRequirements(List<String> goalNames) {
+    Collection<Goal> goals = goalsByPriority(goalNames).values();
+    return goals.stream().allMatch(g -> _loadMonitor.meetCompletenessRequirements(g.clusterModelCompletenessRequirements()));
+  }
+
+  /**
    * Get a goals by priority based on the goal list.
    */
-  public Map<Integer, Goal> goalsByPriority(List<String> goals) {
+  private Map<Integer, Goal> goalsByPriority(List<String> goals) {
     if (goals == null || goals.isEmpty()) {
       return AnalyzerUtils.getGoalMapByPriority(_config);
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetector.java
@@ -212,7 +212,7 @@ public class AnomalyDetector {
 
       // Fixing anomalies is possible only when (1) the state is not in and unavailable state ( e.g. loading or
       // bootstrapping) and (2) the completeness requirements are met for all goals.
-      if (ViolationUtils.isUnavailableState(loadMonitorTaskRunnerState)) {
+      if (!ViolationUtils.isLoadMonitorReady(loadMonitorTaskRunnerState)) {
         LOG.info("Skipping {} because load monitor is in {} state.", skipMsg, loadMonitorTaskRunnerState);
       } else {
         boolean meetCompletenessRequirements = _kafkaCruiseControl.meetCompletenessRequirements(Collections.emptyList());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
@@ -14,7 +14,7 @@ import com.linkedin.kafka.cruisecontrol.executor.ExecutionProposal;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import com.linkedin.kafka.cruisecontrol.monitor.LoadMonitor;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelGeneration;
-import com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunner;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -32,8 +32,8 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * This class will be schedule to run periodically to check if the given goals are violated or not. An alert will be
- * triggered if one of the goal is not met.
+ * This class will be scheduled to run periodically to check if the given goals are violated or not. An alert will be
+ * triggered if one of the goals is not met.
  */
 public class GoalViolationDetector implements Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(GoalViolationDetector.class);
@@ -87,10 +87,7 @@ public class GoalViolationDetector implements Runnable {
 
     AutoCloseable clusterModelSemaphore = null;
     try {
-      LoadMonitorTaskRunner.LoadMonitorTaskRunnerState loadMonitorTaskRunnerState = _loadMonitor.taskRunnerState();
-      if (loadMonitorTaskRunnerState == LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.LOADING ||
-          loadMonitorTaskRunnerState == LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.BOOTSTRAPPING) {
-        LOG.info("Skipping goal violation detection because load monitor is in {} state", loadMonitorTaskRunnerState);
+      if (ViolationUtils.isLoadingOrBootstrapping(_loadMonitor, "goal violation detection")) {
         return;
       }
 
@@ -98,9 +95,8 @@ public class GoalViolationDetector implements Runnable {
       boolean newModelNeeded = true;
       ClusterModel clusterModel = null;
       for (Map.Entry<Integer, Goal> entry : _goals.entrySet()) {
-        int priority = entry.getKey();
         Goal goal = entry.getValue();
-        if (_loadMonitor.meetCompletenessRequirements(goal.clusterModelCompletenessRequirements())) {
+        if (ViolationUtils.meetCompletenessRequirements(_loadMonitor, Collections.singleton(goal), "goal violation detection")) {
           LOG.debug("Detecting if {} is violated.", entry.getValue().name());
           // Because the model generation could be slow, We only get new cluster model if needed.
           if (newModelNeeded) {
@@ -112,10 +108,8 @@ public class GoalViolationDetector implements Runnable {
             clusterModel = null;
             clusterModel = _loadMonitor.clusterModel(now, goal.clusterModelCompletenessRequirements(), new OperationProgress());
           }
+          int priority = entry.getKey();
           newModelNeeded = optimizeForGoal(clusterModel, priority, goal, goalViolations);
-        } else {
-          LOG.debug("Skipping goal violation for {} detection because load completeness requirement is not met.",
-                    goal.name());
         }
       }
       if (clusterModel != null) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
@@ -88,7 +88,7 @@ public class GoalViolationDetector implements Runnable {
     AutoCloseable clusterModelSemaphore = null;
     try {
       LoadMonitorTaskRunner.LoadMonitorTaskRunnerState loadMonitorTaskRunnerState = _loadMonitor.taskRunnerState();
-      if (ViolationUtils.isUnavailableState(loadMonitorTaskRunnerState)) {
+      if (!ViolationUtils.isLoadMonitorReady(loadMonitorTaskRunnerState)) {
         LOG.info("Skipping goal violation detection because load monitor is in {} state.", loadMonitorTaskRunnerState);
         return;
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
@@ -24,8 +24,8 @@ public class GoalViolations extends Anomaly {
   private static final Logger LOG = LoggerFactory.getLogger(GoalViolations.class);
   private final List<Violation> _goalViolations = new ArrayList<>();
 
-  public void addViolation(int priority, String goalName, Set<ExecutionProposal> balancingProposals) {
-    _goalViolations.add(new Violation(priority, goalName, balancingProposals));
+  public void addViolation(int priority, String goalName, Set<ExecutionProposal> executionProposals) {
+    _goalViolations.add(new Violation(priority, goalName, executionProposals));
   }
 
   /**
@@ -40,7 +40,7 @@ public class GoalViolations extends Anomaly {
     // Fix the violations using a rebalance.
     try {
       kafkaCruiseControl.rebalance(Collections.emptyList(), false, null, new OperationProgress());
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalStateException e) {
       LOG.warn(e.getMessage());
     }
   }
@@ -48,12 +48,12 @@ public class GoalViolations extends Anomaly {
   public static class Violation {
     private final int _priority;
     private final String _goalName;
-    private final Set<ExecutionProposal> _balancingProposals;
+    private final Set<ExecutionProposal> _executionProposals;
 
-    public Violation(int priority, String goalName, Set<ExecutionProposal> balancingProposals) {
+    public Violation(int priority, String goalName, Set<ExecutionProposal> executionProposals) {
       _priority = priority;
       _goalName = goalName;
-      _balancingProposals = balancingProposals;
+      _executionProposals = executionProposals;
     }
 
     public int priority() {
@@ -64,8 +64,8 @@ public class GoalViolations extends Anomaly {
       return _goalName;
     }
 
-    public Set<ExecutionProposal> balancingProposals() {
-      return _balancingProposals;
+    public Set<ExecutionProposal> executionProposals() {
+      return _executionProposals;
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
@@ -13,12 +13,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.StringJoiner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * A class that holds all the goal violations.
  */
 public class GoalViolations extends Anomaly {
+  private static final Logger LOG = LoggerFactory.getLogger(GoalViolations.class);
   private final List<Violation> _goalViolations = new ArrayList<>();
 
   public void addViolation(int priority, String goalName, Set<ExecutionProposal> balancingProposals) {
@@ -35,7 +38,11 @@ public class GoalViolations extends Anomaly {
   @Override
   void fix(KafkaCruiseControl kafkaCruiseControl) throws KafkaCruiseControlException {
     // Fix the violations using a rebalance.
-    kafkaCruiseControl.rebalance(Collections.emptyList(), false, null, new OperationProgress());
+    try {
+      kafkaCruiseControl.rebalance(Collections.emptyList(), false, null, new OperationProgress());
+    } catch (IllegalArgumentException e) {
+      LOG.warn(e.getMessage());
+    }
   }
 
   public static class Violation {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
@@ -41,7 +41,7 @@ public class GoalViolations extends Anomaly {
     try {
       kafkaCruiseControl.rebalance(Collections.emptyList(), false, null, new OperationProgress());
     } catch (IllegalStateException e) {
-      LOG.warn(e.getMessage());
+      LOG.warn("Got exception when trying to fix the cluster. " + e.getMessage());
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ViolationUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ViolationUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.detector;
+
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
+import com.linkedin.kafka.cruisecontrol.monitor.LoadMonitor;
+import com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunner;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ViolationUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(ViolationUtils.class);
+
+  private ViolationUtils() {
+
+  }
+
+  public static boolean isLoadingOrBootstrapping(LoadMonitor loadMonitor, String skipMsg) {
+    // loadMonitor is null for unit tests.
+    if (loadMonitor != null) {
+      LoadMonitorTaskRunner.LoadMonitorTaskRunnerState loadMonitorTaskRunnerState = loadMonitor.taskRunnerState();
+      if (loadMonitorTaskRunnerState == LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.LOADING ||
+          loadMonitorTaskRunnerState == LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.BOOTSTRAPPING) {
+        LOG.info("Skipping {} because load monitor is in {} state.", skipMsg, loadMonitorTaskRunnerState);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static boolean meetCompletenessRequirements(LoadMonitor loadMonitor, Collection<Goal> goals, String skipMsg) {
+    // loadMonitor is null for unit tests.
+    if (loadMonitor != null) {
+      for (Goal goal : goals) {
+        if (loadMonitor.meetCompletenessRequirements(goal.clusterModelCompletenessRequirements())) {
+          LOG.debug("Skipping {} for {} because load completeness requirement is not met.",
+                    skipMsg, goals.stream().map(Goal::name).collect(Collectors.toList()));
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ViolationUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ViolationUtils.java
@@ -14,13 +14,13 @@ public class ViolationUtils {
   }
 
   /**
-   * Check whether the load monitor state is unavailable -- i.e. loading or bootstrapping state.
+   * Check whether the load monitor state is ready -- i.e. not in loading or bootstrapping state.
    *
    * @param loadMonitorTaskRunnerState Load monitor task runner state.
-   * @return True if the load monitor is unavailable, false otherwise.
+   * @return True if the load monitor is ready, false otherwise.
    */
-  public static boolean isUnavailableState(LoadMonitorTaskRunner.LoadMonitorTaskRunnerState loadMonitorTaskRunnerState) {
-    return loadMonitorTaskRunnerState == LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.LOADING
-           || loadMonitorTaskRunnerState == LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.BOOTSTRAPPING;
+  public static boolean isLoadMonitorReady(LoadMonitorTaskRunner.LoadMonitorTaskRunnerState loadMonitorTaskRunnerState) {
+    return !(loadMonitorTaskRunnerState == LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.LOADING
+           || loadMonitorTaskRunnerState == LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.BOOTSTRAPPING);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ViolationUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ViolationUtils.java
@@ -8,40 +8,42 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
 import com.linkedin.kafka.cruisecontrol.monitor.LoadMonitor;
 import com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunner;
 import java.util.Collection;
-import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class ViolationUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(ViolationUtils.class);
 
   private ViolationUtils() {
 
   }
 
-  public static boolean isLoadingOrBootstrapping(LoadMonitor loadMonitor, String skipMsg) {
-    // loadMonitor is null for unit tests.
-    if (loadMonitor != null) {
-      LoadMonitorTaskRunner.LoadMonitorTaskRunnerState loadMonitorTaskRunnerState = loadMonitor.taskRunnerState();
-      if (loadMonitorTaskRunnerState == LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.LOADING ||
-          loadMonitorTaskRunnerState == LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.BOOTSTRAPPING) {
-        LOG.info("Skipping {} because load monitor is in {} state.", skipMsg, loadMonitorTaskRunnerState);
-        return true;
-      }
+  /**
+   * Check whether the load monitor state is unavailable (loading or bootstrapping state). Get the state if the load
+   * monitor is unavailable, null otherwise.
+   *
+   * @param loadMonitor Load monitor
+   * @return The state if the load monitor is unavailable, null otherwise.
+   */
+  public static LoadMonitorTaskRunner.LoadMonitorTaskRunnerState isUnavailableState(LoadMonitor loadMonitor) {
+    LoadMonitorTaskRunner.LoadMonitorTaskRunnerState loadMonitorTaskRunnerState = loadMonitor.taskRunnerState();
+    if (loadMonitorTaskRunnerState == LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.LOADING ||
+        loadMonitorTaskRunnerState == LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.BOOTSTRAPPING) {
+      return loadMonitorTaskRunnerState;
     }
-    return false;
+    return null;
   }
 
-  public static boolean meetCompletenessRequirements(LoadMonitor loadMonitor, Collection<Goal> goals, String skipMsg) {
-    // loadMonitor is null for unit tests.
-    if (loadMonitor != null) {
-      for (Goal goal : goals) {
-        if (loadMonitor.meetCompletenessRequirements(goal.clusterModelCompletenessRequirements())) {
-          LOG.debug("Skipping {} for {} because load completeness requirement is not met.",
-                    skipMsg, goals.stream().map(Goal::name).collect(Collectors.toList()));
-          return false;
-        }
+  /**
+   * Check whether the completeness requirements are satisfied for the given goals.
+   *
+   * @param loadMonitor Load monitor of the cluster.
+   * @param goals Goals for which the completeness requirements will be checked. an empty collection of goals represents
+   *              all goals.
+   * @return True if the completeness requirements are satisfied for the given goals, false otherwise.
+   */
+  public static boolean meetCompletenessRequirements(LoadMonitor loadMonitor, Collection<Goal> goals) {
+    for (Goal goal : goals) {
+      if (!loadMonitor.meetCompletenessRequirements(goal.clusterModelCompletenessRequirements())) {
+        return false;
       }
     }
     return true;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ViolationUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ViolationUtils.java
@@ -4,10 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.detector;
 
-import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
-import com.linkedin.kafka.cruisecontrol.monitor.LoadMonitor;
 import com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunner;
-import java.util.Collection;
 
 
 public class ViolationUtils {
@@ -17,35 +14,13 @@ public class ViolationUtils {
   }
 
   /**
-   * Check whether the load monitor state is unavailable (loading or bootstrapping state). Get the state if the load
-   * monitor is unavailable, null otherwise.
+   * Check whether the load monitor state is unavailable -- i.e. loading or bootstrapping state.
    *
-   * @param loadMonitor Load monitor
-   * @return The state if the load monitor is unavailable, null otherwise.
+   * @param loadMonitorTaskRunnerState Load monitor task runner state.
+   * @return True if the load monitor is unavailable, false otherwise.
    */
-  public static LoadMonitorTaskRunner.LoadMonitorTaskRunnerState isUnavailableState(LoadMonitor loadMonitor) {
-    LoadMonitorTaskRunner.LoadMonitorTaskRunnerState loadMonitorTaskRunnerState = loadMonitor.taskRunnerState();
-    if (loadMonitorTaskRunnerState == LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.LOADING ||
-        loadMonitorTaskRunnerState == LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.BOOTSTRAPPING) {
-      return loadMonitorTaskRunnerState;
-    }
-    return null;
-  }
-
-  /**
-   * Check whether the completeness requirements are satisfied for the given goals.
-   *
-   * @param loadMonitor Load monitor of the cluster.
-   * @param goals Goals for which the completeness requirements will be checked. an empty collection of goals represents
-   *              all goals.
-   * @return True if the completeness requirements are satisfied for the given goals, false otherwise.
-   */
-  public static boolean meetCompletenessRequirements(LoadMonitor loadMonitor, Collection<Goal> goals) {
-    for (Goal goal : goals) {
-      if (!loadMonitor.meetCompletenessRequirements(goal.clusterModelCompletenessRequirements())) {
-        return false;
-      }
-    }
-    return true;
+  public static boolean isUnavailableState(LoadMonitorTaskRunner.LoadMonitorTaskRunnerState loadMonitorTaskRunnerState) {
+    return loadMonitorTaskRunnerState == LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.LOADING
+           || loadMonitorTaskRunnerState == LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.BOOTSTRAPPING;
   }
 }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -4,19 +4,16 @@
 
 package com.linkedin.kafka.cruisecontrol.detector;
 
-import com.linkedin.kafka.cruisecontrol.CruiseControlUnitTestUtils;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlState;
-import com.linkedin.kafka.cruisecontrol.analyzer.AnalyzerUtils;
 import com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress;
 import com.linkedin.kafka.cruisecontrol.common.KafkaCruiseControlThreadFactory;
-import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.detector.notifier.AnomalyNotificationResult;
 import com.linkedin.kafka.cruisecontrol.detector.notifier.AnomalyNotifier;
 import com.linkedin.kafka.cruisecontrol.exception.KafkaCruiseControlException;
 import com.linkedin.kafka.cruisecontrol.executor.ExecutorState;
+import com.linkedin.kafka.cruisecontrol.monitor.LoadMonitor;
 import java.util.Collections;
-import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ScheduledExecutorService;
@@ -77,7 +74,7 @@ public class AnomalyDetectorTest {
 
     AnomalyDetector anomalyDetector = new AnomalyDetector(anomalies, 3000L, mockKafkaCruiseControl, mockAnomalyNotifier,
                                                           mockGoalViolationDetector, mockBrokerFailureDetector,
-                                                          mockDetectorScheduler);
+                                                          mockDetectorScheduler, EasyMock.mock(LoadMonitor.class));
 
     try {
       anomalyDetector.startDetection();
@@ -130,9 +127,7 @@ public class AnomalyDetectorTest {
                                                      EasyMock.eq(null),
                                                      EasyMock.anyObject(OperationProgress.class)))
             .andReturn(null);
-    Properties props = CruiseControlUnitTestUtils.getCruiseControlProperties();
-    EasyMock.expect(mockKafkaCruiseControl.goalsByPriority(EasyMock.anyObject())).andReturn(
-        AnalyzerUtils.getGoalMapByPriority(new KafkaCruiseControlConfig(props)));
+    EasyMock.expect(mockKafkaCruiseControl.meetCompletenessRequirements(EasyMock.anyObject())).andReturn(true);
 
     EasyMock.replay(mockAnomalyNotifier);
     EasyMock.replay(mockBrokerFailureDetector);
@@ -142,7 +137,7 @@ public class AnomalyDetectorTest {
 
     AnomalyDetector anomalyDetector = new AnomalyDetector(anomalies, 3000L, mockKafkaCruiseControl, mockAnomalyNotifier,
                                                           mockGoalViolationDetector, mockBrokerFailureDetector,
-                                                          mockDetectorScheduler);
+                                                          mockDetectorScheduler, EasyMock.mock(LoadMonitor.class));
 
     try {
       anomalyDetector.startDetection();
@@ -205,7 +200,7 @@ public class AnomalyDetectorTest {
 
     AnomalyDetector anomalyDetector = new AnomalyDetector(anomalies, 3000L, mockKafkaCruiseControl, mockAnomalyNotifier,
                                                           mockGoalViolationDetector, mockBrokerFailureDetector,
-                                                          mockDetectorScheduler);
+                                                          mockDetectorScheduler, EasyMock.mock(LoadMonitor.class));
 
     try {
       anomalyDetector.startDetection();
@@ -234,7 +229,8 @@ public class AnomalyDetectorTest {
 
     AnomalyDetector anomalyDetector = new AnomalyDetector(new LinkedBlockingDeque<>(), 3000L, mockKafkaCruiseControl,
                                                           mockAnomalyNotifier, mockGoalViolationDetector,
-                                                          mockBrokerFailureDetector, detectorScheduler);
+                                                          mockBrokerFailureDetector, detectorScheduler,
+                                                          EasyMock.mock(LoadMonitor.class));
 
     anomalyDetector.shutdown();
     Thread t = new Thread(anomalyDetector::shutdown);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -4,15 +4,19 @@
 
 package com.linkedin.kafka.cruisecontrol.detector;
 
+import com.linkedin.kafka.cruisecontrol.CruiseControlUnitTestUtils;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlState;
+import com.linkedin.kafka.cruisecontrol.analyzer.AnalyzerUtils;
 import com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress;
 import com.linkedin.kafka.cruisecontrol.common.KafkaCruiseControlThreadFactory;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.detector.notifier.AnomalyNotificationResult;
 import com.linkedin.kafka.cruisecontrol.detector.notifier.AnomalyNotifier;
 import com.linkedin.kafka.cruisecontrol.exception.KafkaCruiseControlException;
 import com.linkedin.kafka.cruisecontrol.executor.ExecutorState;
 import java.util.Collections;
+import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ScheduledExecutorService;
@@ -126,6 +130,9 @@ public class AnomalyDetectorTest {
                                                      EasyMock.eq(null),
                                                      EasyMock.anyObject(OperationProgress.class)))
             .andReturn(null);
+    Properties props = CruiseControlUnitTestUtils.getCruiseControlProperties();
+    EasyMock.expect(mockKafkaCruiseControl.goalsByPriority(EasyMock.anyObject())).andReturn(
+        AnalyzerUtils.getGoalMapByPriority(new KafkaCruiseControlConfig(props)));
 
     EasyMock.replay(mockAnomalyNotifier);
     EasyMock.replay(mockBrokerFailureDetector);


### PR DESCRIPTION
When self healing is enabled, if the anomaly detector fix attempt fails due to (1) `LOADING` or `BOOTSTRAPPING` `loadMonitorTaskRunnerState` or (2) being unable to meet the model completeness requirements, the `IllegalArgumentException` thrown by the goal optimizer is not handled.
This patch catches the exception and logs it in warn level. These warnings are expected to be transient -- i.e. when the state is `RUNNING` and the model completeness is met upon sufficient data collection.