### PR TITLE
Fat jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,6 +241,12 @@ project(':cruise-control') {
     duplicatesStrategy 'exclude'
   }
 
+  tasks.create(name: "buildFatJar", type: Jar) {
+    baseName = project.name + '-all'
+    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    with jar
+  }
+
   compileScala.doLast {
     tasks.copyDependantLibs.execute()
   }


### PR DESCRIPTION
For deployment automation it is easier to have a single jar file. This PR adds a Gradle task to create a FatJar for CruiseControl. I used this task for a deployment automation using [bosh](https://bosh.io/docs/).