### PR TITLE
The linear regression improvements to cruise-control-core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,8 +69,10 @@ project(':cruise-control-core') {
 
   dependencies {
     compile "org.slf4j:slf4j-api:1.7.25"
+    compile "org.slf4j:slf4j-log4j12:1.7.25"
     compile 'junit:junit:4.12'
     compile 'org.apache.commons:commons-math3:3.6.1'
+    compile 'com.google.code.gson:gson:2.7'
 
     testOutput sourceSets.test.output
   }
@@ -121,6 +123,7 @@ project(':cruise-control') {
     compile project(':cruise-control-metrics-reporter')
     compile project(':cruise-control-core')
     compile "org.slf4j:slf4j-api:1.7.25"
+    compile "org.slf4j:slf4j-log4j12:1.7.25"
     compile "org.apache.zookeeper:zookeeper:3.4.6"
     compile "org.apache.kafka:kafka_2.11:0.11.0.2"
     compile 'org.apache.kafka:kafka-clients:0.11.0.2'
@@ -167,6 +170,7 @@ project(':cruise-control-metrics-reporter') {
 
   dependencies {
     compile "org.slf4j:slf4j-api:1.7.25"
+    compile "org.slf4j:slf4j-log4j12:1.7.25"
     compile "org.apache.kafka:kafka_2.11:0.11.0.2"
     compile 'org.apache.kafka:kafka-clients:0.11.0.2'
     compile 'junit:junit:4.12'

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/metricdef/MetricInfo.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/metricdef/MetricInfo.java
@@ -4,10 +4,13 @@
 
 package com.linkedin.cruisecontrol.metricdef;
 
+import java.util.Objects;
+
+
 /**
  * The metric information including the name, id, the way of interpretation and the metric group name.
  */
-public class MetricInfo {
+public class MetricInfo implements Comparable<MetricInfo> {
   private final String _name;
   private final int _id;
   private final AggregationFunction _aggregationFunction;
@@ -52,5 +55,24 @@ public class MetricInfo {
   @Override
   public String toString() {
     return String.format("(name=%s, id=%d, aggregationFunction=%s)", _name, _id, _aggregationFunction);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_name, _id, _aggregationFunction);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null || !(obj instanceof MetricInfo)) {
+      return false;
+    }
+    MetricInfo o = (MetricInfo) obj;
+    return _name.equals(o.name()) && _id == o.id() && _aggregationFunction == o.aggregationFunction();
+  }
+
+  @Override
+  public int compareTo(MetricInfo o) {
+    return Integer.compare(_id, o.id());
   }
 }

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/estimator/MetricEstimator.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/estimator/MetricEstimator.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.cruisecontrol.model.estimator;
+
+import com.linkedin.cruisecontrol.common.CruiseControlConfigurable;
+import com.linkedin.cruisecontrol.metricdef.MetricInfo;
+import com.linkedin.cruisecontrol.model.Entity;
+import com.linkedin.cruisecontrol.monitor.sampling.MetricSample;
+import com.linkedin.cruisecontrol.monitor.sampling.aggregator.AggregatedMetricValues;
+import com.linkedin.cruisecontrol.monitor.sampling.aggregator.MetricValues;
+import java.util.Collection;
+
+
+/**
+ * An interface for the resultant metric estimator. The implementation should take in the provided training data
+ * and estimate the resultant metrics when the causal metrics changes.
+ */
+public interface MetricEstimator extends CruiseControlConfigurable {
+
+  /**
+   * Provide the given {@link MetricSample MetricSamples} as training data to this estimator. The provided training
+   * samples are from MetricSampler. It should contain the resultant metric that this estimator is going to estimate,
+   * as well as the causal metrics related to this resultant metric.
+   *
+   * @param trainingSamples the {@link MetricSample MetricSamples} to train this estimator.
+   */
+  void addTrainingSamples(Collection<? extends MetricSample> trainingSamples);
+
+  /**
+   * Return the training progress of this estimator. The returned value should be between 0.0f and 1.0f, both inclusive.
+   * If the the training is completed, 1.0f should be returned.
+   *
+   * @return the training progress of this estimator.
+   */
+  float trainingProgress();
+
+  /**
+   * Gives a string explaining the training progress in detail. This is for the users who queries the verbose state
+   * of cruise control.
+   *
+   * @return String the detail explanation of the training progress.
+   */
+  String trainingProgressDescription();
+
+  /**
+   * Explicitly train the estimator with the currently available training data provided by
+   * {@link #addTrainingSamples(Collection)}.
+   */
+  void train();
+
+  /**
+   * Given the values of the causal metrics, estimate the values of the resultant metric. The causal metrics
+   * are provided in {@link AggregatedMetricValues}. It may contain multiple windows, The returned {@link MetricValues}
+   * contains the estimated resultant metric in each metric window that are in the given causal metrics.
+   *
+   * @param entity the entity to estimate the resultant metric for.
+   * @param resultantMetric the resultant metrics to estimate.
+   * @param causalMetricValues the causal metrics for the resultant metric to estimate.
+   * @return the estimated resultant metric values.
+   */
+  MetricValues estimate(Entity entity, MetricInfo resultantMetric, AggregatedMetricValues causalMetricValues);
+
+  /**
+   * Given the values of the causal metrics, and potential additions to the causal metrics, estimate the values
+   * of the resultant metric. The causal metrics and potential addtions are provided in {@link AggregatedMetricValues}.
+   * They may contain multiple windows, The returned {@link MetricValues} contains the estimated resultant metric
+   * in each metric window that are in the given causal metrics.
+   *
+   * @param entity the entity to estimate the resultant metric for.
+   * @param resultantMetric the resultant metrics to estimate.
+   * @param causalMetricValues the causal metrics for the resultant metric to estimate.
+   * @param causalMetricValueChanges the changes to the causal metric values.
+   * @param changeType the action of the change, i.e. add or subtract.
+   * @return the estimated resultant metric values.
+   */
+  MetricValues estimate(Entity entity,
+                        MetricInfo resultantMetric,
+                        AggregatedMetricValues causalMetricValues,
+                        AggregatedMetricValues causalMetricValueChanges,
+                        ChangeType changeType);
+
+  /**
+   * Reset the state of the estimator. All the previous training samples and training result should be discarded.
+   */
+  void reset();
+  
+  /**
+   * <p>
+   *   An enum used by {@link #estimate(Entity, MetricInfo, AggregatedMetricValues, AggregatedMetricValues, ChangeType)}
+   *   which indicates whether the given causal metrics changes should added or subtracted from the given causal metric
+   *   values.
+   * </p>
+   * <p>
+   *   A simplified API would have avoided this enum, as the subtraction can be represented by negative values in the
+   *   causal metric values changes. We use ChangeAction so that the caller do not need to negate the values changes
+   *   when the causal metric values of an entity is already available.
+   * </p>
+   */
+  enum ChangeType {
+    ADDITION, SUBTRACTION
+  }
+}

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/estimator/impl/HeterogeneousLinearRegressionEstimator.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/estimator/impl/HeterogeneousLinearRegressionEstimator.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.cruisecontrol.model.estimator.impl;
+
+import com.linkedin.cruisecontrol.metricdef.MetricDef;
+import com.linkedin.cruisecontrol.metricdef.MetricInfo;
+import com.linkedin.cruisecontrol.model.Entity;
+import com.linkedin.cruisecontrol.model.estimator.MetricEstimator;
+import com.linkedin.cruisecontrol.model.regression.LinearRegression;
+import com.linkedin.cruisecontrol.monitor.sampling.MetricSample;
+import com.linkedin.cruisecontrol.monitor.sampling.aggregator.AggregatedMetricValues;
+import com.linkedin.cruisecontrol.monitor.sampling.aggregator.MetricValues;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.linkedin.cruisecontrol.model.estimator.impl.LinearRegressionEstimator.CAUSAL_RELATION_DEFINITION_FILE_CONFIG;
+
+
+/**
+ * An abstract linear regression estimator that supports heterogeneous entities. It is a wrapper around
+ * {@link LinearRegressionEstimator} which is used for homogeneous entities.
+ */
+public abstract class HeterogeneousLinearRegressionEstimator implements MetricEstimator {
+  private final ConcurrentMap<String, LinearRegressionEstimator> _estimatorByEntityType;
+  private String _causalRelationDefinitionFile;
+
+  public HeterogeneousLinearRegressionEstimator() {
+    _estimatorByEntityType = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * @return the metric definition to use for linear regression.
+   */
+  protected abstract MetricDef metricDef();
+
+  /**
+   * Get the type of the entity. The entities of the same type will share the same {@link LinearRegression}s defined
+   * in the causal relation.
+   *
+   * @return a string describing the type of the entity.
+   */
+  protected abstract String entityType(Entity entity);
+
+  @Override
+  public void addTrainingSamples(Collection<? extends MetricSample> trainingSamples) {
+    Map<String, List<MetricSample>> metricSamplesByType = getMetricSamplesByType(trainingSamples);
+    metricSamplesByType.forEach((type, samples) -> {
+      LinearRegressionEstimator homogeneousEstimator =
+          _estimatorByEntityType.computeIfAbsent(type, t -> createHomogeneousEstimator());
+      homogeneousEstimator.addTrainingSamples(samples);
+    });
+  }
+
+  @Override
+  public float trainingProgress() {
+    float result = 0.0f;
+    for (LinearRegressionEstimator homogeneousEstimator : _estimatorByEntityType.values()) {
+      result += homogeneousEstimator.trainingProgress();
+    }
+    return result / _estimatorByEntityType.size();
+  }
+
+  @Override
+  public String trainingProgressDescription() {
+    StringJoiner sj = new StringJoiner("\n");
+    for (Map.Entry<String, LinearRegressionEstimator> entry : _estimatorByEntityType.entrySet()) {
+      sj.add(String.format("Progress for entity type %s: %n%s",
+                           entry.getKey(), entry.getValue().trainingProgressDescription()));
+    }
+    return sj.toString();
+  }
+
+  @Override
+  public void train() {
+    _estimatorByEntityType.values().forEach(LinearRegressionEstimator::train);
+  }
+
+  @Override
+  public MetricValues estimate(Entity entity, MetricInfo resultantMetric, AggregatedMetricValues causalMetricValues) {
+    String entityType = entityType(entity);
+    LinearRegressionEstimator estimator = _estimatorByEntityType.get(entityType);
+    if (estimator == null) {
+      throw new IllegalStateException(String.format("Cannot estimate %s for %s because the estimator does not exist "
+                                                        + "for type %s", resultantMetric.name(), entity, entityType));
+    }
+    return estimator.estimate(entity, resultantMetric, causalMetricValues);
+  }
+
+  @Override
+  public MetricValues estimate(Entity entity,
+                               MetricInfo resultantMetric,
+                               AggregatedMetricValues causalMetricValues,
+                               AggregatedMetricValues causalMetricValueChanges,
+                               ChangeType changeType) {
+    String entityType = entityType(entity);
+    LinearRegressionEstimator estimator = _estimatorByEntityType.get(entityType);
+    if (estimator == null) {
+      throw new IllegalStateException(String.format("Cannot estimate %s for %s because the estimator does not exist "
+                                                        + "for type %s", resultantMetric.name(), entity, entityType));
+    }
+    return estimator.estimate(entity, resultantMetric, causalMetricValues, causalMetricValueChanges, changeType);
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    _causalRelationDefinitionFile = (String) configs.get(CAUSAL_RELATION_DEFINITION_FILE_CONFIG);
+  }
+
+  @Override
+  public void reset() {
+    _estimatorByEntityType.values().forEach(LinearRegressionEstimator::reset);
+  }
+
+  private LinearRegressionEstimator createHomogeneousEstimator() {
+    Map<String, String> configs =
+        Collections.singletonMap(LinearRegressionEstimator.CAUSAL_RELATION_DEFINITION_FILE_CONFIG,
+                                 _causalRelationDefinitionFile);
+    // create a homogeneous estimator and configure it.
+    LinearRegressionEstimator homogeneousEstimator = new HomogeneousLinearRegressionEstimator(this);
+    homogeneousEstimator.configure(configs);
+    return homogeneousEstimator;
+  }
+
+  private Map<String, List<MetricSample>> getMetricSamplesByType(Collection<? extends MetricSample> metricSamples) {
+    Map<String, List<MetricSample>> samplesByType = new HashMap<>();
+    metricSamples.forEach(sample -> samplesByType.computeIfAbsent(entityType(sample.entity()), type -> new ArrayList<>())
+                                                 .add(sample));
+    return samplesByType;
+  }
+
+  /**
+   * A static concrete class that provides the metric def of this heterogeneous linear regression.
+   */
+  private static class HomogeneousLinearRegressionEstimator extends LinearRegressionEstimator {
+    private final HeterogeneousLinearRegressionEstimator _heterogeneousEstimator;
+
+    private HomogeneousLinearRegressionEstimator(HeterogeneousLinearRegressionEstimator heterogeneousEstimator) {
+      _heterogeneousEstimator = heterogeneousEstimator;
+    }
+
+    @Override
+    protected MetricDef metricDef() {
+      return _heterogeneousEstimator.metricDef();
+    }
+
+  }
+}

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/estimator/impl/LinearRegressionEstimator.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/estimator/impl/LinearRegressionEstimator.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.cruisecontrol.model.estimator.impl;
+
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
+import com.linkedin.cruisecontrol.CruiseControlUtils;
+import com.linkedin.cruisecontrol.common.config.ConfigException;
+import com.linkedin.cruisecontrol.metricdef.MetricDef;
+import com.linkedin.cruisecontrol.metricdef.MetricInfo;
+import com.linkedin.cruisecontrol.model.Entity;
+import com.linkedin.cruisecontrol.model.estimator.MetricEstimator;
+import com.linkedin.cruisecontrol.model.regression.LinearRegression;
+import com.linkedin.cruisecontrol.monitor.sampling.MetricSample;
+import com.linkedin.cruisecontrol.monitor.sampling.aggregator.AggregatedMetricValues;
+import com.linkedin.cruisecontrol.monitor.sampling.aggregator.MetricValues;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.stream.Collectors.toList;
+
+
+/**
+ * An abstract class that implements the {@link MetricEstimator} using {@link LinearRegression}.
+ * <p>
+ *   This class reads the causal relations from a config file in the following format:
+ * </p>
+ * <pre>
+ *   {
+ *     "linearRegressions": [
+ *       {
+ *         "name": "regression_1",
+ *         "causalMetrics": ["CausalMetric_1", "CausalMetric_2", "CausalMetric_3"],
+ *         "resultantMetrics": ["ResultantMetric_1", "ResultantMetric_2"],
+ *         "numValueBuckets": 20,
+ *         "numBucketsToCapForFairness": 10,
+ *         "maxSamplesPerBucket": 50,
+ *         "maxExponent": 2,
+ *         "errorStatsWindowSize": 1000
+ *       },
+ *       {
+ *         "name": "regression_2",
+ *         "causalMetrics": ["CausalMetric_1", "CausalMetric_2"],
+ *         "resultantMetrics": ["ResultantMetric_3", "ResultantMetric_4"],
+ *         "numValueBuckets": 20,
+ *         "numBucketsToCapForFairness": 10,
+ *         "maxSamplesPerBucket": 50,
+ *         "maxExponent": 2,
+ *         "errorStatsWindowSize": 1000
+ *       },
+ *       ...
+ *     ]
+ *   }
+ * </pre>
+ * The each regression may contain multiple resultant metrics if they share the same causal metrics. These resultant
+ * metrics are, however, independent to each other.
+ *
+ * This estimator assumes all the metric samples share the same linear regression model, i.e. this estimator assumes
+ * homogeneous entities. The {@link #estimate(Entity, MetricInfo, AggregatedMetricValues)} call ignores the passed
+ * in entities. Use {@link HeterogeneousLinearRegressionEstimator} for heterogeneous use cases.
+ */
+public abstract class LinearRegressionEstimator implements MetricEstimator {
+  private static final Logger LOG = LoggerFactory.getLogger(LinearRegressionEstimator.class);
+  public static final String CAUSAL_RELATION_DEFINITION_FILE_CONFIG = "causal.relation.definition.file";
+  private final Map<String, LinearRegression> _linearRegressionMap;
+  private final Map<MetricInfo, SortedSet<LinearRegression>> _linearRegressionsByResultantMetrics;
+
+  public LinearRegressionEstimator() {
+    _linearRegressionMap = new HashMap<>();
+    _linearRegressionsByResultantMetrics = new HashMap<>();
+  }
+
+  /**
+   * @return the metric definition to use for linear regression.
+   */
+  protected abstract MetricDef metricDef();
+
+  @Override
+  public void addTrainingSamples(Collection<? extends MetricSample> trainingSamples) {
+    _linearRegressionMap.values().forEach(lr -> lr.addMetricSamples(trainingSamples));
+    updateLinearRegressionRank();
+  }
+
+  @Override
+  public float trainingProgress() {
+    double progress = 0.0f;
+    for (LinearRegression lr : _linearRegressionMap.values()) {
+      progress = Math.max(progress, lr.modelCoefficientTrainingCompleteness());
+    }
+    return (float) progress / _linearRegressionMap.size();
+  }
+
+  @Override
+  public String trainingProgressDescription() {
+    StringBuilder sb = new StringBuilder();
+    for (Map.Entry<String, LinearRegression> entry : _linearRegressionMap.entrySet()) {
+      String name = entry.getKey();
+      LinearRegression lr = entry.getValue();
+      sb.append(name).append(": \n").append(lr.modelState()).append("\n\n");
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public void train() {
+    _linearRegressionMap.values().forEach(LinearRegression::updateModelCoefficient);
+  }
+
+  @Override
+  public MetricValues estimate(Entity entity, MetricInfo resultantMetric, AggregatedMetricValues causalMetricValues) {
+    LinearRegression bestRegression = bestLinearRegression(resultantMetric);
+    return bestRegression.estimate(resultantMetric, causalMetricValues, null, null);
+  }
+
+  @Override
+  public MetricValues estimate(Entity entity,
+                               MetricInfo resultantMetric,
+                               AggregatedMetricValues causalMetricValues,
+                               AggregatedMetricValues causalMetricValueChanges,
+                               ChangeType changeType) {
+    LinearRegression bestRegression = bestLinearRegression(resultantMetric);
+    return bestRegression.estimate(resultantMetric, causalMetricValues, causalMetricValueChanges, changeType);
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    String linearRegressionDefinitionFile = (String) configs.get(CAUSAL_RELATION_DEFINITION_FILE_CONFIG);
+    CruiseControlUtils.ensureValidString(CAUSAL_RELATION_DEFINITION_FILE_CONFIG, linearRegressionDefinitionFile);
+    try {
+      loadLinearRegressions(linearRegressionDefinitionFile);
+    } catch (FileNotFoundException e) {
+      throw new ConfigException("Linear regression definition file " + linearRegressionDefinitionFile
+                                    + " is not found.", e);
+    }
+  }
+
+  @Override
+  public void reset() {
+    _linearRegressionMap.values().forEach(LinearRegression::reset);
+  }
+
+  // Methods specific to the linear regression.
+  /**
+   * From the best linear regression, get the coefficients of the given causal metric for the given resultant metric 
+   * with all the exponents.
+   *
+   * @param resultantMetric the resultant metric to get the coefficients for.
+   * @param causalMetric the causal metric whose coefficients should be returned.
+   * @return A mapping from exponents to the coefficient of the given causal metric and resultant metric combination.
+   */
+  public Map<Integer, Double> getCoefficients(MetricInfo resultantMetric, MetricInfo causalMetric) {
+    return bestLinearRegression(resultantMetric).getCoefficients(resultantMetric, causalMetric);
+  }
+
+  /**
+   * Estimate the average value of the given resultant metric using the average values of the given causal metrics.
+   *
+   * @param resultantMetric the resultant metric whose value is to be estimated.
+   * @param causalMetricValues the causal metrics values.
+   * @return the estimated average value of the given resultant metric.
+   */
+  public double estimateAvg(MetricInfo resultantMetric, AggregatedMetricValues causalMetricValues) {
+    return bestLinearRegression(resultantMetric).estimateAvg(resultantMetric, causalMetricValues);
+  }
+
+  /**
+   * Get the estimation error statistics of the best linear regression for the given resultant metric.
+   * 
+   * @param resultantMetric the resultant metric to get the estimation error statistics.
+   * @return the estimation error statistics of this linear regression for the given resultant metric
+   */
+  public DescriptiveStatistics estimationErrorStats(MetricInfo resultantMetric) {
+    return bestLinearRegression(resultantMetric).estimationErrorStats(resultantMetric);
+  }
+
+  /**
+   * Get the state of this best linear regression for the given resultant metric.
+   * 
+   * @return the state of this linear regression.
+   */
+  public LinearRegression.LinearRegressionState modelState(MetricInfo resultantMetric) {
+    return bestLinearRegression(resultantMetric).modelState();
+  }
+  
+  // Package private methods only for unit test.
+  Map<String, LinearRegression> linearRegressions() {
+    return _linearRegressionMap;
+  }
+  
+  Map<MetricInfo, SortedSet<LinearRegression>> linearRegressionByResultantMetrics() {
+    return _linearRegressionsByResultantMetrics;
+  }
+  
+  // private helper methods.
+  /**
+   * Get the best linear regression for the resultant metric. 
+   * The best linear regression is defined using {@link LinearRegressionComparator}.
+   * Package private for unit test.
+   * 
+   * @param resultantMetric the resultant metric to get the the best linear regression. 
+   * @return the best linear regression for the given resultant metric.
+   */
+  LinearRegression bestLinearRegression(MetricInfo resultantMetric) {
+    LinearRegression bestRegression = _linearRegressionsByResultantMetrics.get(resultantMetric).first();
+    if (bestRegression == null || !bestRegression.trainingCompleted(resultantMetric)) {
+      throw new IllegalStateException("The linear regression for resultant metric " + resultantMetric
+                                          + " is not ready.");
+    }
+    return bestRegression;
+  }
+  
+  private void loadLinearRegressions(String linearRegressionDefinitionFile) throws FileNotFoundException {
+    JsonReader reader = null;
+    try {
+      reader = new JsonReader(new InputStreamReader(new FileInputStream(linearRegressionDefinitionFile), StandardCharsets.UTF_8));
+      Gson gson = new Gson();
+      List<LinearRegressionDef> linearRegressionDefList =
+          ((LinearRegressionList) gson.fromJson(reader, LinearRegressionList.class)).linearRegressions;
+      for (LinearRegressionDef linearRegressionDef : linearRegressionDefList) {
+        Set<MetricInfo> resultantMetrics = toMetricInfoSet(linearRegressionDef.resultantMetrics);
+        LinearRegression lr = new LinearRegression(linearRegressionDef.name,
+                                                   resultantMetrics,
+                                                   toMetricInfoSet(linearRegressionDef.causalMetrics),
+                                                   linearRegressionDef.numValueBuckets,
+                                                   linearRegressionDef.numBucketsToCapForFairness,
+                                                   linearRegressionDef.maxSamplesPerBucket,
+                                                   linearRegressionDef.maxExponent,
+                                                   linearRegressionDef.errorStatsWindowSize);
+        if (_linearRegressionMap.put(linearRegressionDef.name, lr) != null) {
+          throw new ConfigException("Linear regression " + linearRegressionDef.name + " is defined more than once.");
+        }
+        for (MetricInfo resultantMetric : resultantMetrics) {
+          _linearRegressionsByResultantMetrics.computeIfAbsent(resultantMetric,
+                                                              rm -> new TreeSet<>(new LinearRegressionComparator(resultantMetric)))
+                                              .add(lr);
+        }
+      }
+    } finally {
+      try {
+        if (reader != null) {
+          reader.close();
+        }
+      } catch (IOException e) {
+        // let it go.
+      }
+    }
+  }
+
+  private void updateLinearRegressionRank() {
+    for (Map.Entry<MetricInfo, SortedSet<LinearRegression>> entry : _linearRegressionsByResultantMetrics.entrySet()) {
+      SortedSet<LinearRegression> linearRegressions = entry.getValue();
+      Set<LinearRegression> temp = new HashSet<>(linearRegressions);
+      linearRegressions.clear();
+      linearRegressions.addAll(temp);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Updated linear regression rank for {} to {}", entry.getKey().name(), 
+                  linearRegressions.stream().map(LinearRegression::name).collect(toList()));
+      }
+      if (LOG.isTraceEnabled()) {
+        for (LinearRegression linearRegression : linearRegressions) {
+          LOG.debug("{} estimation error stats for {}: {}", linearRegression.name(), entry.getKey().name(), 
+                    linearRegression.estimationErrorStats(entry.getKey()));
+        }
+      }
+    }
+  }
+
+  private Set<MetricInfo> toMetricInfoSet(Set<String> metricNames) {
+    Set<MetricInfo> metricInfoSet = new HashSet<>();
+    for (String metricName : metricNames) {
+      metricInfoSet.add(metricDef().metricInfo(metricName));
+    }
+    return metricInfoSet;
+  }
+
+  /**
+   * A class that compares multiple linear regressions for the same resultant metric. The smaller the error
+   * is the higher the linear regression is ranked.
+   */
+  private static class LinearRegressionComparator implements Comparator<LinearRegression> {
+    private final MetricInfo _resultantMetric;
+
+    LinearRegressionComparator(MetricInfo resultantMetric) {
+      _resultantMetric = resultantMetric;
+    }
+
+    @Override
+    public int compare(LinearRegression lr1, LinearRegression lr2) {
+      if (lr1 == lr2) {
+        return 0;
+      }
+      boolean lr1TrainingCompleted = lr1.trainingCompleted(_resultantMetric);
+      boolean lr2TrainingCompleted = lr2.trainingCompleted(_resultantMetric);
+      // First check if the estimation has finished or not.
+      if (lr1TrainingCompleted && !lr2TrainingCompleted) {
+        return -1;
+      } else if (!lr1TrainingCompleted && lr2TrainingCompleted) {
+        return 1;
+      } else if (lr1TrainingCompleted) {
+        // If both are finished, check the error percentile.
+        DescriptiveStatistics errStats1 = lr1.estimationErrorStats(_resultantMetric);
+        DescriptiveStatistics errStats2 = lr2.estimationErrorStats(_resultantMetric);
+        // Compare the errors in this percentile order.
+        for (double percentile : Arrays.asList(95.0, 90.0, 75.0, 50.0)) {
+          int result = Double.compare(errStats1.getPercentile(percentile), errStats2.getPercentile(percentile));
+          if (result != 0) {
+            return result;
+          }
+        }
+      }
+      // Lastly check the name.
+      return lr1.name().compareTo(lr2.name());
+    }
+  }
+
+  /**
+   * Classes for JSON parsing using GSON.
+   */
+  private static class LinearRegressionList {
+    List<LinearRegressionDef> linearRegressions;
+  }
+
+  private static class LinearRegressionDef {
+    String name;
+    Set<String> causalMetrics;
+    Set<String> resultantMetrics;
+    int numValueBuckets;
+    int numBucketsToCapForFairness;
+    int maxSamplesPerBucket;
+    int maxExponent;
+    int errorStatsWindowSize;
+  }
+}

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/regression/BucketInfo.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/regression/BucketInfo.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.cruisecontrol.model.regression;
+
+/**
+ * The bucket information for a causal metric. The bucket size is dynamically adjusted according to the
+ * given number of bucket and the value range.
+ */
+class BucketInfo {
+  private final int _numBuckets;
+  private double _max = Double.MIN_VALUE;
+  private double _min = Double.MAX_VALUE;
+  private double _bucketSize = 0;
+
+  BucketInfo(int numBuckets) {
+    _numBuckets = numBuckets;
+  }
+
+  /**
+   * @return the min value.
+   */
+  double minValue() {
+    return _min;
+  }
+
+  /**
+   * @return the max value.
+   */
+  double maxValue() {
+    return _max;
+  }
+
+  /**
+   * Record the value for a causal metric.
+   * @param value the causal metric value.
+   * @return Whether tbe bucket info has changed or not.
+   */
+  boolean record(double value) {
+    if (value < _min || value > _max) {
+      _max = Math.max(_max, value);
+      _min = Math.min(_min, value);
+      _bucketSize = (_max - _min) / _numBuckets;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Get the bucket number for a value.
+   * @param value the causal metric value.
+   * @return the corresponding bucket of the the causal metric value.
+   */
+  int bucket(double value) {
+    // Update max or min if needed.
+    record(value);
+    return _bucketSize > 0 ? Math.min((int) ((value - _min) / _bucketSize), _numBuckets - 1) : 0;
+  }
+
+  /**
+   * @return the bcuket size.
+   */
+  double bucketSize() {
+    return _bucketSize;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("(range=[%.3f, %.3f], bucketSize=%.3f)", _min, _max, _bucketSize);
+  }
+}

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/regression/CausalRelation.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/regression/CausalRelation.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.cruisecontrol.model.regression;
+
+import com.linkedin.cruisecontrol.metricdef.MetricInfo;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+
+/**
+ * A class holding the metric info and index.
+ * 
+ * Since the metric id of each metric defined in the {@link CausalRelation} may not always be contiguous, the causal 
+ * relation needs to assign an index to each metric. This class maintains the metrics to the assigned index mapping.  
+ */
+public class CausalRelation {
+  private final Set<MetricInfo> _resultantMetrics;
+  private final Set<MetricInfo> _causalMetrics;
+  private final Map<MetricInfo, Integer> _indexes;
+
+  CausalRelation(Collection<MetricInfo> resultantMetrics, Collection<MetricInfo> causalMetrics) {
+    _resultantMetrics = new HashSet<>(resultantMetrics);
+    _causalMetrics = new HashSet<>(causalMetrics);
+    _indexes = new HashMap<>();
+    int i = 0;
+    // First add the causal metrics. We do this so that the index in the causal relation is the same as the
+    // index of the coefficient in the linear regression.
+    for (MetricInfo causalMetric : _causalMetrics) {
+      _indexes.put(causalMetric, i);
+      i++;
+    }
+    // Then add the the resultant metrics.
+    for (MetricInfo resultantMetric : resultantMetrics) {
+      if (causalMetrics.contains(resultantMetric)) {
+        throw new IllegalArgumentException(
+            String.format("The resultant metric %s cannot be in the causal metrics %s", resultantMetric,
+                          _causalMetrics));
+      }
+      _indexes.put(resultantMetric, i);
+      i++;
+    }
+  }
+
+  int index(MetricInfo metricInfo) {
+    return _indexes.get(metricInfo);
+  }
+
+  Map<MetricInfo, Integer> indexes() {
+    return _indexes;
+  }
+
+  public Set<MetricInfo> resultantMetrics() {
+    return Collections.unmodifiableSet(_resultantMetrics);
+  }
+
+  public Set<MetricInfo> causalMetrics() {
+    return Collections.unmodifiableSet(_causalMetrics);
+  }
+}

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/regression/DataForLinearRegression.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/regression/DataForLinearRegression.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.cruisecontrol.model.regression;
+
+import com.linkedin.cruisecontrol.metricdef.MetricInfo;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+
+/**
+ * A class holding the data that could be passed to the linear regression directly.
+ */
+class DataForLinearRegression {
+  private final Map<MetricInfo, double[]> _resultantMetricsValues;
+  private final double[][] _causalMetricsValues;
+  private final Map<MetricInfo, MetricValueSelector> _valueSelectors;
+  private final CausalRelation _causalRelation;
+  private final Set<MetricInfo> _resultantMetrics;
+  private final int _valueCounts;
+  private final int _maxExponent;
+  private volatile int _metricsCount;
+
+  /**
+   * Constructor.
+   * @param causalRelation the defined causal relation.
+   * @param resultantMetrics the resultant metrics to include.
+   * @param valueCounts the total count of values.
+   * @param valueSelectors the value selectors used to pick the values to be added to this class.
+   * @param maxExponent the maximum exponent of the polynomial function.
+   */
+  DataForLinearRegression(CausalRelation causalRelation,
+                          Set<MetricInfo> resultantMetrics,
+                          int valueCounts,
+                          Map<MetricInfo, MetricValueSelector> valueSelectors,
+                          int maxExponent) {
+    _causalRelation = causalRelation;
+    _resultantMetrics = resultantMetrics;
+    _valueCounts = valueCounts;
+    _maxExponent = maxExponent;
+    _resultantMetricsValues = new HashMap<>();
+    _causalMetricsValues = new double[_valueCounts][_causalRelation.causalMetrics().size() * _maxExponent];
+    _valueSelectors = valueSelectors;
+    _metricsCount = 0;
+  }
+
+  /**
+   * Add values for linear regression. This methods only picks the values for the interested metrics. 
+   * @param metricValues an array containing values for all the metrics.
+   */
+  void addValues(double[] metricValues) {
+    int index = _metricsCount++;
+    for (MetricInfo resultantMetric : _resultantMetrics) {
+      double[] resultantMetricValues = 
+          _resultantMetricsValues.computeIfAbsent(resultantMetric, rm -> new double[_valueCounts]);
+      resultantMetricValues[index] = metricValues[_causalRelation.index(resultantMetric)];
+    }
+
+    for (int i = 1; i <= _maxExponent; i++) {
+      for (MetricInfo metric : _causalRelation.causalMetrics()) {
+        int causalMetricIndex = _causalRelation.index(metric);
+        double metricValue = metricValues[causalMetricIndex];
+        int valueIndex = causalMetricIndex + (i - 1) * _causalRelation.causalMetrics().size();
+        _causalMetricsValues[index][valueIndex] = Math.pow(metricValue, i);
+      }
+    }
+  }
+
+  /**
+   * @return the resultant metric values for linear regression.
+   */
+  Map<MetricInfo, double[]> resultantMetricValues() {
+    return _resultantMetricsValues;
+  }
+
+  /**
+   * @return the causal metric values for linear regression.
+   */
+  double[][] causalMetricsValues() {
+    return _causalMetricsValues;
+  }
+
+  /**
+   * @return the value selectors used to pick the values for linear regression.
+   */
+  Map<MetricInfo, MetricValueSelector> metricValueSelectors() {
+    return _valueSelectors;
+  }
+}

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/regression/LinearRegression.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/regression/LinearRegression.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.cruisecontrol.model.regression;
+
+import com.linkedin.cruisecontrol.metricdef.MetricInfo;
+import com.linkedin.cruisecontrol.model.estimator.MetricEstimator;
+import com.linkedin.cruisecontrol.monitor.sampling.MetricSample;
+import com.linkedin.cruisecontrol.monitor.sampling.aggregator.AggregatedMetricValues;
+import com.linkedin.cruisecontrol.monitor.sampling.aggregator.MetricValues;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.apache.commons.math3.stat.descriptive.SynchronizedDescriptiveStatistics;
+import org.apache.commons.math3.stat.regression.OLSMultipleLinearRegression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A class that perform the linear regression for causal relations. This class supports multiple resultant
+ * metrics as long as the resultant metrics share the same causal metrics.
+ *
+ * This class is thread safe, but it just uses simple synchronization because the sample update frequency is
+ * expected to be low.
+ */
+public class LinearRegression {
+  private static final Logger LOG = LoggerFactory.getLogger(LinearRegression.class);
+  private final String _name;
+  // From resultant metric ids to the coefficients to that metric.
+  private final Map<MetricInfo, LinearRegressionCoefficients> _coefficients;
+  // The estimation errors for each of the resultant metric.
+  private final Map<MetricInfo, SynchronizedDescriptiveStatistics> _estimationErrorStats;
+  // The regression metrics accumulator that helps handling the metric selection and filtering
+  private final CausalRelation _causalRelation;
+  private final RegressionMetricsAccumulator _metricsAccumulator;
+  private final int _maxExponent;
+  private final int _errStatsWindowSize;
+
+  /**
+   * Construct a LinearRegression to represent the causal relation among given resultant metrics and causal metrics.
+   * The resultant metrics and causal metrics are assumed to be independent to each other.
+   *
+   * @param name the name of this linear regression.
+   * @param resultantMetrics the resultant metrics in the causal relation.
+   * @param causalMetrics the causal metrics in the causal relation.
+   * @param numBuckets the number of buckets to use to hold the metric values.
+   * @param numBucketsToCapForFairness the number of top buckets with most samples to cap.
+   *                                   See {@link MetricValueSelector} for more details.
+   * @param maxSamplesPerBucket maximum number of metric values to use in each bucket for the linear regression.
+   * @param maxExponent the degree of polynomial function to use in the linear regression.
+   * @param errStatsWindowSize the number of values to keep when track the estimation error statistics.
+   */
+  public LinearRegression(String name,
+                          Set<MetricInfo> resultantMetrics,
+                          Set<MetricInfo> causalMetrics,
+                          int numBuckets,
+                          int numBucketsToCapForFairness,
+                          int maxSamplesPerBucket,
+                          int maxExponent,
+                          int errStatsWindowSize) {
+    _name = name;
+    _causalRelation = new CausalRelation(resultantMetrics, causalMetrics);
+    _coefficients = new HashMap<>();
+    _estimationErrorStats = new HashMap<>();
+    _metricsAccumulator = new RegressionMetricsAccumulator(_causalRelation, numBuckets, numBucketsToCapForFairness,
+                                                           maxSamplesPerBucket, maxExponent);
+    _maxExponent = maxExponent;
+    _errStatsWindowSize = errStatsWindowSize;
+  }
+
+  /**
+   * Get the name of this linear regression.
+   * @return the name of this linear regression.
+   */
+  public String name() {
+    return _name;
+  }
+
+  /**
+   * @return the causal relation of this linear regression.
+   */
+  public CausalRelation causalRelation() {
+    return _causalRelation;
+  }
+
+  /**
+   * @return the max exponent used in this linear regression, i.e. the order of the polynomial function.
+   */
+  public int maxExponent() {
+    return _maxExponent;
+  }
+
+  /**
+   * Add a collection of metric samples as the training data for this linear regression.
+   *
+   * @param trainingSamples the {@link MetricSample}s to add as training data.
+   */
+  public synchronized void addMetricSamples(Collection<? extends MetricSample> trainingSamples) {
+    if (trainingSamples != null && !trainingSamples.isEmpty()) {
+      boolean maybeRemoveOldValues = false;
+      for (MetricSample sample : trainingSamples) {
+        double[] values = new double[_causalRelation.indexes().size()];
+        for (Map.Entry<MetricInfo, Integer> entry : _causalRelation.indexes().entrySet()) {
+          MetricInfo metric = entry.getKey();
+          int index = entry.getValue();
+          values[index] = sample.metricValue(metric.id());
+        }
+        if (_metricsAccumulator.recordMetricValues(values)) {
+          maybeRemoveOldValues = true;
+        }
+        // For each sample added to the linear regression, the sample is used both for training and coefficients
+        // verification.
+        updateEstimationError(sample);
+        LOG.trace("{} added metric sample {}", _name, sample);
+      }
+      if (maybeRemoveOldValues) {
+        _metricsAccumulator.maybeRemoveOldValues();
+      }
+    }
+  }
+
+  /**
+   * Trigger the calculation of the model parameters.
+   *
+   * @return A set of resultant metrics whose causal metric coefficients are generated;
+   */
+  public synchronized Set<MetricInfo> updateModelCoefficient() {
+    Set<MetricInfo> completedResultantMetrics = new HashSet<>();
+    for (MetricInfo resultantMetric : _causalRelation.resultantMetrics()) {
+      DataForLinearRegression dataForLinearRegression =
+          _metricsAccumulator.getRegressionData(Collections.singleton(resultantMetric));
+      if (updateModelCoefficient(dataForLinearRegression)) {
+        completedResultantMetrics.add(resultantMetric);
+      }
+    }
+    return completedResultantMetrics;
+  }
+
+  /**
+   * Check if the training for a given resultant metric has completed, i.e. the coefficients for all the defined
+   * causal metrics are available.
+   *
+   * @param resultantMetric the resultant metric to check.
+   * @return true if all the coefficients of causal metrics for the given resultant metric is ready, false otherwise.
+   */
+  public synchronized boolean trainingCompleted(MetricInfo resultantMetric) {
+    return _coefficients.containsKey(resultantMetric);
+  }
+
+  /**
+   * Get the coefficients of the given causal metric for the given resultant metric with all the exponents.
+   *
+   * @param resultantMetric the resultant metric to get the coefficients for.
+   * @param causalMetric the causal metric whose coefficients should be returned.
+   * @return A mapping from exponents to the coefficient of the given causal metric and resultant metric combination.
+   */
+  public synchronized Map<Integer, Double> getCoefficients(MetricInfo resultantMetric, MetricInfo causalMetric) {
+    LinearRegressionCoefficients coefficientsForResultantMetric = _coefficients.get(resultantMetric);
+    if (coefficientsForResultantMetric == null) {
+      return null;
+    } else {
+      return coefficientsForResultantMetric.getCoefficients(causalMetric);
+    }
+  }
+
+  /**
+   * Estimate the values of the resultant metric given the causal metric values and the potential value changes.
+   *
+   * @param resultantMetric the resultant metric whose values are to be estimated.
+   * @param causalMetricValues the causal metric values to use for the estimation.
+   * @param causalMetricValueChanges the potential changes to the causal metrics.
+   * @param changeType the type of causal metric value changes, i.e. add or subtract.
+   * @return a {@link MetricValues} of the resultant metric.
+   */
+  public synchronized MetricValues estimate(MetricInfo resultantMetric,
+                                            AggregatedMetricValues causalMetricValues,
+                                            AggregatedMetricValues causalMetricValueChanges,
+                                            MetricEstimator.ChangeType changeType) {
+    LinearRegressionCoefficients coefficientsForResultantMetric = _coefficients.get(resultantMetric);
+    if (coefficientsForResultantMetric == null) {
+      throw new IllegalStateException("The coefficients for resultant metric " + resultantMetric + " are not "
+                                          + "available for linear regression " + _name);
+    }
+    MetricValues result = new MetricValues(causalMetricValues.length());
+    // Iterate over the exponents
+    for (int exp = 1; exp <= _maxExponent; exp++) {
+      Map<MetricInfo, Double> coefficients = coefficientsForResultantMetric.getCoefficients(exp);
+      // Iterate over each causal metric
+      for (Map.Entry<MetricInfo, Double> entry : coefficients.entrySet()) {
+        MetricInfo causalMetric = entry.getKey();
+        double coefficient = entry.getValue();
+        MetricValues valuesForCausalMetric = causalMetricValues.valuesFor(causalMetric.id());
+        MetricValues valueChangesForCausalMetric =
+            causalMetricValueChanges == null ? null : causalMetricValueChanges.valuesFor(causalMetric.id());
+        // Iterate over the values.
+        for (int i = 0; i < result.length(); i++) {
+          double causalMetricValue = valuesForCausalMetric.get(i);
+          if (valueChangesForCausalMetric != null) {
+            switch (changeType) {
+              case ADDITION:
+                causalMetricValue += valueChangesForCausalMetric.get(i);
+                break;
+              case SUBTRACTION:
+                causalMetricValue -= valueChangesForCausalMetric.get(i);
+                break;
+              default:
+                throw new IllegalArgumentException("Invalid change type " + changeType);
+            }
+          }
+          result.add(i, coefficient * Math.pow(causalMetricValue, exp));
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Estimate the average value of the given resultant metric using the average values of the given causal metrics.
+   *
+   * @param resultantMetric the resultant metric whose value is to be estimated.
+   * @param causalMetricValues the causal metrics values.
+   * @return the estimated average value of the given resultant metric.
+   */
+  public synchronized double estimateAvg(MetricInfo resultantMetric, AggregatedMetricValues causalMetricValues) {
+    LinearRegressionCoefficients coefficientsForResultantMetric = _coefficients.get(resultantMetric);
+    if (coefficientsForResultantMetric == null) {
+      throw new IllegalStateException("The coefficients for resultant metric " + resultantMetric + " are not "
+                                          + "available for linear regression " + _name);
+    }
+    double estimatedResultantMetricValue = 0.0;
+    for (int exp = 1; exp <= _maxExponent; exp++) {
+      Map<MetricInfo, Double> coefficientsForExp = coefficientsForResultantMetric.getCoefficients(exp);
+      for (Map.Entry<MetricInfo, Double> entry : coefficientsForExp.entrySet()) {
+        estimatedResultantMetricValue +=
+            entry.getValue() * Math.pow(causalMetricValues.valuesFor(entry.getKey().id()).avg(), exp);
+      }
+    }
+    return estimatedResultantMetricValue;
+  }
+
+  /**
+   * Get the estimation error statistics of this linear regression for the given resultant metric.
+   * 
+   * @param resultantMetric the resultant metric to get the estimation error statistics.
+   * @return the estimation error statistics of this linear regression for the given resultant metric
+   */
+  public synchronized DescriptiveStatistics estimationErrorStats(MetricInfo resultantMetric) {
+    return _estimationErrorStats.get(resultantMetric);
+  }
+
+  /**
+   * Get the training completeness in a percent from 0 to 1. 0 means no training data at all, 1 means training
+   * data is complete. The value returned by this method should not be confused with
+   * {@link #trainingCompleted(MetricInfo)}. That method checks whether the coefficients could be generated or not.
+   * This method indicates the completeness of the training data. In another word, based on what quality of the
+   * training data were those coefficients generated.
+   *
+   * @return a double between 0 and 1, indicating the training data quality.
+   */
+  public synchronized double modelCoefficientTrainingCompleteness() {
+    return _metricsAccumulator.trainingDataCompleteness();
+  }
+
+  /**
+   * Get the state of this linear regression.
+   * @return the state of this linear regression.
+   */
+  public synchronized LinearRegressionState modelState() {
+    DataForLinearRegression dataForLinearRegression =
+        _metricsAccumulator.getRegressionData(_causalRelation.resultantMetrics());
+    updateModelCoefficient(dataForLinearRegression);
+    Map<MetricInfo, String> errorStatsSummary = new TreeMap<>();
+    _estimationErrorStats.forEach((m, errStats) -> errorStatsSummary.put(m, errorStatsSummary(errStats)));
+    return new LinearRegressionState(_coefficients,
+                                     _metricsAccumulator.diversitySummary(),
+                                     _metricsAccumulator.diversitySummary(dataForLinearRegression),
+                                     errorStatsSummary);
+  }
+
+  /**
+   * Reset the state of this linear regression.
+   */
+  public synchronized void reset() {
+    LOG.info("Resetting linear regression {}", _name);
+    _coefficients.clear();
+    _estimationErrorStats.clear();
+    _metricsAccumulator.reset();
+  }
+
+  /**
+   * Update the linear regression model coefficients.
+   * @param dataForLinearRegression the data to perform linear regression.
+   * @return true if the coefficients has been generated, false otherwise.
+   */
+  private boolean updateModelCoefficient(DataForLinearRegression dataForLinearRegression) {
+    try {
+      if (dataForLinearRegression.causalMetricsValues().length >= _causalRelation.causalMetrics().size()) {
+        updateCoefficients(dataForLinearRegression);
+        return true;
+      }
+    } catch (Exception e) {
+      LOG.warn("{} Received exception when updating coefficients", _name, e);
+    }
+    return false;
+  }
+
+  private void updateCoefficients(DataForLinearRegression dataForLinearRegression) {
+    for (Map.Entry<MetricInfo, double[]> entry : dataForLinearRegression.resultantMetricValues().entrySet()) {
+      MetricInfo resultantMetric = entry.getKey();
+      double[] resultantMetricValues = entry.getValue();
+      OLSMultipleLinearRegression regression = new OLSMultipleLinearRegression();
+      regression.setNoIntercept(true);
+      regression.newSampleData(resultantMetricValues, dataForLinearRegression.causalMetricsValues());
+      double[] parameters = regression.estimateRegressionParameters();
+      LinearRegressionCoefficients coefficients = new LinearRegressionCoefficients();
+      for (MetricInfo causalMetric : _causalRelation.causalMetrics()) {
+        for (int exp = 1; exp <= _maxExponent; exp++) {
+          int paramIndex = _causalRelation.index(causalMetric) + (exp - 1) * _causalRelation.causalMetrics().size();
+          coefficients.setCoefficients(exp, causalMetric, parameters[paramIndex]);
+        }
+      }
+      _coefficients.put(resultantMetric, coefficients);
+      // Log only when debug is enabled.
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(String.format("%s coefficients generated for %s: %s = %s", _name, resultantMetric.name(), 
+                                resultantMetric.name(), coefficients.toStringWithIndent("", "")));
+      }
+    }
+  }
+  
+  private void updateEstimationError(MetricSample sample) {
+    for (MetricInfo resultantMetric : _causalRelation.resultantMetrics()) {
+      LinearRegressionCoefficients coefficients = _coefficients.get(resultantMetric);
+      if (coefficients != null) {
+        double estimatedResultantMetricValue = 0.0;
+        for (int exp = 1; exp <= _maxExponent; exp++) {
+          Map<MetricInfo, Double> coefficientsForExp = coefficients.getCoefficients(exp);
+          for (Map.Entry<MetricInfo, Double> entry : coefficientsForExp.entrySet()) {
+            MetricInfo causalMetric = entry.getKey();
+            estimatedResultantMetricValue +=
+                coefficientsForExp.get(causalMetric) * Math.pow(sample.metricValue(causalMetric.id()), exp);
+          }
+        }
+        double actualResultantMetricValue = sample.metricValue(resultantMetric.id());
+        double error = Math.abs(estimatedResultantMetricValue - actualResultantMetricValue);
+        DescriptiveStatistics estimationErrorStatsForRM =
+            _estimationErrorStats.computeIfAbsent(resultantMetric, rm -> new SynchronizedDescriptiveStatistics(_errStatsWindowSize));
+        estimationErrorStatsForRM.addValue(error);
+        LOG.debug("{} estimated {}: actual: {}, estimated: {}, error: {}", _name, resultantMetric.name(),
+                  actualResultantMetricValue, estimatedResultantMetricValue,
+                  estimatedResultantMetricValue - actualResultantMetricValue);
+      }
+    }
+  }
+
+  private String errorStatsSummary(DescriptiveStatistics errorStats) {
+    return String.format("Mean: %.3f, Std_Dev: %.3f, 50 Percentile: %.3f, 75 Percentile: %.3f, "
+                             + "90 Percentile: %.3f, 95 Percentile: %.3f, 99 Percentile: %.3f, 99.9 Percentile: %.3f",
+                         errorStats.getMean(), errorStats.getStandardDeviation(), errorStats.getPercentile(50),
+                         errorStats.getPercentile(75), errorStats.getPercentile(90),
+                         errorStats.getPercentile(95), errorStats.getPercentile(99),
+                         errorStats.getPercentile(99.9));
+  }
+
+  /**
+   * A class describing the linear regression state.
+   * 1. The coefficients.
+   * 2. The summary of available sample values
+   * 3. The summary of used sample values
+   * 4. The summary of estimation error stats.
+   */
+  public static class LinearRegressionState {
+    private final Map<MetricInfo, LinearRegressionCoefficients> _modelCoefficients;
+    private final String _availableSampleValuesSummary;
+    private final String _usedSampleValuesSummary;
+    private final Map<MetricInfo, String> _estimationErrorStatsSummary;
+
+    LinearRegressionState(Map<MetricInfo, LinearRegressionCoefficients> coefficients,
+                          String availableSampleValuesSummary,
+                          String usedSampleValuesSummary,
+                          Map<MetricInfo, String> estimationErrorStatsSummary) {
+      _modelCoefficients = coefficients;
+      _availableSampleValuesSummary = availableSampleValuesSummary;
+      _usedSampleValuesSummary = usedSampleValuesSummary;
+      _estimationErrorStatsSummary = estimationErrorStatsSummary;
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder builder = new StringBuilder();
+      builder.append("All available data summary\n").append(_availableSampleValuesSummary).append("\n\n");
+      builder.append("Used data summary\n").append(_usedSampleValuesSummary);
+      builder.append("Coefficients from available samples: \n");
+      for (Map.Entry<MetricInfo, LinearRegressionCoefficients> entry : _modelCoefficients.entrySet()) {
+        MetricInfo resultantMetric = entry.getKey();
+        LinearRegressionCoefficients coefficientsForMetric = entry.getValue();
+        builder.append(String.format("\tCoefficients for %s%n", resultantMetric.name()));
+        builder.append(coefficientsForMetric.toStringWithIndent("\t", "\n"));
+        builder.append("\n");
+      }
+
+      for (Map.Entry<MetricInfo, String> entry : _estimationErrorStatsSummary.entrySet()) {
+        MetricInfo resultantMetric = entry.getKey();
+        builder.append(String.format("%n%n%s estimation error histogram:%n", resultantMetric.name()))
+               .append("\t").append(entry.getValue()).append("\n");
+      }
+      return builder.toString();
+    }
+  }
+}

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/regression/LinearRegressionCoefficients.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/regression/LinearRegressionCoefficients.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.cruisecontrol.model.regression;
+
+import com.linkedin.cruisecontrol.metricdef.MetricInfo;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.TreeMap;
+
+
+/**
+ * A class that hosts the linear regression coefficients for a single metric. The coefficients of a linear 
+ * regression model are represented in a polynomial form. More specifically,
+ * <p>
+ *   <tt>RM = Sum(A(i, j) * CM(i)^j), where CM(i) means the i(th) causal metric, i = 0, 1, ... k; 
+ *   j means the order of the causal metric, j = 1, 2, ... n</tt>
+ * </p>
+ * This class hosts the coefficients A(i, j).
+ */
+public class LinearRegressionCoefficients {
+  // A map whose keys are the exponents and the values are coefficients for the corresponding exponents.
+  private final Map<Integer, Map<MetricInfo, Double>> _coefficients;
+  private int _metricNameMaxLength = 0;
+
+  /**
+   * This class should not be constructed outside of the package.
+   */
+  LinearRegressionCoefficients() {
+    _coefficients = new TreeMap<>();
+  }
+
+  /**
+   * Set the coefficient for a given exponent and causal metric.
+   * @param exponent the exponent to set the coefficient for.
+   * @param causalMetric the causal metric to set the coefficient for.
+   * @param coefficient the coefficient.
+   */
+  void setCoefficients(int exponent, MetricInfo causalMetric, double coefficient) {
+    _coefficients.computeIfAbsent(exponent, e -> new TreeMap<>())
+                 .put(causalMetric, coefficient);
+    _metricNameMaxLength = Math.max(_metricNameMaxLength, causalMetric.name().length());
+  }
+
+  /**
+   * Get the coefficients of a given causal metric.
+   * 
+   * @param causalMetric the causal metric to get coefficients for;
+   * @return a mapping from exponent to the coefficients of the given causal metric.
+   */
+  Map<Integer, Double> getCoefficients(MetricInfo causalMetric) {
+    Map<Integer, Double> coefficients = new HashMap<>();
+    for (Map.Entry<Integer, Map<MetricInfo, Double>> entry : _coefficients.entrySet()) {
+      coefficients.put(entry.getKey(), entry.getValue().get(causalMetric));
+    }
+    return coefficients;
+  }
+
+  /**
+   * Get the coefficients for all causal metrics of a given exponent.
+   *
+   * @param exponent the exponent to get coefficients.
+   * @return a mapping from causal metrics to their coefficients for the given exponent.
+   */
+  Map<MetricInfo, Double> getCoefficients(int exponent) {
+    return _coefficients.get(exponent);
+  }
+
+  /**
+   * Get the well formatted string of the coefficients with given indentation.
+   * @param indent the indentation to apply.
+   * @return the formatted string with the indentation.
+   */
+  String toStringWithIndent(String indent, String exponentSplitter) {
+    StringBuilder sb = new StringBuilder();
+    for (Map.Entry<Integer, Map<MetricInfo, Double>> entry : _coefficients.entrySet()) {
+      int exponent = entry.getKey();
+      Map<MetricInfo, Double> coefficients = entry.getValue();
+      sb.append(indent);
+      appendWithExponents(sb, coefficients, exponent).append(exponentSplitter);
+    }
+    return sb.toString();
+  }
+  
+  private StringBuilder appendWithExponents(StringBuilder sb, Map<MetricInfo, Double> coefficients, int exponent) {
+    int maxExponentStringLength = Integer.toString(_coefficients.size()).length();
+    int exponentLength = Integer.toString(exponent).length();
+    StringJoiner sj = new StringJoiner(" + ", "", exponent == _coefficients.size() ? "" : " + ");
+    for (Map.Entry<MetricInfo, Double> entry : coefficients.entrySet()) {
+      MetricInfo causalMetric = entry.getKey();
+      int metricPrintLength = maxExponentStringLength + causalMetric.name().length() - exponentLength;
+      sj.add(String.format("%.4f * %" + metricPrintLength + "s^%d", 
+                           entry.getValue(), entry.getKey().name(), exponent));
+    }
+    return sb.append(sj.toString());
+  }
+}

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/regression/MetricDiversity.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/regression/MetricDiversity.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.cruisecontrol.model.regression;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * A class that helps maintain the observed value diversity of a single type of metric.
+ *
+ * The diversity is defined by the diversity of witnessed values. The witnessed value range is divided into a configured
+ * number of buckets. So the buckets may change if the witnessed value range changes.
+ *
+ * Each value is then put into their corresponding bucket.
+ *
+ * To throttle memory consumption, if a bucket has more than maxSamplesPerBucket values, no more value observation is
+ * needed for that bucket.
+ *
+ * This class is not thread safe.
+ */
+class MetricDiversity {
+  private final int _maxCountPerBucket;
+  private final BucketInfo _bucketInfo;
+  private final SortedMap<Integer, Integer> _countsByBucket = new TreeMap<>();
+
+  /**
+   * Construct the diversity for a metric.
+   *
+   * @param numBuckets the number of bucket to use for the witnessed value range of the metric.
+
+   * @param maxCountPerBucket the maximum number of samples to keep for each bucket. Once a bucket has reached this
+   *                            number, the bucket no longer need any value observations.
+   */
+  MetricDiversity(int numBuckets, int maxCountPerBucket) {
+    _bucketInfo = new BucketInfo(numBuckets);
+    _maxCountPerBucket = maxCountPerBucket;
+  }
+
+  /**
+   * Update the bucket information. If a the method returns true, the caller should call {@link #clear()} to
+   * discard all the diversity information and rerun all the retained values by calling record one by one.
+   *
+   * @param value the value of the causal metrics.
+   * @return true if the bucket information is changed, false otherwise.
+   */
+  boolean updateBucketInfo(double value) {
+    return _bucketInfo.record(value);
+  }
+
+  /**
+   * Clear the diversity information.
+   */
+  void clear() {
+    _countsByBucket.clear();
+  }
+
+  /**
+   * Check whether this value can be removed from the linear regression model.
+   *
+   * @param value the value to check
+   * @return true if the value can be removed, false otherwise.
+   */
+  boolean shouldRemove(double value) {
+    // If the bucket already has more samples than needed.
+    int countForBucket = _countsByBucket.getOrDefault(_bucketInfo.bucket(value), 0);
+    return countForBucket > _maxCountPerBucket;
+  }
+
+  /**
+   * Record a sample value addition to the linear regression model.
+   * @param value the value added.
+   * @return true if the bucket the value belongs to has reached capacity, false otherwise.
+   */
+  boolean addValue(double value) {
+    int bucket = _bucketInfo.bucket(value);
+    return _countsByBucket.compute(bucket, (b, c) -> c == null ? 1 : c + 1) > _maxCountPerBucket;
+  }
+
+  /**
+   * Record a sample value removal from the linear regression model.
+   * @param value the value removed.
+   */
+  void removeSample(double value) {
+    int bucket = _bucketInfo.bucket(value);
+    // the value removal Should not change the maxSamplesToInclude.
+    _countsByBucket.compute(bucket, (b, c) -> c - 1 == 0 ? null : c - 1);
+  }
+
+  /**
+   * Get the value counts in each bucket. The returned map only contains the bucket that has at least one
+   * value. So the size of the map can also be used as the number of non-empty buckets.
+   *
+   * @return the counts in each bucket.
+   */
+  Map<Integer, Integer> countsByBucket() {
+    return Collections.unmodifiableMap(_countsByBucket);
+  }
+
+  /**
+   * Get the bucket of a value. This method should have change the existing bucketing.
+   * @param value the value to query.
+   * @return the bucket the value belongs to.
+   */
+  int bucket(double value) {
+    if (value < _bucketInfo.minValue() || value > _bucketInfo.maxValue()) {
+      throw new IllegalStateException(String.format("value %f in DiversityForMetric.bucket() should not "
+                                                        + "change the bucketing %s.", value, _bucketInfo));
+    }
+    return _bucketInfo.bucket(value);
+  }
+
+  String diversitySummary() {
+    return diversitySummary(_countsByBucket);
+  }
+
+  String diversitySummary(Map<Integer, Integer> countsPerBucket) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("BucketInfo: ").append(_bucketInfo).append("\n");
+    sb.append("CountsPerBucket:").append("\n");
+    for (Map.Entry<Integer, Integer> entry : countsPerBucket.entrySet()) {
+      double bucketStart = entry.getKey() * _bucketInfo.bucketSize() + _bucketInfo.minValue();
+      double bucketEnd = bucketStart + _bucketInfo.bucketSize();
+      sb.append(String.format("%10.2f - %10.2f: %10d%n", bucketStart, bucketEnd, entry.getValue()));
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public String toString() {
+    return String.format("BucketInfo: %s, countsPerBucket: %s", _bucketInfo, _countsByBucket);
+  }
+}

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/regression/MetricValueSelector.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/regression/MetricValueSelector.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.cruisecontrol.model.regression;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+
+/**
+ * A class that helps select metric values for linear regression.
+ *
+ * Ideally we should have same number of witnessed values in each of the buckets, i.e. uniform distribution.
+ * In reality, it is unlikely that the raw witnessed values will distribute evenly. So we need discard some
+ * of the values if the buckets those value belongs to already have enough observations.
+ *
+ * We define the sufficiency of observations as the following. Given N buckets sorted by the number of values in them in
+ * descending order. Users can define a number M where M < N. Assume the M(th) bucket in the above sorted bucket
+ * list has X values, if a bucket has more than X values it is considered to have enough observations, and any
+ * further values to that bucket should not be included into the linear regression model to avoid one bucket
+ * dominating the linear regression result.
+ */
+public class MetricValueSelector {
+  private final int _numBucketsToCapForFairness;
+  private final MetricDiversity _metricDiversity;
+  private final Map<Integer, Integer> _includedCountsByBuckets;
+  private int _fairCountCap;
+
+  /**
+   * @param numBucketsToCapForFairness the number of buckets with most observations to ensure the fairness. This is to
+   *                                   handle the case that some of the buckets has much more observations than other
+   *                                   buckets. For example, if bucket 0, 1, 2, 3 has 10, 100, 1000, 200 observations
+   *                                   respectively, having numBucketsToCapForFairness set to 3 will try to let the top
+   *                                   3 buckets has the same number of counts. i.e. bucket 2 and bucket 3 would be
+   *                                   be capped to have only 100 values for linear regression. It is possible that
+   *                                   there are more values included because some other values in the same observation
+   *                                   is required by some other metrics.
+   */
+  MetricValueSelector(int numBucketsToCapForFairness, MetricDiversity metricDiversity) {
+    _numBucketsToCapForFairness = numBucketsToCapForFairness;
+    _metricDiversity = metricDiversity;
+    _includedCountsByBuckets = new HashMap<>();
+    updateMaxSamplesToInclude();
+  }
+
+  /**
+   * @return the upper bound of value counts in a bucket for fairness.
+   */
+  int fairCountCap() {
+    return _fairCountCap;
+  }
+
+  /**
+   * Check whether a value should be included into the linear regression model.
+   * @param value the value to check.
+   * @return true if the value is considered as included in the linear regression, false otherwise.
+   */
+  boolean include(double value) {
+    int bucket = _metricDiversity.bucket(value);
+    int countForBucket = _includedCountsByBuckets.getOrDefault(bucket, 0);
+    return countForBucket < _fairCountCap;
+  }
+
+  void included(double value) {
+    int bucket = _metricDiversity.bucket(value);
+    _includedCountsByBuckets.compute(bucket, (b, c) -> c == null ? 1 : c + 1);
+  }
+
+  Map<Integer, Integer> includedCountsByBuckets() {
+    return Collections.unmodifiableMap(_includedCountsByBuckets);
+  }
+
+  private void updateMaxSamplesToInclude() {
+    Map<Integer, Integer> countsByBucket = _metricDiversity.countsByBucket();
+    // Not many buckets have data.
+    if (countsByBucket.size() <= _numBucketsToCapForFairness) {
+      _fairCountCap = Integer.MAX_VALUE;
+      return;
+    }
+    // In case we have huge number of buckets, only keep the buckets that are needed to the priority queue.
+    PriorityQueue<Integer> counts = new PriorityQueue<>();
+    countsByBucket.values().forEach(count -> {
+      if (counts.size() < _numBucketsToCapForFairness + 1) {
+        counts.add(count);
+      } else {
+        if (!counts.isEmpty() && count > counts.peek()) {
+          counts.poll();
+          counts.add(count);
+        }
+      }
+    });
+    _fairCountCap = counts.poll();
+  }
+}

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/regression/RegressionMetricsAccumulator.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/model/regression/RegressionMetricsAccumulator.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.cruisecontrol.model.regression;
+
+import com.linkedin.cruisecontrol.metricdef.MetricInfo;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A class that helps holding the raw metrics values for a causal relation regression. The raw metric values are
+ * kept with diversity requirement.
+ *
+ * @see MetricDiversity
+ */
+public class RegressionMetricsAccumulator {
+  private static final Logger LOG = LoggerFactory.getLogger(RegressionMetricsAccumulator.class);
+  // The sample id generator.
+  private static final AtomicLong ID_GENERATOR = new AtomicLong(0);
+  // Sample id to the sample value array.
+  private final SortedMap<Long, double[]> _values;
+  // The metric id to the diversity of that metric.
+  private final Map<MetricInfo, MetricDiversity> _diversityForMetrics;
+  // The number of buckets to maintain.
+  private final int _numBuckets;
+  // The number of buckets to include for linear regression model. If there are N buckets and this value is set to x,
+  // then number of samples in the x'th bucket ordered by number of samples will be used to determine the maximum
+  // samples in each bucket that will be used.
+  private final int _numBucketsToCapForFairness;
+  // The maximum allowed number for each bucket.
+  private final int _maxSamplesPerBucket;
+  // The causal relation among all the metrics.
+  private final CausalRelation _causalRelation;
+  // The degree of the polynomial function to use for regression.
+  private final int _maxExponent;
+
+  RegressionMetricsAccumulator(CausalRelation causalRelation,
+                               int numBuckets,
+                               int numBucketsToCapForFairness,
+                               int maxSamplesPerBucket,
+                               int maxExponent) {
+    _causalRelation = causalRelation;
+    // Use the reverse order to prioritize the newer samples.
+    _values = new TreeMap<>(Comparator.reverseOrder());
+    _diversityForMetrics = new HashMap<>();
+    _numBuckets = numBuckets;
+    _numBucketsToCapForFairness = numBucketsToCapForFairness;
+    _maxSamplesPerBucket = maxSamplesPerBucket;
+    _maxExponent = maxExponent;
+  }
+
+  /**
+   * Record a new observation of the raw metric values.
+   * @param metricValues the observation of metric values. The index represents the index of each metric in the
+   * {@link CausalRelation}.
+   *                     
+   * @return true if there might be some old metric values that need to be removed, false otherwise.
+   */
+  synchronized boolean recordMetricValues(double[] metricValues) {
+    // rebucket if needed.
+    maybeRebucket(metricValues);
+    // Always add the metric to the map.
+    _values.put(ID_GENERATOR.getAndIncrement(), metricValues);
+    boolean maybeRemoveOldValues = false;
+    for (Map.Entry<MetricInfo, MetricDiversity> diversityEntry : _diversityForMetrics.entrySet()) {
+      MetricInfo metric = diversityEntry.getKey();
+      MetricDiversity diversity = diversityEntry.getValue();
+      if (diversity.addValue(metricValues[_causalRelation.index(metric)])) {
+        maybeRemoveOldValues = true;
+      }
+    }
+    return maybeRemoveOldValues;
+  }
+
+  /**
+   * Remove some old values that are no longer needed from the accumulator.
+   */
+  synchronized void maybeRemoveOldValues() {
+    Map<Long, double[]> valuesInReverseOrder = new TreeMap<>(_values);
+    for (Map.Entry<Long, double[]> entry : valuesInReverseOrder.entrySet()) {
+      double[] values = entry.getValue();
+      boolean shouldRemove = true;
+      for (Map.Entry<MetricInfo, MetricDiversity> diversityEntry : _diversityForMetrics.entrySet()) {
+        MetricInfo metric = diversityEntry.getKey();
+        MetricDiversity diversity = diversityEntry.getValue();
+        shouldRemove = shouldRemove && diversity.shouldRemove(values[_causalRelation.index(metric)]);
+      }
+      // The values are only removed when all the metrics agrees.
+      if (shouldRemove) {
+        _values.remove(entry.getKey());
+        for (Map.Entry<MetricInfo, MetricDiversity> diversityEntry : _diversityForMetrics.entrySet()) {
+          MetricInfo metric = diversityEntry.getKey();
+          MetricDiversity diversity = diversityEntry.getValue();
+          diversity.removeSample(values[_causalRelation.index(metric)]);
+        }
+      }
+    }
+  }
+
+  /**
+   * Get the data for linear regression.
+   *
+   * @return {@link DataForLinearRegression} that is ready for regression.
+   */
+  synchronized DataForLinearRegression getRegressionData(Set<MetricInfo> resultantMetrics) {
+    for (MetricInfo resultantMetric : resultantMetrics) {
+      if (!_causalRelation.resultantMetrics().contains(resultantMetric)) {
+        throw new IllegalArgumentException("Metric " + resultantMetric.name() + " is not defined as a resultant" 
+                                               + " metric. Defined resultant metrics are " 
+                                               + _causalRelation.resultantMetrics());
+      }
+    }
+    Map<MetricInfo, MetricValueSelector> valueSelectors = new HashMap<>();
+
+    for (MetricInfo resultantMetric : resultantMetrics) {
+      MetricDiversity resultantMetricDiversity = _diversityForMetrics.get(resultantMetric);
+      valueSelectors.put(resultantMetric, new MetricValueSelector(_numBucketsToCapForFairness, resultantMetricDiversity));
+    }
+
+    _causalRelation.causalMetrics().forEach(causalMetric -> {
+      MetricDiversity causalMetricDiversity = _diversityForMetrics.get(causalMetric);
+      valueSelectors.put(causalMetric, new MetricValueSelector(_numBucketsToCapForFairness, causalMetricDiversity));
+    });
+
+
+    List<double[]> valuesIncluded = new ArrayList<>();
+    for (double[] valuesForMetrics : _values.values()) {
+      if (shouldInclude(valuesForMetrics, valueSelectors)) {
+        valuesIncluded.add(valuesForMetrics);
+      }
+    }
+    DataForLinearRegression data = new DataForLinearRegression(_causalRelation, resultantMetrics, 
+                                                               valuesIncluded.size(), valueSelectors, _maxExponent);
+    valuesIncluded.forEach(data::addValues);
+    return data;
+  }
+
+  /**
+   * @return the sample values that is kept for linear regression.
+   */
+  synchronized Map<Long, double[]> sampleValues() {
+    return Collections.unmodifiableMap(_values);
+  }
+
+  /**
+   * Clear the state of the RegressionMetricsAccumulator.
+   */
+  synchronized void reset() {
+    _values.clear();
+    _diversityForMetrics.clear();
+  }
+
+  /**
+   * @return the diversity for the metrics.
+   */
+  synchronized Map<MetricInfo, MetricDiversity> diversityForMetrics() {
+    return Collections.unmodifiableMap(_diversityForMetrics);
+  }
+
+  /**
+   * Get the training data completeness. The training data completeness is defined as the following:
+   * <ol>
+   *   1. For each metric, <tt>CompletenessForMetric = min(1, NonEmptyBucket / NumBucketsToCapForFairness)</tt>;
+   *   2. For all the metrics, <tt>OverallCompleteness = Sum(CompletenessForMetric) / NumMetrics</tt>;
+   * </ol>
+   *
+   * Note that as the new metric values come in, dynamic rebucketing may happen. Therefore it is possible that a
+   * previously completed metric become not completed later on.
+   *
+   * @return the overall completeness of the metric values.
+   */
+  synchronized double trainingDataCompleteness() {
+    double sumOfMetricCompleteness = 0.0;
+    for (MetricDiversity diversity : _diversityForMetrics.values()) {
+      int numNonEmptyBuckets = diversity.countsByBucket().size();
+      sumOfMetricCompleteness += Math.min(1.0, (double) numNonEmptyBuckets / _numBucketsToCapForFairness);
+    }
+    return sumOfMetricCompleteness / _causalRelation.indexes().size();
+  }
+
+  /**
+   * Get the diversity summary of the accumulated metric sample values.
+   * @return the diversity summary of the accumulated metric sample values.
+   */
+  synchronized String diversitySummary() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("NumSamples: ").append(_values.size()).append("\n");
+    sb.append("Diversity: \n");
+    for (Map.Entry<MetricInfo, MetricDiversity> entry : _diversityForMetrics.entrySet()) {
+      sb.append(entry.getKey().name()).append("\n").append(entry.getValue().diversitySummary()).append("\n");
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Get the string summary of diversity of the given data. 
+   * 
+   * @param dataForLinearRegression The data to get the diversity summary for.
+   * @return A string summarize the diversity of the given data.
+   */
+  synchronized String diversitySummary(DataForLinearRegression dataForLinearRegression) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("NumSamples: ").append(dataForLinearRegression.causalMetricsValues().length).append("\n");
+    sb.append("Diversity: \n");
+    for (Map.Entry<MetricInfo, MetricValueSelector> entry : dataForLinearRegression.metricValueSelectors().entrySet()) {
+      MetricInfo metric = entry.getKey();
+      sb.append(metric.name()).append("\n")
+        .append("fairCountCap: ").append(entry.getValue().fairCountCap()).append("\n")
+        .append(_diversityForMetrics.get(metric).diversitySummary(entry.getValue().includedCountsByBuckets())).append("\n");
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Determine if a given value array should be included in the linear regression data.
+   * @param values the value array check.
+   * @param valueSelectors the selectors to choose values.
+   * @return true if the value should be included, false otherwise.
+   */
+  private boolean shouldInclude(double[] values, Map<MetricInfo, MetricValueSelector> valueSelectors) {
+    boolean included = false;
+    for (Map.Entry<MetricInfo, MetricValueSelector> entry : valueSelectors.entrySet()) {
+      MetricInfo metric = entry.getKey();
+      MetricValueSelector valueSelector = entry.getValue();
+      included = valueSelector.include(values[_causalRelation.index(metric)]);
+      if (included) {
+        break;
+      }
+    }
+    if (included) {
+      valueSelectors.forEach((metric, valueSelector) -> valueSelector.included(values[_causalRelation.index(metric)]));
+    }
+    return included;
+  }
+
+  /**
+   * Rebucket the value range for a metric if the witnessed value range has changed.
+   * @param metricValues a new observation of metric values.
+   */
+  private void maybeRebucket(double[] metricValues) {
+    for (Map.Entry<MetricInfo, Integer> entry : _causalRelation.indexes().entrySet()) {
+      MetricInfo metric = entry.getKey();
+      int metricIndex = entry.getValue();
+      MetricDiversity diversity =
+          _diversityForMetrics.computeIfAbsent(metric, c -> new MetricDiversity(_numBuckets,
+                                                                                _maxSamplesPerBucket));
+      // Update the bucket info. If the bucket has chnanged, we need to run all the metrics through the diversity
+      // again to rebucket them.
+      if (diversity.updateBucketInfo(metricValues[metricIndex])) {
+        diversity.clear();
+        for (double[] values : _values.values()) {
+          diversity.addValue(values[metricIndex]);
+        }
+        LOG.debug("Rebucketed for metric {}. Diversity: {}", metric, diversity);
+      }
+    }
+  }
+}

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricValues.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricValues.java
@@ -13,6 +13,8 @@ import java.util.StringJoiner;
 
 /**
  * A class hosting the values of a particular metric.
+ * 
+ * The metric values are ordered from newer to older. i.e. the newer values are at lower indexes.
  */
 public class MetricValues {
   // Values are sorted from the newest to the oldest -- i.e. the newest value is in index 0.
@@ -38,10 +40,28 @@ public class MetricValues {
    */
   public void set(int index, double value) {
     if (_max == _values[index] && value < _max) {
-      _max = Float.MIN_VALUE;
+      _max = Float.NEGATIVE_INFINITY;
+    } else if (_max != Float.NEGATIVE_INFINITY && value > _max) {
+      _max = (float) value;
     }
     _sumForAvg += value - _values[index];
     _values[index] = (float) value;
+  }
+
+  /**
+   * Add a value at the given index. 
+   * @param index the index to add the value.
+   * @param value the value to add.
+   */
+  public void add(int index, double value) {
+    if (_max == _values[index] && value < 0) {
+      _max = Float.NEGATIVE_INFINITY;
+    }
+    _sumForAvg += value;
+    _values[index] += (float) value;
+    if (_max != Float.NEGATIVE_INFINITY && _values[index] > _max) {
+      _max = _values[index];
+    }
   }
 
   /**
@@ -61,7 +81,7 @@ public class MetricValues {
   public void clear() {
     Arrays.fill(_values, 0);
     _sumForAvg = 0;
-    _max = Float.MIN_VALUE;
+    _max = Float.NEGATIVE_INFINITY;
   }
 
   /**
@@ -83,7 +103,7 @@ public class MetricValues {
                                                            + "MetricValue with length %d",
                                                        values.length, _values.length));
     }
-    _max = Float.MIN_VALUE;
+    _max = Float.NEGATIVE_INFINITY;
     for (int i = 0; i < _values.length; i++) {
       double toAdd = values[i];
       _values[i] += toAdd;
@@ -103,7 +123,7 @@ public class MetricValues {
                                                            + "MetricValue with length %d",
                                                        metricValues.length(), _values.length));
     }
-    _max = Float.MIN_VALUE;
+    _max = Float.NEGATIVE_INFINITY;
     for (int i = 0; i < _values.length; i++) {
       double toAdd = metricValues.get(i);
       _values[i] += toAdd;
@@ -123,7 +143,7 @@ public class MetricValues {
                                                            + "MetricValue with length %d",
                                                        values.length, _values.length));
     }
-    _max = Float.MIN_VALUE;
+    _max = Float.NEGATIVE_INFINITY;
     for (int i = 0; i < _values.length; i++) {
       double toDeduct = values[i];
       _values[i] -= toDeduct;
@@ -143,7 +163,7 @@ public class MetricValues {
                                                            + "MetricValue with length %d",
                                                        metricValues.length(), _values.length));
     }
-    _max = Float.MIN_VALUE;
+    _max = Float.NEGATIVE_INFINITY;
     for (int i = 0; i < _values.length; i++) {
       double toDeduct = metricValues.get(i);
       _values[i] -= toDeduct;
@@ -171,6 +191,9 @@ public class MetricValues {
   }
 
   /**
+   * Get the last values of all the values. Notice that the values are ordered from
+   * newer to older. i.e. newer values are at lower indexes.
+   * 
    * @return the last value of all the values in this MetricValues.
    */
   public float latest() {

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/ValuesAndExtrapolations.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/ValuesAndExtrapolations.java
@@ -27,6 +27,7 @@ public class ValuesAndExtrapolations {
   public ValuesAndExtrapolations(AggregatedMetricValues metricValues, Map<Integer, Extrapolation> extrapolations) {
     _metricValues = metricValues;
     _extrapolations = extrapolations;
+    _windows = null;
   }
 
   /**
@@ -74,11 +75,16 @@ public class ValuesAndExtrapolations {
   }
 
   /**
-   * Method to set the windows array.
+   * Method to set the windows array. The windows can only be set once. After that it is immutable.
+   * 
    * @param windows the windows for the values.
    */
   public void setWindows(List<Long> windows) {
-    _windows = windows;
+    if (_windows == null) {
+      _windows = windows;
+    } else {
+      throw new IllegalStateException("The windows have been set and they are immutable.");
+    }
   }
 
   /**

--- a/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/CruiseControlUnitTestUtils.java
+++ b/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/CruiseControlUnitTestUtils.java
@@ -13,9 +13,9 @@ import com.linkedin.cruisecontrol.monitor.sampling.aggregator.MetricSampleAggreg
 
 
 public class CruiseControlUnitTestUtils {
-  public static final String METRIC1 = "m1";
-  public static final String METRIC2 = "m2";
-  public static final String METRIC3 = "m3";
+  public static final String METRIC1 = "METRIC1";
+  public static final String METRIC2 = "METRIC2";
+  public static final String METRIC3 = "METRIC3";
 
   private CruiseControlUnitTestUtils() {
 

--- a/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/IntegerEntity.java
+++ b/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/IntegerEntity.java
@@ -18,6 +18,11 @@ public class IntegerEntity extends Entity<String> {
   }
 
   @Override
+  public String toString() {
+    return String.format("(group:%s, id:%d)", _group, _id);
+  }
+
+  @Override
   public String group() {
     return _group;
   }

--- a/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/model/estimator/impl/LinearRegressionEstimatorTest.java
+++ b/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/model/estimator/impl/LinearRegressionEstimatorTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.  
+ */
+
+package com.linkedin.cruisecontrol.model.estimator.impl;
+
+import com.linkedin.cruisecontrol.CruiseControlUnitTestUtils;
+import com.linkedin.cruisecontrol.IntegerEntity;
+import com.linkedin.cruisecontrol.metricdef.MetricDef;
+import com.linkedin.cruisecontrol.metricdef.MetricInfo;
+import com.linkedin.cruisecontrol.model.regression.LinearRegression;
+import com.linkedin.cruisecontrol.monitor.sampling.MetricSample;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.SortedSet;
+import org.junit.Test;
+
+import static com.linkedin.cruisecontrol.CruiseControlUnitTestUtils.METRIC1;
+import static com.linkedin.cruisecontrol.CruiseControlUnitTestUtils.METRIC2;
+import static com.linkedin.cruisecontrol.CruiseControlUnitTestUtils.METRIC3;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class LinearRegressionEstimatorTest {
+  private static final IntegerEntity ENTITY = new IntegerEntity("group", 0); 
+  private static final String CAUSAL_RELATION_FILE = "TestCausalRelation.json";
+  private static final String LINEAR_REGRESSION_NAME_1 = "regression_1";
+  private static final String LINEAR_REGRESSION_NAME_2 = "regression_2";
+  
+  @Test
+  public void testLoadLinearRegressions() {
+    LinearRegressionEstimator linearRegressionEstimator = getLinearRegressionEstimator();
+
+    MetricDef metricDef = CruiseControlUnitTestUtils.getMetricDef();
+    Map<String, LinearRegression> linearRegressions = linearRegressionEstimator.linearRegressions();
+    assertEquals(2, linearRegressions.size());
+    Map<MetricInfo, SortedSet<LinearRegression>> linearRegressionsByResultantMetrics =
+        linearRegressionEstimator.linearRegressionByResultantMetrics();
+    assertEquals(2, linearRegressionsByResultantMetrics.size());
+    SortedSet<LinearRegression> regressionsForMetric3 = linearRegressionsByResultantMetrics.get(metricDef.metricInfo(METRIC3));
+    assertEquals(2, regressionsForMetric3.size());
+    assertTrue(regressionsForMetric3.contains(linearRegressions.get(LINEAR_REGRESSION_NAME_1)));
+    assertTrue(regressionsForMetric3.contains(linearRegressions.get(LINEAR_REGRESSION_NAME_2)));
+    SortedSet<LinearRegression> regressionsForMetric2 = linearRegressionsByResultantMetrics.get(metricDef.metricInfo(METRIC2));
+    assertEquals(1, regressionsForMetric2.size());
+    assertTrue(regressionsForMetric2.contains(linearRegressions.get(LINEAR_REGRESSION_NAME_2)));
+    
+    Set<MetricInfo> causalMetrics = linearRegressions.get(LINEAR_REGRESSION_NAME_1).causalRelation().causalMetrics();
+    Set<MetricInfo> resultantMetrics = linearRegressions.get(LINEAR_REGRESSION_NAME_1).causalRelation().resultantMetrics();
+    assertEquals(2, causalMetrics.size());
+    assertTrue(causalMetrics.containsAll(Arrays.asList(metricDef.metricInfo(METRIC1), metricDef.metricInfo(METRIC2))));
+    assertEquals(1, resultantMetrics.size());
+    assertTrue(resultantMetrics.contains(metricDef.metricInfo(METRIC3)));
+
+    causalMetrics = linearRegressions.get(LINEAR_REGRESSION_NAME_2).causalRelation().causalMetrics();
+    resultantMetrics = linearRegressions.get(LINEAR_REGRESSION_NAME_2).causalRelation().resultantMetrics();
+    assertEquals(1, causalMetrics.size());
+    assertTrue(causalMetrics.contains(metricDef.metricInfo(METRIC1)));
+    assertEquals(2, resultantMetrics.size());
+    assertTrue(resultantMetrics.containsAll(Arrays.asList(metricDef.metricInfo(METRIC2), metricDef.metricInfo(METRIC3))));
+  }
+  
+  @Test
+  public void testBestRegression() {
+    LinearRegressionEstimator linearRegressionEstimator = getLinearRegressionEstimator();
+    // Iterate over each linear regression definition and provide metric samples that fits into their model.
+    // Then verify that that linear regression was picked to be the best linear regression.
+    for (LinearRegression linearRegression : linearRegressionEstimator.linearRegressions().values()) {
+      linearRegressionEstimator.reset();
+      List<MetricSample<String, IntegerEntity>> samples =
+          generateMetricSamplesForRegression(linearRegression.causalRelation().causalMetrics(),
+                                             linearRegression.causalRelation().resultantMetrics(),
+                                             linearRegression.maxExponent(),
+                                             123456789L);
+      linearRegressionEstimator.addTrainingSamples(samples);
+      linearRegressionEstimator.train();
+      // Add another set of samples to trigger estimation.
+      samples = generateMetricSamplesForRegression(linearRegression.causalRelation().causalMetrics(),
+                                                   linearRegression.causalRelation().resultantMetrics(),
+                                                   linearRegression.maxExponent(),
+                                                   987654321L);
+      linearRegressionEstimator.addTrainingSamples(samples);
+      for (MetricInfo resultantMetric : linearRegression.causalRelation().resultantMetrics()) {
+        assertEquals(linearRegression.name(), linearRegressionEstimator.bestLinearRegression(resultantMetric).name());
+      }
+    }
+  }
+
+  /**
+   * A private method generates the data that best fits causal relation definition and linear regression max exponent.
+   *
+   * @return the metric samples that conform to the above polynomial function.
+   */
+  private List<MetricSample<String, IntegerEntity>> generateMetricSamplesForRegression(Set<MetricInfo> causalMetrics,
+                                                                                       Set<MetricInfo> resultantMetrics,
+                                                                                       int maxExponent,
+                                                                                       long randomSeed) {
+    List<MetricSample<String, IntegerEntity>> samples = new ArrayList<>();
+    Random random = new Random(randomSeed);
+    for (int i = 0; i < 10; i++) {
+      MetricSample<String, IntegerEntity> sample = new MetricSample<>(ENTITY);
+      for (MetricInfo causalMetric : causalMetrics) {
+        sample.record(causalMetric, random.nextInt(10));
+      }
+      for (MetricInfo resultantMetric : resultantMetrics) {
+        double value = 0.0;
+        for (MetricInfo causalMetric : causalMetrics) {
+          // The coefficient of each causal metric for a given resultant metric is the sum of their metric id.
+          // The exponential value is applied to the coefficients as well.
+          int coefficient = resultantMetric.id() + causalMetric.id();
+          double valueAddition = 0.0;
+          for (int exp = 1; exp <= maxExponent; exp++) {
+            valueAddition += Math.pow(coefficient, exp) * Math.pow(sample.metricValue(causalMetric.id()), exp);
+          }
+          value += valueAddition;
+        }
+        sample.record(resultantMetric, value);
+      }
+      sample.close(i);
+      samples.add(sample);
+    }
+    return samples;
+  }
+  
+  private LinearRegressionEstimator getLinearRegressionEstimator() {
+    LinearRegressionEstimator linearRegressionEstimator = new TestLinearRegressionEstimator();
+    String causalRelationFileName = this.getClass().getClassLoader().getResource(CAUSAL_RELATION_FILE).getFile();
+    Map<String, String> config =
+        Collections.singletonMap(LinearRegressionEstimator.CAUSAL_RELATION_DEFINITION_FILE_CONFIG,
+                                 causalRelationFileName);
+    linearRegressionEstimator.configure(config);
+    return linearRegressionEstimator;
+  }
+  
+  private static class TestLinearRegressionEstimator extends LinearRegressionEstimator {
+    @Override
+    protected MetricDef metricDef() {
+      return CruiseControlUnitTestUtils.getMetricDef();
+    }
+  }
+}

--- a/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/model/regression/BucketInfoTest.java
+++ b/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/model/regression/BucketInfoTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.cruisecontrol.model.regression;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class BucketInfoTest {
+  @Test
+  public void testNoDataSample() {
+    BucketInfo bucketInfo = new BucketInfo(5);
+    assertEquals(0, bucketInfo.bucket(1.0f));
+  }
+
+  @Test
+  public void testBucket() {
+    BucketInfo bucketInfo = new BucketInfo(5);
+    bucketInfo.record(11.0f);
+    assertEquals(4, bucketInfo.bucket(21.0f));
+    assertEquals(4, bucketInfo.bucket(19.0f));
+    assertEquals(3, bucketInfo.bucket(17.0f));
+    assertEquals(2, bucketInfo.bucket(15.0f));
+    assertEquals(1, bucketInfo.bucket(13.0f));
+    assertEquals(0, bucketInfo.bucket(11.0f));
+
+    // Record a larger value
+    bucketInfo.record(31.0f);
+    assertEquals(4, bucketInfo.bucket(31.0f));
+    assertEquals(4, bucketInfo.bucket(27.0f));
+    assertEquals(3, bucketInfo.bucket(23.0f));
+    assertEquals(2, bucketInfo.bucket(19.0f));
+    assertEquals(1, bucketInfo.bucket(15.0f));
+    assertEquals(0, bucketInfo.bucket(11.0f));
+
+    // record a smaller value
+    bucketInfo.record(1.0f);
+    assertEquals(4, bucketInfo.bucket(31.0f));
+    assertEquals(4, bucketInfo.bucket(25.5f));
+    assertEquals(3, bucketInfo.bucket(19.5f));
+    assertEquals(2, bucketInfo.bucket(13.5f));
+    assertEquals(1, bucketInfo.bucket(7.0f));
+    assertEquals(0, bucketInfo.bucket(1.0f));
+  }
+
+
+}

--- a/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/model/regression/LinearRegressionTest.java
+++ b/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/model/regression/LinearRegressionTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.  
+ */
+
+package com.linkedin.cruisecontrol.model.regression;
+
+import com.linkedin.cruisecontrol.CruiseControlUnitTestUtils;
+import com.linkedin.cruisecontrol.IntegerEntity;
+import com.linkedin.cruisecontrol.metricdef.MetricDef;
+import com.linkedin.cruisecontrol.monitor.sampling.MetricSample;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static com.linkedin.cruisecontrol.CruiseControlUnitTestUtils.METRIC1;
+import static com.linkedin.cruisecontrol.CruiseControlUnitTestUtils.METRIC2;
+import static com.linkedin.cruisecontrol.CruiseControlUnitTestUtils.METRIC3;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class LinearRegressionTest {
+  private static final double DELTA = 1E-6;
+  private static final IntegerEntity ENTITY = new IntegerEntity("group", 0);
+  private static final double COEFFICIENT_1 = 2.0;
+  private static final double COEFFICIENT_2 = 3.0;
+  
+  private int _maxExponent;
+  
+  @Parameterized.Parameters(name = "maxExponent = {0}")
+  public static Collection<Object[]> exponents() {
+    List<Object[]> exponents = new ArrayList<>();
+    exponents.add(new Integer[]{1});
+    exponents.add(new Integer[]{2});
+    exponents.add(new Integer[]{3});
+    return exponents;
+  }
+  
+  
+  public LinearRegressionTest(int maxExponent) {
+    _maxExponent = maxExponent;
+  }
+  
+  @Test
+  public void testLinearRegression() {
+    LinearRegression linearRegression = getLinearRegression();
+    linearRegression.addMetricSamples(generateMetricSamples(_maxExponent));
+    linearRegression.updateModelCoefficient();
+    
+    MetricDef metricDef = CruiseControlUnitTestUtils.getMetricDef();
+    Map<Integer, Double> coefficients1 = 
+        linearRegression.getCoefficients(metricDef.metricInfo(METRIC2), metricDef.metricInfo(METRIC1));
+    Map<Integer, Double> coefficients2 =
+        linearRegression.getCoefficients(metricDef.metricInfo(METRIC3), metricDef.metricInfo(METRIC1));
+    for (int exp = 1; exp <= _maxExponent; exp++) {
+      assertEquals(COEFFICIENT_1, coefficients1.get(exp), DELTA);
+      assertEquals(COEFFICIENT_2, coefficients2.get(exp), DELTA);
+    }
+  }
+  
+  private LinearRegression getLinearRegression() {
+    MetricDef metricDef = CruiseControlUnitTestUtils.getMetricDef();
+    return new LinearRegression("test", 
+                                new HashSet<>(Arrays.asList(metricDef.metricInfo(METRIC2),
+                                                            metricDef.metricInfo(METRIC3))),
+                                Collections.singleton(metricDef.metricInfo(METRIC1)),
+                                5,
+                                0,
+                                3,
+                                _maxExponent,
+                                10);
+  }
+
+  /**
+   * A private method generates the data with the given max exponent. The polynomial function for the causal relation
+   * are:
+   * METRIC1(i) = i, where i = 1, 2, ... _maxExponent
+   * METRIC2(i) = Sum(COEFFICIENT_1 * METRIC1^i), where i = 1, 2, ... _maxExponent
+   * METRIC3(i) = Sum(COEFFICIENT_2 * METRIC1^i), where i = 1, 2, ... _maxExponent
+   * 
+   * @param maxExponent the max exponent for the linear regression.
+   * @return the metric samples that conform to the above polynomial function.
+   */
+  private List<MetricSample<String, IntegerEntity>> generateMetricSamples(int maxExponent) {
+    MetricDef metricDef = CruiseControlUnitTestUtils.getMetricDef(); 
+    List<MetricSample<String, IntegerEntity>> samples = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      MetricSample<String, IntegerEntity> sample = new MetricSample<>(ENTITY);
+      double value1 = i;
+      double value2 = 0;
+      double value3 = 0;
+      for (int exp = 1; exp <= maxExponent; exp++) {
+        value2 = (value2 + COEFFICIENT_1) * value1;
+        value3 = (value3 + COEFFICIENT_2) * value1;
+      }
+      sample.record(metricDef.metricInfo(METRIC1), value1);
+      sample.record(metricDef.metricInfo(METRIC2), value2);
+      sample.record(metricDef.metricInfo(METRIC3), value3);
+      sample.close(i);
+      samples.add(sample);
+    }
+    return samples;
+  }
+}

--- a/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/model/regression/MetricDiversityTest.java
+++ b/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/model/regression/MetricDiversityTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.cruisecontrol.model.regression;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class MetricDiversityTest {
+
+  @Test
+  public void testShouldRemove() {
+    MetricDiversity diversity = new MetricDiversity(5, 10);
+    diversity.addValue(6.0f);
+    diversity.addValue(1.0f);
+    assertShouldNotRemove(Arrays.asList(1.0f, 6.0f), diversity);
+
+    for (int i = 1; i < 6; i++) {
+      for (int j = 0; j <= 10; j++) {
+        diversity.addValue((float) i * 1);
+      }
+    }
+    assertShouldRemove(Arrays.asList(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f), diversity);
+  }
+
+  private void assertShouldRemove(Collection<Float> values, MetricDiversity diversity) {
+    values.forEach(v -> assertTrue(v + " should be needed.", diversity.shouldRemove(v)));
+  }
+
+  private void assertShouldNotRemove(Collection<Float> values, MetricDiversity diversity) {
+    values.forEach(v -> assertFalse(v + " should not be needed.", diversity.shouldRemove(v)));
+  }
+}

--- a/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/model/regression/MetricValueSelectorTest.java
+++ b/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/model/regression/MetricValueSelectorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.cruisecontrol.model.regression;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class MetricValueSelectorTest {
+
+  @Test
+  public void testInclude() {
+    MetricDiversity diversity = new MetricDiversity(20, 50);
+    diversity.updateBucketInfo(0);
+    diversity.updateBucketInfo(20);
+    for (int i = 1; i < 21; i++) {
+      for (int j = 0; j < i; j++) {
+        diversity.addValue(j);
+      }
+    }
+
+    for (int numBucketsToCap = 0; numBucketsToCap < 20; numBucketsToCap++) {
+      MetricValueSelector valueSelector = new MetricValueSelector(numBucketsToCap, diversity);
+      assertEquals(20 - numBucketsToCap, valueSelector.fairCountCap());
+      for (int i = 1; i < 21; i++) {
+        for (int j = 0; j < i; j++) {
+          if (valueSelector.include(j)) {
+            valueSelector.included(j);
+          }
+          if (j > numBucketsToCap || (i - j) < valueSelector.fairCountCap()) {
+            assertTrue(String.format("numBucketToCap=%d, Value %d, %d should be included", numBucketsToCap, i, j), valueSelector.include(j));
+          } else {
+            assertFalse(String.format("numBucketToCap=%d, Value %d, %d should not be included", numBucketsToCap, i, j), valueSelector.include(j));
+          }
+        }
+      }
+    }
+  }
+}

--- a/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/model/regression/RegressionMetricsAccumulatorTest.java
+++ b/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/model/regression/RegressionMetricsAccumulatorTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.cruisecontrol.model.regression;
+
+import com.linkedin.cruisecontrol.CruiseControlUnitTestUtils;
+import com.linkedin.cruisecontrol.metricdef.MetricDef;
+import com.linkedin.cruisecontrol.metricdef.MetricInfo;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.linkedin.cruisecontrol.CruiseControlUnitTestUtils.METRIC1;
+import static com.linkedin.cruisecontrol.CruiseControlUnitTestUtils.METRIC2;
+import static com.linkedin.cruisecontrol.CruiseControlUnitTestUtils.METRIC3;
+import static org.junit.Assert.*;
+
+
+public class RegressionMetricsAccumulatorTest {
+  private static final int MAX_EXPONENT = 2;
+  private static final double DELTA = 1E-6;
+  private CausalRelation _causalRelation;
+  private MetricDef _metricDef;
+  
+  @Before
+  public void prepare() {
+    _metricDef = CruiseControlUnitTestUtils.getMetricDef();
+    _causalRelation = new CausalRelation(Collections.singleton(_metricDef.metricInfo(METRIC1)), 
+                                         Arrays.asList(_metricDef.metricInfo(METRIC2), _metricDef.metricInfo(METRIC3)));
+  }
+  
+  @Test
+  public void testRecordMetricValues() {
+    List<double[]> data = prepareData(10);
+    RegressionMetricsAccumulator accumulator = getMetricsAccumulator();
+    for (double[] values : data) {
+      accumulator.recordMetricValues(values);
+    }
+    accumulator.maybeRemoveOldValues();
+    // Should not have removed anything.
+    Map<MetricInfo, MetricDiversity> diversityForMetrics = accumulator.diversityForMetrics();
+    assertEquals(_causalRelation.indexes().size(), diversityForMetrics.size());
+    for (MetricDiversity diversity : diversityForMetrics.values()) {
+      Map<Integer, Integer> counts = diversity.countsByBucket();
+      for (int i = 0; i < 5; i++) {
+        assertEquals("There should be 2 values in bucket " + i, 2, counts.get(i).intValue());
+      }
+    }
+  }
+
+  @Test
+  public void testMaybeRemoveOldValues() {
+    List<double[]> data = prepareData(100);
+    RegressionMetricsAccumulator accumulator = getMetricsAccumulator();
+    for (double[] values : data) {
+      accumulator.recordMetricValues(values);
+    }
+    accumulator.maybeRemoveOldValues();
+    // Should have removed additional value samples.
+    Map<MetricInfo, MetricDiversity> diversityForMetrics = accumulator.diversityForMetrics();
+    assertEquals(_causalRelation.indexes().size(), diversityForMetrics.size());
+    for (MetricDiversity diversity : diversityForMetrics.values()) {
+      Map<Integer, Integer> counts = diversity.countsByBucket();
+      for (int i = 0; i < 5; i++) {
+        assertEquals("There should be 2 values in bucket " + i, 5, counts.get(i).intValue());
+      }
+    }
+    // Check the samples
+    Map<Long, double[]> sampleValues = accumulator.sampleValues();
+    assertEquals(5 * 5, sampleValues.size());
+  }
+
+  @Test
+  public void testGetRegressionData() {
+    List<double[]> data = prepareData(10);
+    RegressionMetricsAccumulator accumulator = getMetricsAccumulator();
+    for (double[] values : data) {
+      accumulator.recordMetricValues(values);
+    }
+    accumulator.maybeRemoveOldValues();
+    Set<MetricInfo> resultantMetrics = _causalRelation.resultantMetrics();
+    DataForLinearRegression regressionData = accumulator.getRegressionData(resultantMetrics);
+
+    double[] dataForResultantMetric = regressionData.resultantMetricValues().get(_metricDef.metricInfo(METRIC1));
+    assertEquals(10, dataForResultantMetric.length);
+    int resultantMetricIndex = _causalRelation.indexes().get(_metricDef.metricInfo(METRIC1));
+    for (int i = 0; i < 10; i++) {
+      // Because the metrics are prioritized in reverse order, the later samples will show first.
+      assertEquals((9 - i) + (double) resultantMetricIndex / 10, dataForResultantMetric[i], DELTA);
+    }
+
+    double[][] causalMetricData = regressionData.causalMetricsValues();
+    assertEquals(10, causalMetricData.length);
+    for (int i = 0; i < 10; i++) {
+      for (MetricInfo metricInfo : _causalRelation.causalMetrics()) {
+        int causalMetricIndex = _causalRelation.indexes().get(metricInfo);
+        for (int exp = 1; exp <= MAX_EXPONENT; exp++) {
+          // Because the metrics are prioritized in reverse order, the later samples will show first.
+          assertEquals(Math.pow((9 - i) + (double) causalMetricIndex / 10, exp), 
+                       causalMetricData[i][causalMetricIndex + (exp - 1) * _causalRelation.causalMetrics().size()], 
+                       DELTA);
+        }
+      }
+    }
+  }
+  
+  private RegressionMetricsAccumulator getMetricsAccumulator() {
+    return new RegressionMetricsAccumulator(_causalRelation, 5, 3, 5, 2);
+  }
+
+  private List<double[]> prepareData(int numSamplesPerMetric) {
+    List<double[]> data = new ArrayList<>();
+    for (int i = 0; i < numSamplesPerMetric; i++) {
+      double[] values = new double[_causalRelation.indexes().size()];
+      for (int index : _causalRelation.indexes().values()) {
+        values[index] = i + (double) index / 10;
+      }
+      data.add(values);
+    }
+    return data;
+  }
+  
+  
+}

--- a/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricValuesTest.java
+++ b/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricValuesTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information. 
+ */
+
+package com.linkedin.cruisecontrol.monitor.sampling.aggregator;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class MetricValuesTest {
+  private static final double DELTA = 1E-6;
+  
+  @Test
+  public void testSet() {     
+    MetricValues metricValues = getMetricValues();
+    metricValues.set(2, 4.0);
+    assertValues(metricValues, 1.0, 3.0, 4.0, (double) 8 / 3, 4.0, 1.0);
+  }
+  
+  @Test 
+  public void testSetLowerAtMaxIndex() {
+    MetricValues metricValues = getMetricValues();
+    metricValues.set(1, 1.0);
+    assertValues(metricValues, 1.0, 1.0, 2.0, (double) 4 / 3, 2.0, 1.0);
+  }
+
+  @Test
+  public void testSetHigherAtMaxIndex() {
+    MetricValues metricValues = getMetricValues();
+    metricValues.set(1, 4.0);
+    assertValues(metricValues, 1.0, 4.0, 2.0, (double) 7 / 3, 4.0, 1.0);
+  }
+  
+  @Test
+  public void testAddAtIndex() {
+    MetricValues metricValues = getMetricValues();
+    metricValues.add(0, 1);
+    assertValues(metricValues, 2.0, 3.0, 2.0, (double) 7 / 3, 3.0, 2.0);
+  }
+  
+  @Test
+  public void testAddPositiveAtMaxIndex() {
+    MetricValues metricValues = getMetricValues();
+    metricValues.add(1, 1);
+    assertValues(metricValues, 1.0, 4.0, 2.0, (double) 7 / 3, 4.0, 1.0);
+  }
+  
+  @Test
+  public void testAddNegativeAtMaxIndex() {
+    MetricValues metricValues = getMetricValues();
+    metricValues.add(1, -1);
+    assertValues(metricValues, 1.0, 2.0, 2.0, (double) 5 / 3, 2.0, 1.0);
+  }
+  
+  @Test
+  public void testAddArray() {
+    MetricValues metricValues = getMetricValues();
+    metricValues.add(new double[]{1.0, 2.0, 4.0});
+    assertValues(metricValues, 2.0, 5.0, 6.0, (double) 13 / 3, 6.0, 2.0);
+  }
+  
+  @Test
+  public void testSubtractArray() {
+    MetricValues metricValues = getMetricValues();
+    metricValues.subtract(new double[]{1.0, 4.0, 1.0});
+    assertValues(metricValues, 0.0, -1.0, 1.0, 0.0, 1.0, 0.0);
+  }
+  
+  @Test
+  public void testClear() {
+    MetricValues metricValues = getMetricValues();
+    metricValues.clear();
+    assertValues(metricValues, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+  }
+  
+  private void assertValues(MetricValues values, double first, double second, double third, 
+                            double avg, double max, double latest) {
+    assertEquals(first, values.get(0), DELTA);
+    assertEquals(second, values.get(1), DELTA);
+    assertEquals(third, values.get(2), DELTA);
+    assertEquals(avg, values.avg(), DELTA);
+    assertEquals(max, values.max(), DELTA);
+    assertEquals(latest, values.latest(), DELTA);
+  }
+  
+  private MetricValues getMetricValues() {
+    MetricValues metricValues = new MetricValues(3);
+    metricValues.set(0, 1.0);
+    metricValues.set(1, 3.0);
+    metricValues.set(2, 2.0);
+    assertValues(metricValues, 1.0, 3.0, 2.0, 2.0, 3.0, 1.0);
+    return metricValues;
+  }
+  
+}

--- a/cruise-control-core/src/test/resources/TestCausalRelation.json
+++ b/cruise-control-core/src/test/resources/TestCausalRelation.json
@@ -1,0 +1,34 @@
+{
+  "linearRegressions": [
+    {
+      "name": "regression_1",
+      "causalMetrics": [
+        "METRIC1",
+        "METRIC2"
+      ],
+      "resultantMetrics": [
+        "METRIC3"
+      ],
+      "numValueBuckets": 20,
+      "numBucketsToCapForFairness": 10,
+      "maxSamplesPerBucket": 50,
+      "maxExponent": 1,
+      "errorStatsWindowSize": 1000
+    },
+    {
+      "name": "regression_2",
+      "causalMetrics": [
+        "METRIC1"
+      ],
+      "resultantMetrics": [
+        "METRIC2",
+        "METRIC3"
+      ],
+      "numValueBuckets": 10,
+      "numBucketsToCapForFairness": 5,
+      "maxSamplesPerBucket": 20,
+      "maxExponent": 2,
+      "errorStatsWindowSize": 2000
+    }
+  ]
+}

--- a/cruise-control-core/src/test/resources/log4j.properties
+++ b/cruise-control-core/src/test/resources/log4j.properties
@@ -14,5 +14,3 @@ log4j.logger.kafka=ERROR
 # zkclient can be verbose, during debugging it is common to adjust is separately
 log4j.logger.org.I0Itec.zkclient.ZkClient=WARN
 log4j.logger.org.apache.zookeeper=WARN
-
-log4j.logger.com.linkedin.cruisecontrol.monitor.sampling.newaggregator=ERROR


### PR DESCRIPTION
This is the first part of the patch that generalize the linear regression in cruise control core. A followup patch will migrate KafkaCruiseControl to depend on this patch.
1. Added configure based linear regression model
2. Support multiple linear regression definition for the same resultant metric, and the best one will be picked up.
3. Implemented value selector to choose the sample values to maximize fairness.