### PR TITLE
Detect if Kafka cluster is reporting no alive brokers before creating sample store topics.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
@@ -132,7 +132,11 @@ public class KafkaSampleStore implements SampleStore {
     Properties props = new Properties();
     props.setProperty(LogConfig.RetentionMsProp(), Long.toString(retentionMs));
     props.setProperty(LogConfig.CleanupPolicyProp(), DEFAULT_CLEANUP_POLICY);
-    int replicationFactor = Math.min(2, zkUtils.getAllBrokersInCluster().size());
+    int numberOfBrokersInCluster = zkUtils.getAllBrokersInCluster().size();
+    if (numberOfBrokersInCluster == 0) {
+      throw new IllegalStateException("Kafka cluster has no alive brokers.");
+    }
+    int replicationFactor = Math.min(2, numberOfBrokersInCluster);
     if (!topics.containsKey(_partitionMetricSampleStoreTopic)) {
       AdminUtils.createTopic(zkUtils, _partitionMetricSampleStoreTopic, 32, replicationFactor, props, RackAwareMode.Safe$.MODULE$);
     } else {


### PR DESCRIPTION
Identifies the occurrence of cases mentioned in Issue https://github.com/linkedin/cruise-control/issues/155.