### PR TITLE
Improve the MetricSampleAggregator behavior.

### DIFF
--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/AggregationOptions.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/AggregationOptions.java
@@ -18,6 +18,7 @@ public class AggregationOptions<G, E extends Entity<G>> {
   private final double _minValidEntityRatio;
   private final double _minValidEntityGroupRatio;
   private final int _minValidWindows;
+  private final int _maxAllowedExtrapolationsPerEntity;
   private final Set<E> _interestedEntities;
   private final Granularity _granularity;
   private final boolean _includeInvalidEntities;
@@ -33,6 +34,7 @@ public class AggregationOptions<G, E extends Entity<G>> {
    * @param minValidWindows The minimum required number of valid windows required in the result. A valid window
    *                        is a window within which both <tt>Min Valid Entity Ratio</tt> and
    *                        <tt>Min Valid Entity Group Ratio</tt> are met.
+   * @param maxAllowedExtrapolationsPerEntity the maximum allowed {@link Extrapolation}s per entity in the aggregation.
    * @param interestedEntities All the entities to include in this aggregation. Sometimes not all the entities are
    *                           interested. This option allows users to aggregate only part of the entities.
    * @param granularity The granularity of the aggregation.
@@ -47,6 +49,7 @@ public class AggregationOptions<G, E extends Entity<G>> {
   public AggregationOptions(double minValidEntityRatio,
                             double minValidEntityGroupRatio,
                             int minValidWindows,
+                            int maxAllowedExtrapolationsPerEntity,
                             Set<E> interestedEntities,
                             Granularity granularity,
                             boolean includeInvalidEntities) {
@@ -56,6 +59,7 @@ public class AggregationOptions<G, E extends Entity<G>> {
     _minValidEntityRatio = minValidEntityRatio;
     _minValidEntityGroupRatio = minValidEntityGroupRatio;
     _minValidWindows = minValidWindows;
+    _maxAllowedExtrapolationsPerEntity = maxAllowedExtrapolationsPerEntity;
     _interestedEntities = interestedEntities == null ? Collections.emptySet() : interestedEntities;
     _granularity = granularity == null ? Granularity.ENTITY : granularity;
     _includeInvalidEntities = includeInvalidEntities;
@@ -82,6 +86,13 @@ public class AggregationOptions<G, E extends Entity<G>> {
    */
   public int minValidWindows() {
     return _minValidWindows;
+  }
+
+  /**
+   * @return the maximum allowed extrapolations per entity.
+   */
+  public int maxAllowedExtrapolationsPerEntity() {
+    return _maxAllowedExtrapolationsPerEntity;
   }
 
   /**
@@ -145,6 +156,8 @@ public class AggregationOptions<G, E extends Entity<G>> {
     } else if (_minValidWindows != other.minValidWindows()) {
       return false;
     } else if (_granularity != other.granularity()) {
+      return false;
+    } else if (_maxAllowedExtrapolationsPerEntity != other.maxAllowedExtrapolationsPerEntity()) {
       return false;
     } else if (_interestedEntities.size() != other.interestedEntities().size()) {
       return false;

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregatorState.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregatorState.java
@@ -9,6 +9,7 @@ import com.linkedin.cruisecontrol.model.Entity;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -209,6 +210,7 @@ class MetricSampleAggregatorState<G, E extends Entity<G>> extends WindowIndexedA
                                                              AggregationOptions<G, E> options,
                                                              long currentGeneration) {
     MetricSampleCompleteness<G, E> completeness = new MetricSampleCompleteness<>(currentGeneration, _windowMs);
+    Map<E, Integer> entityExtrapolations = new HashMap<>();
     completeness.addValidEntities(new HashSet<>(options.interestedEntities()));
     completeness.addValidEntityGroups(new HashSet<>(options.interestedEntityGroups()));
 
@@ -220,7 +222,7 @@ class MetricSampleAggregatorState<G, E extends Entity<G>> extends WindowIndexedA
         break;
       }
       WindowState<G, E> windowState = entry.getValue();
-      windowState.maybeInclude(windowIdx, completeness, options);
+      windowState.maybeInclude(windowIdx, completeness, entityExtrapolations, options);
     }
     // No window is included. We need to clear the valid entity and entity group. Otherwise we keep them.
     if (completeness.validWindowIndexes().isEmpty()) {

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleCompleteness.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleCompleteness.java
@@ -31,6 +31,7 @@ public class MetricSampleCompleteness<G, E extends Entity<G>> extends LongGenera
   private final SortedMap<Long, Float> _validEntityRatioByWindowIndex;
   private final SortedMap<Long, Float> _validEntityRatioWithGroupGranularityByWindowIndex;
   private final SortedMap<Long, Float> _validEntityGroupRatioByWindowIndex;
+  private final SortedMap<Long, Float> _extrapolatedEntitiesByWindowIndex;
   private final SortedSet<Long> _validWindowIndexes;
   private final long _windowMs;
   private final Set<E> _validEntities;
@@ -43,6 +44,7 @@ public class MetricSampleCompleteness<G, E extends Entity<G>> extends LongGenera
     _validEntityRatioByWindowIndex = new TreeMap<>(Collections.reverseOrder());
     _validEntityRatioWithGroupGranularityByWindowIndex = new TreeMap<>(Collections.reverseOrder());
     _validEntityGroupRatioByWindowIndex = new TreeMap<>(Collections.reverseOrder());
+    _extrapolatedEntitiesByWindowIndex = new TreeMap<>(Collections.reverseOrder());
     _validWindowIndexes = new TreeSet<>(Collections.reverseOrder());
     _validEntities = new HashSet<>();
     _validEntityGroups = new HashSet<>();
@@ -61,6 +63,10 @@ public class MetricSampleCompleteness<G, E extends Entity<G>> extends LongGenera
 
   void addValidEntityGroupRatio(long windowIndex, float validEntityGroupRatio) {
     _validEntityGroupRatioByWindowIndex.put(windowIndex, validEntityGroupRatio);
+  }
+
+  void addExtrapolationEntityRatio(long windowIndex, float extrapolatedEntityRatio) {
+    _extrapolatedEntitiesByWindowIndex.put(windowIndex, extrapolatedEntityRatio);
   }
 
   void addValidWindowIndex(long windowIndex) {
@@ -122,6 +128,14 @@ public class MetricSampleCompleteness<G, E extends Entity<G>> extends LongGenera
    */
   public SortedMap<Long, Float> validEntityGroupRatioByWindowIndex() {
     return _validEntityGroupRatioByWindowIndex;
+  }
+
+  /**
+   * Get the number of extrapolated entities.
+   * @return The number of extrapolated entities by window index.
+   */
+  public SortedMap<Long, Float> extrapolatedEntitiesByWindowIndex() {
+    return _extrapolatedEntitiesByWindowIndex;
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
@@ -223,11 +223,11 @@ public class GoalOptimizer implements Runnable {
    * Get the analyzer state from the goal optimizer.
    */
   public AnalyzerState state() {
-    Map<Goal, Boolean> goalRediness = new LinkedHashMap<>(_goalsByPriority.size());
+    Map<Goal, Boolean> goalReadiness = new LinkedHashMap<>(_goalsByPriority.size());
     for (Goal goal : _goalsByPriority.values()) {
-      goalRediness.put(goal, _loadMonitor.meetCompletenessRequirements(goal.clusterModelCompletenessRequirements()));
+      goalReadiness.put(goal, _loadMonitor.meetCompletenessRequirements(goal.clusterModelCompletenessRequirements()));
     }
-    return new AnalyzerState(_bestProposal != null, goalRediness);
+    return new AnalyzerState(_bestProposal != null, goalReadiness);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -350,26 +350,24 @@ public class Executor {
     private void moveLeaderships() {
       int numTotalLeadershipMovements = _executionTaskManager.remainingLeadershipMovements().size();
       LOG.info("Starting {} leadership movements.", numTotalLeadershipMovements);
-      int leaderMoved = 0;
+      _numFinishedLeadershipMovements = 0;
       while (!_executionTaskManager.remainingLeadershipMovements().isEmpty() && !_stopRequested.get()) {
         updateOngoingExecutionState();
-        moveLeadershipInBatch(numTotalLeadershipMovements);
+        _numFinishedLeadershipMovements += moveLeadershipInBatch();
         LOG.info("{}/{} ({}%) leadership movements completed.", _numFinishedLeadershipMovements,
                  numTotalLeadershipMovements, _numFinishedLeadershipMovements * 100 / numTotalLeadershipMovements);
       }
       LOG.info("Leadership movements finished.");
     }
 
-    private void moveLeadershipInBatch(int numTotalLeadershipMovements) {
+    private int moveLeadershipInBatch() {
       List<ExecutionTask> leadershipMovementTasks = _executionTaskManager.getLeadershipMovementTasks();
       int numLeadershipToMove = leadershipMovementTasks.size();
       LOG.debug("Executing {} leadership movements in a batch.", numLeadershipToMove);
-      int alreadyFinishedLeadershipMovements = _numFinishedLeadershipMovements;
       // Execute the leadership movements.
       if (!leadershipMovementTasks.isEmpty() && !_stopRequested.get()) {
         // Mark leadership movements in progress.
         _executionTaskManager.markTasksInProgress(leadershipMovementTasks);
-        _numFinishedLeadershipMovements = alreadyFinishedLeadershipMovements + numLeadershipToMove - leadershipMovementTasks.size();
 
         // Run preferred leader election.
         ExecutorUtils.executePreferredLeaderElection(_zkUtils, leadershipMovementTasks);
@@ -378,7 +376,7 @@ public class Executor {
           waitForExecutionTaskToFinish();
         }
       }
-      _numFinishedLeadershipMovements = alreadyFinishedLeadershipMovements + numLeadershipToMove;
+      return numLeadershipToMove;
     }
 
     /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/SamplingFetcher.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/SamplingFetcher.java
@@ -30,7 +30,7 @@ import static com.linkedin.kafka.cruisecontrol.monitor.metricdefinition.KafkaMet
  * A metric fetcher that is responsible for fetching the metric samples to monitor the cluster load.
  */
 class SamplingFetcher extends MetricFetcher {
-  private final Logger LOG = LoggerFactory.getLogger(MetricFetcher.class);
+  private final Logger LOG = LoggerFactory.getLogger(SamplingFetcher.class);
   // The metadata of the cluster this metric fetcher is fetching from.
   private final MetricSampler _metricSampler;
   private final Cluster _cluster;
@@ -147,7 +147,7 @@ class SamplingFetcher extends MetricFetcher {
                        + "The metric sample will be ignored.", tp);
         }
       }
-      LOG.debug("Collected {}{} partition metric samples for {} partitions. Total partition assigned: {}.",
+      LOG.info("Collected {}{} partition metric samples for {} partitions. Total partition assigned: {}.",
                 partitionMetricSamples.size(), discarded > 0 ? String.format("(%d discarded)", discarded) : "",
                 returnedPartitions.size(), _assignedPartitions.size());
     } else {
@@ -173,7 +173,7 @@ class SamplingFetcher extends MetricFetcher {
         }
         returnedBrokerIds.add(brokerMetricSample.brokerId());
       }
-      LOG.debug("Collected {}{} broker metric samples for {} brokers.",
+      LOG.info("Collected {}{} broker metric samples for {} brokers.",
                 brokerMetricSamples.size(), discarded > 0 ? String.format("(%d discarded)", discarded) : "",
                 returnedBrokerIds.size());
     } else {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaBrokerMetricSampleAggregator.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaBrokerMetricSampleAggregator.java
@@ -27,6 +27,8 @@ public class KafkaBrokerMetricSampleAggregator extends MetricSampleAggregator<St
   private static final double MIN_VALID_GROUP_RATIO = 0.0;
   private static final int MIN_VALID_WINDOWS = 1;
   private static final boolean INCLUDE_INVALID_ENTITIES = false;
+
+  private final int _maxAllowedExtrapoloationsPerBroker;
   /**
    * Construct the metric sample aggregator.
    *
@@ -36,9 +38,10 @@ public class KafkaBrokerMetricSampleAggregator extends MetricSampleAggregator<St
     super(config.getInt(KafkaCruiseControlConfig.NUM_BROKER_METRICS_WINDOWS_CONFIG),
           config.getLong(KafkaCruiseControlConfig.BROKER_METRICS_WINDOW_MS_CONFIG),
           config.getInt(KafkaCruiseControlConfig.MIN_SAMPLES_PER_BROKER_METRICS_WINDOW_CONFIG),
-          config.getInt(KafkaCruiseControlConfig.MAX_ALLOWED_EXTRAPOLATIONS_PER_BROKER_CONFIG),
           config.getInt(KafkaCruiseControlConfig.BROKER_METRIC_SAMPLE_AGGREGATOR_COMPLETENESS_CACHE_SIZE_CONFIG),
           KafkaMetricDef.brokerMetricDef());
+    _maxAllowedExtrapoloationsPerBroker =
+        config.getInt(KafkaCruiseControlConfig.MAX_ALLOWED_EXTRAPOLATIONS_PER_BROKER_CONFIG);
   }
 
   /**
@@ -48,7 +51,8 @@ public class KafkaBrokerMetricSampleAggregator extends MetricSampleAggregator<St
    */
   public MetricSampleAggregationResult<String, BrokerEntity> aggregate(Set<BrokerEntity> brokerEntities) {
     AggregationOptions<String, BrokerEntity>  aggregationOptions =
-        new AggregationOptions<>(MIN_VALID_BROKER_RATIO, MIN_VALID_GROUP_RATIO, MIN_VALID_WINDOWS, brokerEntities,
+        new AggregationOptions<>(MIN_VALID_BROKER_RATIO, MIN_VALID_GROUP_RATIO, MIN_VALID_WINDOWS,
+                                 _maxAllowedExtrapoloationsPerBroker, brokerEntities,
                                  AggregationOptions.Granularity.ENTITY, INCLUDE_INVALID_ENTITIES);
     if (super.numAvailableWindows() < 1) {
       LOG.trace("No window is available for any broker.");

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregator.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregator.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
  */
 public class KafkaPartitionMetricSampleAggregator extends MetricSampleAggregator<String, PartitionEntity> {
   private static final Logger LOG = LoggerFactory.getLogger(KafkaPartitionMetricSampleAggregator.class);
+  private final int _maxAllowedExtrapolationsPerPartition;
   private final Metadata _metadata;
 
   /**
@@ -57,10 +58,12 @@ public class KafkaPartitionMetricSampleAggregator extends MetricSampleAggregator
     super(config.getInt(KafkaCruiseControlConfig.NUM_PARTITION_METRICS_WINDOWS_CONFIG),
           config.getLong(KafkaCruiseControlConfig.PARTITION_METRICS_WINDOW_MS_CONFIG),
           config.getInt(KafkaCruiseControlConfig.MIN_SAMPLES_PER_PARTITION_METRICS_WINDOW_CONFIG),
-          config.getInt(KafkaCruiseControlConfig.MAX_ALLOWED_EXTRAPOLATIONS_PER_PARTITION_CONFIG),
           config.getInt(KafkaCruiseControlConfig.PARTITION_METRIC_SAMPLE_AGGREGATOR_COMPLETENESS_CACHE_SIZE_CONFIG),
           KafkaMetricDef.commonMetricDef());
     _metadata = metadata;
+    _maxAllowedExtrapolationsPerPartition =
+        config.getInt(KafkaCruiseControlConfig.MAX_ALLOWED_EXTRAPOLATIONS_PER_PARTITION_CONFIG);
+
   }
 
   /**
@@ -181,6 +184,7 @@ public class KafkaPartitionMetricSampleAggregator extends MetricSampleAggregator
         new AggregationOptions<>(minMonitoredPartitionsPercentage,
                                  0.0,
                                  1,
+                                 _maxAllowedExtrapolationsPerPartition,
                                  allPartitions(clusterAndGeneration.cluster()),
                                  AggregationOptions.Granularity.ENTITY_GROUP,
                                  true);
@@ -199,6 +203,7 @@ public class KafkaPartitionMetricSampleAggregator extends MetricSampleAggregator
         new AggregationOptions<>(0.0,
                                  0.0,
                                  1,
+                                 _maxAllowedExtrapolationsPerPartition,
                                  allPartitions(clusterAndGeneration.cluster()),
                                  AggregationOptions.Granularity.ENTITY_GROUP,
                                  true);
@@ -216,6 +221,7 @@ public class KafkaPartitionMetricSampleAggregator extends MetricSampleAggregator
         new AggregationOptions<>(0.0,
                                  0.0,
                                  1,
+                                 _maxAllowedExtrapolationsPerPartition,
                                  allPartitions(clusterAndGeneration.cluster()),
                                  AggregationOptions.Granularity.ENTITY_GROUP,
                                  true);
@@ -287,6 +293,7 @@ public class KafkaPartitionMetricSampleAggregator extends MetricSampleAggregator
     return new AggregationOptions<>(requirements.minMonitoredPartitionsPercentage(),
                                     0.0,
                                     requirements.minRequiredNumWindows(),
+                                    _maxAllowedExtrapolationsPerPartition,
                                     allPartitions,
                                     AggregationOptions.Granularity.ENTITY_GROUP,
                                     requirements.includeAllTopics());

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregatorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregatorTest.java
@@ -360,7 +360,7 @@ public class KafkaPartitionMetricSampleAggregatorTest {
   }
 
   @Test
-  public void testValidWindowsWithTooManyExtrapolationss() {
+  public void testValidWindowsWithTooManyExtrapolations() {
     TestContext ctx = setupScenario4();
     KafkaPartitionMetricSampleAggregator aggregator = ctx.aggregator();
     MetadataClient.ClusterAndGeneration clusterAndGeneration = ctx.clusterAndGeneration(0);
@@ -541,14 +541,16 @@ public class KafkaPartitionMetricSampleAggregatorTest {
     TopicPartition t2p0 = new TopicPartition("TOPIC2", 0);
     TopicPartition t2p1 = new TopicPartition("TOPIC2", 1);
     List<TopicPartition> allPartitions = Arrays.asList(TP, t0p1, t1p0, t1p1, t2p0, t2p1);
-    KafkaCruiseControlConfig config = new KafkaCruiseControlConfig(getLoadMonitorProperties());
+    Properties props = getLoadMonitorProperties();
+    props.setProperty(KafkaCruiseControlConfig.MAX_ALLOWED_EXTRAPOLATIONS_PER_PARTITION_CONFIG, "0");
+    KafkaCruiseControlConfig config = new KafkaCruiseControlConfig(props);
     Metadata metadata = getMetadata(allPartitions);
     KafkaPartitionMetricSampleAggregator aggregator = new KafkaPartitionMetricSampleAggregator(config, metadata);
 
     for (TopicPartition tp : Arrays.asList(TP, t1p0, t2p0, t2p1)) {
       populateSampleAggregator(NUM_WINDOWS + 1, MIN_SAMPLES_PER_WINDOW, aggregator, tp);
     }
-    // Let t0p1 have too many extrapolationss.
+    // Let t0p1 have too many extrapolations.
     populateSampleAggregator(NUM_WINDOWS + 1, MIN_SAMPLES_PER_WINDOW - 1, aggregator, t0p1);
     // let t1p1 miss another earlier window
     populateSampleAggregator(5, MIN_SAMPLES_PER_WINDOW, aggregator, t1p1);


### PR DESCRIPTION
This patch allows the entities that has more than required valid windows to be included in the aggregation, even if they have more than max allowed extrapolations.