### PR TITLE
Add several configs to KafkaCruiseControlConfig and improve its usage in reflective created object.

### DIFF
--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -46,16 +46,19 @@ metric.reporter.topic.pattern=__CruiseControlMetrics
 # The sample store class name
 sample.store.class=com.linkedin.kafka.cruisecontrol.monitor.sampling.KafkaSampleStore
 
-# The config for the Kafka sample store to save the partition metric samples.
+# The config for the Kafka sample store to save the partition metric samples
 partition.metric.sample.store.topic=__KafkaCruiseControlPartitionMetricSamples
 
-# The config for the Kafka sample store to save the model training samples.
+# The config for the Kafka sample store to save the model training samples
 broker.metric.sample.store.topic=__KafkaCruiseControlModelTrainingSamples
 
-# The config for the number of Kafka sample store consumer threads.
+# The replication factor of Kafka metric sample store topic
+num.metric.sample.store.topic.replication.factor=3
+
+# The config for the number of Kafka sample store consumer threads
 num.sample.loading.threads=8
 
-# The partition assignor class for the metric samplers.
+# The partition assignor class for the metric samplers
 metric.sampler.partition.assignor.class=com.linkedin.kafka.cruisecontrol.monitor.sampling.DefaultMetricSamplerPartitionAssignor
 
 # The metric sampling interval in milliseconds

--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -53,7 +53,7 @@ partition.metric.sample.store.topic=__KafkaCruiseControlPartitionMetricSamples
 broker.metric.sample.store.topic=__KafkaCruiseControlModelTrainingSamples
 
 # The replication factor of Kafka metric sample store topic
-num.metric.sample.store.topic.replication.factor=3
+sample.store.topic.replication.factor=3
 
 # The config for the number of Kafka sample store consumer threads
 num.sample.loading.threads=8

--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -53,7 +53,7 @@ partition.metric.sample.store.topic=__KafkaCruiseControlPartitionMetricSamples
 broker.metric.sample.store.topic=__KafkaCruiseControlModelTrainingSamples
 
 # The replication factor of Kafka metric sample store topic
-sample.store.topic.replication.factor=3
+sample.store.topic.replication.factor=2
 
 # The config for the number of Kafka sample store consumer threads
 num.sample.loading.threads=8

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlMain.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlMain.java
@@ -51,7 +51,7 @@ public class KafkaCruiseControlMain {
     MetricRegistry dropwizardMetricsRegistry = new MetricRegistry();
     JmxReporter jmxReporter = JmxReporter.forRegistry(dropwizardMetricsRegistry).inDomain(METRIC_DOMAIN).build();
     jmxReporter.start();
-    
+
     AsyncKafkaCruiseControl kafkaCruiseControl = new AsyncKafkaCruiseControl(new KafkaCruiseControlConfig(props),
                                                                              dropwizardMetricsRegistry);
 
@@ -66,7 +66,7 @@ public class KafkaCruiseControlMain {
     holderWebapp.setInitParameter("resourceBase", "./cruise-control-ui/dist/");
     context.addServlet(holderWebapp, "/*");
     // Kafka Cruise Control servlet data
-    KafkaCruiseControlServlet kafkaCruiseControlServlet = 
+    KafkaCruiseControlServlet kafkaCruiseControlServlet =
         new KafkaCruiseControlServlet(kafkaCruiseControl, 10000L, 60000L, dropwizardMetricsRegistry);
     ServletHolder servletHolder = new ServletHolder(kafkaCruiseControlServlet);
     context.addServlet(servletHolder, "/kafkacruisecontrol/*");

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -38,7 +38,7 @@ public class KafkaCruiseControlUtils {
    */
   public static String getRequiredConfig(Map<String, ?> configs, String configName) {
     String value = (String) configs.get(configName);
-    if (value == null) {
+    if (value == null || value.isEmpty()) {
       throw new ConfigException(String.format("Configuration %s must be provided.", configName));
     }
     return value;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -42,8 +42,8 @@ public abstract class AbstractGoal implements Goal {
   private boolean _finished;
   protected boolean _succeeded = true;
   protected BalancingConstraint _balancingConstraint;
-  protected int _numWindows = 1;
-  protected double _minMonitoredPartitionPercentage = 0.995;
+  protected int _numWindows;
+  protected double _minMonitoredPartitionPercentage;
 
   /**
    * Constructor of Abstract Goal class sets the _finished flag to false to signal that the goal requirements have not

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -55,17 +55,10 @@ public abstract class AbstractGoal implements Goal {
 
   @Override
   public void configure(Map<String, ?> configs) {
-    _balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(configs, false));
-    String numWindowsString = (String) configs.get(KafkaCruiseControlConfig.NUM_PARTITION_METRICS_WINDOWS_CONFIG);
-    if (numWindowsString != null && !numWindowsString.isEmpty()) {
-      _numWindows = Integer.parseInt(numWindowsString);
-    }
-    String minMonitoredPartitionPercentageString =
-        (String) configs.get(KafkaCruiseControlConfig.MIN_VALID_PARTITION_RATIO_CONFIG);
-    if (minMonitoredPartitionPercentageString != null
-        && !minMonitoredPartitionPercentageString.isEmpty()) {
-      _minMonitoredPartitionPercentage = Double.parseDouble(minMonitoredPartitionPercentageString);
-    }
+    KafkaCruiseControlConfig parsedConfig = new KafkaCruiseControlConfig(configs, false);
+    _balancingConstraint = new BalancingConstraint(parsedConfig);
+    _numWindows = parsedConfig.getInt(KafkaCruiseControlConfig.NUM_PARTITION_METRICS_WINDOWS_CONFIG);
+    _minMonitoredPartitionPercentage = parsedConfig.getDouble(KafkaCruiseControlConfig.MIN_VALID_PARTITION_RATIO_CONFIG);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -265,12 +265,6 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
   private static final String LINEAR_REGRESSION_MODEL_MIN_NUM_CPU_UTIL_BUCKETS_DOC = "The minimum number of full CPU"
       + " utilization buckets required to generate a linear regression model.";
 
-  /**
-   * <code>num.sample.loading.threads</code>
-   */
-  public static final String NUM_SAMPLE_LOADING_THREADS_CONFIG = "num.sample.loading.threads";
-  private static final String NUM_SAMPLE_LOADING_THREADS_DOC = "The config for the number of Kafka sample store consumer threads.";
-
   // Analyzer configs
   /**
    * <code>cpu.balance.threshold</code>
@@ -523,18 +517,6 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
       + "that persist the metric samples that have already been aggregated into Kafka Cruise Control. Later on the "
       + "persisted samples can be reloaded from the sample store to Kafka Cruise Control.";
 
-  /**
-   * <code>partition.metric.sample.store.topic</code>
-   */
-  public static final String PARTITION_METRIC_SAMPLE_STORE_TOPIC_CONFIG = "partition.metric.sample.store.topic";
-  private static final String PARTITION_METRIC_SAMPLE_STORE_TOPIC_DOC = "The name of topic which is used to store the partition sample records.";
-
-  /**
-   * <code>broker.metric.sample.store.topic</code>
-   */
-  public static final String BROKER_METRIC_SAMPLE_STORE_TOPIC_CONFIG = "broker.metric.sample.store.topic";
-  private static final String BROKER_METRIC_SAMPLE_STORE_TOPIC_DOC = "The name of topic which is used to store the broker sample records.";
-
   static {
     CONFIG = new ConfigDef()
         .define(BOOTSTRAP_SERVERS_CONFIG, ConfigDef.Type.LIST, ConfigDef.Importance.HIGH,
@@ -685,11 +667,6 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 5,
                 ConfigDef.Importance.MEDIUM,
                 LINEAR_REGRESSION_MODEL_MIN_NUM_CPU_UTIL_BUCKETS_DOC)
-        .define(NUM_SAMPLE_LOADING_THREADS_CONFIG,
-                ConfigDef.Type.INT,
-                8,
-                ConfigDef.Importance.MEDIUM,
-                NUM_SAMPLE_LOADING_THREADS_DOC)
         .define(LINEAR_REGRESSION_MODEL_REQUIRED_SAMPLES_PER_CPU_UTIL_BUCKET_CONFIG,
                 ConfigDef.Type.INT,
                 100,
@@ -902,16 +879,6 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 KafkaSampleStore.class.getName(),
                 ConfigDef.Importance.LOW,
                 SAMPLE_STORE_CLASS_DOC)
-        .define(PARTITION_METRIC_SAMPLE_STORE_TOPIC_CONFIG,
-            ConfigDef.Type.STRING,
-            "__KafkaCruiseControlPartitionMetricSamples",
-            ConfigDef.Importance.HIGH,
-            PARTITION_METRIC_SAMPLE_STORE_TOPIC_DOC)
-        .define(BROKER_METRIC_SAMPLE_STORE_TOPIC_CONFIG,
-            ConfigDef.Type.STRING,
-            "__KafkaCruiseControlModelTrainingSamples",
-            ConfigDef.Importance.HIGH,
-            BROKER_METRIC_SAMPLE_STORE_TOPIC_DOC)
         .withClientSslSupport()
         .withClientSaslSupport();
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
@@ -48,6 +48,16 @@ import org.slf4j.LoggerFactory;
 /**
  * The sample store that implements the {@link SampleStore}. It stores the partition metric samples and broker metric
  * samples back to Kafka and load from Kafka at startup.
+ *
+ * Required configurations for this class.
+ * <ul>
+ *   <li>{@link #PARTITION_METRIC_SAMPLE_STORE_TOPIC_CONFIG}: The config for the topic name of Kafka topic to store partition samples.</li>
+ *   <li>{@link #BROKER_METRIC_SAMPLE_STORE_TOPIC_CONFIG}: The config for the topic name of Kafka topic to store broker samples.</li>
+ *   <li>{@link #NUM_SAMPLE_LOADING_THREADS_CONFIG}: The config for the number of Kafka sample store consumer threads, default value is
+ *   set to {@link #DEFAULT_NUM_SAMPLE_LOADING_THREADS}.</li>
+ *   <li>{@link #SAMPLE_STORE_TOPIC_REPLICATION_FACTOR_CONFIG}: The config for the replication factor of Kafka sample store topics,
+ *   default value is set to {@link #DEFAULT_SAMPLE_STORE_TOPIC_REPLICATION_FACTOR}.</li>
+ * </ul>
  */
 public class KafkaSampleStore implements SampleStore {
   private static final Logger LOG = LoggerFactory.getLogger(KafkaSampleStore.class);
@@ -58,6 +68,7 @@ public class KafkaSampleStore implements SampleStore {
   private static final ConsumerRecords<byte[], byte[]> SHUTDOWN_RECORDS = new ConsumerRecords<>(Collections.emptyMap());
 
   protected static final Integer DEFAULT_NUM_SAMPLE_LOADING_THREADS = 8;
+  protected static final Integer DEFAULT_SAMPLE_STORE_TOPIC_REPLICATION_FACTOR = 2;
   protected static final String PRODUCER_CLIENT_ID = "KafkaCruiseControlSampleStoreProducer";
   protected static final String CONSUMER_CLIENT_ID = "KafkaCruiseControlSampleStoreConsumer";
   protected static final Random RANDOM = new Random();
@@ -65,7 +76,7 @@ public class KafkaSampleStore implements SampleStore {
   protected ExecutorService _metricProcessorExecutor;
   protected String _partitionMetricSampleStoreTopic;
   protected String _brokerMetricSampleStoreTopic;
-  protected Integer _metricSampleStoreTopicReplicationFactor;
+  protected Integer _sampleStoreTopicReplicationFactor;
   protected volatile double _loadingProgress;
   protected Producer<byte[], byte[]> _producer;
   protected volatile boolean _shutdown = false;
@@ -73,14 +84,14 @@ public class KafkaSampleStore implements SampleStore {
   public static final String PARTITION_METRIC_SAMPLE_STORE_TOPIC_CONFIG = "partition.metric.sample.store.topic";
   public static final String BROKER_METRIC_SAMPLE_STORE_TOPIC_CONFIG = "broker.metric.sample.store.topic";
   public static final String NUM_SAMPLE_LOADING_THREADS_CONFIG = "num.sample.loading.threads";
-  public static final String NUM_METRIC_SAMPLE_STORE_TOPIC_REPLICATION_FACTOR_CONFIG = "num.metric.sample.store.topic.replication.factor";
+  public static final String SAMPLE_STORE_TOPIC_REPLICATION_FACTOR_CONFIG = "sample.store.topic.replication.factor";
 
   @Override
   public void configure(Map<String, ?> config) {
     _partitionMetricSampleStoreTopic = KafkaCruiseControlUtils.getRequiredConfig(config, PARTITION_METRIC_SAMPLE_STORE_TOPIC_CONFIG);
     _brokerMetricSampleStoreTopic = KafkaCruiseControlUtils.getRequiredConfig(config, BROKER_METRIC_SAMPLE_STORE_TOPIC_CONFIG);
-    String metricSampleStoreTopicReplicationFactorString = (String) config.get(NUM_METRIC_SAMPLE_STORE_TOPIC_REPLICATION_FACTOR_CONFIG);
-    _metricSampleStoreTopicReplicationFactor = metricSampleStoreTopicReplicationFactorString == null || metricSampleStoreTopicReplicationFactorString.isEmpty()
+    String metricSampleStoreTopicReplicationFactorString = (String) config.get(SAMPLE_STORE_TOPIC_REPLICATION_FACTOR_CONFIG);
+    _sampleStoreTopicReplicationFactor = metricSampleStoreTopicReplicationFactorString == null || metricSampleStoreTopicReplicationFactorString.isEmpty()
                                ? null : Integer.parseInt(metricSampleStoreTopicReplicationFactorString);
     String numProcessingThreadsString = (String) config.get(NUM_SAMPLE_LOADING_THREADS_CONFIG);
     int numProcessingThreads = numProcessingThreadsString == null || numProcessingThreadsString.isEmpty()
@@ -151,8 +162,8 @@ public class KafkaSampleStore implements SampleStore {
         throw new IllegalStateException(String.format("Kafka cluster has no alive brokers. (zookeeper.connect = %s",
                                                       config.get(KafkaCruiseControlConfig.ZOOKEEPER_CONNECT_CONFIG)));
       }
-      int replicationFactor = _metricSampleStoreTopicReplicationFactor == null ? Math.min(2, numberOfBrokersInCluster) :
-                              _metricSampleStoreTopicReplicationFactor;
+      int replicationFactor = _sampleStoreTopicReplicationFactor == null ? Math.min(DEFAULT_SAMPLE_STORE_TOPIC_REPLICATION_FACTOR,
+                              numberOfBrokersInCluster) : _sampleStoreTopicReplicationFactor;
 
       ensureTopicCreated(zkUtils, topics.keySet(), _partitionMetricSampleStoreTopic, partitionSampleRetentionMs,
                          replicationFactor);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/ReadOnlyKafkaSampleStore.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/ReadOnlyKafkaSampleStore.java
@@ -23,8 +23,8 @@ public class ReadOnlyKafkaSampleStore extends KafkaSampleStore {
   public void configure(Map<String, ?> config) {
     _partitionMetricSampleStoreTopic = KafkaCruiseControlUtils.getRequiredConfig(config, PARTITION_METRIC_SAMPLE_STORE_TOPIC_CONFIG);
     _brokerMetricSampleStoreTopic = KafkaCruiseControlUtils.getRequiredConfig(config, BROKER_METRIC_SAMPLE_STORE_TOPIC_CONFIG);
-    String metricSampleStoreTopicReplicationFactorString = (String) config.get(NUM_METRIC_SAMPLE_STORE_TOPIC_REPLICATION_FACTOR_CONFIG);
-    _metricSampleStoreTopicReplicationFactor = metricSampleStoreTopicReplicationFactorString == null || metricSampleStoreTopicReplicationFactorString.isEmpty()
+    String metricSampleStoreTopicReplicationFactorString = (String) config.get(SAMPLE_STORE_TOPIC_REPLICATION_FACTOR_CONFIG);
+    _sampleStoreTopicReplicationFactor = metricSampleStoreTopicReplicationFactorString == null || metricSampleStoreTopicReplicationFactorString.isEmpty()
         ? null : Integer.parseInt(metricSampleStoreTopicReplicationFactorString);
     String numProcessingThreadsString = (String) config.get(NUM_SAMPLE_LOADING_THREADS_CONFIG);
     int numProcessingThreads = numProcessingThreadsString == null || numProcessingThreadsString.isEmpty()


### PR DESCRIPTION
Remove the config of pluggable component from centralized config definition in KafkaCruiseControlConfig so that user can have their own class implementation and customized config of these pluggable component and plug in to use with Cruise Control.