### PR TITLE
Remove the redundant config max.proposal.candidates.

### DIFF
--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -139,9 +139,6 @@ metric.anomaly.percentile.upper.threshold=90.0
 # The metric anomaly percentile lower threshold
 metric.anomaly.percentile.lower.threshold=10.0
 
-# The maximum number of optimization proposal candidates should the analyzer precompute.
-max.proposal.candidates=10
-
 # How often should the cached proposal be expired and recalculated if necessary
 proposal.expiration.ms=60000
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -381,15 +381,6 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                                                                     + "the current state to identify metric anomalies.";
 
   /**
-   * <code>max.proposal.candidates</code>
-   */
-  public static final String MAX_PROPOSAL_CANDIDATES_CONFIG = "max.proposal.candidates";
-  private static final String MAX_PROPOSAL_CANDIDATES_DOC = "Kafka Cruise Control precomputes the optimization proposal"
-      + "candidates continuously in the background. This config sets the maximum number of candidate proposals to "
-      + "precompute for each cluster workload model. The more proposal candidates are generated, the more likely a "
-      + "better optimization proposal will be found, but more CPU will be used as well.";
-
-  /**
    * <code>proposal.expiration.ms</code>
    */
   public static final String PROPOSAL_EXPIRATION_MS_CONFIG = "proposal.expiration.ms";
@@ -747,12 +738,6 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 ConfigDef.Type.LIST,
                 DEFAULT_METRIC_ANOMALY_FINDER_CLASS,
                 ConfigDef.Importance.MEDIUM, METRIC_ANOMALY_FINDER_CLASSES_DOC)
-        .define(MAX_PROPOSAL_CANDIDATES_CONFIG,
-                ConfigDef.Type.INT,
-                10,
-                atLeast(1),
-                ConfigDef.Importance.MEDIUM,
-                MAX_PROPOSAL_CANDIDATES_DOC)
         .define(PROPOSAL_EXPIRATION_MS_CONFIG,
                 ConfigDef.Type.LONG,
                 900000,


### PR DESCRIPTION
This config sets the number of times that the same cluster model is optimized with the same set of goals by a given precomputation thread. We used to need this config because the Analyzer component was not deterministic -- i.e. used to generate different optimizations under the same circumstances. However, this is no longer the case; hence, we can safely remove this config to avoid redundant loss of performance when this config is set to a value greater than 1 -- not that the default value was `10`.