### PR TITLE
Add caching to the sorted replicas in the cluster model.

### DIFF
--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricValues.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricValues.java
@@ -155,14 +155,14 @@ public class MetricValues {
   /**
    * @return the average value of all the values in this MetricValues.
    */
-  public float avg() {
+  public double avg() {
     return (float) (_sumForAvg / _values.length);
   }
 
   /**
    * @return the max value of all the values in this MetricValues.
    */
-  public float max() {
+  public double max() {
     if (_max >= 0) {
       return _max;
     } else {

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricValues.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricValues.java
@@ -155,14 +155,14 @@ public class MetricValues {
   /**
    * @return the average value of all the values in this MetricValues.
    */
-  public double avg() {
+  public float avg() {
     return (float) (_sumForAvg / _values.length);
   }
 
   /**
    * @return the max value of all the values in this MetricValues.
    */
-  public double max() {
+  public float max() {
     if (_max >= 0) {
       return _max;
     } else {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CapacityGoal.java
@@ -349,11 +349,11 @@ public abstract class CapacityGoal extends AbstractGoal {
   }
 
   private String sortName() {
-    return resource().name() + "-ALL";
+    return name() + "-" + resource().name() + "-ALL";
   }
 
   private String sortNameByLeader() {
-    return resource().name() + "-LEADER";
+    return name() + "-" + resource().name() + "-LEADER";
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CapacityGoal.java
@@ -18,6 +18,7 @@ import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
 import com.linkedin.kafka.cruisecontrol.model.Load;
 import com.linkedin.kafka.cruisecontrol.model.Replica;
 
+import com.linkedin.kafka.cruisecontrol.model.ReplicaSortFunctionFactory;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 import java.util.List;
 import java.util.Set;
@@ -172,6 +173,13 @@ public abstract class CapacityGoal extends AbstractGoal {
       throw new OptimizationFailureException("Insufficient healthy cluster capacity for resource:" + resource() +
           " existing cluster utilization " + existingUtilization + " allowed capacity " + allowedCapacity);
     }
+    clusterModel.trackSortedReplicas(sortName(),
+                                     ReplicaSortFunctionFactory.deprioritizeImmigrants(),
+                                     ReplicaSortFunctionFactory.sortByMetricGroupValue(resource().name()));
+    clusterModel.trackSortedReplicas(sortNameByLeader(),
+                                     ReplicaSortFunctionFactory.selectLeaders(),
+                                     ReplicaSortFunctionFactory.deprioritizeImmigrants(),
+                                     ReplicaSortFunctionFactory.sortByMetricGroupValue(resource().name()));
   }
 
   /**
@@ -190,6 +198,8 @@ public abstract class CapacityGoal extends AbstractGoal {
     // Sanity check: No self-healing eligible replica should remain at a decommissioned broker.
     AnalyzerUtils.ensureNoReplicaOnDeadBrokers(clusterModel);
     finish();
+    clusterModel.untrackSortedReplicas(sortName());
+    clusterModel.untrackSortedReplicas(sortNameByLeader());
   }
 
   /**
@@ -269,7 +279,8 @@ public abstract class CapacityGoal extends AbstractGoal {
     if (currentResource == Resource.NW_OUT || currentResource == Resource.CPU) {
       // Sort replicas by descending order of preference to relocate. Preference is based on resource cost.
       // Only leaders in the source broker are sorted.
-      List<Replica> sortedLeadersInSourceBroker = broker.sortedLeadersFor(currentResource);
+      List<Replica> sortedLeadersInSourceBroker =
+          broker.trackedSortedReplicas(sortNameByLeader()).reverselySortedReplicas();
       for (Replica leader : sortedLeadersInSourceBroker) {
         if (shouldExclude(leader, excludedTopics)) {
           continue;
@@ -302,7 +313,7 @@ public abstract class CapacityGoal extends AbstractGoal {
       // Move replicas that are sorted in descending order of preference to relocate (preference is based on
       // utilization) until the source broker utilization gets under the capacity limit. If the capacity limit cannot
       // be satisfied, throw an exception.
-      for (Replica replica : broker.sortedReplicas(currentResource)) {
+      for (Replica replica : broker.trackedSortedReplicas(sortName()).reverselySortedReplicas()) {
         if (shouldExclude(replica, excludedTopics)) {
           continue;
         }
@@ -335,6 +346,14 @@ public abstract class CapacityGoal extends AbstractGoal {
             + broker.host().name() + " for resource " + currentResource);
       }
     }
+  }
+
+  private String sortName() {
+    return resource().name() + "-ALL";
+  }
+
+  private String sortNameByLeader() {
+    return resource().name() + "-LEADER";
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -447,9 +447,8 @@ public class ClusterModel implements Serializable {
    * in a single place.
    *
    * The sorted replica will only be updated in the following cases:
-   * 1. A replica is added to a broker
-   * 2. A replica is removed from a broker
-   * 3. A replica's role has changed from leader to follower, and vice versa.
+   * 1. A replica is added to or removed from a broker
+   * 2. A replica's role has changed from leader to follower, and vice versa.
    *
    * The sorted replicas are named using the given sortName, and can be accessed using
    * {@link Broker#trackedSortedReplicas(String)}. If the sorted replicas are no longer needed,
@@ -473,9 +472,8 @@ public class ClusterModel implements Serializable {
    * caller to prioritize a certain type of replicas, e.g immigrant replicas.
    *
    * The sorted replica will only be updated in the following cases:
-   * 1. A replica is added to a broker
-   * 2. A replica is removed from a broker
-   * 3. A replica's role has changed from leader to follower, and vice versa.
+   * 1. A replica is added to or removed from abroker
+   * 2. A replica's role has changed from leader to follower, and vice versa.
    *
    * The sorted replicas are named using the given sortName, and can be accessed using
    * {@link Broker#trackedSortedReplicas(String)}. If the sorted replicas are no longer needed,
@@ -503,9 +501,8 @@ public class ClusterModel implements Serializable {
    * in a single place.
    *
    * The sorted replica will only be updated in the following cases:
-   * 1. A replica is added to a broker
-   * 2. A replica is removed from a broker
-   * 3. A replica's role has changed from leader to follower, and vice versa.
+   * 1. A replica is added to or removed from a broker
+   * 2. A replica's role has changed from leader to follower, and vice versa.
    *
    * The sorted replicas are named using the given sortName, and can be accessed using
    * {@link Broker#trackedSortedReplicas(String)}. If the sorted replicas are no longer needed,
@@ -525,7 +522,7 @@ public class ClusterModel implements Serializable {
   }
 
   /**
-   * Untrack the sorted replcias with the given name to release memory.
+   * Untrack the sorted replicas with the given name to release memory.
    *
    * @param sortName the name of the sorted replicas.
    */

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -28,6 +28,7 @@ import java.util.TreeSet;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.commons.math3.stat.descriptive.moment.Variance;
@@ -437,6 +438,99 @@ public class ClusterModel implements Serializable {
   public Broker broker(int brokerId) {
     Rack rack = _brokerIdToRack.get(brokerId);
     return rack == null ? null : rack.broker(brokerId);
+  }
+
+  /**
+   * Ask the cluster model to keep track of the replicas sorted with the given score function.
+   *
+   * It is recommended to use the functions from {@link ReplicaSortFunctionFactory} so the functions can be maintained
+   * in a single place.
+   *
+   * The sorted replica will only be updated in the following cases:
+   * 1. A replica is added to a broker
+   * 2. A replica is removed from a broker
+   * 3. A replica's role has changed from leader to follower, and vice versa.
+   *
+   * The sorted replicas are named using the given sortName, and can be accessed using
+   * {@link Broker#trackedSortedReplicas(String)}. If the sorted replicas are no longer needed,
+   * {@link #untrackSortedReplicas(String)} to release memory.
+   *
+   * @param sortName the name of the sorted replicas.
+   * @param scoreFunction the score function to sort the replicas with the same priority.
+   * @see SortedReplicas
+   */
+  public void trackSortedReplicas(String sortName, Function<Replica, Double> scoreFunction) {
+    trackSortedReplicas(sortName, null, scoreFunction);
+  }
+
+  /**
+   * Ask the cluster model to keep track of the replicas sorted with the given priority function and score function.
+   *
+   * It is recommended to use the functions from {@link ReplicaSortFunctionFactory} so the functions can be maintained
+   * in a single place.
+   *
+   * The sort will first use the priority function then the score function. The priority function allows the
+   * caller to prioritize a certain type of replicas, e.g immigrant replicas.
+   *
+   * The sorted replica will only be updated in the following cases:
+   * 1. A replica is added to a broker
+   * 2. A replica is removed from a broker
+   * 3. A replica's role has changed from leader to follower, and vice versa.
+   *
+   * The sorted replicas are named using the given sortName, and can be accessed using
+   * {@link Broker#trackedSortedReplicas(String)}. If the sorted replicas are no longer needed,
+   * {@link #untrackSortedReplicas(String)} to release memory.
+   *
+   * @param sortName the name of the sorted replicas.
+   * @param priorityFunc the priority function to sort the replicas
+   * @param scoreFunc the score function to sort the replicas with the same priority.
+   * @see SortedReplicas
+   */
+  public void trackSortedReplicas(String sortName,
+                                  Function<Replica, Integer> priorityFunc,
+                                  Function<Replica, Double> scoreFunc) {
+    trackSortedReplicas(sortName, null, priorityFunc, scoreFunc);
+  }
+
+  /**
+   * Ask the cluster model to keep track of the replicas sorted with the given priority function and score function.
+   *
+   * The sort will first use the priority function then the score function. The priority function allows the
+   * caller to prioritize a certain type of replicas, e.g immigrant replicas. The selection function determines
+   * which replicas to be included in the sorted replicas.
+   *
+   * It is recommended to use the functions from {@link ReplicaSortFunctionFactory} so the functions can be maintained
+   * in a single place.
+   *
+   * The sorted replica will only be updated in the following cases:
+   * 1. A replica is added to a broker
+   * 2. A replica is removed from a broker
+   * 3. A replica's role has changed from leader to follower, and vice versa.
+   *
+   * The sorted replicas are named using the given sortName, and can be accessed using
+   * {@link Broker#trackedSortedReplicas(String)}. If the sorted replicas are no longer needed,
+   * {@link #untrackSortedReplicas(String)} to release memory.
+   *
+   * @param sortName the name of the sorted replicas.
+   * @param selectionFunc the selection function to decide which replicas to include in the sort.
+   * @param priorityFunc the priority function to sort the replicas
+   * @param scoreFunc the score function to sort the replicas with the same priority.
+   * @see SortedReplicas
+   */
+  public void trackSortedReplicas(String sortName,
+                                  Function<Replica, Boolean> selectionFunc,
+                                  Function<Replica, Integer> priorityFunc,
+                                  Function<Replica, Double> scoreFunc) {
+    _brokers.forEach(b -> b.trackSortedReplicas(sortName, selectionFunc, priorityFunc, scoreFunc));
+  }
+
+  /**
+   * Untrack the sorted replcias with the given name to release memory.
+   *
+   * @param sortName the name of the sorted replicas.
+   */
+  public void untrackSortedReplicas(String sortName) {
+    _brokers.forEach(b -> b.untrackSortedReplicas(sortName));
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Load.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Load.java
@@ -91,11 +91,8 @@ public class Load implements Serializable {
     return max(result, 0.0);
   }
 
-  /**
-   * See {@link #expectedUtilizationFor(Resource, boolean)}.
-   */
   public double expectedUtilizationFor(Resource resource) {
-    return expectedUtilizationFor(resource, false);
+    return expectedUtilizationFor(resource, _metricValues, false);
   }
 
   /**
@@ -279,5 +276,26 @@ public class Load implements Serializable {
   @Override
   public String toString() {
     return "<Load>" + _metricValues.toString() + "</Load>%n";
+  }
+
+  public static double expectedUtilizationFor(Resource resource,
+                                              AggregatedMetricValues aggregatedMetricValues,
+                                              boolean ignoreMissingMetric) {
+    if (aggregatedMetricValues.isEmpty()) {
+      return 0.0;
+    }
+    double result = 0;
+    for (MetricInfo info : KafkaMetricDef.resourceToMetricInfo(resource)) {
+      MetricValues valuesForId = aggregatedMetricValues.valuesFor(info.id());
+      if (!ignoreMissingMetric && valuesForId == null) {
+        throw new IllegalArgumentException(String.format("The aggregated metric values does not contain metric "
+                                                             + "%s for resource %s.",
+                                                         info, resource.name()));
+      }
+      if (valuesForId != null) {
+        result += resource == Resource.DISK ? valuesForId.latest() : valuesForId.avg();
+      }
+    }
+    return max(result, 0.0);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Load.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Load.java
@@ -278,6 +278,18 @@ public class Load implements Serializable {
     return "<Load>" + _metricValues.toString() + "</Load>%n";
   }
 
+  /**
+   * Get a single snapshot value that is representative for the given resource. The current algorithm uses
+   * (1) the mean of the recent resource load for inbound network load, outbound network load, and cpu load
+   * (2) the latest utilization for disk space usage.
+   *
+   * @param resource Resource for which the expected utilization will be provided.
+   * @param aggregatedMetricValues the aggregated metric values to calculate the expected utilization.
+   * @param ignoreMissingMetric whether it is allowed for the value of the given resource to be missing.
+   *                            If the value of the given resource is not found, when set to true, 0 will be returned.
+   *                            Otherwise, an exception will be thrown.
+   * @return A single representative utilization value on a resource.
+   */
   public static double expectedUtilizationFor(Resource resource,
                                               AggregatedMetricValues aggregatedMetricValues,
                                               boolean ignoreMissingMetric) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Rack.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Rack.java
@@ -269,7 +269,9 @@ public class Rack implements Serializable {
     for (Resource r : Resource.cachedValues()) {
       double capacity = 0;
       for (Host h : _hosts.values()) {
-        capacity += h.capacityFor(r);
+        if (h.isAlive()) {
+          capacity += h.capacityFor(r);
+        }
       }
       _rackCapacity[r.id()] = capacity;
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Replica.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Replica.java
@@ -130,6 +130,14 @@ public class Replica implements Serializable, Comparable<Replica> {
     // Remove leadership from the replica.
     setLeadership(false);
 
+    return leaderLoadDelta(true);
+  }
+
+  public AggregatedMetricValues leaderLoadDelta() {
+    return leaderLoadDelta(false);
+  }
+
+  private AggregatedMetricValues leaderLoadDelta(boolean updateLoad) {
     // Get the inbound/outbound network and cpu load associated with leadership from the given replica.
     // All the following metric values are in a shared mode to avoid data copy.
     // Just get the first metric id because CPU only has one metric id in the group. Eventually the per replica
@@ -142,14 +150,16 @@ public class Replica implements Serializable, Comparable<Replica> {
 
     // Compute the cpu delta, the order matters here, we need to compute cpu load change before the network outbound
     // load is cleared.
-    MetricValues cpuLoadChange = updateCpuLoadAsFollower(leadershipNwOutLoad);
+    MetricValues cpuLoadChange = computeCpuLoadAsFollower(leadershipNwOutLoad, updateLoad);
     leadershipLoadDelta.add(cpuMetricId, cpuLoadChange);
 
     // We need to add the NW_OUT values to the delta before clearing the metric.
     leadershipLoadDelta.add(leadershipNwOutLoad);
 
     // Remove the outbound network leadership load from replica.
-    _load.clearLoadFor(Resource.NW_OUT);
+    if (updateLoad) {
+      _load.clearLoadFor(Resource.NW_OUT);
+    }
 
     // Return removed leadership load.
     return leadershipLoadDelta;
@@ -161,7 +171,7 @@ public class Replica implements Serializable, Comparable<Replica> {
    * @param leadershipNwOutLoad the leadership network outbound bytes rate.
    * @return the cpu load change.
    */
-  private MetricValues updateCpuLoadAsFollower(AggregatedMetricValues leadershipNwOutLoad) {
+  private MetricValues computeCpuLoadAsFollower(AggregatedMetricValues leadershipNwOutLoad, boolean updateLoad) {
     // Just get the first metric id because CPU only has one metric id in the group. Eventually the per replica
     // CPU utilization will be removed to use resource estimation at broker level.
     int cpuMetricId = KafkaMetricDef.resourceToMetricIds(Resource.CPU).get(0);
@@ -180,7 +190,9 @@ public class Replica implements Serializable, Comparable<Replica> {
                                                                       cpuLoad.get(i));
       // The order matters here. We have to first set the cpu load change, then update the cpu load for this replica.
       cpuLoadChange.set(i, cpuLoad.get(i) - newCpuLoad);
-      cpuLoad.set(i, newCpuLoad);
+      if (updateLoad) {
+        cpuLoad.set(i, newCpuLoad);
+      }
     }
     return cpuLoadChange;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ReplicaSortFunctionFactory.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ReplicaSortFunctionFactory.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ *
+ */
+
+package com.linkedin.kafka.cruisecontrol.model;
+
+import com.linkedin.cruisecontrol.monitor.sampling.aggregator.MetricValues;
+import com.linkedin.kafka.cruisecontrol.monitor.metricdefinition.KafkaMetricDef;
+
+import java.util.function.Function;
+
+/**
+ * A factory class of replica sort functions. It is always preferred to
+ */
+public class ReplicaSortFunctionFactory {
+
+  private ReplicaSortFunctionFactory() {
+
+  }
+  /** Prioritize the immigrants replicas */
+  private static final Function<Replica, Integer> PRIORITIZE_IMMIGRANTS = r -> r.originalBroker() != r.broker() ? 0 : 1;
+  /** De-prioritize the immigrants replicas */
+  private static final Function<Replica, Integer> DEPRIORITIZE_IMMIGRANTS = r -> r.originalBroker() != r.broker() ? 1 : 0;
+  /** Select leaders only */
+  private static final Function<Replica, Boolean> SELECT_LEADERS = Replica::isLeader;
+
+  // Score functions
+  /**
+   * @param metricName the metric name to score
+   * @return a score function to score by the metric value of the given metric name.
+   */
+  public static Function<Replica, Double> sortByMetricValue(String metricName) {
+    return r ->
+        r.load().loadByWindows().valuesFor(KafkaMetricDef.commonMetricDef().metricInfo(metricName).id()).avg();
+  }
+
+  /**
+   * @param metricGroup the metric name to score
+   * @return a score function to score by the metric group value of the given metric group.
+   */
+  public static Function<Replica, Double> sortByMetricGroupValue(String metricGroup) {
+    return r -> {
+      MetricValues metricValues = r.load()
+                                   .loadByWindows()
+                                   .valuesForGroup(metricGroup, KafkaMetricDef.commonMetricDef(), true);
+      return metricValues.avg();
+    };
+  }
+
+  // Priority functions
+  /**
+   * @return a priority function that prioritize the immigrants replicas.
+   */
+  public static Function<Replica, Integer> prioritizeImmigrants() {
+    return PRIORITIZE_IMMIGRANTS;
+  }
+
+  /**
+   * This priority function can be used together with {@link SortedReplicas#reverselySortedReplicas()}
+   * to provide sorted replicas in descending order of score and prioritize the immigrants replicas.
+   *
+   * @return a priority function that de-prioritize the immigrants replicas
+   */
+  public static Function<Replica, Integer> deprioritizeImmigrants() {
+    return DEPRIORITIZE_IMMIGRANTS;
+  }
+
+  // Selection functions
+
+  /**
+   * @return a selection function that only include leaders.
+   */
+  public static Function<Replica, Boolean> selectLeaders() {
+    return SELECT_LEADERS;
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ReplicaWrapper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ReplicaWrapper.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.model;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+
+/**
+ * A class that helps host replica and its score. This class is useful for searching on top of sorted set.
+ */
+public class ReplicaWrapper implements Comparable<ReplicaWrapper> {
+  private final Replica _replica;
+  private final double _score;
+  private final Function<Replica, Integer> _priorityFunction;
+
+  public ReplicaWrapper(Replica replica, double score, Function<Replica, Integer> priorityFunction) {
+    _replica = replica;
+    _score = score;
+    _priorityFunction = priorityFunction;
+  }
+
+  /**
+   * @return The score associated with the replica for sorting purpose.
+   */
+  public double score() {
+    return _score;
+  }
+
+  /**
+   * @return the replica.
+   */
+  public Replica replica() {
+    return _replica;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("(Partition=%s,Broker=%d,Score=%f)",
+                         _replica.topicPartition(), _replica.broker().id(), _score);
+  }
+
+  @Override
+  public int compareTo(ReplicaWrapper o) {
+    if (o == null) {
+      throw new IllegalArgumentException("Cannot compare to a null object.");
+    }
+    // First compare the priority function.
+    int result = comparePriority(o.replica());
+    if (result != 0) {
+      return result;
+    }
+    // Then compare the score.
+    result = Double.compare(this.score(), o.score());
+    if (result != 0) {
+      return result;
+    }
+
+    if (this.replica() == Replica.MAX_REPLICA || o.replica() == Replica.MIN_REPLICA) {
+      return 1;
+    } else if (this.replica() == Replica.MIN_REPLICA || o.replica() == Replica.MAX_REPLICA) {
+      return -1;
+    } else {
+      return this.replica().compareTo(o.replica());
+    }
+  }
+
+  private int comparePriority(Replica replica) {
+    if (_replica == Replica.MAX_REPLICA || _replica == Replica.MIN_REPLICA
+        || replica == Replica.MAX_REPLICA || replica == Replica.MIN_REPLICA) {
+      return 0;
+    }
+    int result = 0;
+    if (_priorityFunction != null) {
+      int p1 = _priorityFunction.apply(_replica);
+      int p2 = _priorityFunction.apply(replica);
+      return Integer.compare(p1, p2);
+    } else {
+      return 0;
+    }
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj != null && obj instanceof ReplicaWrapper && ((ReplicaWrapper) obj).score() == _score
+        && ((ReplicaWrapper) obj).replica().equals(_replica);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_replica, _score);
+  }
+
+  /**
+   * Get a ReplicaWrapper for searching purpose on a collection. The returned ReplicaWrapper is:
+   * 1. Smaller than any ReplicaWrapper whose score is greater than or equals to the given score.
+   * 2. Greater than any ReplicaWrapper whose score is smaller than the given score.
+   *
+   * @param score the given score.
+   * @return A ReplicaWrapper that meets the above condition.
+   */
+  public static ReplicaWrapper greaterThanOrEqualsTo(double score) {
+    return new ReplicaWrapper(Replica.MIN_REPLICA, score, null);
+  }
+
+  /**
+   * Get a ReplicaWrapper for searching purpose on a collection. The returned ReplicaWrapper is:
+   * 1. Smaller than any ReplicaWrapper whose score is greater than the given score.
+   * 2. Greater than any ReplicaWrapper whose score is smaller than or equals to the given score.
+   *
+   * @param score the given score.
+   * @return A ReplicaWrapper that meets the above condition.
+   */
+  public static ReplicaWrapper greaterThan(double score) {
+    return new ReplicaWrapper(Replica.MAX_REPLICA, score, null);
+  }
+
+  /**
+   * Get a ReplicaWrapper for searching purpose on a collection. The returned ReplicaWrapper is:
+   * 1. Greater than any ReplicaWrapper whose score is smaller than or equals to the given score.
+   * 2. Smaller than any ReplicaWrapper whose score is greater than the given score.
+   *
+   * @param score the given score.
+   * @return A ReplicaWrapper that meets the above condition.
+   */
+  public static ReplicaWrapper lessThanOrEqualsTo(double score) {
+    return new ReplicaWrapper(Replica.MAX_REPLICA, score, null);
+  }
+
+  /**
+   * Get a ReplicaWrapper for searching purpose on a collection. The returned ReplicaWrapper is:
+   * 1. Greater than any ReplicaWrapper whose score is smaller than the given score.
+   * 2. Smaller than any ReplicaWrapper whose score is greater than or equals to the given score.
+   *
+   * @param score the given score.
+   * @return A ReplicaWrapper that meets the above condition.
+   */
+  public static ReplicaWrapper lessThan(double score) {
+    return new ReplicaWrapper(Replica.MIN_REPLICA, score, null);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ReplicaWrapper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ReplicaWrapper.java
@@ -72,7 +72,6 @@ public class ReplicaWrapper implements Comparable<ReplicaWrapper> {
         || replica == Replica.MAX_REPLICA || replica == Replica.MIN_REPLICA) {
       return 0;
     }
-    int result = 0;
     if (_priorityFunction != null) {
       int p1 = _priorityFunction.apply(_replica);
       int p2 = _priorityFunction.apply(replica);
@@ -84,7 +83,7 @@ public class ReplicaWrapper implements Comparable<ReplicaWrapper> {
 
   @Override
   public boolean equals(Object obj) {
-    return obj != null && obj instanceof ReplicaWrapper && ((ReplicaWrapper) obj).score() == _score
+    return obj instanceof ReplicaWrapper && ((ReplicaWrapper) obj).score() == _score
         && ((ReplicaWrapper) obj).replica().equals(_replica);
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicas.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicas.java
@@ -22,9 +22,9 @@ import java.util.function.Function;
  *  <ul>
  *     <li>
  *      <tt>ScoreFunction</tt>: the score function generates a score for each replica to sort. The replicas are
- *      sorted based on their score in ascending order. Those who wants a descending order needs to use
+ *      sorted based on their score in ascending order. Those who want a descending order need to use
  *      the descending iterator of {@link #sortedReplicas()}. As alternatives, {@link #reverselySortedReplicas()}
- *      and {@link #reverselySortedReplicaWrappers()} are provide as convenience.
+ *      and {@link #reverselySortedReplicaWrappers()} are provided for convenience.
  *    </li>
  *    <li>
  *      <tt>SelectionFunction</tt>(optional): the selection function decides which replicas to include in the sorted

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicas.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicas.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ *
+ */
+
+package com.linkedin.kafka.cruisecontrol.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.TreeSet;
+import java.util.function.Function;
+
+/**
+ * A class used by the brokers to host the replicas sorted in a certain order.
+ * <p>
+ *  The SortedReplicas uses three functions to sort the replicas in the broker.
+ *  <ul>
+ *     <li>
+ *      <tt>ScoreFunction</tt>: the score function generates a score for each replica to sort. The replicas are
+ *      sorted based on their score in ascending order. Those who wants a descending order needs to use
+ *      the descending iterator of {@link #sortedReplicas()}. As alternatives, {@link #reverselySortedReplicas()}
+ *      and {@link #reverselySortedReplicaWrappers()} are provide as convenience.
+ *    </li>
+ *    <li>
+ *      <tt>SelectionFunction</tt>(optional): the selection function decides which replicas to include in the sorted
+ *      replica list. For example, in some cases, the users may only want to have sorted leader replicas.
+ *    </li>
+ *    <li>
+ *      <tt>PriorityFunction</tt>(optional): the priority function allows users to prioritize certain replicas in the
+ *      sorted replicas. The replicas will be sorted by their priority first. The replicas with the same priority are
+ *      then sorted with their score from the <tt>scoreFunction</tt>.
+ *      Note that if a priority function is provided, the <tt>NavigableSet</tt> returned by the
+ *      {@link #sortedReplicas()} is no longer binary searchable based on the score.
+ *    </li>
+ *  </ul>
+ * </p>
+ *
+ * <p>
+ *   The SortedReplicas are initialized lazily, i.e. until one of {@link #sortedReplicas()},
+ *   {@link #reverselySortedReplicas()} and {@link #reverselySortedReplicaWrappers()} is invoked, the sorted replicas
+ *   will not be populated.
+ * </p>
+ */
+public class SortedReplicas {
+  private final Broker _broker;
+  private final Map<Replica, ReplicaWrapper> _replicaWrapperMap;
+  private final NavigableSet<ReplicaWrapper> _sortedReplicas;
+  private final Function<Replica, Boolean> _selectionFunc;
+  private final Function<Replica, Integer> _priorityFunc;
+  private final Function<Replica, Double> _scoreFunc;
+  private boolean _initialized;
+
+  SortedReplicas(Broker broker,
+                 Function<Replica, Boolean> selectionFunc,
+                 Function<Replica, Integer> priorityFunction,
+                 Function<Replica, Double> scoreFunction) {
+    this(broker, selectionFunc, priorityFunction, scoreFunction, true);
+  }
+
+  SortedReplicas(Broker broker,
+                 Function<Replica, Boolean> selectionFunc,
+                 Function<Replica, Integer> priorityFunc,
+                 Function<Replica, Double> scoreFunc,
+                 boolean initialize) {
+    _broker = broker;
+    _sortedReplicas = new TreeSet<>();
+    _replicaWrapperMap = new HashMap<>();
+    _selectionFunc = selectionFunc;
+    _scoreFunc = scoreFunc;
+    _priorityFunc = priorityFunc;
+    // If the sorted replicas need to be initialized, we set the initialized to false and initialize the replicas
+    // lazily. If the sorted replicas do not need to be initialized, we simply set the initialized to true, so that
+    // all the methods will function normally.
+    _initialized = !initialize;
+  }
+
+  /**
+   * Get the sorted replicas in the ascending order of their priority and score.
+   * This method initialize the sorted replicas if it hasn't been initialized.
+   *
+   * @return the sorted replicas in the ascending order of their priority and score.
+   */
+  public NavigableSet<ReplicaWrapper> sortedReplicas() {
+    ensureInitialize();
+    return Collections.unmodifiableNavigableSet(_sortedReplicas);
+  }
+
+  /**
+   * Get a list of replica wrappers in the descending order of their priority and score.
+   * This method initialize the sorted replicas if it hasn't been initialized.
+   *
+   * @return a list of replica wrappers in the descending order of their priority and score.
+   */
+  public List<ReplicaWrapper> reverselySortedReplicaWrappers() {
+    ensureInitialize();
+    List<ReplicaWrapper> result = new ArrayList<>(_sortedReplicas.size());
+    Iterator<ReplicaWrapper> reverseIter = _sortedReplicas.descendingIterator();
+    while (reverseIter.hasNext()) {
+      result.add(reverseIter.next());
+    }
+    return result;
+  }
+
+  /**
+   * Get a list of replicas in the descending order of their priority and score.
+   * This method initialize the sorted replicas if it hasn't been initialized.
+   *
+   * @return a list of replicas in the descending order of their priority and score.
+   */
+  public List<Replica> reverselySortedReplicas() {
+    ensureInitialize();
+    List<Replica> result = new ArrayList<>(_sortedReplicas.size());
+    Iterator<ReplicaWrapper> reverseIter = _sortedReplicas.descendingIterator();
+    while (reverseIter.hasNext()) {
+      result.add(reverseIter.next().replica());
+    }
+    return result;
+  }
+
+  /**
+   * @return the selection function of this {@link SortedReplicas}
+   */
+  public Function<Replica, Boolean> selectionFunction() {
+    return _selectionFunc;
+  }
+
+  /**
+   * @return the priority function of this {@link SortedReplicas}
+   */
+  public Function<Replica, Integer> priorityFunction() {
+    return _priorityFunc;
+  }
+
+  /**
+   * @return the score function of this {@link SortedReplicas}
+   */
+  public Function<Replica, Double> scoreFunction() {
+    return _scoreFunc;
+  }
+
+  /**
+   * Add a new replicas to the sorted replicas. It has no impact if this {@link SortedReplicas} has not been
+   * initialized.
+   *
+   * @param replica the replica to add.
+   */
+  void add(Replica replica) {
+    if (_initialized) {
+      if (_selectionFunc == null || _selectionFunc.apply(replica)) {
+        double score = _scoreFunc.apply(replica);
+        ReplicaWrapper rw = new ReplicaWrapper(replica, score, _priorityFunc);
+        add(rw);
+      }
+    }
+  }
+
+  /**
+   * Remove a new replicas to the sorted replicas. It has no impact if this {@link SortedReplicas} has not been
+   * initialized.
+   *
+   * @param replica the replica to remove.
+   */
+  void remove(Replica replica) {
+    if (_initialized) {
+      ReplicaWrapper rw = _replicaWrapperMap.remove(replica);
+      if (rw != null) {
+        _sortedReplicas.remove(rw);
+      }
+    }
+  }
+
+  // Unit test only function.
+  int numReplicas() {
+    return _sortedReplicas.size();
+  }
+
+  private void ensureInitialize() {
+    if (!_initialized) {
+      _initialized = true;
+      _broker.replicas().forEach(this::add);
+    }
+  }
+
+  private void add(ReplicaWrapper rw) {
+    ReplicaWrapper old = _replicaWrapperMap.put(rw.replica(), rw);
+    if (old != null) {
+      _sortedReplicas.remove(old);
+    }
+    _sortedReplicas.add(rw);
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicasTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicasTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
  */
 
 package com.linkedin.kafka.cruisecontrol.model;
@@ -38,7 +38,7 @@ public class SortedReplicasTest {
     int numReplicas = sr.sortedReplicas().size();
     Replica replica1 = new Replica(new TopicPartition(TOPIC, 105), broker, false);
     sr.add(replica1);
-    assertEquals("The selection function should have filterd out the replica",
+    assertEquals("The selection function should have filtered out the replica",
                  numReplicas, sr.sortedReplicas().size());
 
     Replica replica2 = new Replica(new TopicPartition(TOPIC, 103), broker, true);
@@ -134,7 +134,7 @@ public class SortedReplicasTest {
       }
     }
 
-    if (PRIORITY_FUNC != null) {
+    if (sr.priorityFunction() != null) {
       assertEquals(5, totalNumPriorities);
     }
   }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicasTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicasTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.model;
+
+import com.linkedin.kafka.cruisecontrol.common.TestConstants;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Test;
+
+import java.util.NavigableSet;
+import java.util.Random;
+import java.util.function.Function;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit test for {@link SortedReplicas}
+ */
+public class SortedReplicasTest {
+  private static final String TOPIC = "topic";
+  private static final String SORT_NAME = "sortName";
+  private static final Random RANDOM = new Random(0xDEADBEEF);
+
+  private static final Function<Replica, Boolean> SELECTION_FUNC = Replica::isLeader;
+  private static final Function<Replica, Integer> PRIORITY_FUNC = r -> r.topicPartition().partition() % 5;
+  private static final Function<Replica, Double> SCORE_FUNC = r -> RANDOM.nextDouble();
+
+  private static final int NUM_REPLICAS = 100;
+
+  @Test
+  public void testAddAndRemove() {
+    Broker broker = generateBroker(NUM_REPLICAS);
+    broker.trackSortedReplicas(SORT_NAME, SELECTION_FUNC, PRIORITY_FUNC, SCORE_FUNC);
+    SortedReplicas sr = broker.trackedSortedReplicas(SORT_NAME);
+
+    int numReplicas = sr.sortedReplicas().size();
+    Replica replica1 = new Replica(new TopicPartition(TOPIC, 105), broker, false);
+    sr.add(replica1);
+    assertEquals("The selection function should have filterd out the replica",
+                 numReplicas, sr.sortedReplicas().size());
+
+    Replica replica2 = new Replica(new TopicPartition(TOPIC, 103), broker, true);
+    sr.add(replica2);
+    assertEquals("The replica should have been added.", numReplicas + 1, sr.sortedReplicas().size());
+
+    verifySortedReplicas(sr);
+
+    // Removing a none existing replica should not throw exception.
+    sr.remove(replica1);
+    assertEquals(numReplicas + 1, sr.sortedReplicas().size());
+    verifySortedReplicas(sr);
+
+    // Remove an existing replica
+    sr.remove(replica2);
+    assertEquals(numReplicas, sr.sortedReplicas().size());
+    verifySortedReplicas(sr);
+  }
+
+  @Test
+  public void testLazyInitialization() {
+    Broker broker = generateBroker(NUM_REPLICAS);
+    broker.trackSortedReplicas(SORT_NAME, null, null, SCORE_FUNC);
+    SortedReplicas sr = broker.trackedSortedReplicas(SORT_NAME);
+
+    assertEquals("The replicas should be sorted lazily", 0, sr.numReplicas());
+    Replica replica = new Replica(new TopicPartition(TOPIC, 105), broker, false);
+    sr.add(replica);
+    assertEquals("The replicas should be sorted lazily", 0, sr.numReplicas());
+    sr.remove(replica);
+    assertEquals("The replicas should be sorted lazily", 0, sr.numReplicas());
+    NavigableSet<ReplicaWrapper> sortedReplicas = sr.sortedReplicas();
+    assertEquals("There should be ", NUM_REPLICAS, sortedReplicas.size());
+    assertEquals("The replicas should now be sorted", NUM_REPLICAS, sr.numReplicas());
+  }
+
+  @Test
+  public void testScoreFunctionOnly() {
+    Broker broker = generateBroker(NUM_REPLICAS);
+    broker.trackSortedReplicas(SORT_NAME, null, null, SCORE_FUNC);
+    SortedReplicas sr = broker.trackedSortedReplicas(SORT_NAME);
+
+    double lastScore = Double.NEGATIVE_INFINITY;
+    for (ReplicaWrapper rw : sr.sortedReplicas()) {
+      assertTrue(rw.score() >= lastScore);
+    }
+  }
+
+  @Test
+  public void testPriorityFunction() {
+    Broker broker = generateBroker(NUM_REPLICAS);
+    broker.trackSortedReplicas(SORT_NAME, null, PRIORITY_FUNC, SCORE_FUNC);
+    SortedReplicas sr = broker.trackedSortedReplicas(SORT_NAME);
+
+    assertEquals(NUM_REPLICAS, sr.sortedReplicas().size());
+
+    verifySortedReplicas(sr);
+  }
+
+  @Test
+  public void testSelectionFunction() {
+    Broker broker = generateBroker(NUM_REPLICAS);
+    broker.trackSortedReplicas(SORT_NAME, SELECTION_FUNC, PRIORITY_FUNC, SCORE_FUNC);
+    SortedReplicas sr = broker.trackedSortedReplicas(SORT_NAME);
+
+    assertEquals(broker.leaderReplicas().size(), sr.sortedReplicas().size());
+
+    verifySortedReplicas(sr);
+  }
+
+  private void verifySortedReplicas(SortedReplicas sr) {
+    int lastPriority = -1;
+    double lastScore = Double.NEGATIVE_INFINITY;
+    int totalNumPriorities = 0;
+    NavigableSet<ReplicaWrapper> sortedReplicas = sr.sortedReplicas();
+    for (ReplicaWrapper rw : sortedReplicas) {
+      // Check the selection correctness.
+      if (sr.selectionFunction() != null) {
+        assertTrue(SELECTION_FUNC.apply(rw.replica()));
+      }
+      // Check the prioritization correctness.
+      if (sr.priorityFunction() != null) {
+        int priority = PRIORITY_FUNC.apply(rw.replica());
+        assertTrue(lastPriority <= priority);
+      }
+      // Check the score sorting correctness.
+      if (sr.priorityFunction() != null && lastPriority < PRIORITY_FUNC.apply(rw.replica())) {
+        lastPriority = PRIORITY_FUNC.apply(rw.replica());
+        lastScore = rw.score();
+        totalNumPriorities++;
+      } else {
+        assertTrue(lastScore <= rw.score());
+      }
+    }
+
+    if (PRIORITY_FUNC != null) {
+      assertEquals(5, totalNumPriorities);
+    }
+  }
+
+  private Broker generateBroker(int numReplicas) {
+    Rack rack = new Rack("rack");
+    Host host = new Host("host", rack);
+    Broker broker = new Broker(host, 0, TestConstants.BROKER_CAPACITY);
+
+    for (int i = 0; i < numReplicas; i++) {
+      Replica r = new Replica(new TopicPartition(TOPIC, i), broker, i % 3 == 0);
+      broker.addReplica(r);
+    }
+    return broker;
+  }
+}


### PR DESCRIPTION
This is the first part of abstract resource distribution goal. The patch adds the support of 
caching the sorted replicas in the cluster model. This will be used for replica search in later patches.

Two follow up patches will be submitted:
1. A patch adds a generic replica search algorithm and flow.
2. the abstract metric distribution goal based on (1).