### PR TITLE
Fix JSON response for multiple endpoints

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaClusterState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaClusterState.java
@@ -120,11 +120,11 @@ public class KafkaClusterState {
   private List<Object> getJsonPartitions(Set<PartitionInfo> partitions) {
     List<Object> partitionList = new ArrayList<>();
     for (PartitionInfo partitionInfo : partitions) {
-      Set<String> replicas =
-          Arrays.stream(partitionInfo.replicas()).map(Node::idString).collect(Collectors.toSet());
-      Set<String> inSyncReplicas =
-          Arrays.stream(partitionInfo.inSyncReplicas()).map(Node::idString).collect(Collectors.toSet());
-      Set<String> outOfSyncReplicas = new HashSet<>(replicas);
+      Set<Integer> replicas =
+          Arrays.stream(partitionInfo.replicas()).map(Node::id).collect(Collectors.toSet());
+      Set<Integer> inSyncReplicas =
+          Arrays.stream(partitionInfo.inSyncReplicas()).map(Node::id).collect(Collectors.toSet());
+      Set<Integer> outOfSyncReplicas = new HashSet<>(replicas);
       outOfSyncReplicas.removeAll(inSyncReplicas);
 
       Map<String, Object> recordMap = new HashMap<>();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaClusterState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaClusterState.java
@@ -127,13 +127,13 @@ public class KafkaClusterState {
       Set<String> outOfSyncReplicas = new HashSet<>(replicas);
       outOfSyncReplicas.removeAll(inSyncReplicas);
 
-      Map<String, String> recordMap = new HashMap<>();
+      Map<String, Object> recordMap = new HashMap<>();
       recordMap.put(TOPIC, partitionInfo.topic());
-      recordMap.put(PARTITION, Integer.toString(partitionInfo.partition()));
-      recordMap.put(LEADER, Integer.toString(partitionInfo.leader() == null ? -1 : partitionInfo.leader().id()));
-      recordMap.put(REPLICAS, replicas.toString());
-      recordMap.put(IN_SYNC, inSyncReplicas.toString());
-      recordMap.put(OUT_OF_SYNC, outOfSyncReplicas.toString());
+      recordMap.put(PARTITION, partitionInfo.partition());
+      recordMap.put(LEADER, partitionInfo.leader() == null ? -1 : partitionInfo.leader().id());
+      recordMap.put(REPLICAS, replicas);
+      recordMap.put(IN_SYNC, inSyncReplicas);
+      recordMap.put(OUT_OF_SYNC, outOfSyncReplicas);
       partitionList.add(recordMap);
     }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -917,6 +917,7 @@ public class ClusterModel implements Serializable {
       hostEntry.put("NnwOutRate", AnalyzerUtils.nanToZero(broker.load().expectedUtilizationFor(Resource.NW_OUT)));
       hostEntry.put("PnwOutRate", AnalyzerUtils.nanToZero(potentialLeadershipLoadFor(broker.id()).expectedUtilizationFor(Resource.NW_OUT)));
       hostEntry.put("Replicas", broker.replicas().size());
+      hostEntry.put("LeaderReplicas", broker.leaderReplicas().size());
 
       finalClusterStats.add(hostEntry);
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -586,11 +586,11 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       throws IOException {
     String resp;
     if (json) {
-      Map<String, Object> exceptionMap = new HashMap<>();
-      exceptionMap.put("version", JSON_VERSION);
-      exceptionMap.put("Message", message);
+      Map<String, Object> respMap = new HashMap<>();
+      respMap.put("version", JSON_VERSION);
+      respMap.put("Message", message);
       Gson gson = new Gson();
-      resp = gson.toJson(exceptionMap);
+      resp = gson.toJson(respMap);
     } else {
       resp = message == null ? "" : message;
     }
@@ -1101,7 +1101,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       }
       switch (endPoint) {
         case REBALANCE:
-          sb.append("%n%nCluster load after rebalance%n");
+          sb.append("%n%nCluster load after rebalance:%n");
           break;
         case ADD_BROKER:
           sb.append(String.format("%n%nCluster load after adding broker %s:%n", brokerIds));

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -1131,11 +1131,17 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       out.write(optimizerResult.brokerStatsAfterOptimization().toString().getBytes(StandardCharsets.UTF_8));
     } else {
       Map <String, Object> ret= new HashMap<>();
+
       ret.put("proposalSummary", optimizerResult.getProposalSummary()); //TODO: need to pick patch #240 and apply here
-      List<Object> goalResult= new ArrayList<>();
+      List<Object> goalResultList= new ArrayList<>();
       for (Map.Entry<Goal, ClusterModelStats> entry : optimizerResult.statsByGoalPriority().entrySet()) {
-        //TODO
+        Goal goal = entry.getKey();
+        Map<String, Object> goalResult=new HashMap<>();
+        goalResult.put("goalName", goal.name());
+        goalResult.put("result", goalResultDescription(goal, optimizerResult));
+        goalResult.put("clusterStats", entry.getValue().getJsonStructure());
       }
+      ret.put("goalSummary", goalResultList);
     }
     out.flush();
     return true;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -1140,8 +1140,16 @@ public class KafkaCruiseControlServlet extends HttpServlet {
         goalResult.put("goalName", goal.name());
         goalResult.put("result", goalResultDescription(goal, optimizerResult));
         goalResult.put("clusterStats", entry.getValue().getJsonStructure());
+        goalResultList.add(goalResult);
       }
       ret.put("goalSummary", goalResultList);
+      ret.put("resultingClusterLoad", optimizerResult.brokerStatsAfterOptimization().getJsonStructure());
+      ret.put("version", JSON_VERSION);
+      Gson gson = new GsonBuilder()
+          .serializeNulls()
+          .serializeSpecialFloatingPointValues()
+          .create();
+      out.write(gson.toJson(ret).getBytes(StandardCharsets.UTF_8));
     }
     out.flush();
     return true;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -552,8 +552,8 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       _asyncKafkaCruiseControl.bootstrapLoadMonitor(clearMetrics);
     }
 
-    String retMsg = String.format("Bootstrap started. Check status through %s", getStateCheckUrl(request));
-    setSuccessResponse(response, retMsg, SC_OK, json);
+    String msg = String.format("Bootstrap started. Check status through %s", getStateCheckUrl(request));
+    setSuccessResponse(response, msg, SC_OK, json);
   }
 
   private void setErrorResponse(HttpServletResponse response,
@@ -616,8 +616,8 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       return;
     }
     _asyncKafkaCruiseControl.trainLoadModel(startMs, endMs);
-    String retMessage = String.format("Load model training started. Check status through %s", getStateCheckUrl(request));
-    setSuccessResponse(response, retMessage, SC_OK, json);
+    String message = String.format("Load model training started. Check status through %s", getStateCheckUrl(request));
+    setSuccessResponse(response, message, SC_OK, json);
   }
 
   private boolean getClusterLoad(HttpServletRequest request, HttpServletResponse response) throws Exception {
@@ -1107,7 +1107,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
           sb.append(String.format("%n%nCluster load after adding broker %s:%n", brokerIds));
           break;
         case REMOVE_BROKER:
-          sb.append(String.format("%n%nnCluster load after removing broker %s:%n", brokerIds));
+          sb.append(String.format("%n%nCluster load after removing broker %s:%n", brokerIds));
           break;
         case DEMOTE_BROKER:
           sb.append(String.format("%n%nCluster load after demoting broker %s:%n", brokerIds));
@@ -1117,26 +1117,26 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       }
       sb.append(optimizerResult.brokerStatsAfterOptimization().toString());
     } else {
-      Map<String, Object> ret = new HashMap<>();
+      Map<String, Object> retMap = new HashMap<>();
 
-      ret.put("proposalSummary", optimizerResult.getProposalSummaryForJson());
-      List<Object> goalResultList = new ArrayList<>();
+      retMap.put("proposalSummary", optimizerResult.getProposalSummaryForJson());
+      List<Object> goalStatusList = new ArrayList<>();
       for (Map.Entry<Goal, ClusterModelStats> entry : optimizerResult.statsByGoalPriority().entrySet()) {
         Goal goal = entry.getKey();
-        Map<String, Object> goalResult = new HashMap<>();
-        goalResult.put("goalName", goal.name());
-        goalResult.put("result", goalResultDescription(goal, optimizerResult));
-        goalResult.put("clusterStats", entry.getValue().getJsonStructure());
-        goalResultList.add(goalResult);
+        Map<String, Object> goalRecord = new HashMap<>();
+        goalRecord.put("goalName", goal.name());
+        goalRecord.put("status", goalResultDescription(goal, optimizerResult));
+        goalRecord.put("clusterModelStats", entry.getValue().getJsonStructure());
+        goalStatusList.add(goalRecord);
       }
-      ret.put("goalSummary", goalResultList);
-      ret.put("resultingClusterLoad", optimizerResult.brokerStatsAfterOptimization().getJsonStructure());
-      ret.put("version", JSON_VERSION);
+      retMap.put("goalSummary", goalStatusList);
+      retMap.put("resultingClusterLoad", optimizerResult.brokerStatsAfterOptimization().getJsonStructure());
+      retMap.put("version", JSON_VERSION);
       Gson gson = new GsonBuilder()
           .serializeNulls()
           .serializeSpecialFloatingPointValues()
           .create();
-      sb.append(gson.toJson(ret));
+      sb.append(gson.toJson(retMap));
     }
     return sb.toString();
   }
@@ -1276,7 +1276,6 @@ public class KafkaCruiseControlServlet extends HttpServlet {
     setResponseCode(response, SC_OK, false);
     OutputStream out = response.getOutputStream();
     out.write(generateGoalAndClusterStatusAfterExecution(json, optimizerResult, endPoint, brokerIds).getBytes(StandardCharsets.UTF_8));
-    out.write(optimizerResult.getProposalSummary().getBytes(StandardCharsets.UTF_8));
     out.flush();
     return true;
   }


### PR DESCRIPTION
1. fix the issue reported in ticket https://github.com/linkedin/cruise-control/issues/223 , add leader replica count per broker information in JSON response

2. fix get bootstrap/train JSON response,  remove traceStack field and rename errorMessage to message in normal response

3. fix kafka_cluster_state JSON response, increase readability of some fields

4. fix get load/partition_load JSON response reported in ticket https://github.com/linkedin/cruise-control/issues/263 . remove granularity parameter for get load request; add topic and partition parameter for get partition_load request. the topic parameter supports filtering partition based on matching a regular expression. the partition parameter supports filtering partition based on specific partition number or a partition number range

5. fix post add_broker/remove_broker/rebalance/demote_broker JSON response, refactor the code to generate response(both JSON and normal format) in a central place

6. add support of json=true parameter to post stop_proposal_execution/pause_sampling/resume_sampling request, return a response indicate CC has successfully accept the request