### PR TITLE
Add parameters to set concurrent_partition_movements_per_broker and concurrent_leader_movements on the fly.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AddBrokerRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AddBrokerRunnable.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 /**
  * The async runnable for {@link KafkaCruiseControl#addBrokers(Collection, boolean, boolean, List,
- * ModelCompletenessRequirements, com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean)}
+ * ModelCompletenessRequirements, com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean, Integer, Integer)}
  */
 class AddBrokerRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult> {
   private final Collection<Integer> _brokerIds;
@@ -21,6 +21,8 @@ class AddBrokerRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult>
   private final List<String> _goals;
   private final ModelCompletenessRequirements _modelCompletenessRequirements;
   private final boolean _allowCapacityEstimation;
+  private final Integer _concurrentPartitionMovements;
+  private final Integer _concurrentLeaderMovements;
 
   AddBrokerRunnable(KafkaCruiseControl kafkaCruiseControl,
                     OperationFuture<GoalOptimizer.OptimizerResult> future,
@@ -29,7 +31,9 @@ class AddBrokerRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult>
                     boolean throttleAddedBrokers,
                     List<String> goals,
                     ModelCompletenessRequirements modelCompletenessRequirements,
-                    boolean allowCapacityEstimation) {
+                    boolean allowCapacityEstimation,
+                    Integer concurrentPartitionMovements,
+                    Integer concurrentLeaderMovements) {
     super(kafkaCruiseControl, future);
     _brokerIds = brokerIds;
     _dryRun = dryRun;
@@ -37,12 +41,14 @@ class AddBrokerRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult>
     _goals = goals;
     _modelCompletenessRequirements = modelCompletenessRequirements;
     _allowCapacityEstimation = allowCapacityEstimation;
+    _concurrentPartitionMovements = concurrentPartitionMovements;
+    _concurrentLeaderMovements = concurrentLeaderMovements;
   }
 
   @Override
   protected GoalOptimizer.OptimizerResult getResult() throws Exception {
     return _kafkaCruiseControl.addBrokers(_brokerIds, _dryRun, _throttleAddedBrokers, _goals,
                                           _modelCompletenessRequirements, _future.operationProgress(),
-                                          _allowCapacityEstimation);
+                                          _allowCapacityEstimation, _concurrentPartitionMovements, _concurrentLeaderMovements);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AsyncKafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AsyncKafkaCruiseControl.java
@@ -27,14 +27,15 @@ import java.util.concurrent.Executors;
  *
  * <ul>
  * <li>{@link KafkaCruiseControl#decommissionBrokers(Collection, boolean, boolean, List, ModelCompletenessRequirements,
- * OperationProgress, boolean)}</li>
+ * OperationProgress, boolean, Integer, Integer)}</li>
  * <li>{@link KafkaCruiseControl#addBrokers(Collection, boolean, boolean, List, ModelCompletenessRequirements,
- * OperationProgress, boolean)}</li>
+ * OperationProgress, boolean, Integer, Integer)}</li>
+ * <li>{@link KafkaCruiseControl#demoteBrokers(Collection, boolean, OperationProgress, boolean, Integer)}</li>
  * <li>{@link KafkaCruiseControl#clusterModel(long, ModelCompletenessRequirements, OperationProgress, boolean)}</li>
  * <li>{@link KafkaCruiseControl#clusterModel(long, long, ModelCompletenessRequirements, OperationProgress, boolean)}</li>
  * <li>{@link KafkaCruiseControl#getOptimizationProposals(OperationProgress, boolean)}</li>
  * <li>{@link KafkaCruiseControl#getOptimizationProposals(List, ModelCompletenessRequirements, OperationProgress, boolean)}</li>
- * <li>{@link KafkaCruiseControl#rebalance(List, boolean, ModelCompletenessRequirements, OperationProgress, boolean)}</li>
+ * <li>{@link KafkaCruiseControl#rebalance(List, boolean, ModelCompletenessRequirements, OperationProgress, boolean, Integer, Integer)}</li>
  * </ul>
  *
  * The other operations are non-blocking by default.
@@ -67,36 +68,43 @@ public class AsyncKafkaCruiseControl extends KafkaCruiseControl {
 
   /**
    * @see KafkaCruiseControl#decommissionBrokers(Collection, boolean, boolean, List, ModelCompletenessRequirements,
-   * OperationProgress, boolean)
+   * OperationProgress, boolean, Integer, Integer)
    */
   public OperationFuture<GoalOptimizer.OptimizerResult> decommissionBrokers(Collection<Integer> brokerIds,
                                                                             boolean dryRun,
                                                                             boolean throttleDecommissionedBrokers,
                                                                             List<String> goals,
                                                                             ModelCompletenessRequirements requirements,
-                                                                            boolean allowCapacityEstimation) {
+                                                                            boolean allowCapacityEstimation,
+                                                                            Integer concurrentPartitionMovements,
+                                                                            Integer concurrentLeaderMovements) {
     OperationFuture<GoalOptimizer.OptimizerResult> future = new OperationFuture<>("Decommission brokers");
     pending(future.operationProgress());
     _sessionExecutor.submit(new DecommissionBrokersRunnable(this, future, brokerIds, dryRun,
                                                             throttleDecommissionedBrokers, goals, requirements,
-                                                            allowCapacityEstimation));
+                                                            allowCapacityEstimation,
+                                                            concurrentPartitionMovements,
+                                                            concurrentLeaderMovements));
     return future;
   }
 
   /**
    * @see KafkaCruiseControl#addBrokers(Collection, boolean, boolean, List, ModelCompletenessRequirements,
-   * OperationProgress, boolean)
+   * OperationProgress, boolean, Integer, Integer)
    */
   public OperationFuture<GoalOptimizer.OptimizerResult> addBrokers(Collection<Integer> brokerIds,
                                                                    boolean dryRun,
                                                                    boolean throttleAddedBrokers,
                                                                    List<String> goals,
                                                                    ModelCompletenessRequirements requirements,
-                                                                   boolean allowCapacityEstimation) {
+                                                                   boolean allowCapacityEstimation,
+                                                                   Integer concurrentPartitionMovements,
+                                                                   Integer concurrentLeaderMovements) {
     OperationFuture<GoalOptimizer.OptimizerResult> future = new OperationFuture<>("Add brokers");
     pending(future.operationProgress());
-    _sessionExecutor.submit(new AddBrokerRunnable(this, future, brokerIds, dryRun, throttleAddedBrokers,
-                                                  goals, requirements, allowCapacityEstimation));
+    _sessionExecutor.submit(
+        new AddBrokerRunnable(this, future, brokerIds, dryRun, throttleAddedBrokers, goals, requirements,
+                              allowCapacityEstimation, concurrentPartitionMovements, concurrentLeaderMovements));
     return future;
   }
 
@@ -154,28 +162,32 @@ public class AsyncKafkaCruiseControl extends KafkaCruiseControl {
   }
 
   /**
-   * @see KafkaCruiseControl#rebalance(List, boolean, ModelCompletenessRequirements, OperationProgress, boolean)
+   * @see KafkaCruiseControl#rebalance(List, boolean, ModelCompletenessRequirements, OperationProgress, boolean, Integer, Integer)
    */
   public OperationFuture<GoalOptimizer.OptimizerResult> rebalance(List<String> goals,
                                                                   boolean dryRun,
                                                                   ModelCompletenessRequirements requirements,
-                                                                  boolean allowCapacityEstimation) {
+                                                                  boolean allowCapacityEstimation,
+                                                                  Integer concurrentPartitionMovements,
+                                                                  Integer concurrentLeaderMovements) {
     OperationFuture<GoalOptimizer.OptimizerResult> future = new OperationFuture<>("Rebalance");
     pending(future.operationProgress());
     _sessionExecutor.submit(new RebalanceRunnable(this, future, goals, dryRun, requirements,
-                                                  allowCapacityEstimation));
+                                                  allowCapacityEstimation, concurrentPartitionMovements, concurrentLeaderMovements));
     return future;
   }
 
   /**
-   * @see KafkaCruiseControl#demoteBrokers(Collection, boolean, OperationProgress, boolean)
+   * @see KafkaCruiseControl#demoteBrokers(Collection, boolean, OperationProgress, boolean, Integer)
    */
   public OperationFuture<GoalOptimizer.OptimizerResult> demoteBrokers(Collection<Integer> brokerIds,
                                                                       boolean dryRun,
-                                                                      boolean allowCapacityEstimation) {
+                                                                      boolean allowCapacityEstimation,
+                                                                      Integer concurrentLeaderMovements) {
     OperationFuture<GoalOptimizer.OptimizerResult> future = new OperationFuture<>("Demote");
     pending(future.operationProgress());
-    _sessionExecutor.submit(new DemoteBrokerRunnable(this, future, brokerIds, dryRun, allowCapacityEstimation));
+    _sessionExecutor.submit(new DemoteBrokerRunnable(this, future, brokerIds, dryRun,
+                                                     allowCapacityEstimation, concurrentLeaderMovements));
     return future;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DecommissionBrokersRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DecommissionBrokersRunnable.java
@@ -12,7 +12,8 @@ import java.util.List;
 
 /**
  * The async runnable for {@link KafkaCruiseControl#decommissionBrokers(Collection, boolean, boolean, List,
- * ModelCompletenessRequirements, com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean)}
+ * ModelCompletenessRequirements, com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean,
+ * Integer, Integer)}
  */
 class DecommissionBrokersRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult> {
   private final Collection<Integer> _brokerIds;
@@ -21,6 +22,8 @@ class DecommissionBrokersRunnable extends OperationRunnable<GoalOptimizer.Optimi
   private final List<String> _goals;
   private final ModelCompletenessRequirements _modelCompletenessRequirements;
   private final boolean _allowCapacityEstimation;
+  private final Integer _concurrentPartitionMovements;
+  private final Integer _concurrentLeaderMovements;
 
   DecommissionBrokersRunnable(KafkaCruiseControl kafkaCruiseControl,
                               OperationFuture<GoalOptimizer.OptimizerResult> future,
@@ -29,7 +32,9 @@ class DecommissionBrokersRunnable extends OperationRunnable<GoalOptimizer.Optimi
                               boolean throttleRemovedBrokers,
                               List<String> goals,
                               ModelCompletenessRequirements modelCompletenessRequirements,
-                              boolean allowCapacityEstimation) {
+                              boolean allowCapacityEstimation,
+                              Integer concurrentPartitionMovements,
+                              Integer concurrentLeaderMovements) {
     super(kafkaCruiseControl, future);
     _brokerIds = brokerIds;
     _dryRun = dryRun;
@@ -37,12 +42,14 @@ class DecommissionBrokersRunnable extends OperationRunnable<GoalOptimizer.Optimi
     _goals = goals;
     _modelCompletenessRequirements = modelCompletenessRequirements;
     _allowCapacityEstimation = allowCapacityEstimation;
+    _concurrentPartitionMovements = concurrentPartitionMovements;
+    _concurrentLeaderMovements = concurrentLeaderMovements;
   }
 
   @Override
   protected GoalOptimizer.OptimizerResult getResult() throws Exception {
     return _kafkaCruiseControl.decommissionBrokers(_brokerIds, _dryRun, _throttleRemovedBrokers, _goals,
                                                    _modelCompletenessRequirements, _future.operationProgress(),
-                                                   _allowCapacityEstimation);
+                                                   _allowCapacityEstimation, _concurrentPartitionMovements, _concurrentLeaderMovements);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DemoteBrokerRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DemoteBrokerRunnable.java
@@ -13,20 +13,24 @@ public class DemoteBrokerRunnable extends OperationRunnable<GoalOptimizer.Optimi
   private final Collection<Integer> _brokerIds;
   private final boolean _dryRun;
   private final boolean _allowCapacityEstimation;
+  private final Integer _concurrentLeaderMovements;
 
   DemoteBrokerRunnable(KafkaCruiseControl kafkaCruiseControl,
                        OperationFuture<GoalOptimizer.OptimizerResult> future,
                        Collection<Integer> brokerIds,
                        boolean dryRun,
-                       boolean allowCapacityEstimation) {
+                       boolean allowCapacityEstimation,
+                       Integer concurrentLeaderMovements) {
     super(kafkaCruiseControl, future);
     _brokerIds = brokerIds;
     _dryRun = dryRun;
     _allowCapacityEstimation = allowCapacityEstimation;
+    _concurrentLeaderMovements = concurrentLeaderMovements;
   }
 
   @Override
   protected GoalOptimizer.OptimizerResult getResult() throws Exception {
-    return _kafkaCruiseControl.demoteBrokers(_brokerIds, _dryRun, _future.operationProgress(), _allowCapacityEstimation);
+    return _kafkaCruiseControl.demoteBrokers(_brokerIds, _dryRun, _future.operationProgress(),
+                                             _allowCapacityEstimation, _concurrentLeaderMovements);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/RebalanceRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/RebalanceRunnable.java
@@ -11,25 +11,31 @@ import java.util.List;
 
 /**
  * The async runnable for {@link KafkaCruiseControl#rebalance(List, boolean, ModelCompletenessRequirements,
- * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean)}
+ * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean, Integer, Integer)}
  */
 class RebalanceRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult> {
   private final List<String> _goals;
   private final boolean _dryRun;
   private final ModelCompletenessRequirements _modelCompletenessRequirements;
   private final boolean _allowCapacityEstimation;
+  private final Integer _concurrentPartitionMovements;
+  private final Integer _concurrentLeaderMovements;
 
   RebalanceRunnable(KafkaCruiseControl kafkaCruiseControl,
                     OperationFuture<GoalOptimizer.OptimizerResult> future,
                     List<String> goals,
                     boolean dryRun,
                     ModelCompletenessRequirements modelCompletenessRequirements,
-                    boolean allowCapacityEstimation) {
+                    boolean allowCapacityEstimation,
+                    Integer concurrentPartitionMovements,
+                    Integer concurrentLeaderMovements) {
     super(kafkaCruiseControl, future);
     _goals = goals;
     _dryRun = dryRun;
     _modelCompletenessRequirements = modelCompletenessRequirements;
     _allowCapacityEstimation = allowCapacityEstimation;
+    _concurrentPartitionMovements = concurrentPartitionMovements;
+    _concurrentLeaderMovements = concurrentLeaderMovements;
   }
 
   @Override
@@ -38,6 +44,8 @@ class RebalanceRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult>
                                          _dryRun,
                                          _modelCompletenessRequirements,
                                          _future.operationProgress(),
-                                         _allowCapacityEstimation);
+                                         _allowCapacityEstimation,
+                                         _concurrentPartitionMovements,
+                                         _concurrentLeaderMovements);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailures.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailures.java
@@ -43,7 +43,7 @@ public class BrokerFailures extends KafkaAnomaly {
     if (_failedBrokers != null && !_failedBrokers.isEmpty()) {
       _kafkaCruiseControl.decommissionBrokers(_failedBrokers.keySet(), false, false,
                                              Collections.emptyList(), null, new OperationProgress(),
-                                              _allowCapacityEstimation);
+                                              _allowCapacityEstimation, null, null);
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
@@ -47,7 +47,8 @@ public class GoalViolations extends KafkaAnomaly {
     // Fix the violations using a rebalance.
     try {
       _kafkaCruiseControl.rebalance(
-          Collections.emptyList(), false, null, new OperationProgress(), _allowCapacityEstimation);
+          Collections.emptyList(), false, null, new OperationProgress(), _allowCapacityEstimation,
+          null, null);
     } catch (IllegalStateException e) {
       LOG.warn("Got exception when trying to fix the cluster. " + e.getMessage());
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskManager.java
@@ -118,7 +118,7 @@ public class ExecutionTaskManager {
   }
 
   public synchronized int leadershipMovementConcurrency() {
-    return _requestedLeadershipMovementConcurrency == null ? _defaultPartitionMovementConcurrency
+    return _requestedLeadershipMovementConcurrency == null ? _defaultLeadershipMovementConcurrency
                                                            : _requestedLeadershipMovementConcurrency;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskManager.java
@@ -35,8 +35,10 @@ public class ExecutionTaskManager {
   private final ExecutionTaskTracker _executionTaskTracker;
   private final Set<TopicPartition> _inProgressPartitions;
   private final ExecutionTaskPlanner _executionTaskPlanner;
-  private final int _partitionMovementConcurrency;
-  private final int _leadershipMovementConcurrency;
+  private final int _defaultPartitionMovementConcurrency;
+  private final int _defaultLeadershipMovementConcurrency;
+  private Integer _requestedPartitionMovementConcurrency;
+  private Integer _requestedLeadershipMovementConcurrency;
   private final Set<Integer> _brokersToSkipConcurrencyCheck;
   private final Time _time;
   private volatile long _inExecutionDataToMove;
@@ -68,28 +70,56 @@ public class ExecutionTaskManager {
   /**
    * The constructor of The Execution task manager.
    *
-   * @param partitionMovementConcurrency The maximum number of concurrent partition movements per broker.
-   * @param leadershipMovementConcurrency The maximum number of concurrent leadership movements per batch.
+   * @param defaultPartitionMovementConcurrency The maximum number of concurrent partition movements per broker. It can
+   *                                            be overwritten by user parameter upon post request.
+   * @param defaultLeadershipMovementConcurrency The maximum number of concurrent leadership movements per batch. It can
+   *                                             be overwritten by user parameter upon post request.
    * @param dropwizardMetricRegistry The metric registry.
    * @param time The time object to get the time.
    */
-  public ExecutionTaskManager(int partitionMovementConcurrency,
-                              int leadershipMovementConcurrency,
+  public ExecutionTaskManager(int defaultPartitionMovementConcurrency,
+                              int defaultLeadershipMovementConcurrency,
                               MetricRegistry dropwizardMetricRegistry,
                               Time time) {
     _inProgressReplicaMovementsByBrokerId = new HashMap<>();
     _inProgressPartitions = new HashSet<>();
     _executionTaskTracker = new ExecutionTaskTracker();
     _executionTaskPlanner = new ExecutionTaskPlanner();
-    _partitionMovementConcurrency = partitionMovementConcurrency;
-    _leadershipMovementConcurrency = leadershipMovementConcurrency;
+    _defaultPartitionMovementConcurrency = defaultPartitionMovementConcurrency;
+    _defaultLeadershipMovementConcurrency = defaultLeadershipMovementConcurrency;
     _brokersToSkipConcurrencyCheck = new HashSet<>();
     _inExecutionDataToMove = 0L;
     _time = time;
     _isKafkaAssignerMode = false;
+    _requestedPartitionMovementConcurrency = null;
+    _requestedLeadershipMovementConcurrency = null;
 
     // Register gauge sensors.
     registerGaugeSensors(dropwizardMetricRegistry);
+  }
+
+  /**
+   * Dynamically set the partition movement concurrency per broker and the leadership movement concurrency.
+   *
+   * @param requestedPartitionMovementConcurrency The maximum number of concurrent partition movements per broker
+   *                                              (if null, use {@link #_defaultPartitionMovementConcurrency}).
+   * @param requestedLeadershipMovementConcurrency The maximum number of concurrent leader movements
+   *                                               (if null, {@link #_defaultLeadershipMovementConcurrency}).
+   */
+  public synchronized void setRequestedMovementConcurrency(Integer requestedPartitionMovementConcurrency,
+                                                           Integer requestedLeadershipMovementConcurrency) {
+    _requestedPartitionMovementConcurrency = requestedPartitionMovementConcurrency;
+    _requestedLeadershipMovementConcurrency = requestedLeadershipMovementConcurrency;
+  }
+
+  public synchronized int partitionMovementConcurrency() {
+    return _requestedPartitionMovementConcurrency == null ? _defaultPartitionMovementConcurrency
+                                                          : _requestedPartitionMovementConcurrency;
+  }
+
+  public synchronized int leadershipMovementConcurrency() {
+    return _requestedLeadershipMovementConcurrency == null ? _defaultPartitionMovementConcurrency
+                                                           : _requestedLeadershipMovementConcurrency;
   }
 
   /**
@@ -128,6 +158,7 @@ public class ExecutionTaskManager {
    */
   public synchronized List<ExecutionTask> getReplicaMovementTasks() {
     Map<Integer, Integer> readyBrokers = new HashMap<>();
+    int partitionMovementConcurrency = partitionMovementConcurrency();
     for (Map.Entry<Integer, Integer> entry : _inProgressReplicaMovementsByBrokerId.entrySet()) {
       // We skip the concurrency level check if caller requested so.
       // This is useful when we detected a broker failure and want to move all its partitions to the
@@ -135,7 +166,7 @@ public class ExecutionTaskManager {
       if (_brokersToSkipConcurrencyCheck.contains(entry.getKey())) {
         readyBrokers.put(entry.getKey(), Integer.MAX_VALUE);
       } else {
-        readyBrokers.put(entry.getKey(), Math.max(0, _partitionMovementConcurrency - entry.getValue()));
+        readyBrokers.put(entry.getKey(), Math.max(0, partitionMovementConcurrency - entry.getValue()));
       }
     }
     return _executionTaskPlanner.getReplicaMovementTasks(readyBrokers, _inProgressPartitions);
@@ -145,7 +176,7 @@ public class ExecutionTaskManager {
    * Returns a list of proposals that move the leadership.
    */
   public synchronized List<ExecutionTask> getLeadershipMovementTasks() {
-    return _executionTaskPlanner.getLeadershipMovementTasks(_leadershipMovementConcurrency);
+    return _executionTaskPlanner.getLeadershipMovementTasks(leadershipMovementConcurrency());
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -239,22 +239,30 @@ public class KafkaCruiseControlServlet extends HttpServlet {
    * <pre>
    * 1. Decommission a broker.
    *    POST /kafkacruisecontrol/remove_broker?brokerid=[id1,id2...]&amp;dryrun=[true/false]&amp;throttle_removed_broker=[true/false]&amp;goals=[goal1,goal2...]
+   *    &amp;allow_capacity_estimation=[true/false]&amp;concurrent_partition_movements_per_broker=[true/false]&amp;concurrent_leader_movements=[true/false]
+   *    &amp;json=[true/false]
    *
    * 2. Add a broker
    *    POST /kafkacruisecontrol/add_broker?brokerid=[id1,id2...]&amp;dryrun=[true/false]&amp;throttle_added_broker=[true/false]&amp;goals=[goal1,goal2...]
+   *    &amp;allow_capacity_estimation=[true/false]&amp;concurrent_partition_movements_per_broker=[true/false]&amp;concurrent_leader_movements=[true/false]
+   *    &amp;json=[true/false]
    *
    * 3. Trigger a workload balance.
-   *    POST /kafkacruisecontrol/rebalance?dryrun=[true/false]&amp;force=[true/false]&amp;goals=[goal1,goal2...]
+   *    POST /kafkacruisecontrol/rebalance?dryrun=[true/false]&amp;force=[true/false]&amp;goals=[goal1,goal2...]&amp;allow_capacity_estimation=[true/false]
+   *    &amp;concurrent_partition_movements_per_broker=[true/false]&amp;concurrent_leader_movements=[true/false]&amp;json=[true/false]
    *
    * 4. Stop the proposal execution.
-   *    POST /kafkacruisecontrol/stop_proposal_execution
+   *    POST /kafkacruisecontrol/stop_proposal_execution?json=[true/false]
    *
-   * 5.Pause metrics sampling. (RUNNING -&gt; PAUSED).
-   *    POST /kafkacruisecontrol/pause_sampling
+   * 5. Pause metrics sampling. (RUNNING -&gt; PAUSED).
+   *    POST /kafkacruisecontrol/pause_sampling?json=[true/false]
    *
-   * 6.Resume metrics sampling. (PAUSED -&gt; RUNNING).
-   *    POST /kafkacruisecontrol/resume_sampling
+   * 6. Resume metrics sampling. (PAUSED -&gt; RUNNING).
+   *    POST /kafkacruisecontrol/resume_sampling?json=[true/false]
    *
+   * 7. Demote a broker
+   *    POST /kafkacruisecontrol/demote_broker?brokerid=[id1,id2...]&amp;dryrun=[true/false]&amp;concurrent_leader_movements=[true/false]
+   *    &amp;allow_capacity_estimation=[true/false]&amp;json=[true/false]
    *
    * <b>NOTE: All the timestamps are epoch time in second granularity.</b>
    * </pre>

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -471,6 +471,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
     Resource resource;
     long startMs;
     long endMs;
+    int entries;
     Pattern topic = KafkaCruiseControlServletUtils.topic(request);
     int partitionUpperBoundary;
     int partitionLowerBoundary;
@@ -493,6 +494,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       endMs = endMsValue == null ? System.currentTimeMillis() : endMsValue;
       partitionLowerBoundary = KafkaCruiseControlServletUtils.partitionBoundary(request, false);
       partitionUpperBoundary = KafkaCruiseControlServletUtils.partitionBoundary(request, true);
+      entries = KafkaCruiseControlServletUtils.entries(request);
     } catch (Exception e) {
       handleParameterParseException(e, response, e.getMessage(), json);
       // Close session
@@ -510,7 +512,6 @@ public class KafkaCruiseControlServlet extends HttpServlet {
     List<Partition> sortedPartitions = clusterModel.replicasSortedByUtilization(resource);
     OutputStream out = response.getOutputStream();
 
-    int entries = KafkaCruiseControlServletUtils.entries(request);
     int numEntries = 0;
     setResponseCode(response, SC_OK, json);
     boolean wantMaxLoad = KafkaCruiseControlServletUtils.wantMaxLoad(request);
@@ -896,6 +897,8 @@ public class KafkaCruiseControlServlet extends HttpServlet {
   private boolean addOrRemoveBroker(HttpServletRequest request, HttpServletResponse response, EndPoint endPoint)
       throws Exception {
     List<Integer> brokerIds;
+    Integer concurrentPartitionMovements;
+    Integer concurrentLeaderMovements;
     boolean dryrun;
     DataFrom dataFrom;
     boolean throttleAddedOrRemovedBrokers;
@@ -907,6 +910,8 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       goals = KafkaCruiseControlServletUtils.getGoals(request);
       dataFrom = KafkaCruiseControlServletUtils.getDataFrom(request);
       throttleAddedOrRemovedBrokers = KafkaCruiseControlServletUtils.throttleAddedOrRemovedBrokers(request, endPoint);
+      concurrentPartitionMovements = KafkaCruiseControlServletUtils.concurrentMovementsPerBroker(request, true);
+      concurrentLeaderMovements = KafkaCruiseControlServletUtils.concurrentMovementsPerBroker(request, false);
     } catch (Exception e) {
       handleParameterParseException(e, response, e.getMessage(), json);
       // Close session
@@ -927,7 +932,9 @@ public class KafkaCruiseControlServlet extends HttpServlet {
                                                                               throttleAddedOrRemovedBrokers,
                                                                               goalsAndRequirements.goals(),
                                                                               goalsAndRequirements.requirements(),
-                                                                              allowCapacityEstimation));
+                                                                              allowCapacityEstimation,
+                                                                              concurrentPartitionMovements,
+                                                                              concurrentLeaderMovements));
     } else {
       optimizerResult =
           getAndMaybeReturnProgress(request, response,
@@ -936,7 +943,9 @@ public class KafkaCruiseControlServlet extends HttpServlet {
                                                                                        throttleAddedOrRemovedBrokers,
                                                                                        goalsAndRequirements.goals(),
                                                                                        goalsAndRequirements.requirements(),
-                                                                                       allowCapacityEstimation));
+                                                                                       allowCapacityEstimation,
+                                                                                       concurrentPartitionMovements,
+                                                                                       concurrentLeaderMovements));
     }
     if (optimizerResult == null) {
       return false;
@@ -953,11 +962,15 @@ public class KafkaCruiseControlServlet extends HttpServlet {
     boolean dryrun;
     DataFrom dataFrom;
     List<String> goals;
+    Integer concurrentPartitionMovements;
+    Integer concurrentLeaderMovements;
     boolean json = KafkaCruiseControlServletUtils.wantJSON(request);
     try {
       dryrun = KafkaCruiseControlServletUtils.getDryRun(request);
       goals = KafkaCruiseControlServletUtils.getGoals(request);
       dataFrom = KafkaCruiseControlServletUtils.getDataFrom(request);
+      concurrentPartitionMovements = KafkaCruiseControlServletUtils.concurrentMovementsPerBroker(request, true);
+      concurrentLeaderMovements = KafkaCruiseControlServletUtils.concurrentMovementsPerBroker(request, false);
     } catch (Exception e) {
       handleParameterParseException(e, response, e.getMessage(), json);
       // Close session
@@ -973,7 +986,9 @@ public class KafkaCruiseControlServlet extends HttpServlet {
                                   () -> _asyncKafkaCruiseControl.rebalance(goalsAndRequirements.goals(),
                                                                            dryrun,
                                                                            goalsAndRequirements.requirements(),
-                                                                           allowCapacityEstimation));
+                                                                           allowCapacityEstimation,
+                                                                           concurrentPartitionMovements,
+                                                                           concurrentLeaderMovements));
     if (optimizerResult == null) {
       return false;
     }
@@ -995,10 +1010,12 @@ public class KafkaCruiseControlServlet extends HttpServlet {
     private boolean demoteBroker(HttpServletRequest request, HttpServletResponse response, EndPoint endPoint) throws Exception {
     List<Integer> brokerIds;
     boolean dryrun;
+    Integer concurrentLeaderMovements;
     boolean json = KafkaCruiseControlServletUtils.wantJSON(request);
     try {
       brokerIds = KafkaCruiseControlServletUtils.brokerIds(request);
       dryrun = KafkaCruiseControlServletUtils.getDryRun(request);
+      concurrentLeaderMovements = KafkaCruiseControlServletUtils.concurrentMovementsPerBroker(request, false);
     } catch (Exception e) {
       handleParameterParseException(e, response, e.getMessage(), json);
       // Close session
@@ -1009,7 +1026,10 @@ public class KafkaCruiseControlServlet extends HttpServlet {
     boolean allowCapacityEstimation = KafkaCruiseControlServletUtils.allowCapacityEstimation(request);
     GoalOptimizer.OptimizerResult optimizerResult =
           getAndMaybeReturnProgress(request, response,
-                                    () -> _asyncKafkaCruiseControl.demoteBrokers(brokerIds, dryrun, allowCapacityEstimation));
+                                    () -> _asyncKafkaCruiseControl.demoteBrokers(brokerIds,
+                                                                                 dryrun,
+                                                                                 allowCapacityEstimation,
+                                                                                 concurrentLeaderMovements));
     if (optimizerResult == null) {
       return false;
     }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -145,7 +145,9 @@ public class AnomalyDetectorTest {
                                                      EasyMock.eq(false),
                                                      EasyMock.eq(null),
                                                      EasyMock.anyObject(OperationProgress.class),
-                                                     EasyMock.eq(true)))
+                                                     EasyMock.eq(true),
+                                                     EasyMock.eq(null),
+                                                     EasyMock.eq(null)))
             .andReturn(null);
     EasyMock.expect(mockKafkaCruiseControl.meetCompletenessRequirements(EasyMock.anyObject())).andReturn(true);
 
@@ -219,6 +221,8 @@ public class AnomalyDetectorTest {
                                                         Collections.emptySet(),
                                                         Collections.emptySet(),
                                                         1L,
+                                                        1,
+                                                        1,
                                                         1),
                 null, null));
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskManagerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskManagerTest.java
@@ -35,7 +35,7 @@ public class ExecutionTaskManagerTest {
     Set<PartitionInfo> partitions = new HashSet<>();
     partitions.add(new PartitionInfo(tp.topic(), tp.partition(), expectedReplicas.get(1), isrArray, isrArray));
 
-    return new Cluster(null, expectedReplicas, partitions, Collections.<String>emptySet(), Collections.<String>emptySet());
+    return new Cluster(null, expectedReplicas, partitions, Collections.emptySet(), Collections.emptySet());
   }
 
   @Test
@@ -63,6 +63,7 @@ public class ExecutionTaskManagerTest {
       taskManager.addExecutionProposals(Collections.singletonList(proposal),
                                         Collections.emptySet(),
                                         generateExpectedCluster(proposal, tp));
+      taskManager.setRequestedMovementConcurrency(null, null);
       List<ExecutionTask> tasks = taskManager.getReplicaMovementTasks();
       assertEquals(1, tasks.size());
       ExecutionTask task  = tasks.get(0);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -176,7 +176,9 @@ public class ExecutorTest extends AbstractKafkaIntegrationTestHarness {
     executor.setExecutionMode(false);
     executor.executeProposals(proposalsToExecute,
                               Collections.emptySet(),
-                              EasyMock.mock(LoadMonitor.class));
+                              EasyMock.mock(LoadMonitor.class),
+                              null,
+                              null);
     // Wait until the execution to start so the task timestamp is set to time.milliseconds.
     while (executor.state().state() != ExecutorState.State.LEADER_MOVEMENT_TASK_IN_PROGRESS) {
       Thread.sleep(10);
@@ -223,7 +225,7 @@ public class ExecutorTest extends AbstractKafkaIntegrationTestHarness {
     KafkaCruiseControlConfig configs = new KafkaCruiseControlConfig(getExecutorProperties());
     Executor executor = new Executor(configs, new SystemTime(), new MetricRegistry());
     executor.setExecutionMode(false);
-    executor.executeProposals(proposalsToExecute, Collections.emptySet(), EasyMock.mock(LoadMonitor.class));
+    executor.executeProposals(proposalsToExecute, Collections.emptySet(), EasyMock.mock(LoadMonitor.class), null, null);
 
     Map<TopicPartition, Integer> replicationFactors = new HashMap<>();
     for (ExecutionProposal proposal : proposalsToCheck) {


### PR DESCRIPTION
Fixes the issue https://github.com/linkedin/cruise-control/issues/257.