### PR TITLE
Fix acceptance of window with zero valid entity as valid window in MetricSampleAggregator

### DIFF
--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/WindowState.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/WindowState.java
@@ -67,7 +67,7 @@ public class WindowState<G, E extends Entity<G>> extends LongGenerationed {
     int totalNumEntities = options.interestedEntities().size();
     int numValidEntitiesAfterMerge =
         numValidElementsAfterMerge(completeness.validEntities(), validEntitiesForWindow);
-    return (float) numValidEntitiesAfterMerge / totalNumEntities >= options.minValidEntityRatio();
+    return numValidEntitiesAfterMerge > 0 && (float) numValidEntitiesAfterMerge / totalNumEntities >= options.minValidEntityRatio();
   }
 
   private boolean meetValidEntityGroupRatioAfterMerge(MetricSampleCompleteness<G, E> completeness,
@@ -76,7 +76,7 @@ public class WindowState<G, E extends Entity<G>> extends LongGenerationed {
     int totalNumEntityGroups = options.interestedEntityGroups().size();
     int numValidEntityGroupsAfterMerge =
         numValidElementsAfterMerge(completeness.validEntityGroups(), validEntityGroupForWindow);
-    return (float) numValidEntityGroupsAfterMerge / totalNumEntityGroups >= options.minValidEntityGroupRatio();
+    return numValidEntityGroupsAfterMerge > 0 && (float) numValidEntityGroupsAfterMerge / totalNumEntityGroups >= options.minValidEntityGroupRatio();
   }
 
   /**

--- a/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregatorTest.java
+++ b/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregatorTest.java
@@ -230,10 +230,11 @@ public class MetricSampleAggregatorTest {
                                  AggregationOptions.Granularity.ENTITY, true);
 
     MetricSampleCompleteness<String, IntegerEntity> completeness = aggregator.completeness(-1, Long.MAX_VALUE, options);
-    assertEquals(20, completeness.validWindowIndexes().size());
-    assertEquals(1, completeness.validEntities().size());
+    assertEquals(17, completeness.validWindowIndexes().size());
+    assertEquals(2, completeness.validEntities().size());
     assertTrue(completeness.validEntities().contains(ENTITY1));
-    assertTrue(completeness.validEntityGroups().isEmpty());
+    assertTrue(completeness.validEntities().contains(ENTITY3));
+    assertTrue(completeness.validEntityGroups().contains("g2"));
     assertCompletenessByWindowIndex(completeness);
   }
 

--- a/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregatorTest.java
+++ b/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregatorTest.java
@@ -234,7 +234,7 @@ public class MetricSampleAggregatorTest {
     assertEquals(2, completeness.validEntities().size());
     assertTrue(completeness.validEntities().contains(ENTITY1));
     assertTrue(completeness.validEntities().contains(ENTITY3));
-    assertTrue(completeness.validEntityGroups().contains("g2"));
+    assertTrue(completeness.validEntityGroups().contains(ENTITY3.group()));
     assertCompletenessByWindowIndex(completeness);
   }
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregatorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregatorTest.java
@@ -116,8 +116,10 @@ public class KafkaPartitionMetricSampleAggregatorTest {
     Map<PartitionEntity, ValuesAndExtrapolations> aggregateResult =
         metricSampleAggregator.aggregate(clusterAndGeneration(cluster), Long.MAX_VALUE, new OperationProgress())
                               .valuesAndExtrapolations();
-    assertEquals(1, aggregateResult.size(), 0);
-    assertEquals(NUM_WINDOWS, aggregateResult.get(PE).windows().size(), 0);
+    // Partition "topic-0" should be valid in all NUM_WINDOW windows and Partition "topic1-0" should not since
+    // there is no sample for it.
+    assertEquals(1, aggregateResult.size());
+    assertEquals(NUM_WINDOWS, aggregateResult.get(PE).windows().size());
 
     ModelCompletenessRequirements requirements =
         new ModelCompletenessRequirements(1, 0.0, true);
@@ -182,7 +184,8 @@ public class KafkaPartitionMetricSampleAggregatorTest {
         metricSampleAggregator.aggregate(clusterAndGeneration(metadata.fetch()),
                                          NUM_WINDOWS * WINDOW_MS,
                                          new OperationProgress());
-    assertEquals(NUM_WINDOWS - 2, result.valuesAndExtrapolations().get(PE).windows().size(), 0);
+    // Partition "topic-0" is expected to be a valid partition in result with valid sample values for window [3, NUM_WINDOWS].
+    assertEquals(NUM_WINDOWS - 2, result.valuesAndExtrapolations().get(PE).windows().size());
 
     populateSampleAggregator(2, MIN_SAMPLES_PER_WINDOW - 2, metricSampleAggregator);
 
@@ -257,7 +260,8 @@ public class KafkaPartitionMetricSampleAggregatorTest {
           metricSampleAggregator.aggregate(clusterAndGeneration(metadata.fetch()),
                                            NUM_WINDOWS * WINDOW_MS,
                                            new OperationProgress());
-      assertEquals(NUM_WINDOWS - 3, result.valuesAndExtrapolations().get(PE).windows().size(), 0);
+      // Partition "topic-0" is expected to be a valid partition in result, with valid sample values collected for window [1, NUM_WINDOW - 3].
+      assertEquals(NUM_WINDOWS - 3, result.valuesAndExtrapolations().get(PE).windows().size());
   }
 
   @Test

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregatorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregatorTest.java
@@ -109,15 +109,15 @@ public class KafkaPartitionMetricSampleAggregatorTest {
 
     populateSampleAggregator(NUM_WINDOWS + 1, MIN_SAMPLES_PER_WINDOW, metricSampleAggregator);
 
-    TopicPartition tp1 = new TopicPartition(TOPIC, 1);
+    TopicPartition tp1 = new TopicPartition(TOPIC + "1", 0);
     Cluster cluster = getCluster(Arrays.asList(TP, tp1));
     metadata.update(cluster, Collections.emptySet(), 1);
 
     Map<PartitionEntity, ValuesAndExtrapolations> aggregateResult =
         metricSampleAggregator.aggregate(clusterAndGeneration(cluster), Long.MAX_VALUE, new OperationProgress())
                               .valuesAndExtrapolations();
-    assertTrue("tp1 should not be included because recent metric window does not include all topics",
-               aggregateResult.isEmpty());
+    assertEquals(1, aggregateResult.size(), 0);
+    assertEquals(NUM_WINDOWS, aggregateResult.get(PE).windows().size(), 0);
 
     ModelCompletenessRequirements requirements =
         new ModelCompletenessRequirements(1, 0.0, true);
@@ -182,7 +182,7 @@ public class KafkaPartitionMetricSampleAggregatorTest {
         metricSampleAggregator.aggregate(clusterAndGeneration(metadata.fetch()),
                                          NUM_WINDOWS * WINDOW_MS,
                                          new OperationProgress());
-    assertTrue(result.valuesAndExtrapolations().isEmpty());
+    assertEquals(NUM_WINDOWS - 2, result.valuesAndExtrapolations().get(PE).windows().size(), 0);
 
     populateSampleAggregator(2, MIN_SAMPLES_PER_WINDOW - 2, metricSampleAggregator);
 
@@ -257,7 +257,7 @@ public class KafkaPartitionMetricSampleAggregatorTest {
           metricSampleAggregator.aggregate(clusterAndGeneration(metadata.fetch()),
                                            NUM_WINDOWS * WINDOW_MS,
                                            new OperationProgress());
-      assertTrue(result.valuesAndExtrapolations().isEmpty());
+      assertEquals(NUM_WINDOWS - 3, result.valuesAndExtrapolations().get(PE).windows().size(), 0);
   }
 
   @Test


### PR DESCRIPTION
When `_minValidEntityRatio` in `AggregationOptions` is set to zero, `MetricSampleAggregator` will take window with zero valid entity as valid window in its `completeness()` and `aggregate()` method. At the same time, valid entity are collect as **entities which are valid in all valid windows**. This result in a corner scenario that if `_minValidEntityRatio` is set to zero and there happens to be one or more window with zero valid entity,  there will be zero valid entity in `MetricSampleAggregationResult`, which is used in `ClusterModel`.

One Cruise Control client visible case will be that client make a request to `partition_load` endpoint with parameter `min_valid_partition_ratio` set to 0. If in one window in Cruise Control's sample history has zero valid entity( can happen if Kafka cluster down for a while in the past and reporter does not report the metrics), the user will see no partition load at all in response.

This patch deals with with this corner case.