### PR TITLE
Add min_valid_partition_ratio parameter to partition_load endpoint

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -358,7 +358,7 @@ public class KafkaCruiseControl {
    * Get the cluster model for a given time window.
    * @param from the start time of the window
    * @param to the end time of the window
-   * @param requirements the model completeness requirement to enforce.
+   * @param minValidPartitionRatio the minimal valid partition ratio requirement of model from request
    * @param operationProgress the progress of the job to report.
    * @param allowCapacityEstimation Allow capacity estimation in cluster model if the requested broker capacity is unavailable.
    * @return the cluster workload model.
@@ -366,11 +366,15 @@ public class KafkaCruiseControl {
    */
   public ClusterModel clusterModel(long from,
                                    long to,
-                                   ModelCompletenessRequirements requirements,
+                                   Double minValidPartitionRatio,
                                    OperationProgress operationProgress,
                                    boolean allowCapacityEstimation)
       throws KafkaCruiseControlException {
     try (AutoCloseable ignored = _loadMonitor.acquireForModelGeneration(operationProgress)) {
+      if (minValidPartitionRatio == null) {
+        minValidPartitionRatio = _config.getDouble(KafkaCruiseControlConfig.MIN_VALID_PARTITION_RATIO_CONFIG);
+      }
+      ModelCompletenessRequirements requirements = new ModelCompletenessRequirements(1, minValidPartitionRatio, false);
       ClusterModel clusterModel = _loadMonitor.clusterModel(from, to, requirements, operationProgress);
       sanityCheckCapacityEstimation(allowCapacityEstimation, clusterModel.capacityEstimationInfoByBrokerId());
       return clusterModel;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -358,7 +358,7 @@ public class KafkaCruiseControl {
    * Get the cluster model for a given time window.
    * @param from the start time of the window
    * @param to the end time of the window
-   * @param minValidPartitionRatio the minimal valid partition ratio requirement of model from request
+   * @param minValidPartitionRatio the minimum valid partition ratio requirement of model
    * @param operationProgress the progress of the job to report.
    * @param allowCapacityEstimation Allow capacity estimation in cluster model if the requested broker capacity is unavailable.
    * @return the cluster workload model.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AsyncKafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AsyncKafkaCruiseControl.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Executors;
  * OperationProgress, boolean, Integer, Integer)}</li>
  * <li>{@link KafkaCruiseControl#demoteBrokers(Collection, boolean, OperationProgress, boolean, Integer)}</li>
  * <li>{@link KafkaCruiseControl#clusterModel(long, ModelCompletenessRequirements, OperationProgress, boolean)}</li>
- * <li>{@link KafkaCruiseControl#clusterModel(long, long, ModelCompletenessRequirements, OperationProgress, boolean)}</li>
+ * <li>{@link KafkaCruiseControl#clusterModel(long, long, Double, OperationProgress, boolean)}</li>
  * <li>{@link KafkaCruiseControl#getOptimizationProposals(OperationProgress, boolean)}</li>
  * <li>{@link KafkaCruiseControl#state(OperationProgress, Set)}</li>
  * <li>{@link KafkaCruiseControl#getOptimizationProposals(List, ModelCompletenessRequirements, OperationProgress, boolean)}</li>
@@ -123,16 +123,16 @@ public class AsyncKafkaCruiseControl extends KafkaCruiseControl {
   }
 
   /**
-   * @see KafkaCruiseControl#clusterModel(long, long, ModelCompletenessRequirements, OperationProgress, boolean)
+   * @see KafkaCruiseControl#clusterModel(long, long, Double, OperationProgress, boolean)
    */
   public OperationFuture<ClusterModel> clusterModel(long startMs,
                                                     long endMs,
-                                                    ModelCompletenessRequirements requirements,
+                                                    Double minValidPartitionRatio,
                                                     boolean allowCapacityEstimation) {
     OperationFuture<ClusterModel> future =
         new OperationFuture<>(String.format("Get cluster model from %d to %d", startMs, endMs));
     pending(future.operationProgress());
-    _sessionExecutor.submit(new GetClusterModelInRangeRunnable(this, future, startMs, endMs, requirements, allowCapacityEstimation));
+    _sessionExecutor.submit(new GetClusterModelInRangeRunnable(this, future, startMs, endMs, minValidPartitionRatio, allowCapacityEstimation));
     return future;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetClusterModelInRangeRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetClusterModelInRangeRunnable.java
@@ -6,28 +6,27 @@ package com.linkedin.kafka.cruisecontrol.async;
 
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
-import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 
 /**
- * The async runnable for {@link KafkaCruiseControl#clusterModel(long, long, ModelCompletenessRequirements,
+ * The async runnable for {@link KafkaCruiseControl#clusterModel(long, long, Double,
  * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean)}
  */
 class GetClusterModelInRangeRunnable extends OperationRunnable<ClusterModel> {
   private final long _startMs;
   private final long _endMs;
-  private final ModelCompletenessRequirements _modelCompletenessRequirements;
+  private final Double _minValidPartitionRatio;
   private final boolean _allowCapacityEstimation;
 
   GetClusterModelInRangeRunnable(KafkaCruiseControl kafkaCruiseControl,
                                  OperationFuture<ClusterModel> future,
                                  long startMs,
                                  long endMs,
-                                 ModelCompletenessRequirements modelCompletenessRequirements,
+                                 Double minValidPartitionRatio,
                                  boolean allowCapacityEstimation) {
     super(kafkaCruiseControl, future);
     _startMs = startMs;
     _endMs = endMs;
-    _modelCompletenessRequirements = modelCompletenessRequirements;
+    _minValidPartitionRatio = minValidPartitionRatio;
     _allowCapacityEstimation = allowCapacityEstimation;
   }
 
@@ -35,7 +34,7 @@ class GetClusterModelInRangeRunnable extends OperationRunnable<ClusterModel> {
   protected ClusterModel getResult() throws Exception {
     return _kafkaCruiseControl.clusterModel(_startMs,
                                             _endMs,
-                                            _modelCompletenessRequirements,
+                                            _minValidPartitionRatio,
                                             _future.operationProgress(),
                                             _allowCapacityEstimation);
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -471,6 +471,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
     int partitionUpperBoundary;
     int partitionLowerBoundary;
     boolean json = wantJSON(request);
+    Double minValidPartitionRatio;
     String resourceString = resourceString(request);
     try {
       resource = Resource.valueOf(resourceString.toUpperCase());
@@ -490,6 +491,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       partitionLowerBoundary = partitionBoundary(request, false);
       partitionUpperBoundary = partitionBoundary(request, true);
       entries = entries(request);
+      minValidPartitionRatio = minValidPartitionRatio(request);
     } catch (Exception e) {
       handleParameterParseException(e, response, e.getMessage(), json);
       // Close session
@@ -497,10 +499,9 @@ public class KafkaCruiseControlServlet extends HttpServlet {
     }
 
     boolean allowCapacityEstimation = allowCapacityEstimation(request);
-    ModelCompletenessRequirements requirements = new ModelCompletenessRequirements(1, 0.98, false);
     // Get cluster model asynchronously.
     ClusterModel clusterModel = getAndMaybeReturnProgress(
-            request, response, () -> _asyncKafkaCruiseControl.clusterModel(startMs, endMs, requirements, allowCapacityEstimation));
+            request, response, () -> _asyncKafkaCruiseControl.clusterModel(startMs, endMs, minValidPartitionRatio, allowCapacityEstimation));
     if (clusterModel == null) {
       return false;
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
@@ -299,7 +299,7 @@ class KafkaCruiseControlServletUtils {
     } else {
       Double minValidPartitionRatio = Double.parseDouble(minValidPartitionRatioString);
       if (minValidPartitionRatio > 1.0 || minValidPartitionRatio < 0.0) {
-        throw new IllegalArgumentException("The requested minimal partition ratio must be in range [0.0, 1.0] (Requested: "
+        throw new IllegalArgumentException("The requested minimum partition ratio must be in range [0.0, 1.0] (Requested: "
             + minValidPartitionRatio.toString() + ").");
       }
       return minValidPartitionRatio;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
@@ -58,6 +58,7 @@ class KafkaCruiseControlServletUtils {
   private static final String CONCURRENT_LEADER_MOVEMENTS_PARAM = "concurrent_leader_movements";
   private static final String DEFAULT_PARTITION_LOAD_RESOURCE = "disk";
   private static final String SUBSTATES_PARAM = "substates";
+  private static final String MIN_VALID_PARTITION_RATIO_PARAM = "min_valid_partition_ratio";
 
   static final Map<EndPoint, Set<String>> VALID_ENDPOINT_PARAM_NAMES;
   static {
@@ -89,6 +90,7 @@ class KafkaCruiseControlServletUtils {
     partitionLoad.add(MAX_LOAD_PARAM);
     partitionLoad.add(TOPIC_PARAM);
     partitionLoad.add(PARTITION_PARAM);
+    partitionLoad.add(MIN_VALID_PARTITION_RATIO_PARAM);
 
     Set<String> proposals = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     proposals.add(VERBOSE_PARAM);
@@ -288,6 +290,20 @@ class KafkaCruiseControlServletUtils {
   static Pattern topic(HttpServletRequest request) {
     String topicString = request.getParameter(TOPIC_PARAM);
     return topicString != null ? Pattern.compile(topicString) : null;
+  }
+
+  static Double minValidPartitionRatio(HttpServletRequest request) {
+    String minValidPartitionRatioString = request.getParameter(MIN_VALID_PARTITION_RATIO_PARAM);
+    if (minValidPartitionRatioString == null) {
+      return null;
+    } else {
+      Double minValidPartitionRatio = Double.parseDouble(minValidPartitionRatioString);
+      if (minValidPartitionRatio > 1.0 || minValidPartitionRatio < 0.0) {
+        throw new IllegalArgumentException("The requested minimal partition ratio must be in range [0.0, 1.0] (Requested: "
+            + minValidPartitionRatio.toString() + ").");
+      }
+      return minValidPartitionRatio;
+    }
   }
 
   static String resourceString(HttpServletRequest request) {


### PR DESCRIPTION
* For better flexibility of specifying the completeness requirement during cluster model generation,  add min_valid_partition_ratio to partition_load endpoint to set the completeness requirement on the fly.  

* Another change is when this parameter is missing in request, instead of using the hard code value(0.98) use the value set via CC config parameter `min.valid.partition.ratio`