### PR TITLE
Fix state endpoint response with substates.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -540,6 +540,10 @@ public class KafkaCruiseControl {
    */
   public KafkaCruiseControlState state(OperationProgress operationProgress, Set<KafkaCruiseControlState.SubState> substates) {
     MetadataClient.ClusterAndGeneration clusterAndGeneration = null;
+    // In case no substate is specified, return all substates.
+    substates = !substates.isEmpty() ? substates
+                                     : new HashSet<>(Arrays.asList(KafkaCruiseControlState.SubState.values()));
+
     if (KafkaCruiseControlUtils.shouldRefreshClusterAndGeneration(substates)) {
       clusterAndGeneration = _loadMonitor.refreshClusterAndGeneration();
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlState.java
@@ -82,8 +82,8 @@ public class KafkaCruiseControlState {
   public String toString() {
     return String.format("%s%s%s",
                          _monitorState != null ? String.format("MonitorState: %s%n", _monitorState) : "",
-                         _executorState != null ? String.format("ExecutorState: %s%n", _monitorState) : "",
-                         _analyzerState != null ? String.format("AnalyzerState: %s%n", _monitorState) : "");
+                         _executorState != null ? String.format("ExecutorState: %s%n", _executorState) : "",
+                         _analyzerState != null ? String.format("AnalyzerState: %s%n", _analyzerState) : "");
   }
 
   private void writeVerboseMonitorState(OutputStream out) throws IOException {


### PR DESCRIPTION
* Return all `substates` in the `state` endpoint if `substates` is empty.
* Fix plain text state response for executor and analyzer substates.