### PR TITLE
Fix the compatibility version to 0.11.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Cruise Control for Apache Kafka
     * Rebalance the cluster
 
 ### Environment Requirements
-* The current master branch of Cruise Control is compatible with Apache Kafka 0.10.1 and above
+* The current master branch of Cruise Control is compatible with Apache Kafka 0.11.0.0 and above
 * message.format.version 0.10.0 and above is needed
 * The master branch compiles with Scala 2.11
 


### PR DESCRIPTION
Current implementation relies on replicas list returned from a broker to have the same order as in zookeeper.
But due to https://issues.apache.org/jira/browse/KAFKA-5329 it's not guaranteed in Kafka < 0.11.0.0.

As an alternative we can change the implementation to not rely on the specific followers order.