### PR TITLE
Add sanity check against attempts to create a broker with null capacity.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
@@ -55,6 +55,9 @@ public class Broker implements Serializable, Comparable<Broker> {
    * @param brokerCapacity The capacity of the broker.
    */
   Broker(Host host, int id, Map<Resource, Double> brokerCapacity) {
+    if (brokerCapacity == null) {
+      throw new IllegalArgumentException("Attempt to create broker " + id + " on host " + host.name() + " with null capacity.");
+    }
     _host = host;
     _id = id;
     _brokerCapacity = new double[Resource.cachedValues().size()];


### PR DESCRIPTION
This fix enables CC to identify attempts to create brokers with null capacity -- e.g. as it is potentially the case in issue-https://github.com/linkedin/cruise-control/issues/214.