### PR TITLE
Add sensors to track the session lifetime and request execution time

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/OperationFuture.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/OperationFuture.java
@@ -19,12 +19,12 @@ public class OperationFuture<T> extends CompletableFuture<T> {
   private final String _operation;
   private final OperationProgress _operationProgress;
   private volatile Thread _executionThread = null;
-  private long _finishTime;
+  private long _finishTimeNs;
 
   public OperationFuture(String operation) {
     _operation = "'" + operation + "'";
     _operationProgress = new OperationProgress();
-    _finishTime = -1;
+    _finishTimeNs = -1;
   }
 
   @Override
@@ -104,11 +104,18 @@ public class OperationFuture<T> extends CompletableFuture<T> {
      return _operationProgress;
   }
 
-  public void setFinishTime(long finishTime) {
-    _finishTime = finishTime;
+  /**
+   * Record the finish time of this operation, invoked at the end of corresponding {@link OperationRunnable#run()}.
+   * @param finishTimeNs the system time when this operation completes.
+   */
+  public void setFinishTimeNs(long finishTimeNs) {
+    _finishTimeNs = finishTimeNs;
   }
 
-  public long getFinishTime() {
-    return _finishTime;
+  /**
+   * @return the integer representing the finish time of this operation.
+   */
+  public long finishTimeNs() {
+    return _finishTimeNs;
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/OperationFuture.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/OperationFuture.java
@@ -19,10 +19,12 @@ public class OperationFuture<T> extends CompletableFuture<T> {
   private final String _operation;
   private final OperationProgress _operationProgress;
   private volatile Thread _executionThread = null;
+  private long _finishTime;
 
   public OperationFuture(String operation) {
     _operation = "'" + operation + "'";
     _operationProgress = new OperationProgress();
+    _finishTime = -1;
   }
 
   @Override
@@ -100,5 +102,13 @@ public class OperationFuture<T> extends CompletableFuture<T> {
    */
   public OperationProgress operationProgress() {
      return _operationProgress;
+  }
+
+  public void setFinishTime(long finishTime) {
+    _finishTime = finishTime;
+  }
+
+  public long getFinishTime() {
+    return _finishTime;
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/OperationRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/OperationRunnable.java
@@ -43,7 +43,8 @@ abstract class OperationRunnable<T> implements Runnable {
           ((Pending) steps.get(0)).done();
         }
         _future.complete(getResult());
-        _future.setFinishTime(System.nanoTime());
+        // If operation completes successfully (i.e with no exception thrown), record the operation finish time.
+        _future.setFinishTimeNs(System.nanoTime());
       }
     } catch (Exception e) {
       LOG.debug("Received exception when trying to execute runnable for \"" + _future.operation() + "\"", e);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/OperationRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/OperationRunnable.java
@@ -43,6 +43,7 @@ abstract class OperationRunnable<T> implements Runnable {
           ((Pending) steps.get(0)).done();
         }
         _future.complete(getResult());
+        _future.setFinishTime(System.nanoTime());
       }
     } catch (Exception e) {
       LOG.debug("Received exception when trying to execute runnable for \"" + _future.operation() + "\"", e);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/EndPoint.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/EndPoint.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.servlet;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -41,6 +42,7 @@ enum EndPoint {
       PAUSE_SAMPLING,
       RESUME_SAMPLING,
       DEMOTE_BROKER);
+  private static final List<EndPoint> CACHED_VALUES = Collections.unmodifiableList(Arrays.asList(values()));
 
   public static List<EndPoint> getEndpoint() {
     return GET_ENDPOINT;
@@ -48,5 +50,13 @@ enum EndPoint {
 
   public static List<EndPoint> postEndpoint() {
     return POST_ENDPOINT;
+  }
+
+  /**
+   * Use this instead of values() because values() creates a new array each time.
+   * @return enumerated values in the same order as values()
+   */
+  public static List<EndPoint> cachedValues() {
+    return CACHED_VALUES;
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -168,8 +168,6 @@ public class KafkaCruiseControlServlet extends HttpServlet {
         } else {
           if (EndPoint.getEndpoint().contains(endPoint)) {
             _requestMeter.get(endPoint).mark();
-          } else {
-            throw new UserRequestException("Invalid URL for GET");
           }
           long requestExecutionStartTime = System.nanoTime();
           switch (endPoint) {
@@ -296,8 +294,6 @@ public class KafkaCruiseControlServlet extends HttpServlet {
         } else {
           if (EndPoint.postEndpoint().contains(endPoint)) {
             _requestMeter.get(endPoint).mark();
-          } else {
-            throw new UserRequestException("Invalid URL for POST");
           }
           long requestExecutionStartTime = System.nanoTime();
           switch (endPoint) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -69,8 +69,8 @@ public class KafkaCruiseControlServlet extends HttpServlet {
   private final SessionManager _sessionManager;
   private final long _maxBlockMs;
   private final ThreadLocal<Integer> _asyncOperationStep;
-  private final HashMap<EndPoint, Meter> _requestMeter = new HashMap<>();
-  private final HashMap<EndPoint, Timer> _requestExecutionTimer = new HashMap<>();
+  private final Map<EndPoint, Meter> _requestMeter = new HashMap<>();
+  private final Map<EndPoint, Timer> _requestExecutionTimer = new HashMap<>();
 
   public KafkaCruiseControlServlet(AsyncKafkaCruiseControl asynckafkaCruiseControl,
                                    long maxBlockMs,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -4,7 +4,9 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet;
 
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import com.linkedin.kafka.cruisecontrol.KafkaClusterState;
 import com.linkedin.kafka.cruisecontrol.common.Resource;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlState;
@@ -67,16 +69,24 @@ public class KafkaCruiseControlServlet extends HttpServlet {
   private final SessionManager _sessionManager;
   private final long _maxBlockMs;
   private final ThreadLocal<Integer> _asyncOperationStep;
+  private final HashMap<EndPoint, Meter> _requestMeter = new HashMap<>();
+  private final HashMap<EndPoint, Timer> _requestExecutionTimer = new HashMap<>();
 
   public KafkaCruiseControlServlet(AsyncKafkaCruiseControl asynckafkaCruiseControl,
                                    long maxBlockMs,
                                    long sessionExpiryMs,
                                    MetricRegistry dropwizardMetricRegistry) {
     _asyncKafkaCruiseControl = asynckafkaCruiseControl;
-    _sessionManager = new SessionManager(5, sessionExpiryMs, Time.SYSTEM, dropwizardMetricRegistry);
+    _sessionManager = new SessionManager(5, sessionExpiryMs, Time.SYSTEM, dropwizardMetricRegistry, _requestExecutionTimer);
     _maxBlockMs = maxBlockMs;
     _asyncOperationStep = new ThreadLocal<>();
     _asyncOperationStep.set(0);
+
+    for (EndPoint endpoint : EndPoint.values()) {
+      _requestMeter.put(endpoint, dropwizardMetricRegistry.meter(MetricRegistry.name("KafkaCruiseControlServelet", endpoint.name() + "-request-meter")));
+      _requestExecutionTimer.put(endpoint, dropwizardMetricRegistry.timer(MetricRegistry.name("KafkaCruiseControlServelet",
+                                  endpoint.name() + "-request-execution-timer")));
+    }
   }
 
   @Override
@@ -156,35 +166,44 @@ public class KafkaCruiseControlServlet extends HttpServlet {
                                            endPoint, userParams.toString());
           setErrorResponse(response, "", errorResp, SC_BAD_REQUEST, wantJSON(request));
         } else {
+          if (EndPoint.getEndpoint().contains(endPoint)) {
+            _requestMeter.get(endPoint).mark();
+          } else {
+            throw new UserRequestException("Invalid URL for GET");
+          }
+          long requestExecutionStartTime = System.nanoTime();
           switch (endPoint) {
             case BOOTSTRAP:
               bootstrap(request, response);
+              _requestExecutionTimer.get(endPoint).update(System.nanoTime() - requestExecutionStartTime, TimeUnit.NANOSECONDS);
               break;
             case TRAIN:
               train(request, response);
+              _requestExecutionTimer.get(endPoint).update(System.nanoTime() - requestExecutionStartTime, TimeUnit.NANOSECONDS);
               break;
             case LOAD:
               if (getClusterLoad(request, response)) {
-                _sessionManager.closeSession(request);
+                _sessionManager.closeSession(request, false);
               }
               break;
             case PARTITION_LOAD:
               if (getPartitionLoad(request, response)) {
-                _sessionManager.closeSession(request);
+                _sessionManager.closeSession(request, false);
               }
               break;
             case PROPOSALS:
               if (getProposals(request, response)) {
-                _sessionManager.closeSession(request);
+                _sessionManager.closeSession(request, false);
               }
               break;
             case STATE:
               if (getState(request, response)) {
-                _sessionManager.closeSession(request);
+                _sessionManager.closeSession(request, false);
               }
               break;
             case KAFKA_CLUSTER_STATE:
               getKafkaClusterState(request, response);
+              _requestExecutionTimer.get(endPoint).update(System.nanoTime() - requestExecutionStartTime, TimeUnit.NANOSECONDS);
               break;
             default:
               throw new UserRequestException("Invalid URL for GET");
@@ -202,7 +221,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       StringWriter sw = new StringWriter();
       ure.printStackTrace(new PrintWriter(sw));
       setErrorResponse(response, sw.toString(), errorMessage, SC_BAD_REQUEST, wantJSON(request));
-      _sessionManager.closeSession(request);
+      _sessionManager.closeSession(request, true);
     } catch (Exception e) {
       StringWriter sw = new StringWriter();
       PrintWriter pw = new PrintWriter(sw);
@@ -210,7 +229,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       String errorMessage = String.format("Error processing GET request '%s' due to '%s'.", request.getPathInfo(), e.getMessage());
       LOG.error(errorMessage, e);
       setErrorResponse(response, sw.toString(), errorMessage, SC_INTERNAL_SERVER_ERROR, wantJSON(request));
-      _sessionManager.closeSession(request);
+      _sessionManager.closeSession(request, true);
     } finally {
       try {
         response.getOutputStream().close();
@@ -275,33 +294,42 @@ public class KafkaCruiseControlServlet extends HttpServlet {
                                            endPoint, userParams.toString());
           setErrorResponse(response, "", errorResp, SC_BAD_REQUEST, wantJSON(request));
         } else {
+          if (EndPoint.postEndpoint().contains(endPoint)) {
+            _requestMeter.get(endPoint).mark();
+          } else {
+            throw new UserRequestException("Invalid URL for POST");
+          }
+          long requestExecutionStartTime = System.nanoTime();
           switch (endPoint) {
             case ADD_BROKER:
             case REMOVE_BROKER:
               if (addOrRemoveBroker(request, response, endPoint)) {
-                _sessionManager.closeSession(request);
+                _sessionManager.closeSession(request, false);
               }
               break;
             case REBALANCE:
               if (rebalance(request, response, endPoint)) {
-                _sessionManager.closeSession(request);
+                _sessionManager.closeSession(request, false);
               }
               break;
             case STOP_PROPOSAL_EXECUTION:
               stopProposalExecution();
               setSuccessResponse(response, "Proposal execution stopped.", wantJSON(request));
+              _requestExecutionTimer.get(endPoint).update(System.nanoTime() - requestExecutionStartTime, TimeUnit.NANOSECONDS);
               break;
             case PAUSE_SAMPLING:
               pauseSampling();
               setSuccessResponse(response, "Metric sampling paused.", wantJSON(request));
+              _requestExecutionTimer.get(endPoint).update(System.nanoTime() - requestExecutionStartTime, TimeUnit.NANOSECONDS);
               break;
             case RESUME_SAMPLING:
               resumeSampling();
               setSuccessResponse(response, "Metric sampling resumed.", wantJSON(request));
+              _requestExecutionTimer.get(endPoint).update(System.nanoTime() - requestExecutionStartTime, TimeUnit.NANOSECONDS);
               break;
             case DEMOTE_BROKER:
               if (demoteBroker(request, response, endPoint)) {
-                _sessionManager.closeSession(request);
+                _sessionManager.closeSession(request, false);
               }
               break;
             default:
@@ -320,7 +348,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       StringWriter sw = new StringWriter();
       ure.printStackTrace(new PrintWriter(sw));
       setErrorResponse(response, sw.toString(), errorMessage, SC_BAD_REQUEST, wantJSON(request));
-      _sessionManager.closeSession(request);
+      _sessionManager.closeSession(request, true);
     } catch (Exception e) {
       StringWriter sw = new StringWriter();
       PrintWriter pw = new PrintWriter(sw);
@@ -328,7 +356,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       String errorMessage = String.format("Error processing POST request '%s' due to: '%s'.", request.getPathInfo(), e.getMessage());
       LOG.error(errorMessage, e);
       setErrorResponse(response, sw.toString(), errorMessage, SC_INTERNAL_SERVER_ERROR, wantJSON(request));
-      _sessionManager.closeSession(request);
+      _sessionManager.closeSession(request, true);
     } finally {
       try {
         response.getOutputStream().close();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/SessionManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/SessionManager.java
@@ -27,7 +27,6 @@ import javax.servlet.http.HttpSession;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static com.linkedin.kafka.cruisecontrol.servlet.KafkaCruiseControlServletUtils.endPoint;
 
 
 /**
@@ -136,7 +135,7 @@ public class SessionManager {
                                        + "has reached the servlet capacity.");
       }
       LOG.info("Created session for {}", session);
-      info = new SessionInfo(requestString, request.getParameterMap(), endPoint(request));
+      info = new SessionInfo(requestString, request.getParameterMap(), KafkaCruiseControlServletUtils.endPoint(request));
       OperationFuture<T> future = operation.get();
       info.addFuture(future);
       _inProgressSessions.put(session, info);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/SessionManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/SessionManager.java
@@ -54,7 +54,7 @@ public class SessionManager {
                                                                                      null));
   private final Timer _sessionLifetimeTimer;
   private final Meter _sessionCreationFailureMeter;
-  private final HashMap<EndPoint, Timer> _requestExecutionTimer;
+  private final Map<EndPoint, Timer> _requestExecutionTimer;
 
   /**
    * Construct the session manager.
@@ -63,7 +63,7 @@ public class SessionManager {
    * @param time the time object for unit test.
    * @param dropwizardMetricRegistry the metric registry to record metrics.
    */
-  SessionManager(int capacity, long sessionExpiryMs, Time time, MetricRegistry dropwizardMetricRegistry, HashMap<EndPoint, Timer> requestExecutionTimer) {
+  SessionManager(int capacity, long sessionExpiryMs, Time time, MetricRegistry dropwizardMetricRegistry, Map<EndPoint, Timer> requestExecutionTimer) {
     _capacity = capacity;
     _sessionExpiryMs = sessionExpiryMs;
     _time = time;
@@ -252,7 +252,7 @@ public class SessionManager {
     }
 
     private long executionTime() {
-      return lastFuture().getFinishTime() == -1 ? -1 : lastFuture().getFinishTime() - _requestTime;
+      return lastFuture().finishTimeNs() == -1 ? -1 : lastFuture().finishTimeNs() - _requestTime;
     }
 
     private EndPoint endPoint() {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/SessionManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/SessionManager.java
@@ -5,7 +5,9 @@
 package com.linkedin.kafka.cruisecontrol.servlet;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import com.linkedin.kafka.cruisecontrol.async.OperationFuture;
 import com.linkedin.kafka.cruisecontrol.common.KafkaCruiseControlThreadFactory;
 import java.util.ArrayList;
@@ -25,6 +27,7 @@ import javax.servlet.http.HttpSession;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import static com.linkedin.kafka.cruisecontrol.servlet.KafkaCruiseControlServletUtils.*;
 
 
 /**
@@ -49,6 +52,9 @@ public class SessionManager {
       Executors.newSingleThreadScheduledExecutor(new KafkaCruiseControlThreadFactory("SessionCleaner",
                                                                                      true,
                                                                                      null));
+  private final Timer _sessionLifetimeTimer;
+  private final Meter _sessionCreationFailureMeter;
+  private final HashMap<EndPoint, Timer> _requestExecutionTimer;
 
   /**
    * Construct the session manager.
@@ -57,12 +63,16 @@ public class SessionManager {
    * @param time the time object for unit test.
    * @param dropwizardMetricRegistry the metric registry to record metrics.
    */
-  SessionManager(int capacity, long sessionExpiryMs, Time time, MetricRegistry dropwizardMetricRegistry) {
+  SessionManager(int capacity, long sessionExpiryMs, Time time, MetricRegistry dropwizardMetricRegistry, HashMap<EndPoint, Timer> requestExecutionTimer) {
     _capacity = capacity;
     _sessionExpiryMs = sessionExpiryMs;
     _time = time;
     _inProgressSessions = new HashMap<>();
     _sessionCleaner.scheduleAtFixedRate(new ExpiredSessionCleaner(), 0, 5, TimeUnit.SECONDS);
+    _requestExecutionTimer = requestExecutionTimer;
+    // Metrics registration
+    _sessionLifetimeTimer = dropwizardMetricRegistry.timer(MetricRegistry.name("SessionManager", "session-lifetime-timer"));
+    _sessionCreationFailureMeter = dropwizardMetricRegistry.meter(MetricRegistry.name("SessionManager", "session-creation-failure-meter"));
     dropwizardMetricRegistry.register(MetricRegistry.name("SessionManager", "num-active-sessions"),
                                       (Gauge<Integer>) _inProgressSessions::size);
 
@@ -121,11 +131,12 @@ public class SessionManager {
       }
       // The session does not exist, add it.
       if (_inProgressSessions.size() >= _capacity) {
+        _sessionCreationFailureMeter.mark();
         throw new RuntimeException("There are already " + _inProgressSessions.size() + " active sessions, which "
                                        + "has reached the servlet capacity.");
       }
       LOG.info("Created session for {}", session);
-      info = new SessionInfo(requestString, request.getParameterMap());
+      info = new SessionInfo(requestString, request.getParameterMap(), endPoint(request));
       OperationFuture<T> future = operation.get();
       info.addFuture(future);
       _inProgressSessions.put(session, info);
@@ -155,7 +166,7 @@ public class SessionManager {
    * Close the session for the given request.
    * @param request the request to close its session.
    */
-  synchronized void closeSession(HttpServletRequest request) {
+  synchronized void closeSession(HttpServletRequest request, boolean hasError) {
     // Response associated with this request has already been flushed; hence, do not attempt to create a new session.
     HttpSession session = request.getSession(false);
     if (session == null) {
@@ -165,6 +176,10 @@ public class SessionManager {
     if (info != null && info.lastFuture().isDone()) {
       LOG.info("Closing session {}", session);
       session.invalidate();
+      _sessionLifetimeTimer.update(System.nanoTime() - info.requestTime(), TimeUnit.NANOSECONDS);
+      if (!hasError && info.executionTime() > 0) {
+        _requestExecutionTimer.get(info.endPoint()).update(info.executionTime(), TimeUnit.NANOSECONDS);
+      }
     }
   }
 
@@ -184,7 +199,12 @@ public class SessionManager {
         LOG.info("Expiring session {}.", session);
         iter.remove();
         session.invalidate();
-        info.lastFuture().cancel(true);
+        _sessionLifetimeTimer.update(System.nanoTime() - info.requestTime(), TimeUnit.NANOSECONDS);
+        if (info.lastFuture().isDone() && info.executionTime() > 0) {
+          _requestExecutionTimer.get(info.endPoint()).update(info.executionTime(), TimeUnit.NANOSECONDS);
+        } else {
+          info.lastFuture().cancel(true);
+        }
       }
     }
   }
@@ -196,11 +216,15 @@ public class SessionManager {
     private final String _requestUrl;
     private final Map<String, String[]> _requestParameters;
     private final List<OperationFuture> _operationFuture;
+    private final long _requestTime;
+    private final EndPoint _endPoint;
 
-    private SessionInfo(String requestUrl, Map<String, String[]> requestParameters) {
+    private SessionInfo(String requestUrl, Map<String, String[]> requestParameters, EndPoint endPoint) {
       _operationFuture = new ArrayList<>();
       _requestUrl = requestUrl;
       _requestParameters = requestParameters;
+      _requestTime = System.nanoTime();
+      _endPoint = endPoint;
     }
 
     private int numFutures() {
@@ -221,6 +245,18 @@ public class SessionManager {
 
     private String requestUrl() {
       return _requestUrl;
+    }
+
+    private long requestTime() {
+      return _requestTime;
+    }
+
+    private long executionTime() {
+      return lastFuture().getFinishTime() == -1 ? -1 : lastFuture().getFinishTime() - _requestTime;
+    }
+
+    private EndPoint endPoint() {
+      return _endPoint;
     }
 
     private boolean paramEquals(Map<String, String[]> parameters) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/SessionManagerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/SessionManagerTest.java
@@ -29,21 +29,21 @@ public class SessionManagerTest {
   @Test
   public void testCreateAndCloseSession() {
     TestContext context = prepareRequests(true, 1);
-    SessionManager sessionManager = new SessionManager(1, 1000, context.time(), new MetricRegistry());
+    SessionManager sessionManager = new SessionManager(1, 1000, context.time(), new MetricRegistry(), null);
 
     sessionManager.getAndCreateSessionIfNotExist(context.request(0),
                                                  () -> new OperationFuture<>("testCreateSession"),
                                                  0);
     assertEquals(1, sessionManager.numSessions());
 
-    sessionManager.closeSession(context.request(0));
+    sessionManager.closeSession(context.request(0), false);
     assertEquals(0, sessionManager.numSessions());
   }
 
   @Test
   public void testSessionExpiration() {
     TestContext context = prepareRequests(true, 2);
-    SessionManager sessionManager = new SessionManager(2, 1000, context.time(), new MetricRegistry());
+    SessionManager sessionManager = new SessionManager(2, 1000, context.time(), new MetricRegistry(), null);
 
     List<OperationFuture<Integer>> futures = new ArrayList<>();
     for (int i = 0; i < 2; i++) {
@@ -74,7 +74,7 @@ public class SessionManagerTest {
   @Test
   public void testCreateSessionReachingCapacity() {
     TestContext context = prepareRequests(false, 2);
-    SessionManager sessionManager = new SessionManager(1, 1000, context.time(), new MetricRegistry());
+    SessionManager sessionManager = new SessionManager(1, 1000, context.time(), new MetricRegistry(), null);
 
     sessionManager.getAndCreateSessionIfNotExist(context.request(0),
                                                  () -> new OperationFuture<>("testCreateSession"),
@@ -100,7 +100,7 @@ public class SessionManagerTest {
   @Test
   public void testMultipleOperationRequest() {
     TestContext context = prepareRequests(false, 1);
-    SessionManager sessionManager = new SessionManager(1, 1000, context.time(), new MetricRegistry());
+    SessionManager sessionManager = new SessionManager(1, 1000, context.time(), new MetricRegistry(), null);
     HttpServletRequest request = context.request(0);
     OperationFuture<Integer> future1 = new OperationFuture<>("future1");
     OperationFuture<String> future2 = new OperationFuture<>("future2");
@@ -119,7 +119,7 @@ public class SessionManagerTest {
   @Test (expected = IllegalArgumentException.class)
   public void testSkipStep() {
     TestContext context = prepareRequests(false, 1);
-    SessionManager sessionManager = new SessionManager(1, 1000, context.time(), new MetricRegistry());
+    SessionManager sessionManager = new SessionManager(1, 1000, context.time(), new MetricRegistry(), null);
     HttpServletRequest request = context.request(0);
     sessionManager.getAndCreateSessionIfNotExist(request, () -> null, 1);
   }


### PR DESCRIPTION
Add following metrics
1. timer to trace the session avg/max life time
2. meter to trace the rate session manager fails new session creation due to capacity limit(already have 5 ongoing sessions)
3. timer per endpoint to trace the avg execution time for requests routed to each endpoint
4. meter per endpoint to trace the rate each endpoint receives new request