### PR TITLE
Add parameter to allow/disallow capacity estimation upon cluster model generation.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -395,9 +395,7 @@ public class KafkaCruiseControl {
                                                                 boolean allowCapacityEstimation)
       throws KafkaCruiseControlException {
     try {
-      GoalOptimizer.OptimizerResult result = _goalOptimizer.optimizations(operationProgress, allowCapacityEstimation);
-      sanityCheckCapacityEstimation(allowCapacityEstimation, result.capacityEstimationInfoByBrokerId());
-      return result;
+      return _goalOptimizer.optimizations(operationProgress, allowCapacityEstimation);
     } catch (InterruptedException ie) {
       throw new KafkaCruiseControlException("Interrupted when getting the optimization proposals", ie);
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -113,6 +113,7 @@ public class KafkaCruiseControl {
    * @param goals the goals to be met when decommissioning the brokers. When empty all goals will be used.
    * @param requirements The cluster model completeness requirements.
    * @param operationProgress the progress to report.
+   * @param allowCapacityEstimation Allow capacity estimation in cluster model if the requested broker capacity is unavailable.
    * @return the optimization result.
    *
    * @throws KafkaCruiseControlException when any exception occurred during the decommission process.
@@ -122,7 +123,8 @@ public class KafkaCruiseControl {
                                                            boolean throttleDecommissionedBroker,
                                                            List<String> goals,
                                                            ModelCompletenessRequirements requirements,
-                                                           OperationProgress operationProgress)
+                                                           OperationProgress operationProgress,
+                                                           boolean allowCapacityEstimation)
       throws KafkaCruiseControlException {
     Map<Integer, Goal> goalsByPriority = goalsByPriority(goals);
     ModelCompletenessRequirements modelCompletenessRequirements =
@@ -131,7 +133,8 @@ public class KafkaCruiseControl {
       ClusterModel clusterModel = _loadMonitor.clusterModel(_time.milliseconds(), modelCompletenessRequirements,
                                                             operationProgress);
       brokerIds.forEach(id -> clusterModel.setBrokerState(id, Broker.State.DEAD));
-      GoalOptimizer.OptimizerResult result = getOptimizationProposals(clusterModel, goalsByPriority, operationProgress);
+      GoalOptimizer.OptimizerResult result =
+          getOptimizationProposals(clusterModel, goalsByPriority, operationProgress, allowCapacityEstimation);
       if (!dryRun) {
         executeProposals(result.goalProposals(), throttleDecommissionedBroker ? Collections.emptyList() : brokerIds);
       }
@@ -144,6 +147,25 @@ public class KafkaCruiseControl {
   }
 
   /**
+   * Check whether the given capacity estimation info indicates estimations for any broker when capacity estimation is
+   * not permitted.
+   *
+   * @param allowCapacityEstimation Allow capacity estimation in cluster model if the requested broker capacity is unavailable.
+   * @param capacityEstimationInfoByBrokerId Capacity estimation info by broker id for which there has been an estimation.
+   */
+  public static void sanityCheckCapacityEstimation(boolean allowCapacityEstimation,
+                                                   Map<Integer, String> capacityEstimationInfoByBrokerId) {
+    if (!(allowCapacityEstimation || capacityEstimationInfoByBrokerId.isEmpty())) {
+      StringBuilder sb = new StringBuilder();
+      sb.append("Allow capacity estimation or fix dependencies to capture broker capacities.%n");
+      for (Map.Entry<Integer, String> entry : capacityEstimationInfoByBrokerId.entrySet()) {
+        sb.append(String.format("Broker: %d: info: %s%n", entry.getKey(), entry.getValue()));
+      }
+      throw new IllegalStateException(sb.toString());
+    }
+  }
+
+  /**
    * Add brokers
    * @param brokerIds the broker ids.
    * @param dryRun whether it is a dry run or not.
@@ -151,6 +173,7 @@ public class KafkaCruiseControl {
    * @param goals the goals to be met when adding the brokers. When empty all goals will be used.
    * @param requirements The cluster model completeness requirements.
    * @param operationProgress The progress of the job to update.
+   * @param allowCapacityEstimation Allow capacity estimation in cluster model if the requested broker capacity is unavailable.
    * @return The optimization result.
    * @throws KafkaCruiseControlException when any exception occurred during the broker addition.
    */
@@ -159,15 +182,18 @@ public class KafkaCruiseControl {
                                                   boolean throttleAddedBrokers,
                                                   List<String> goals,
                                                   ModelCompletenessRequirements requirements,
-                                                  OperationProgress operationProgress) throws KafkaCruiseControlException {
+                                                  OperationProgress operationProgress,
+                                                  boolean allowCapacityEstimation) throws KafkaCruiseControlException {
     try (AutoCloseable ignored = _loadMonitor.acquireForModelGeneration(operationProgress)) {
       Map<Integer, Goal> goalsByPriority = goalsByPriority(goals);
       ModelCompletenessRequirements modelCompletenessRequirements =
           modelCompletenessRequirements(goalsByPriority.values()).weaker(requirements);
-      ClusterModel clusterModel =
-          _loadMonitor.clusterModel(_time.milliseconds(), modelCompletenessRequirements, operationProgress);
+      ClusterModel clusterModel = _loadMonitor.clusterModel(_time.milliseconds(),
+                                                            modelCompletenessRequirements,
+                                                            operationProgress);
       brokerIds.forEach(id -> clusterModel.setBrokerState(id, Broker.State.NEW));
-      GoalOptimizer.OptimizerResult result = getOptimizationProposals(clusterModel, goalsByPriority, operationProgress);
+      GoalOptimizer.OptimizerResult result =
+          getOptimizationProposals(clusterModel, goalsByPriority, operationProgress, allowCapacityEstimation);
       if (!dryRun) {
         executeProposals(result.goalProposals(), throttleAddedBrokers ? Collections.emptyList() : brokerIds);
       }
@@ -185,14 +211,17 @@ public class KafkaCruiseControl {
    * @param dryRun whether it is a dry run or not.
    * @param requirements The cluster model completeness requirements.
    * @param operationProgress the progress of the job to report.
+   * @param allowCapacityEstimation Allow capacity estimation in cluster model if the requested broker capacity is unavailable.
    * @return the optimization result.
-   * @throws KafkaCruiseControlException when the rebalacnce encounter errors.
+   * @throws KafkaCruiseControlException when the rebalance encounter errors.
    */
   public GoalOptimizer.OptimizerResult rebalance(List<String> goals,
                                                  boolean dryRun,
                                                  ModelCompletenessRequirements requirements,
-                                                 OperationProgress operationProgress) throws KafkaCruiseControlException {
-    GoalOptimizer.OptimizerResult result = getOptimizationProposals(goals, requirements, operationProgress);
+                                                 OperationProgress operationProgress,
+                                                 boolean allowCapacityEstimation) throws KafkaCruiseControlException {
+    GoalOptimizer.OptimizerResult result = getOptimizationProposals(goals, requirements, operationProgress, allowCapacityEstimation);
+    sanityCheckCapacityEstimation(allowCapacityEstimation, result.capacityEstimationInfoByBrokerId());
     if (!dryRun) {
       executeProposals(result.goalProposals(), Collections.emptySet());
     }
@@ -213,11 +242,13 @@ public class KafkaCruiseControl {
    * @param brokerIds the broker ids to move off.
    * @param dryRun whether it is a dry run or not
    * @param operationProgress the progress of the job to report.
+   * @param allowCapacityEstimation Allow capacity estimation in cluster model if the requested broker capacity is unavailable.
    * @return the optimization result.
    */
   public GoalOptimizer.OptimizerResult demoteBrokers(Collection<Integer> brokerIds,
                                                      boolean dryRun,
-                                                     OperationProgress operationProgress)
+                                                     OperationProgress operationProgress,
+                                                     boolean allowCapacityEstimation)
       throws KafkaCruiseControlException {
     PreferredLeaderElectionGoal goal = new PreferredLeaderElectionGoal();
     try (AutoCloseable ignored = _loadMonitor.acquireForModelGeneration(operationProgress)) {
@@ -228,7 +259,7 @@ public class KafkaCruiseControl {
       GoalOptimizer.OptimizerResult result =
           getOptimizationProposals(clusterModel,
                                    goalsByPriority(Collections.singletonList(goal.getClass().getSimpleName())),
-                                   operationProgress);
+                                   operationProgress, allowCapacityEstimation);
       if (!dryRun) {
         executeProposals(result.goalProposals(), brokerIds);
       }
@@ -243,8 +274,8 @@ public class KafkaCruiseControl {
   /**
    * Get the broker load stats from the cache. null will be returned if their is no cached broker load stats.
    */
-  public ClusterModel.BrokerStats cachedBrokerLoadStats() {
-    return _loadMonitor.cachedBrokerLoadStats();
+  public ClusterModel.BrokerStats cachedBrokerLoadStats(boolean allowCapacityEstimation) {
+    return _loadMonitor.cachedBrokerLoadStats(allowCapacityEstimation);
   }
 
   /**
@@ -252,15 +283,19 @@ public class KafkaCruiseControl {
    * @param now time.
    * @param requirements the model completeness requirements.
    * @param operationProgress the progress of the job to report.
+   * @param allowCapacityEstimation Allow capacity estimation in cluster model if the requested broker capacity is unavailable.
    * @return the cluster workload model.
    * @throws KafkaCruiseControlException when the cluster model generation encounter errors.
    */
   public ClusterModel clusterModel(long now,
                                    ModelCompletenessRequirements requirements,
-                                   OperationProgress operationProgress)
+                                   OperationProgress operationProgress,
+                                   boolean allowCapacityEstimation)
       throws KafkaCruiseControlException {
     try (AutoCloseable ignored = _loadMonitor.acquireForModelGeneration(operationProgress)) {
-      return _loadMonitor.clusterModel(now, requirements, operationProgress);
+      ClusterModel clusterModel = _loadMonitor.clusterModel(now, requirements, operationProgress);
+      sanityCheckCapacityEstimation(allowCapacityEstimation, clusterModel.capacityEstimationInfoByBrokerId());
+      return clusterModel;
     } catch (KafkaCruiseControlException kcce) {
       throw kcce;
     } catch (Exception e) {
@@ -274,16 +309,20 @@ public class KafkaCruiseControl {
    * @param to the end time of the window
    * @param requirements the model completeness requirement to enforce.
    * @param operationProgress the progress of the job to report.
+   * @param allowCapacityEstimation Allow capacity estimation in cluster model if the requested broker capacity is unavailable.
    * @return the cluster workload model.
    * @throws KafkaCruiseControlException when the cluster model generation encounter errors.
    */
   public ClusterModel clusterModel(long from,
                                    long to,
                                    ModelCompletenessRequirements requirements,
-                                   OperationProgress operationProgress)
+                                   OperationProgress operationProgress,
+                                   boolean allowCapacityEstimation)
       throws KafkaCruiseControlException {
     try (AutoCloseable ignored = _loadMonitor.acquireForModelGeneration(operationProgress)) {
-      return _loadMonitor.clusterModel(from, to, requirements, operationProgress);
+      ClusterModel clusterModel = _loadMonitor.clusterModel(from, to, requirements, operationProgress);
+      sanityCheckCapacityEstimation(allowCapacityEstimation, clusterModel.capacityEstimationInfoByBrokerId());
+      return clusterModel;
     } catch (KafkaCruiseControlException kcce) {
       throw kcce;
     } catch (Exception e) {
@@ -349,12 +388,16 @@ public class KafkaCruiseControl {
    * Get the optimization proposals from the current cluster. The result would be served from the cached result if
    * it is still valid.
    * @param operationProgress the job progress to report.
+   * @param allowCapacityEstimation Allow capacity estimation in cluster model if the requested broker capacity is unavailable.
    * @return The optimization result.
    */
-  public GoalOptimizer.OptimizerResult getOptimizationProposals(OperationProgress operationProgress)
+  public GoalOptimizer.OptimizerResult getOptimizationProposals(OperationProgress operationProgress,
+                                                                boolean allowCapacityEstimation)
       throws KafkaCruiseControlException {
     try {
-      return _goalOptimizer.optimizations(operationProgress);
+      GoalOptimizer.OptimizerResult result = _goalOptimizer.optimizations(operationProgress, allowCapacityEstimation);
+      sanityCheckCapacityEstimation(allowCapacityEstimation, result.capacityEstimationInfoByBrokerId());
+      return result;
     } catch (InterruptedException ie) {
       throw new KafkaCruiseControlException("Interrupted when getting the optimization proposals", ie);
     }
@@ -363,14 +406,16 @@ public class KafkaCruiseControl {
   /**
    * Optimize a cluster workload model.
    * @param goals a list of goals to optimize. When empty all goals will be used.
-   * @param requirements the model completeness requirements to enforce when generating the propsoals.
+   * @param requirements the model completeness requirements to enforce when generating the proposals.
    * @param operationProgress the progress of the job to report.
+   * @param allowCapacityEstimation Allow capacity estimation in cluster model if the requested broker capacity is unavailable.
    * @return The optimization result.
    * @throws KafkaCruiseControlException
    */
   public GoalOptimizer.OptimizerResult getOptimizationProposals(List<String> goals,
                                                                 ModelCompletenessRequirements requirements,
-                                                                OperationProgress operationProgress) throws KafkaCruiseControlException {
+                                                                OperationProgress operationProgress,
+                                                                boolean allowCapacityEstimation) throws KafkaCruiseControlException {
     GoalOptimizer.OptimizerResult result;
     Map<Integer, Goal> goalsByPriority = goalsByPriority(goals);
     ModelCompletenessRequirements modelCompletenessRequirements =
@@ -387,24 +432,28 @@ public class KafkaCruiseControl {
       try (AutoCloseable ignored = _loadMonitor.acquireForModelGeneration(operationProgress)) {
         // The cached proposals are computed with ignoreMinMonitoredPartitions = true. So if user provided a different
         // setting, we need to generate a new model.
-        ClusterModel clusterModel =
-            _loadMonitor.clusterModel(-1, _time.milliseconds(), modelCompletenessRequirements, operationProgress);
-        result = getOptimizationProposals(clusterModel, goalsByPriority, operationProgress);
+        ClusterModel clusterModel = _loadMonitor.clusterModel(-1,
+                                                              _time.milliseconds(),
+                                                              modelCompletenessRequirements,
+                                                              operationProgress);
+        result = getOptimizationProposals(clusterModel, goalsByPriority, operationProgress, allowCapacityEstimation);
       } catch (KafkaCruiseControlException kcce) {
         throw kcce;
       } catch (Exception e) {
         throw new KafkaCruiseControlException(e);
       }
     } else {
-      result = getOptimizationProposals(operationProgress);
+      result = getOptimizationProposals(operationProgress, allowCapacityEstimation);
     }
     return result;
   }
 
   private GoalOptimizer.OptimizerResult getOptimizationProposals(ClusterModel clusterModel,
                                                                  Map<Integer, Goal> goalsByPriority,
-                                                                 OperationProgress operationProgress)
+                                                                 OperationProgress operationProgress,
+                                                                 boolean allowCapacityEstimation)
       throws KafkaCruiseControlException {
+    sanityCheckCapacityEstimation(allowCapacityEstimation, clusterModel.capacityEstimationInfoByBrokerId());
     synchronized (this) {
       return _goalOptimizer.optimizations(clusterModel, goalsByPriority, operationProgress);
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUtils.java
@@ -15,6 +15,7 @@ import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
 
 import com.linkedin.kafka.cruisecontrol.model.RawAndDerivedResource;
 import com.linkedin.kafka.cruisecontrol.model.Replica;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -294,4 +295,33 @@ public class AnalyzerUtils {
     }
   }
 
+  /**
+   * Get all permutations of the given list of goals to permute.
+   *
+   * @param toPermute List of goals to permute.
+   * @return A set containing all possible permutations of the given list of goals to permute.
+   */
+  public static Set<List<Goal>> getPermutations(List<Goal> toPermute) {
+    Set<List<Goal>> allPermutations = new HashSet<>();
+    // Handle the case with single goal to permute.
+    if (toPermute.size() == 1) {
+      allPermutations.add(toPermute);
+      return allPermutations;
+    }
+
+    for (int i = 0; i < toPermute.size(); i++) {
+      // Copy the original list and remove the goal that we will prepend to the permutations of the remaining goals.
+      List<Goal> remainingToPermute = new ArrayList<>(toPermute);
+      Goal goal = toPermute.get(i);
+      remainingToPermute.remove(i);
+
+      // Prepend the goal to permutations of the remaining goals.
+      for (List<Goal> permutedRemaining: getPermutations(remainingToPermute)) {
+        permutedRemaining.add(0, goal);
+        allPermutations.add(permutedRemaining);
+      }
+    }
+
+    return allPermutations;
+  }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AddBrokerRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AddBrokerRunnable.java
@@ -11,8 +11,8 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * The async runnable for {@link KafkaCruiseControl#addBrokers(Collection, boolean, boolean, List, 
- * ModelCompletenessRequirements, com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress)} 
+ * The async runnable for {@link KafkaCruiseControl#addBrokers(Collection, boolean, boolean, List,
+ * ModelCompletenessRequirements, com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean)}
  */
 class AddBrokerRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult> {
   private final Collection<Integer> _brokerIds;
@@ -20,25 +20,28 @@ class AddBrokerRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult>
   private final boolean _throttleAddedBrokers;
   private final List<String> _goals;
   private final ModelCompletenessRequirements _modelCompletenessRequirements;
+  private final boolean _allowCapacityEstimation;
 
-  AddBrokerRunnable(KafkaCruiseControl kafkaCruiseControl, 
+  AddBrokerRunnable(KafkaCruiseControl kafkaCruiseControl,
                     OperationFuture<GoalOptimizer.OptimizerResult> future,
-                    Collection<Integer> brokerIds, 
-                    boolean dryRun, 
-                    boolean throttleAddedBrokers, 
+                    Collection<Integer> brokerIds,
+                    boolean dryRun,
+                    boolean throttleAddedBrokers,
                     List<String> goals,
-                    ModelCompletenessRequirements modelCompletenessRequirements) {
+                    ModelCompletenessRequirements modelCompletenessRequirements,
+                    boolean allowCapacityEstimation) {
     super(kafkaCruiseControl, future);
     _brokerIds = brokerIds;
     _dryRun = dryRun;
     _throttleAddedBrokers = throttleAddedBrokers;
     _goals = goals;
     _modelCompletenessRequirements = modelCompletenessRequirements;
+    _allowCapacityEstimation = allowCapacityEstimation;
   }
 
   @Override
   protected GoalOptimizer.OptimizerResult getResult() throws Exception {
     return _kafkaCruiseControl.addBrokers(_brokerIds, _dryRun, _throttleAddedBrokers, _goals,
-                                          _modelCompletenessRequirements, _future.operationProgress());
+                                          _modelCompletenessRequirements, _future.operationProgress(), _allowCapacityEstimation);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DecommissionBrokersRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DecommissionBrokersRunnable.java
@@ -11,8 +11,8 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * The async runnable for {@link KafkaCruiseControl#decommissionBrokers(Collection, boolean, boolean, List, 
- * ModelCompletenessRequirements, com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress)}
+ * The async runnable for {@link KafkaCruiseControl#decommissionBrokers(Collection, boolean, boolean, List,
+ * ModelCompletenessRequirements, com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean)}
  */
 class DecommissionBrokersRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult> {
   private final Collection<Integer> _brokerIds;
@@ -20,25 +20,28 @@ class DecommissionBrokersRunnable extends OperationRunnable<GoalOptimizer.Optimi
   private final boolean _throttleRemovedBrokers;
   private final List<String> _goals;
   private final ModelCompletenessRequirements _modelCompletenessRequirements;
+  private final boolean _allowCapacityEstimation;
 
-  DecommissionBrokersRunnable(KafkaCruiseControl kafkaCruiseControl, 
-                              OperationFuture<GoalOptimizer.OptimizerResult> future, 
-                              Collection<Integer> brokerIds, 
-                              boolean dryRun, 
-                              boolean throttleRemovedBrokers, 
-                              List<String> goals, 
-                              ModelCompletenessRequirements modelCompletenessRequirements) {
+  DecommissionBrokersRunnable(KafkaCruiseControl kafkaCruiseControl,
+                              OperationFuture<GoalOptimizer.OptimizerResult> future,
+                              Collection<Integer> brokerIds,
+                              boolean dryRun,
+                              boolean throttleRemovedBrokers,
+                              List<String> goals,
+                              ModelCompletenessRequirements modelCompletenessRequirements,
+                              boolean allowCapacityEstimation) {
     super(kafkaCruiseControl, future);
     _brokerIds = brokerIds;
     _dryRun = dryRun;
     _throttleRemovedBrokers = throttleRemovedBrokers;
     _goals = goals;
     _modelCompletenessRequirements = modelCompletenessRequirements;
+    _allowCapacityEstimation = allowCapacityEstimation;
   }
 
   @Override
   protected GoalOptimizer.OptimizerResult getResult() throws Exception {
-    return _kafkaCruiseControl.decommissionBrokers(_brokerIds, _dryRun, _throttleRemovedBrokers, _goals, 
-                                                   _modelCompletenessRequirements, _future.operationProgress());
+    return _kafkaCruiseControl.decommissionBrokers(_brokerIds, _dryRun, _throttleRemovedBrokers, _goals,
+                                                   _modelCompletenessRequirements, _future.operationProgress(), _allowCapacityEstimation);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DemoteBrokerRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DemoteBrokerRunnable.java
@@ -12,18 +12,21 @@ import java.util.Collection;
 public class DemoteBrokerRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult> {
   private final Collection<Integer> _brokerIds;
   private final boolean _dryRun;
+  private final boolean _allowCapacityEstimation;
 
   DemoteBrokerRunnable(KafkaCruiseControl kafkaCruiseControl,
                        OperationFuture<GoalOptimizer.OptimizerResult> future,
                        Collection<Integer> brokerIds,
-                       boolean dryRun) {
+                       boolean dryRun,
+                       boolean allowCapacityEstimation) {
     super(kafkaCruiseControl, future);
     _brokerIds = brokerIds;
     _dryRun = dryRun;
+    _allowCapacityEstimation = allowCapacityEstimation;
   }
 
   @Override
   protected GoalOptimizer.OptimizerResult getResult() throws Exception {
-    return _kafkaCruiseControl.demoteBrokers(_brokerIds, _dryRun, _future.operationProgress());
+    return _kafkaCruiseControl.demoteBrokers(_brokerIds, _dryRun, _future.operationProgress(), _allowCapacityEstimation);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetBrokerStatsRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetBrokerStatsRunnable.java
@@ -10,27 +10,33 @@ import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 
 
 /**
- * The async runnable to get the {@link com.linkedin.kafka.cruisecontrol.model.ClusterModel.BrokerStats} for the cluster 
+ * The async runnable to get the {@link com.linkedin.kafka.cruisecontrol.model.ClusterModel.BrokerStats} for the cluster
  * model.
- * 
- * @see KafkaCruiseControl#clusterModel(long, ModelCompletenessRequirements, 
- * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress) 
+ *
+ * @see KafkaCruiseControl#clusterModel(long, ModelCompletenessRequirements,
+ * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean)
  */
 class GetBrokerStatsRunnable extends OperationRunnable<ClusterModel.BrokerStats> {
   private final long _time;
   private final ModelCompletenessRequirements _modelCompletenessRequirements;
-  
+  private final boolean _allowCapacityEstimation;
+
   GetBrokerStatsRunnable(KafkaCruiseControl kafkaCruiseControl,
                          OperationFuture<ClusterModel.BrokerStats> future,
                          long time,
-                         ModelCompletenessRequirements modelCompletenessRequirements) {
+                         ModelCompletenessRequirements modelCompletenessRequirements,
+                         boolean allowCapacityEstimation) {
     super(kafkaCruiseControl, future);
     _time = time;
     _modelCompletenessRequirements = modelCompletenessRequirements;
+    _allowCapacityEstimation = allowCapacityEstimation;
   }
 
   @Override
   protected ClusterModel.BrokerStats getResult() throws Exception {
-    return _kafkaCruiseControl.clusterModel(_time, _modelCompletenessRequirements, _future.operationProgress()).brokerStats();
+    return _kafkaCruiseControl.clusterModel(_time,
+                                            _modelCompletenessRequirements,
+                                            _future.operationProgress(),
+                                            _allowCapacityEstimation).brokerStats();
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetClusterModelInRangeRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetClusterModelInRangeRunnable.java
@@ -10,26 +10,33 @@ import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 
 /**
  * The async runnable for {@link KafkaCruiseControl#clusterModel(long, long, ModelCompletenessRequirements,
- * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress)}
+ * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean)}
  */
 class GetClusterModelInRangeRunnable extends OperationRunnable<ClusterModel> {
   private final long _startMs;
   private final long _endMs;
   private final ModelCompletenessRequirements _modelCompletenessRequirements;
-  
+  private final boolean _allowCapacityEstimation;
+
   GetClusterModelInRangeRunnable(KafkaCruiseControl kafkaCruiseControl,
                                  OperationFuture<ClusterModel> future,
                                  long startMs,
                                  long endMs,
-                                 ModelCompletenessRequirements modelCompletenessRequirements) {
+                                 ModelCompletenessRequirements modelCompletenessRequirements,
+                                 boolean allowCapacityEstimation) {
     super(kafkaCruiseControl, future);
     _startMs = startMs;
     _endMs = endMs;
     _modelCompletenessRequirements = modelCompletenessRequirements;
+    _allowCapacityEstimation = allowCapacityEstimation;
   }
 
   @Override
   protected ClusterModel getResult() throws Exception {
-    return _kafkaCruiseControl.clusterModel(_startMs, _endMs, _modelCompletenessRequirements, _future.operationProgress());
+    return _kafkaCruiseControl.clusterModel(_startMs,
+                                            _endMs,
+                                            _modelCompletenessRequirements,
+                                            _future.operationProgress(),
+                                            _allowCapacityEstimation);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetClusterModelUntilRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetClusterModelUntilRunnable.java
@@ -9,24 +9,30 @@ import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 
 /**
- * The async runnable for {@link KafkaCruiseControl#clusterModel(long, ModelCompletenessRequirements, 
- * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress)}
+ * The async runnable for {@link KafkaCruiseControl#clusterModel(long, ModelCompletenessRequirements,
+ * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean)}
  */
 class GetClusterModelUntilRunnable extends OperationRunnable<ClusterModel> {
   private final long _time;
   private final ModelCompletenessRequirements _modelCompletenessRequirements;
+  private final boolean _allowCapacityEstimation;
 
   GetClusterModelUntilRunnable(KafkaCruiseControl kafkaCruiseControl,
                                OperationFuture<ClusterModel> future,
                                long time,
-                               ModelCompletenessRequirements modelCompletenessRequirements) {
+                               ModelCompletenessRequirements modelCompletenessRequirements,
+                               boolean allowCapacityEstimation) {
     super(kafkaCruiseControl, future);
     _time = time;
     _modelCompletenessRequirements = modelCompletenessRequirements;
+    _allowCapacityEstimation = allowCapacityEstimation;
   }
 
   @Override
   protected ClusterModel getResult() throws Exception {
-    return _kafkaCruiseControl.clusterModel(_time, _modelCompletenessRequirements, _future.operationProgress());
+    return _kafkaCruiseControl.clusterModel(_time,
+                                            _modelCompletenessRequirements,
+                                            _future.operationProgress(),
+                                            _allowCapacityEstimation);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetOptimizationProposalsRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetOptimizationProposalsRunnable.java
@@ -11,29 +11,35 @@ import java.util.List;
 
 /**
  * The async runnable for {@link KafkaCruiseControl#getOptimizationProposals(
- * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress)} and 
- * {@link KafkaCruiseControl#getOptimizationProposals(List, ModelCompletenessRequirements, 
- * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress)}
+ * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean)} and
+ * {@link KafkaCruiseControl#getOptimizationProposals(List, ModelCompletenessRequirements,
+ * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean)}
  */
 class GetOptimizationProposalsRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult> {
   private final List<String> _goals;
   private final ModelCompletenessRequirements _modelCompletenessRequirements;
-  
+  private final boolean _allowCapacityEstimation;
+
   GetOptimizationProposalsRunnable(KafkaCruiseControl kafkaCruiseControl,
                                    OperationFuture<GoalOptimizer.OptimizerResult> future,
                                    List<String> goals,
-                                   ModelCompletenessRequirements modelCompletenessRequirements) {
+                                   ModelCompletenessRequirements modelCompletenessRequirements,
+                                   boolean allowCapacityEstimation) {
     super(kafkaCruiseControl, future);
     _goals = goals;
     _modelCompletenessRequirements = modelCompletenessRequirements;
+    _allowCapacityEstimation = allowCapacityEstimation;
   }
 
   @Override
   protected GoalOptimizer.OptimizerResult getResult() throws Exception {
     if (_goals != null) {
-      return _kafkaCruiseControl.getOptimizationProposals(_goals, _modelCompletenessRequirements, _future.operationProgress());
+      return _kafkaCruiseControl.getOptimizationProposals(_goals,
+                                                          _modelCompletenessRequirements,
+                                                          _future.operationProgress(),
+                                                          _allowCapacityEstimation);
     } else {
-      return _kafkaCruiseControl.getOptimizationProposals(_future.operationProgress());
+      return _kafkaCruiseControl.getOptimizationProposals(_future.operationProgress(), _allowCapacityEstimation);
     }
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetStateRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetStateRunnable.java
@@ -13,7 +13,7 @@ import com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress;
  * The async runnable for {@link KafkaCruiseControl#state(OperationProgress)}
  */
 class GetStateRunnable extends OperationRunnable<KafkaCruiseControlState> {
-  
+
   GetStateRunnable(KafkaCruiseControl kafkaCruiseControl, OperationFuture<KafkaCruiseControlState> future) {
     super(kafkaCruiseControl, future);
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/RebalanceRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/RebalanceRunnable.java
@@ -10,27 +10,34 @@ import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 import java.util.List;
 
 /**
- * The async runnable for {@link KafkaCruiseControl#rebalance(List, boolean, ModelCompletenessRequirements, 
- * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress)}
+ * The async runnable for {@link KafkaCruiseControl#rebalance(List, boolean, ModelCompletenessRequirements,
+ * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean)}
  */
 class RebalanceRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult> {
   private final List<String> _goals;
   private final boolean _dryRun;
   private final ModelCompletenessRequirements _modelCompletenessRequirements;
-  
+  private final boolean _allowCapacityEstimation;
+
   RebalanceRunnable(KafkaCruiseControl kafkaCruiseControl,
                     OperationFuture<GoalOptimizer.OptimizerResult> future,
                     List<String> goals,
                     boolean dryRun,
-                    ModelCompletenessRequirements modelCompletenessRequirements) {
+                    ModelCompletenessRequirements modelCompletenessRequirements,
+                    boolean allowCapacityEstimation) {
     super(kafkaCruiseControl, future);
     _goals = goals;
     _dryRun = dryRun;
     _modelCompletenessRequirements = modelCompletenessRequirements;
+    _allowCapacityEstimation = allowCapacityEstimation;
   }
 
   @Override
   protected GoalOptimizer.OptimizerResult getResult() throws Exception {
-    return _kafkaCruiseControl.rebalance(_goals, _dryRun, _modelCompletenessRequirements, _future.operationProgress());
+    return _kafkaCruiseControl.rebalance(_goals,
+                                         _dryRun,
+                                         _modelCompletenessRequirements,
+                                         _future.operationProgress(),
+                                         _allowCapacityEstimation);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolver.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolver.java
@@ -54,8 +54,11 @@ import java.util.Set;
  *   }
  * </pre>
  *
- * The broker id -1 defines the default capacity. A broker capacity is overridden if there is a capacity defined for
- * a particular broker id. The units of the definition are:
+ * The broker id -1 defines the default broker capacity estimate. A broker capacity is overridden if there is a capacity
+ * defined for a particular broker id. In case a broker capacity is missing, the default estimate for a broker capacity
+ * will be used.
+ *
+ * The units of the definition are:
  * <ul>
  *  <li>DISK - MB</li>
  *  <li>CPU - Percent</li>
@@ -66,7 +69,7 @@ import java.util.Set;
 public class BrokerCapacityConfigFileResolver implements BrokerCapacityConfigResolver {
   public static final String CAPACITY_CONFIG_FILE = "capacity.config.file";
   private static final int DEFAULT_CAPACITY_BROKER_ID = -1;
-  private static Map<Integer, Map<Resource, Double>> _capacitiesForBrokers;
+  private static Map<Integer, BrokerCapacityInfo> _capacitiesForBrokers;
 
   @Override
   public void configure(Map<String, ?> configs) {
@@ -79,16 +82,17 @@ public class BrokerCapacityConfigFileResolver implements BrokerCapacityConfigRes
   }
 
   @Override
-  public Map<Resource, Double> capacityForBroker(String rack, String host, int brokerId) {
+  public BrokerCapacityInfo capacityForBroker(String rack, String host, int brokerId) {
     if (brokerId >= 0) {
-      Map<Resource, Double> capacity = _capacitiesForBrokers.get(brokerId);
+      BrokerCapacityInfo capacity = _capacitiesForBrokers.get(brokerId);
       if (capacity != null) {
         return capacity;
       } else {
-        return _capacitiesForBrokers.get(DEFAULT_CAPACITY_BROKER_ID);
+        String info = String.format("Missing broker id(%d) in capacity config file.", brokerId);
+        return new BrokerCapacityInfo(_capacitiesForBrokers.get(DEFAULT_CAPACITY_BROKER_ID).capacity(), info);
       }
     } else {
-      throw new IllegalArgumentException("The broker id should be non-negative.");
+      throw new IllegalArgumentException("The broker id(" + brokerId + ") should be non-negative.");
     }
   }
 
@@ -100,7 +104,10 @@ public class BrokerCapacityConfigFileResolver implements BrokerCapacityConfigRes
       Set<BrokerCapacity> brokerCapacities = ((BrokerCapacities) gson.fromJson(reader, BrokerCapacities.class)).brokerCapacities;
       _capacitiesForBrokers = new HashMap<>();
       for (BrokerCapacity bc : brokerCapacities) {
-        _capacitiesForBrokers.put(bc.brokerId, bc.capacity);
+        boolean isDefault = bc.brokerId == DEFAULT_CAPACITY_BROKER_ID;
+        BrokerCapacityInfo brokerCapacityInfo =
+            new BrokerCapacityInfo(bc.capacity, isDefault ? "The default broker capacity." : "");
+        _capacitiesForBrokers.put(bc.brokerId, brokerCapacityInfo);
       }
     } finally {
       try {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolver.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolver.java
@@ -106,7 +106,8 @@ public class BrokerCapacityConfigFileResolver implements BrokerCapacityConfigRes
       for (BrokerCapacity bc : brokerCapacities) {
         boolean isDefault = bc.brokerId == DEFAULT_CAPACITY_BROKER_ID;
         BrokerCapacityInfo brokerCapacityInfo =
-            new BrokerCapacityInfo(bc.capacity, isDefault ? "The default broker capacity." : "");
+            isDefault ? new BrokerCapacityInfo(bc.capacity, "The default broker capacity.")
+                      : new BrokerCapacityInfo(bc.capacity);
         _capacitiesForBrokers.put(bc.brokerId, brokerCapacityInfo);
       }
     } finally {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigResolver.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigResolver.java
@@ -6,7 +6,6 @@ package com.linkedin.kafka.cruisecontrol.config;
 
 import com.linkedin.cruisecontrol.common.CruiseControlConfigurable;
 import com.linkedin.kafka.cruisecontrol.common.Resource;
-import java.util.Map;
 
 
 /**
@@ -23,10 +22,12 @@ public interface BrokerCapacityConfigResolver extends CruiseControlConfigurable,
    * Network Inbound - KB/s
    * Network Outbounds - KB/s
    *
+   * May estimate the capacity of a broker, if it is not directly available.
+   *
    * @param rack The rack of the broker
    * @param host The host of the broker
    * @param brokerId the id of the broker
    * @return The capacity of each resource for the broker
    */
-  Map<Resource, Double> capacityForBroker(String rack, String host, int brokerId);
+  BrokerCapacityInfo capacityForBroker(String rack, String host, int brokerId);
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityInfo.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityInfo.java
@@ -17,6 +17,11 @@ public class BrokerCapacityInfo {
     _estimationInfo = estimationInfo == null ? "" : estimationInfo;
   }
 
+  public BrokerCapacityInfo(Map<Resource, Double> capacity) {
+    _capacity = capacity;
+    _estimationInfo = "";
+  }
+
   /**
    * @return The broker capacity for different resource types.
    */

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityInfo.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityInfo.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.config;
+
+import com.linkedin.kafka.cruisecontrol.common.Resource;
+import java.util.Map;
+
+
+public class BrokerCapacityInfo {
+  private final Map<Resource, Double> _capacity;
+  private final String _estimationInfo;
+
+  public BrokerCapacityInfo(Map<Resource, Double> capacity, String estimationInfo) {
+    _capacity = capacity;
+    _estimationInfo = estimationInfo == null ? "" : estimationInfo;
+  }
+
+  /**
+   * @return The broker capacity for different resource types.
+   */
+  public Map<Resource, Double> capacity() {
+    return _capacity;
+  }
+
+  /**
+   * @return True if the capacity of the broker for at least one resource is based on an estimation, false otherwise.
+   */
+  public boolean isEstimated() {
+    return !_estimationInfo.isEmpty();
+  }
+
+  /**
+   * @return Empty string if no estimation, related estimation info otherwise.
+   */
+  public String estimationInfo() {
+    return _estimationInfo;
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -445,7 +445,7 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
       + "priority goals will be executed first.";
 
   /**
-   * <code>default.gaols</code>
+   * <code>default.goals</code>
    */
   public static final String DEFAULT_GOALS_CONFIG = "default.goals";
   private static final String DEFAULT_GOALS_DOC = "The list of goals that will be used by default if no goal list "
@@ -465,6 +465,13 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
   public static final String ANOMALY_DETECTION_INTERVAL_MS_CONFIG = "anomaly.detection.interval.ms";
   private static final String ANOMALY_DETECTION_INTERVAL_MS_DOC = "The interval in millisecond that the detectors will "
       + "run to detect the anomalies.";
+
+  /**
+   * <code>anomaly.detection.allow.capacity.estimation</code>
+   */
+  public static final String ANOMALY_DETECTION_ALLOW_CAPACITY_ESTIMATION_CONFIG = "anomaly.detection.allow.capacity.estimation";
+  private static final String ANOMALY_DETECTION_ALLOW_CAPACITY_ESTIMATION_DOC = "The flag to indicate whether anomaly "
+      + "detection threads allow capacity estimation in the generated cluster model they use.";
 
   /**
    * <code>anomaly.detection.goals</code>
@@ -808,6 +815,11 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 300000L,
                 ConfigDef.Importance.LOW,
                 ANOMALY_DETECTION_INTERVAL_MS_DOC)
+        .define(ANOMALY_DETECTION_ALLOW_CAPACITY_ESTIMATION_CONFIG,
+                ConfigDef.Type.BOOLEAN,
+                true,
+                ConfigDef.Importance.LOW,
+                ANOMALY_DETECTION_ALLOW_CAPACITY_ESTIMATION_DOC)
         .define(ANOMALY_DETECTION_GOALS_CONFIG,
                 ConfigDef.Type.LIST,
                 new StringJoiner(",")

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetector.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AnomalyDetector {
   private static final Logger LOG = LoggerFactory.getLogger(AnomalyDetector.class);
-  private static final Anomaly SHUTDOWN_ANOMALY = new BrokerFailures(null, Collections.emptyMap());
+  private static final Anomaly SHUTDOWN_ANOMALY = new BrokerFailures(null, Collections.emptyMap(), true);
   private final KafkaCruiseControl _kafkaCruiseControl;
   private final AnomalyNotifier _anomalyNotifier;
   // Detectors

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailureDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailureDetector.java
@@ -46,6 +46,7 @@ public class BrokerFailureDetector {
   private final LoadMonitor _loadMonitor;
   private final Queue<Anomaly> _anomalies;
   private final Time _time;
+  private final boolean _allowCapacityEstimation;
 
   public BrokerFailureDetector(KafkaCruiseControlConfig config,
                                LoadMonitor loadMonitor,
@@ -63,6 +64,7 @@ public class BrokerFailureDetector {
     _anomalies = anomalies;
     _time = time;
     _kafkaCruiseControl = kafkaCruiseControl;
+    _allowCapacityEstimation = config.getBoolean(KafkaCruiseControlConfig.ANOMALY_DETECTION_ALLOW_CAPACITY_ESTIMATION_CONFIG);
   }
 
   void startDetection() {
@@ -153,7 +155,7 @@ public class BrokerFailureDetector {
   private void reportBrokerFailures() {
     if (!_failedBrokers.isEmpty()) {
       Map<Integer, Long> failedBrokers = new HashMap<>(_failedBrokers);
-      _anomalies.add(new BrokerFailures(_kafkaCruiseControl, failedBrokers));
+      _anomalies.add(new BrokerFailures(_kafkaCruiseControl, failedBrokers, _allowCapacityEstimation));
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailures.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailures.java
@@ -20,10 +20,14 @@ import java.util.Map;
 public class BrokerFailures extends KafkaAnomaly {
   private final KafkaCruiseControl _kafkaCruiseControl;
   private final Map<Integer, Long> _failedBrokers;
+  private final boolean _allowCapacityEstimation;
 
-  public BrokerFailures(KafkaCruiseControl kafkaCruiseControl, Map<Integer, Long> failedBrokers) {
+  public BrokerFailures(KafkaCruiseControl kafkaCruiseControl,
+                        Map<Integer, Long> failedBrokers,
+                        boolean allowCapacityEstimation) {
     _kafkaCruiseControl = kafkaCruiseControl;
     _failedBrokers = failedBrokers;
+    _allowCapacityEstimation = allowCapacityEstimation;
   }
 
   /**
@@ -38,7 +42,8 @@ public class BrokerFailures extends KafkaAnomaly {
     // Fix the cluster by removing the failed brokers.
     if (_failedBrokers != null && !_failedBrokers.isEmpty()) {
       _kafkaCruiseControl.decommissionBrokers(_failedBrokers.keySet(), false, false,
-                                             Collections.emptyList(), null, new OperationProgress());
+                                             Collections.emptyList(), null, new OperationProgress(),
+                                              _allowCapacityEstimation);
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
@@ -24,9 +24,11 @@ public class GoalViolations extends KafkaAnomaly {
   private static final Logger LOG = LoggerFactory.getLogger(GoalViolations.class);
   private final KafkaCruiseControl _kafkaCruiseControl;
   private final List<Violation> _goalViolations = new ArrayList<>();
+  private final boolean _allowCapacityEstimation;
 
-  public GoalViolations(KafkaCruiseControl kafkaCruiseControl) {
+  public GoalViolations(KafkaCruiseControl kafkaCruiseControl, boolean allowCapacityEstimation) {
     _kafkaCruiseControl = kafkaCruiseControl;
+    _allowCapacityEstimation = allowCapacityEstimation;
   }
 
   public void addViolation(int priority, String goalName, Set<ExecutionProposal> executionProposals) {
@@ -44,7 +46,8 @@ public class GoalViolations extends KafkaAnomaly {
   public void fix() throws KafkaCruiseControlException {
     // Fix the violations using a rebalance.
     try {
-      _kafkaCruiseControl.rebalance(Collections.emptyList(), false, null, new OperationProgress());
+      _kafkaCruiseControl.rebalance(
+          Collections.emptyList(), false, null, new OperationProgress(), _allowCapacityEstimation);
     } catch (IllegalStateException e) {
       LOG.warn("Got exception when trying to fix the cluster. " + e.getMessage());
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -14,11 +14,11 @@ import com.linkedin.cruisecontrol.monitor.sampling.aggregator.Extrapolation;
 import com.linkedin.cruisecontrol.monitor.sampling.aggregator.MetricSampleCompleteness;
 import com.linkedin.cruisecontrol.monitor.sampling.aggregator.MetricValues;
 import com.linkedin.cruisecontrol.monitor.sampling.aggregator.ValuesAndExtrapolations;
-import com.linkedin.kafka.cruisecontrol.common.Resource;
 import com.linkedin.kafka.cruisecontrol.analyzer.AnalyzerUtils;
 import com.linkedin.kafka.cruisecontrol.common.KafkaCruiseControlThreadFactory;
 import com.linkedin.kafka.cruisecontrol.common.MetadataClient;
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityConfigResolver;
+import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.async.progress.GeneratingClusterModel;
 import com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress;
@@ -383,7 +383,9 @@ public class LoadMonitor {
    * @param operationProgress the progress to report.
    * @return A cluster model with the configured number of windows whose timestamp is before given timestamp.
    */
-  public ClusterModel clusterModel(long now, ModelCompletenessRequirements requirements, OperationProgress operationProgress)
+  public ClusterModel clusterModel(long now,
+                                   ModelCompletenessRequirements requirements,
+                                   OperationProgress operationProgress)
       throws NotEnoughValidWindowsException {
     ClusterModel clusterModel = clusterModel(-1L, now, requirements, operationProgress);
     // Micro optimization: put the broker stats construction out of the lock.
@@ -447,7 +449,7 @@ public class LoadMonitor {
         // If the rack is not specified, we use the host info as rack info.
         String rack = getRackHandleNull(node);
         clusterModel.createRack(rack);
-        Map<Resource, Double> brokerCapacity =
+        BrokerCapacityInfo brokerCapacity =
             _brokerCapacityConfigResolver.capacityForBroker(rack, node.host(), node.id());
         clusterModel.createBroker(rack, node.host(), node.id(), brokerCapacity);
       }
@@ -481,12 +483,20 @@ public class LoadMonitor {
    * Get the cached load.
    * @return the cached load, null if the load
    */
-  public ClusterModel.BrokerStats cachedBrokerLoadStats() {
+  public ClusterModel.BrokerStats cachedBrokerLoadStats(boolean allowCapacityEstimation) {
     int clusterGeneration = _metadataClient.refreshMetadata().generation();
     synchronized (this) {
       if (_cachedBrokerLoadGeneration != null
           && clusterGeneration == _cachedBrokerLoadGeneration.clusterGeneration()
           && _partitionMetricSampleAggregator.generation() == _cachedBrokerLoadGeneration.loadGeneration()) {
+        if (allowCapacityEstimation) {
+          // Ensure that there is no capacity estimation in the cached model.
+          for (ClusterModel.SingleBrokerStats singleBrokerStats : _cachedBrokerLoadStats.stats()) {
+            if (singleBrokerStats.isEstimated()) {
+              return null;
+            }
+          }
+        }
         return _cachedBrokerLoadStats;
       }
     }
@@ -559,7 +569,7 @@ public class LoadMonitor {
         String rack = getRackHandleNull(replica);
         // Note that we assume the capacity resolver can still return the broker capacity even if the broker
         // is dead. We need this to get the host resource capacity.
-        Map<Resource, Double> brokerCapacity =
+        BrokerCapacityInfo brokerCapacity =
             _brokerCapacityConfigResolver.capacityForBroker(rack, replica.host(), replica.id());
         clusterModel.handleDeadBroker(rack, replica.id(), brokerCapacity);
         boolean isLeader;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -489,7 +489,7 @@ public class LoadMonitor {
       if (_cachedBrokerLoadGeneration != null
           && clusterGeneration == _cachedBrokerLoadGeneration.clusterGeneration()
           && _partitionMetricSampleAggregator.generation() == _cachedBrokerLoadGeneration.loadGeneration()) {
-        if (allowCapacityEstimation) {
+        if (!allowCapacityEstimation) {
           // Ensure that there is no capacity estimation in the cached model.
           for (ClusterModel.SingleBrokerStats singleBrokerStats : _cachedBrokerLoadStats.stats()) {
             if (singleBrokerStats.isEstimated()) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/PreferredLeaderElectionGoalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/PreferredLeaderElectionGoalTest.java
@@ -109,7 +109,7 @@ public class PreferredLeaderElectionGoalTest {
     for (int i = 0; i < numRacks; i++) {
       clusterModel.createRack("r" + i);
     }
-    BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY, "");
+    BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY);
     int i = 0;
     for (; i < 2; i++) {
       clusterModel.createBroker("r0", "h" + i, i, commonBrokerCapacityInfo);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/PreferredLeaderElectionGoalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/PreferredLeaderElectionGoalTest.java
@@ -9,6 +9,7 @@ import com.linkedin.cruisecontrol.monitor.sampling.aggregator.MetricValues;
 import com.linkedin.kafka.cruisecontrol.common.Resource;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.PreferredLeaderElectionGoal;
 import com.linkedin.kafka.cruisecontrol.common.TestConstants;
+import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
 import com.linkedin.kafka.cruisecontrol.exception.KafkaCruiseControlException;
 import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
@@ -108,13 +109,13 @@ public class PreferredLeaderElectionGoalTest {
     for (int i = 0; i < numRacks; i++) {
       clusterModel.createRack("r" + i);
     }
-
+    BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY, "");
     int i = 0;
     for (; i < 2; i++) {
-      clusterModel.createBroker("r0", "h" + i, i, TestConstants.BROKER_CAPACITY);
+      clusterModel.createBroker("r0", "h" + i, i, commonBrokerCapacityInfo);
     }
     for (int j = 1; j < numRacks; j++, i++) {
-      clusterModel.createBroker("r" + j, "h" + i, i, TestConstants.BROKER_CAPACITY);
+      clusterModel.createBroker("r" + j, "h" + i, i, commonBrokerCapacityInfo);
     }
 
     createReplicaAndSetLoad(clusterModel, "r0", 0, T0P0, 0, true);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
@@ -24,6 +24,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionG
 import com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerDiskUsageDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerEvenRackAwareGoal;
 import com.linkedin.kafka.cruisecontrol.common.Resource;
+import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.common.ClusterProperty;
 import com.linkedin.kafka.cruisecontrol.common.RandomCluster;
@@ -199,7 +200,9 @@ public class RandomClusterTest {
       for (Resource r : Resource.cachedValues()) {
         brokerCapacity.put(r, b.capacityFor(r));
       }
-      clusterWithNewBroker.createBroker(b.rack().id(), Integer.toString(b.id()), b.id(), brokerCapacity);
+
+      BrokerCapacityInfo brokerCapacityInfo = new BrokerCapacityInfo(brokerCapacity, "");
+      clusterWithNewBroker.createBroker(b.rack().id(), Integer.toString(b.id()), b.id(), brokerCapacityInfo);
     }
 
     for (Map.Entry<String, List<Partition>> entry : clusterModel.getPartitionsByTopic().entrySet()) {
@@ -220,11 +223,12 @@ public class RandomClusterTest {
       }
     }
 
+    BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY, "");
     for (int i = 1; i < 3; i++) {
       clusterWithNewBroker.createBroker(Integer.toString(i),
                                         Integer.toString(i + clusterModel.brokers().size() - 1),
                                         i + clusterModel.brokers().size() - 1,
-                                        TestConstants.BROKER_CAPACITY);
+                                        commonBrokerCapacityInfo);
       clusterWithNewBroker.setBrokerState(i + clusterModel.brokers().size() - 1, Broker.State.NEW);
     }
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
@@ -201,7 +201,7 @@ public class RandomClusterTest {
         brokerCapacity.put(r, b.capacityFor(r));
       }
 
-      BrokerCapacityInfo brokerCapacityInfo = new BrokerCapacityInfo(brokerCapacity, "");
+      BrokerCapacityInfo brokerCapacityInfo = new BrokerCapacityInfo(brokerCapacity);
       clusterWithNewBroker.createBroker(b.rack().id(), Integer.toString(b.id()), b.id(), brokerCapacityInfo);
     }
 
@@ -223,7 +223,7 @@ public class RandomClusterTest {
       }
     }
 
-    BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY, "");
+    BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY);
     for (int i = 1; i < 3; i++) {
       clusterWithNewBroker.createBroker(Integer.toString(i),
                                         Integer.toString(i + clusterModel.brokers().size() - 1),

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoalTest.java
@@ -225,7 +225,7 @@ public class KafkaAssignerDiskUsageDistributionGoalTest {
       clusterModel.createRack("r" + i);
     }
 
-    BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY, "");
+    BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY);
     int i = 0;
     for (; i < 2; i++) {
       clusterModel.createBroker("r0", "h" + i, i, commonBrokerCapacityInfo);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoalTest.java
@@ -9,6 +9,7 @@ import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUnitTestUtils;
 import com.linkedin.kafka.cruisecontrol.analyzer.BalancingConstraint;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.internals.BrokerAndSortedReplicas;
 import com.linkedin.kafka.cruisecontrol.common.TestConstants;
+import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
@@ -224,12 +225,13 @@ public class KafkaAssignerDiskUsageDistributionGoalTest {
       clusterModel.createRack("r" + i);
     }
 
+    BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY, "");
     int i = 0;
     for (; i < 2; i++) {
-      clusterModel.createBroker("r0", "h" + i, i, TestConstants.BROKER_CAPACITY);
+      clusterModel.createBroker("r0", "h" + i, i, commonBrokerCapacityInfo);
     }
     for (int j = 1; j < numRacks; j++, i++) {
-      clusterModel.createBroker("r" + j, "h" + i, i, TestConstants.BROKER_CAPACITY);
+      clusterModel.createBroker("r" + j, "h" + i, i, commonBrokerCapacityInfo);
     }
 
     clusterModel.createReplica("r0", 0, T0P0, 0, true);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/DeterministicCluster.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/DeterministicCluster.java
@@ -6,6 +6,7 @@ package com.linkedin.kafka.cruisecontrol.common;
 
 import com.linkedin.cruisecontrol.monitor.sampling.aggregator.AggregatedMetricValues;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUnitTestUtils;
+import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelGeneration;
 
@@ -280,10 +281,11 @@ public class DeterministicCluster {
       cluster.createRack(Integer.toString(i));
     }
 
+    BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(brokerCapacity, "");
     // Create brokers and assign a broker to each rack.
     int brokerId = 0;
     for (Integer rackId : orderedRackIdsOfBrokers) {
-      cluster.createBroker(rackId.toString(), Integer.toString(brokerId), brokerId, brokerCapacity);
+      cluster.createBroker(rackId.toString(), Integer.toString(brokerId), brokerId, commonBrokerCapacityInfo);
       brokerId++;
     }
     return cluster;

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/DeterministicCluster.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/DeterministicCluster.java
@@ -281,7 +281,7 @@ public class DeterministicCluster {
       cluster.createRack(Integer.toString(i));
     }
 
-    BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(brokerCapacity, "");
+    BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(brokerCapacity);
     // Create brokers and assign a broker to each rack.
     int brokerId = 0;
     for (Integer rackId : orderedRackIdsOfBrokers) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolverTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolverTest.java
@@ -9,7 +9,9 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 /**
@@ -25,13 +27,18 @@ public class BrokerCapacityConfigFileResolverTest {
     configs.put(BrokerCapacityConfigFileResolver.CAPACITY_CONFIG_FILE, fileName);
     configResolver.configure(configs);
 
-    assertEquals(200000.0, configResolver.capacityForBroker("", "", 0).get(Resource.NW_IN), 0.01);
-    assertEquals(100000.0, configResolver.capacityForBroker("", "", 2).get(Resource.NW_IN), 0.01);
+    assertEquals(200000.0, configResolver.capacityForBroker("", "", 0)
+                                         .capacity().get(Resource.NW_IN), 0.01);
+    assertEquals(100000.0, configResolver.capacityForBroker("", "", 2)
+                                         .capacity().get(Resource.NW_IN), 0.01);
     try {
       configResolver.capacityForBroker("", "", -1);
       fail("Should have thrown exception for negative broker id");
     } catch (IllegalArgumentException e) {
       // let it go
     }
+
+    assertTrue(configResolver.capacityForBroker("", "", 2).isEstimated());
+    assertTrue(configResolver.capacityForBroker("", "", 2).estimationInfo().length() > 0);
   }
 }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -89,7 +89,7 @@ public class AnomalyDetectorTest {
 
     try {
       anomalyDetector.startDetection();
-      anomalies.add(new BrokerFailures(mockKafkaCruiseControl, Collections.singletonMap(0, 100L)));
+      anomalies.add(new BrokerFailures(mockKafkaCruiseControl, Collections.singletonMap(0, 100L), false));
       while (!anomalies.isEmpty()) {
         // just wait for the anomalies to be drained.
       }
@@ -144,7 +144,8 @@ public class AnomalyDetectorTest {
     EasyMock.expect(mockKafkaCruiseControl.rebalance(EasyMock.eq(Collections.emptyList()),
                                                      EasyMock.eq(false),
                                                      EasyMock.eq(null),
-                                                     EasyMock.anyObject(OperationProgress.class)))
+                                                     EasyMock.anyObject(OperationProgress.class),
+                                                     EasyMock.eq(true)))
             .andReturn(null);
     EasyMock.expect(mockKafkaCruiseControl.meetCompletenessRequirements(EasyMock.anyObject())).andReturn(true);
 
@@ -162,7 +163,7 @@ public class AnomalyDetectorTest {
 
     try {
       anomalyDetector.startDetection();
-      anomalies.add(new GoalViolations(mockKafkaCruiseControl));
+      anomalies.add(new GoalViolations(mockKafkaCruiseControl, true));
       while (!anomalies.isEmpty()) {
         // Just wait for the anomalies to be drained.
       }
@@ -235,7 +236,7 @@ public class AnomalyDetectorTest {
 
     try {
       anomalyDetector.startDetection();
-      anomalies.add(new GoalViolations(mockKafkaCruiseControl));
+      anomalies.add(new GoalViolations(mockKafkaCruiseControl, true));
       while (!anomalies.isEmpty()) {
         // Just wait for the anomalies to be drained.
       }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SelfHealingNotifierTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SelfHealingNotifierTest.java
@@ -38,7 +38,8 @@ public class SelfHealingNotifierTest {
     Map<Integer, Long> failedBrokers = new HashMap<>();
     failedBrokers.put(1, failureTime1);
     failedBrokers.put(2, failureTime2);
-    AnomalyNotificationResult result = anomalyNotifier.onBrokerFailure(new BrokerFailures(mockKafkaCruiseControl, failedBrokers));
+    boolean allowCapacityEstimation = true;
+    AnomalyNotificationResult result = anomalyNotifier.onBrokerFailure(new BrokerFailures(mockKafkaCruiseControl, failedBrokers, allowCapacityEstimation));
     assertEquals(AnomalyNotificationResult.Action.CHECK, result.action());
     assertEquals(SelfHealingNotifier.DEFAULT_ALERT_THRESHOLD_MS + failureTime1 - mockTime.milliseconds(),
                  result.delay());
@@ -46,7 +47,7 @@ public class SelfHealingNotifierTest {
 
     // Sleep to 1 ms before alert.
     mockTime.sleep(result.delay() - 1);
-    result = anomalyNotifier.onBrokerFailure(new BrokerFailures(mockKafkaCruiseControl, failedBrokers));
+    result = anomalyNotifier.onBrokerFailure(new BrokerFailures(mockKafkaCruiseControl, failedBrokers, allowCapacityEstimation));
     assertEquals(AnomalyNotificationResult.Action.CHECK, result.action());
     assertEquals(1, result.delay());
     assertFalse(anomalyNotifier.alertCalled);
@@ -54,7 +55,7 @@ public class SelfHealingNotifierTest {
     // Sleep 1 ms
     mockTime.sleep(1);
     anomalyNotifier.resetAlert();
-    result = anomalyNotifier.onBrokerFailure(new BrokerFailures(mockKafkaCruiseControl, failedBrokers));
+    result = anomalyNotifier.onBrokerFailure(new BrokerFailures(mockKafkaCruiseControl, failedBrokers, allowCapacityEstimation));
     assertEquals(AnomalyNotificationResult.Action.CHECK, result.action());
     assertEquals(SelfHealingNotifier.DEFAULT_AUTO_FIX_THRESHOLD_MS + failureTime1 - mockTime.milliseconds(),
                  result.delay());
@@ -63,7 +64,7 @@ public class SelfHealingNotifierTest {
     // Sleep to 1 ms before alert.
     mockTime.sleep(result.delay() - 1);
     anomalyNotifier.resetAlert();
-    result = anomalyNotifier.onBrokerFailure(new BrokerFailures(mockKafkaCruiseControl, failedBrokers));
+    result = anomalyNotifier.onBrokerFailure(new BrokerFailures(mockKafkaCruiseControl, failedBrokers, allowCapacityEstimation));
     assertEquals(AnomalyNotificationResult.Action.CHECK, result.action());
     assertEquals(1, result.delay());
     assertTrue(anomalyNotifier.alertCalled);
@@ -72,7 +73,7 @@ public class SelfHealingNotifierTest {
     // Sleep 1 ms
     mockTime.sleep(1);
     anomalyNotifier.resetAlert();
-    result = anomalyNotifier.onBrokerFailure(new BrokerFailures(mockKafkaCruiseControl, failedBrokers));
+    result = anomalyNotifier.onBrokerFailure(new BrokerFailures(mockKafkaCruiseControl, failedBrokers, allowCapacityEstimation));
     assertEquals(AnomalyNotificationResult.Action.FIX, result.action());
     assertEquals(-1L, result.delay());
     assertTrue(anomalyNotifier.alertCalled);
@@ -95,7 +96,8 @@ public class SelfHealingNotifierTest {
 
     mockTime.sleep(SelfHealingNotifier.DEFAULT_AUTO_FIX_THRESHOLD_MS + failureTime1);
     anomalyNotifier.resetAlert();
-    AnomalyNotificationResult result = anomalyNotifier.onBrokerFailure(new BrokerFailures(mockKafkaCruiseControl, failedBrokers));
+    AnomalyNotificationResult result = anomalyNotifier.onBrokerFailure(
+        new BrokerFailures(mockKafkaCruiseControl, failedBrokers, true));
     assertEquals(AnomalyNotificationResult.Action.IGNORE, result.action());
     assertTrue(anomalyNotifier.alertCalled);
     assertFalse(anomalyNotifier.autoFixTriggered);


### PR DESCRIPTION
For endpoints that Cruise Control requires generating a cluster model, such as `rebalance`, `add_broker`, `remove_broker`, and `proposals`, Cruise Control will provide an optional parameter to specify whether it is allowed to estimate missing broker capacities or not (default: `allowCapacityEstimation: true`).
In case the estimation for broker capacities is not explicitly allowed, If CC is unable to get a well-formed broker capacity from its external dependencies (i.e. the broker id is missing from the `json` file specifying the broker capacities when the default capacity resolver, `BrokerCapacityConfigFileResolver.java`, is used), it will throw an exception specifying the issue.