### PR TITLE
Add status tracking for leadership movement.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -103,6 +103,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
   private static final int JSON_VERSION = 1;
 
   private static final String PARTITION_MOVEMENTS = "partition movements";
+  private static final String LEADERSHIP_MOVEMENTS = "leadership movements";
 
   private static final Map<EndPoint, Set<String>> VALID_ENDPOINT_PARAM_NAMES;
   static {
@@ -758,13 +759,13 @@ public class KafkaCruiseControlServlet extends HttpServlet {
     boolean json = wantJSON(request);
     try {
       String verboseString = request.getParameter(VERBOSE_PARAM);
-      verbose = verboseString != null && Boolean.parseBoolean(verboseString);
+      verbose = Boolean.parseBoolean(verboseString);
 
       goals = getGoals(request);
       dataFrom = getDataFrom(request);
 
       String ignoreProposalCacheString = request.getParameter(IGNORE_PROPOSAL_CACHE_PARAM);
-      ignoreProposalCache = (ignoreProposalCacheString != null && Boolean.parseBoolean(ignoreProposalCacheString))
+      ignoreProposalCache = (Boolean.parseBoolean(ignoreProposalCacheString))
           || !goals.isEmpty();
     } catch (Exception e) {
       StringWriter sw = new StringWriter();
@@ -859,7 +860,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
 
   private boolean wantJSON(HttpServletRequest request) {
     String jsonString = request.getParameter(JSON_PARAM);
-    return jsonString != null && Boolean.parseBoolean(jsonString);
+    return Boolean.parseBoolean(jsonString);
   }
 
   private void writeKafkaClusterState(OutputStream out, SortedSet<PartitionInfo> partitions, int topicNameLength)
@@ -888,7 +889,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
     boolean json = wantJSON(request);
     try {
       String verboseString = request.getParameter(VERBOSE_PARAM);
-      verbose = verboseString != null && Boolean.parseBoolean(verboseString);
+      verbose = Boolean.parseBoolean(verboseString);
     } catch (Exception e) {
       StringWriter sw = new StringWriter();
       e.printStackTrace(new PrintWriter(sw));
@@ -964,9 +965,9 @@ public class KafkaCruiseControlServlet extends HttpServlet {
     boolean json = wantJSON(request);
     try {
       String verboseString = request.getParameter(VERBOSE_PARAM);
-      verbose = verboseString != null && Boolean.parseBoolean(verboseString);
+      verbose = Boolean.parseBoolean(verboseString);
       String superVerboseString = request.getParameter(SUPER_VERBOSE_PARM);
-      superVerbose = superVerboseString != null && Boolean.parseBoolean(superVerboseString);
+      superVerbose = Boolean.parseBoolean(superVerboseString);
     } catch (Exception e) {
       StringWriter sw = new StringWriter();
       e.printStackTrace(new PrintWriter(sw));
@@ -1023,6 +1024,11 @@ public class KafkaCruiseControlServlet extends HttpServlet {
           out.write(String.format("%n%n%s %s:%n", executorState.state() == ExecutorState.State.STOPPING_EXECUTION
                                                   ? "Cancelled" : "Pending", PARTITION_MOVEMENTS).getBytes(StandardCharsets.UTF_8));
           for (ExecutionTask task : executorState.pendingPartitionMovements()) {
+            out.write(String.format("%s%n", task).getBytes(StandardCharsets.UTF_8));
+          }
+        } else if (executorState.state() == ExecutorState.State.LEADER_MOVEMENT_TASK_IN_PROGRESS) {
+          out.write(String.format("%n%nPending %s:%n", LEADERSHIP_MOVEMENTS).getBytes(StandardCharsets.UTF_8));
+          for (ExecutionTask task : executorState.pendingLeadershipMovements()) {
             out.write(String.format("%s%n", task).getBytes(StandardCharsets.UTF_8));
           }
         }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskManagerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskManagerTest.java
@@ -80,7 +80,7 @@ public class ExecutionTaskManagerTest {
       case IN_PROGRESS:
         taskManager.markTasksInProgress(Collections.singletonList(task));
         assertEquals(0, taskManager.remainingPartitionMovements().size());
-        assertEquals(0, taskManager.remainingLeaderMovements().size());
+        assertEquals(0, taskManager.remainingLeadershipMovements().size());
         assertEquals(1, taskManager.inProgressTasks().size());
         assertEquals(0, taskManager.abortingTasks().size());
         assertEquals(0, taskManager.abortedTasks().size());
@@ -89,7 +89,7 @@ public class ExecutionTaskManagerTest {
       case ABORTING:
         taskManager.markTaskAborting(task);
         assertEquals(0, taskManager.remainingPartitionMovements().size());
-        assertEquals(0, taskManager.remainingLeaderMovements().size());
+        assertEquals(0, taskManager.remainingLeadershipMovements().size());
         assertEquals(0, taskManager.inProgressTasks().size());
         assertEquals(1, taskManager.abortingTasks().size());
         assertEquals(0, taskManager.abortedTasks().size());
@@ -98,7 +98,7 @@ public class ExecutionTaskManagerTest {
       case DEAD:
         taskManager.markTaskDead(task);
         assertEquals(0, taskManager.remainingPartitionMovements().size());
-        assertEquals(0, taskManager.remainingLeaderMovements().size());
+        assertEquals(0, taskManager.remainingLeadershipMovements().size());
         assertEquals(0, taskManager.inProgressTasks().size());
         assertEquals(0, taskManager.abortingTasks().size());
         assertEquals(0, taskManager.abortedTasks().size());
@@ -109,7 +109,7 @@ public class ExecutionTaskManagerTest {
         ExecutionTask.State origState = task.state();
         taskManager.markTaskDone(task);
         assertEquals(0, taskManager.remainingPartitionMovements().size());
-        assertEquals(0, taskManager.remainingLeaderMovements().size());
+        assertEquals(0, taskManager.remainingLeadershipMovements().size());
         assertEquals(0, taskManager.inProgressTasks().size());
         assertEquals(0, taskManager.abortingTasks().size());
         assertEquals(origState == ExecutionTask.State.ABORTING ? 1 : 0, taskManager.abortedTasks().size());

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlannerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlannerTest.java
@@ -91,13 +91,13 @@ public class ExecutionTaskPlannerTest {
                                           Collections.<String>emptySet());
 
     planner.addExecutionProposals(proposals, expectedCluster);
-    List<ExecutionTask> leaderMovementTasks = planner.getLeaderMovementTasks(2);
+    List<ExecutionTask> leaderMovementTasks = planner.getLeadershipMovementTasks(2);
     assertEquals("2 of the leader movements should return in one batch", 2, leaderMovementTasks.size());
     assertEquals(1, leaderMovementTasks.get(0).executionId());
     assertEquals(leaderMovementTasks.get(0).proposal(), leaderMovement1);
     assertEquals(3, leaderMovementTasks.get(1).executionId());
     assertEquals(leaderMovementTasks.get(1).proposal(), leaderMovement2);
-    leaderMovementTasks = planner.getLeaderMovementTasks(2);
+    leaderMovementTasks = planner.getLeadershipMovementTasks(2);
     assertEquals("2 of the leader movements should return in one batch", 2, leaderMovementTasks.size());
     assertEquals(5, leaderMovementTasks.get(0).executionId());
     assertEquals(leaderMovementTasks.get(0).proposal(), leaderMovement3);
@@ -205,11 +205,11 @@ public class ExecutionTaskPlannerTest {
 
     planner.addExecutionProposals(proposals, expectedCluster);
     assertEquals(1, planner.remainingDataToMoveInMB());
-    assertEquals(2, planner.remainingLeaderMovements().size());
+    assertEquals(2, planner.remainingLeadershipMovements().size());
     assertEquals(2, planner.remainingReplicaMovements().size());
     planner.clear();
     assertEquals(0, planner.remainingDataToMoveInMB());
-    assertEquals(0, planner.remainingLeaderMovements().size());
+    assertEquals(0, planner.remainingLeadershipMovements().size());
     assertEquals(0, planner.remainingReplicaMovements().size());
   }
 }


### PR DESCRIPTION
Status tracking for leadership movements for the number of finished tasks, total tasks, and details of each pending task (in verbose mode).