### PR TITLE
Simplifying the KafkaAssignerDiskUsageDistributionGoal logic.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/internals/BrokerAndSortedReplicas.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/internals/BrokerAndSortedReplicas.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ *
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.goals.internals;
+
+import com.linkedin.kafka.cruisecontrol.model.Broker;
+import com.linkedin.kafka.cruisecontrol.model.Replica;
+import java.util.Comparator;
+import java.util.NavigableSet;
+import java.util.TreeSet;
+
+
+/**
+ * A class that maintains the broker and a sorted set of replicas based on a given comparator.
+ */
+public class BrokerAndSortedReplicas {
+  private final Broker _broker;
+  private final NavigableSet<Replica> sortedReplicas;
+
+  public BrokerAndSortedReplicas(Broker broker, Comparator<Replica> comparator) {
+    _broker = broker;
+    sortedReplicas = new TreeSet<>((r1, r2) -> {
+      int result = comparator.compare(r1, r2);
+      return result == 0 ? r1.compareTo(r2) : result;
+    });
+    sortedReplicas.addAll(broker.replicas());
+  }
+
+  public Broker broker() {
+    return _broker;
+  }
+
+  public NavigableSet<Replica> sortedReplicas() {
+    return sortedReplicas;
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/internals/BrokerAndSortedReplicas.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/internals/BrokerAndSortedReplicas.java
@@ -9,7 +9,6 @@ import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.model.Replica;
 import java.util.Comparator;
 import java.util.NavigableSet;
-import java.util.Set;
 import java.util.TreeSet;
 
 
@@ -27,19 +26,6 @@ public class BrokerAndSortedReplicas {
       return result == 0 ? r1.compareTo(r2) : result;
     });
     sortedReplicas.addAll(broker.replicas());
-  }
-
-  public BrokerAndSortedReplicas(Broker broker, Set<String> exclucedTopics, Comparator<Replica> comparator) {
-    _broker = broker;
-    sortedReplicas = new TreeSet<>((r1, r2) -> {
-      int result = comparator.compare(r1, r2);
-      return result == 0 ? r1.compareTo(r2) : result;
-    });
-    broker.replicas().forEach(r -> {
-      if (!exclucedTopics.contains(r.topicPartition().topic())) {
-        sortedReplicas.add(r);
-      }
-    });
   }
 
   public Broker broker() {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/internals/BrokerAndSortedReplicas.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/internals/BrokerAndSortedReplicas.java
@@ -9,6 +9,7 @@ import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.model.Replica;
 import java.util.Comparator;
 import java.util.NavigableSet;
+import java.util.Set;
 import java.util.TreeSet;
 
 
@@ -28,11 +29,35 @@ public class BrokerAndSortedReplicas {
     sortedReplicas.addAll(broker.replicas());
   }
 
+  public BrokerAndSortedReplicas(Broker broker, Set<String> exclucedTopics, Comparator<Replica> comparator) {
+    _broker = broker;
+    sortedReplicas = new TreeSet<>((r1, r2) -> {
+      int result = comparator.compare(r1, r2);
+      return result == 0 ? r1.compareTo(r2) : result;
+    });
+    broker.replicas().forEach(r -> {
+      if (!exclucedTopics.contains(r.topicPartition().topic())) {
+        sortedReplicas.add(r);
+      }
+    });
+  }
+
   public Broker broker() {
     return _broker;
   }
 
   public NavigableSet<Replica> sortedReplicas() {
     return sortedReplicas;
+  }
+
+  @Override
+  public int hashCode() {
+    return _broker.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj != null && obj instanceof BrokerAndSortedReplicas
+        && _broker.equals(((BrokerAndSortedReplicas) obj).broker());
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Replica.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Replica.java
@@ -24,6 +24,9 @@ import org.apache.kafka.common.TopicPartition;
  * object is created as part of a broker structure.
  */
 public class Replica implements Serializable, Comparable<Replica> {
+  // Two static final variables for comparison purpose.
+  public static final Replica MIN_REPLICA = new Replica(null, null, false);
+  public static final Replica MAX_REPLICA = new Replica(null, null, false);
   private final TopicPartition _tp;
   private final Load _load;
   private final Broker _originalBroker;


### PR DESCRIPTION
1. Avoid unnecessary sort of the replicas in the brokers.
2. Use TreeSet instead of implementing binary search on list.
3. Speed up the test by avoid unnecessary sort. After the change the test time reduced from 20 min to 11 min.