### PR TITLE
Handle replica wrapper comparison with non-positive disk capacity and with MAX and MIN_REPLICA.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/internals/BrokerAndSortedReplicas.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/internals/BrokerAndSortedReplicas.java
@@ -43,7 +43,7 @@ public class BrokerAndSortedReplicas {
 
   @Override
   public boolean equals(Object obj) {
-    return obj != null && obj instanceof BrokerAndSortedReplicas
+    return obj instanceof BrokerAndSortedReplicas
         && _broker.equals(((BrokerAndSortedReplicas) obj).broker());
   }
 }


### PR DESCRIPTION
This patch fixes potential errors due to getting 0 disk capacity from capacity resolver while executing `KafkaAssignerDiskUsageDistributionGoal`.
```
Caused by: java.lang.IllegalArgumentException: fromKey > toKey
        at java.util.TreeMap$NavigableSubMap.<init>(TreeMap.java:1368)
        at java.util.TreeMap$AscendingSubMap.<init>(TreeMap.java:1855)
        at java.util.TreeMap.subMap(TreeMap.java:913)
        at java.util.TreeSet.subSet(TreeSet.java:325)
        at com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerDiskUsageDistributionGoal.findReplicaToSwapWith(KafkaAssignerDiskUsageDistributionGoal.java:375)
        at com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerDiskUsageDistributionGoal.swapReplicas(KafkaAssignerDiskUsageDistributionGoal.java:332)
        at com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerDiskUsageDistributionGoal.checkAndOptimize(KafkaAssignerDiskUsageDistributionGoal.java:214)
        at com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerDiskUsageDistributionGoal.optimize(KafkaAssignerDiskUsageDistributionGoal.java:112)
        at com.linkedin.kafka.cruisecontrol.analyzer.GoalOptimizer.optimizations(GoalOptimizer.java:344)
        at com.linkedin.kafka.cruisecontrol.KafkaCruiseControl.getOptimizationProposals(KafkaCruiseControl.java:408)
        at com.linkedin.kafka.cruisecontrol.KafkaCruiseControl.getOptimizationProposals(KafkaCruiseControl.java:391)
        at com.linkedin.kafka.cruisecontrol.KafkaCruiseControl.rebalance(KafkaCruiseControl.java:194)
        at com.linkedin.kafka.cruisecontrol.async.RebalanceRunnable.getResult(RebalanceRunnable.java:34)
        at com.linkedin.kafka.cruisecontrol.async.RebalanceRunnable.getResult(RebalanceRunnable.java:16)
        at com.linkedin.kafka.cruisecontrol.async.OperationRunnable.run(OperationRunnable.java:45)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        ... 1 more
```