### PR TITLE
Add FIX_OFFLINE_REPLICAS endpoint to remove offline replicas from bad disks and dead brokers to alive ones.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Cruise Control for Apache Kafka
     * Decommission brokers
     * Rebalance the cluster
     * Perform preferred leader election (PLE)
+    * Fix offline replicas
 
 ### Environment Requirements
 * The current master branch of Cruise Control is compatible with Apache Kafka 0.11.0.0 and above
@@ -90,7 +91,7 @@ model to simulate the workload of the Kafka cluster. The goal optimizer explores
 cluster workload optimization proposals based on the user-specified list of goals.
 
 Cruise Control also monitors the liveness of all the brokers in the cluster.
-To avoid the loss of redundancy, Cruise Control automatically moves replicas from failed brokers to healthy ones.
+To avoid the loss of redundancy, Cruise Control automatically moves replicas from failed brokers to alive ones.
 
 For more details about how Cruise Control achieves that, see 
 [these slides](https://www.slideshare.net/JiangjieQin/introduction-to-kafka-cruise-control-68180931).
@@ -137,7 +138,7 @@ The goals in Cruise Control are pluggable with different priorities. The default
  * **NetworkInboundUsageDistributionGoal** - Attempts to keep the inbound network utilization variance among brokers within a certain range relative to the average inbound network utilization.
  * **NetworkOutboundUsageDistributionGoal** - Attempts to keep the outbound network utilization variance among brokers within a certain range relative to the average outbound network utilization.
  * **LeaderBytesInDistributionGoal** - Attempts to equalize the leader bytes in rate on each host.
- * **TopicReplicaDistributionGoal** - Attempts to maintain an even distribution of any topic's replicas across the entire cluster.
+ * **TopicReplicaDistributionGoal** - Attempts to maintain an even distribution of any topic's partitions across the entire cluster.
  * **ReplicaDistributionGoal** - Attempts to make all the brokers in a cluster have a similar number of replicas.
  * **PreferredLeaderElectionGoal** - Simply move the leaders to the first replica of each partition.
  * **KafkaAssignerDiskUsageDistributionGoal** - (Kafka-assigner mode) Attempts to distribute disk usage evenly among brokers based on swap.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUtils.java
@@ -112,19 +112,19 @@ public class AnalyzerUtils {
   }
 
   /**
-   * Checks the replicas that are supposed to be moved away from the dead brokers. If there are still replicas
-   * on the dead broker, throw exception.
+   * Checks the replicas that are supposed to be moved away from the dead brokers or broken disks have been moved.
+   * If there are still replicas on the dead brokers or broken disks, throws an exception.
    * @param clusterModel the cluster model to check.
-   * @throws OptimizationFailureException when there are still replicas on the dead broker.
+   * @throws OptimizationFailureException when there are still replicas on the dead brokers or on broken disks.
    */
-  public static void ensureNoReplicaOnDeadBrokers(ClusterModel clusterModel) throws OptimizationFailureException {
-    // Sanity check: No self-healing eligible replica should remain at a decommissioned broker.
+  public static void ensureNoOfflineReplicas(ClusterModel clusterModel) throws OptimizationFailureException {
+    // Sanity check: No self-healing eligible replica should remain at a decommissioned broker or on broken disk.
     for (Replica replica : clusterModel.selfHealingEligibleReplicas()) {
-      if (!replica.broker().isAlive()) {
+      if (replica.isCurrentOffline()) {
         throw new OptimizationFailureException(String.format(
-            "Self healing failed to move the replica %s away from decommissioned broker %d for goal. There are still "
+            "Self healing failed to move the replica %s away from %s broker %d for goal. There are still "
                 + "%d replicas on the broker.",
-            replica, replica.broker().id(), replica.broker().replicas().size()));
+            replica, replica.broker().getState(), replica.broker().id(), replica.broker().replicas().size()));
       }
     }
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/BalancingConstraint.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/BalancingConstraint.java
@@ -44,7 +44,7 @@ public class BalancingConstraint {
     _resourceBalancePercentage.put(Resource.CPU, config.getDouble(KafkaCruiseControlConfig.CPU_BALANCE_THRESHOLD_CONFIG));
     _resourceBalancePercentage.put(Resource.NW_IN, config.getDouble(KafkaCruiseControlConfig.NETWORK_INBOUND_BALANCE_THRESHOLD_CONFIG));
     _resourceBalancePercentage.put(Resource.NW_OUT, config.getDouble(KafkaCruiseControlConfig.NETWORK_OUTBOUND_BALANCE_THRESHOLD_CONFIG));
-    // Set default values for healthy resource capacity threshold.
+    // Set default values for alive resource capacity threshold.
     _capacityThreshold.put(Resource.DISK, config.getDouble(KafkaCruiseControlConfig.DISK_CAPACITY_THRESHOLD_CONFIG));
     _capacityThreshold.put(Resource.CPU, config.getDouble(KafkaCruiseControlConfig.CPU_CAPACITY_THRESHOLD_CONFIG));
     _capacityThreshold.put(Resource.NW_IN, config.getDouble(KafkaCruiseControlConfig.NETWORK_INBOUND_CAPACITY_THRESHOLD_CONFIG));
@@ -157,7 +157,7 @@ public class BalancingConstraint {
   }
 
   /**
-   * Set healthy resource capacity threshold for the given resource.
+   * Set alive resource capacity threshold for the given resource.
    *
    * @param resource          Resource for which the capacity threshold will be set.
    * @param capacityThreshold Capacity threshold for the given resource.
@@ -170,9 +170,9 @@ public class BalancingConstraint {
   }
 
   /**
-   * Set healthy resource capacity threshold for all resources.
+   * Set alive resource capacity threshold for all resources.
    *
-   * @param capacityThreshold Common capacity threshold for all resources in healthy brokers.
+   * @param capacityThreshold Common capacity threshold for all resources in alive brokers.
    */
   void setCapacityThreshold(double capacityThreshold) {
     for (Resource resource : _resources) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
@@ -392,9 +392,9 @@ public class GoalOptimizer implements Runnable {
   }
 
   /**
-   * Depending the existence of dead/decommissioned brokers in the given cluster:
+   * Depending the existence of dead/broken/decommissioned brokers in the given cluster:
    * (1) Re-balance: Generates proposals to update the state of the cluster to achieve a final balanced state.
-   * (2) Self-healing: Generates proposals to move replicas away from decommissioned brokers.
+   * (2) Self-healing: Generates proposals to move replicas away from decommissioned brokers and broken disks.
    * Returns a map from goal names to stats. Initial stats are returned under goal name "init".
    *
    * @param clusterModel The state of the cluster over which the balancing proposal will be applied. Function execution

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/PotentialNwOutGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/PotentialNwOutGoal.java
@@ -195,7 +195,7 @@ public class PotentialNwOutGoal extends AbstractGoal {
     }
     Broker destinationBroker = clusterModel.broker(action.destinationBrokerId());
     double destinationBrokerUtilization = clusterModel.potentialLeadershipLoadFor(destinationBroker.id()).expectedUtilizationFor(Resource.NW_OUT);
-    double destinationCapacity = destinationBroker.host().capacityFor(Resource.NW_OUT) * _balancingConstraint.capacityThreshold(Resource.NW_OUT);
+    double destinationCapacity = destinationBroker.capacityFor(Resource.NW_OUT) * _balancingConstraint.capacityThreshold(Resource.NW_OUT);
     double sourceReplicaUtilization = clusterModel.partition(sourceReplica.topicPartition()).leader().load()
                                                   .expectedUtilizationFor(Resource.NW_OUT);
 
@@ -214,7 +214,7 @@ public class PotentialNwOutGoal extends AbstractGoal {
 
     // Ensure that the source capacity of self-satisfied for action type swap is not violated.
     double sourceBrokerUtilization = clusterModel.potentialLeadershipLoadFor(sourceBroker.id()).expectedUtilizationFor(Resource.NW_OUT);
-    double sourceCapacity = sourceBroker.host().capacityFor(Resource.NW_OUT) * _balancingConstraint.capacityThreshold(Resource.NW_OUT);
+    double sourceCapacity = sourceBroker.capacityFor(Resource.NW_OUT) * _balancingConstraint.capacityThreshold(Resource.NW_OUT);
     return sourceCapacity >= sourceBrokerUtilization + destinationReplicaUtilization - sourceReplicaUtilization;
   }
 
@@ -267,7 +267,7 @@ public class PotentialNwOutGoal extends AbstractGoal {
                                     Set<Goal> optimizedGoals,
                                     Set<String> excludedTopics) {
     double capacityThreshold = _balancingConstraint.capacityThreshold(Resource.NW_OUT);
-    double capacityLimit = broker.host().capacityFor(Resource.NW_OUT) * capacityThreshold;
+    double capacityLimit = broker.capacityFor(Resource.NW_OUT) * capacityThreshold;
     boolean estimatedMaxPossibleNwOutOverLimit = !broker.replicas().isEmpty() &&
         clusterModel.potentialLeadershipLoadFor(broker.id()).expectedUtilizationFor(Resource.NW_OUT) > capacityLimit;
     if (!estimatedMaxPossibleNwOutOverLimit && !(_fixOfflineReplicasOnly && !broker.currentOfflineReplicas().isEmpty())) {
@@ -306,7 +306,7 @@ public class PotentialNwOutGoal extends AbstractGoal {
           // Update brokersUnderEstimatedMaxPossibleNwOut (for destination broker).
           double updatedDestBrokerPotentialNwOut =
               clusterModel.potentialLeadershipLoadFor(destinationBrokerId).expectedUtilizationFor(Resource.NW_OUT);
-          double destCapacityLimit = destinationBroker.host().capacityFor(Resource.NW_OUT) * capacityThreshold;
+          double destCapacityLimit = destinationBroker.capacityFor(Resource.NW_OUT) * capacityThreshold;
           if (updatedDestBrokerPotentialNwOut > destCapacityLimit) {
             candidateBrokers.remove(clusterModel.broker(destinationBrokerId));
           }
@@ -334,8 +334,7 @@ public class PotentialNwOutGoal extends AbstractGoal {
     double capacityThreshold = _balancingConstraint.capacityThreshold(Resource.NW_OUT);
 
     for (Broker aliveBroker : clusterModel.aliveBrokers()) {
-      // We use the hosts capacity instead of the broker capacity.
-      double capacityLimit = aliveBroker.host().capacityFor(Resource.NW_OUT) * capacityThreshold;
+      double capacityLimit = aliveBroker.capacityFor(Resource.NW_OUT) * capacityThreshold;
       if (clusterModel.potentialLeadershipLoadFor(aliveBroker.id()).expectedUtilizationFor(Resource.NW_OUT) < capacityLimit) {
         brokersUnderEstimatedMaxPossibleNwOut.add(aliveBroker);
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
@@ -230,6 +230,8 @@ public class ReplicaCapacityGoal extends AbstractGoal {
     for (Replica replica : new TreeSet<>(broker.replicas())) {
       boolean isReplicaOffline = replica.isCurrentOffline();
       if (broker.replicas().size() <= _balancingConstraint.maxReplicasPerBroker() && !isReplicaOffline) {
+        // The loop uses a TreeSet over replicas with the default replica comparator. This comparator prioritizes offline
+        // replicas; hence, if the current replica is not offline, it means there is no other offline replica on the broker.
         break;
       }
       if (shouldExclude(replica, excludedTopics)) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionGoal.java
@@ -54,13 +54,13 @@ import static com.linkedin.kafka.cruisecontrol.common.Resource.DISK;
 public class ReplicaDistributionGoal extends AbstractGoal {
   private static final Logger LOG = LoggerFactory.getLogger(ReplicaDistributionGoal.class);
   private static final double BALANCE_MARGIN = 0.9;
-  // Flag to indicate whether the self healing failed to relocate all replicas away from dead brokers in its initial
-  // attempt and currently omitting the resource balance limit to relocate remaining replicas.
-  private boolean _selfHealingDeadBrokersOnly;
+  // Flag to indicate whether the self healing failed to relocate all offline replicas away from dead brokers or broken
+  // disks in its initial attempt and currently omitting the replica balance limit to relocate remaining replicas.
+  private boolean _fixOfflineReplicasOnly;
   private final Set<Integer> _brokerIdsAboveBalanceUpperLimit;
   private final Set<Integer> _brokerIdsUnderBalanceLowerLimit;
-  private Map<Integer, BrokerAndSortedReplicas> _brokerAndReplicasMap;
-  private double _avgReplicasOnHealthyBroker;
+  private final Map<Integer, BrokerAndSortedReplicas> _brokerAndReplicasMap;
+  private double _avgReplicasOnAliveBroker;
   private double _balanceUpperLimit;
   private double _balanceLowerLimit;
 
@@ -70,12 +70,12 @@ public class ReplicaDistributionGoal extends AbstractGoal {
   public ReplicaDistributionGoal() {
     _brokerIdsAboveBalanceUpperLimit = new HashSet<>();
     _brokerIdsUnderBalanceLowerLimit = new HashSet<>();
+    _brokerAndReplicasMap = new HashMap<>();
   }
 
   public ReplicaDistributionGoal(BalancingConstraint balancingConstraint) {
+    this();
     _balancingConstraint = balancingConstraint;
-    _brokerIdsAboveBalanceUpperLimit = new HashSet<>();
-    _brokerIdsUnderBalanceLowerLimit = new HashSet<>();
   }
 
   /**
@@ -91,14 +91,14 @@ public class ReplicaDistributionGoal extends AbstractGoal {
    * @return The replica balance upper threshold in percent.
    */
   private double balanceUpperLimit() {
-    return _avgReplicasOnHealthyBroker * (1 + balancePercentageWithMargin());
+    return _avgReplicasOnAliveBroker * (1 + balancePercentageWithMargin());
   }
 
   /**
    * @return The replica balance lower threshold in percent.
    */
   private double balanceLowerLimit() {
-    return _avgReplicasOnHealthyBroker * Math.max(0, (1 - balancePercentageWithMargin()));
+    return _avgReplicasOnAliveBroker * Math.max(0, (1 - balancePercentageWithMargin()));
   }
 
   /**
@@ -187,23 +187,21 @@ public class ReplicaDistributionGoal extends AbstractGoal {
    */
   @Override
   protected void initGoalState(ClusterModel clusterModel, Set<String> excludedTopics) {
-    // Initialize the average replicas on a healthy broker.
+    // Initialize the average replicas on an alive broker.
     int numReplicasInCluster = clusterModel.getReplicaDistribution().values().stream().mapToInt(List::size).sum();
-    _avgReplicasOnHealthyBroker = (numReplicasInCluster / (double) clusterModel.healthyBrokers().size());
+    _avgReplicasOnAliveBroker = (numReplicasInCluster / (double) clusterModel.aliveBrokers().size());
 
     // Log a warning if all replicas are excluded.
     if (clusterModel.topics().equals(excludedTopics)) {
       LOG.warn("All replicas are excluded from {}.", name());
     }
 
-    _brokerAndReplicasMap = new HashMap<>();
-
     for (Broker broker : clusterModel.brokers()) {
       BrokerAndSortedReplicas bas = new BrokerAndSortedReplicas(broker, broker.replicaComparator(DISK));
       _brokerAndReplicasMap.put(broker.id(), bas);
     }
 
-    _selfHealingDeadBrokersOnly = false;
+    _fixOfflineReplicasOnly = false;
     _balanceUpperLimit = balanceUpperLimit();
     _balanceLowerLimit = balanceLowerLimit();
   }
@@ -219,13 +217,13 @@ public class ReplicaDistributionGoal extends AbstractGoal {
    */
   @Override
   protected boolean selfSatisfied(ClusterModel clusterModel, BalancingAction action) {
-    Broker destinationBroker = clusterModel.broker(action.destinationBrokerId());
     Broker sourceBroker = clusterModel.broker(action.sourceBrokerId());
-    // If the source broker is dead and currently self healing dead brokers only, then the proposal must be executed.
-    if (!sourceBroker.isAlive() && _selfHealingDeadBrokersOnly) {
-      return true;
+    // The action must be executed if currently fixing offline replicas only and the offline source replica is proposed
+    // to be moved to another broker.
+    if (_fixOfflineReplicasOnly && sourceBroker.replica(action.topicPartition()).isCurrentOffline()) {
+      return action.balancingAction() == ActionType.REPLICA_MOVEMENT;
     }
-
+    Broker destinationBroker = clusterModel.broker(action.destinationBrokerId());
     //Check that destination and source would not become unbalanced.
     return isReplicaCountUnderBalanceUpperLimitAfterChange(destinationBroker, ADD) &&
         isReplicaCountAboveBalanceLowerLimitAfterChange(sourceBroker, REMOVE);
@@ -257,27 +255,16 @@ public class ReplicaDistributionGoal extends AbstractGoal {
       _brokerIdsUnderBalanceLowerLimit.clear();
       _succeeded = false;
     }
-    // Sanity check: No self-healing eligible replica should remain at a decommissioned broker.
-    for (Replica replica : clusterModel.selfHealingEligibleReplicas()) {
-      if (replica.broker().isAlive()) {
-        continue;
+    // Sanity check: No self-healing eligible replica should remain at a dead broker/disk.
+    try {
+      AnalyzerUtils.ensureNoOfflineReplicas(clusterModel);
+    } catch (OptimizationFailureException ofe) {
+      if (_fixOfflineReplicasOnly) {
+        throw ofe;
       }
-      if (_selfHealingDeadBrokersOnly) {
-        throw new OptimizationFailureException(
-            "Self healing failed to move the replica away from decommissioned brokers.");
-      }
-      _selfHealingDeadBrokersOnly = true;
-      LOG.warn("Omitting resource balance limit to relocate remaining replicas from dead brokers to healthy ones.");
+      _fixOfflineReplicasOnly = true;
+      LOG.warn("Omitting resource balance limit to relocate remaining replicas from dead brokers/disks.");
       return;
-    }
-    // No dead broker contains replica.
-    _selfHealingDeadBrokersOnly = false;
-
-    // Sanity check: No self-healing eligible replica should remain at a decommissioned broker.
-    for (Replica replica : clusterModel.selfHealingEligibleReplicas()) {
-      if (!replica.broker().isAlive()) {
-        throw new OptimizationFailureException("Self healing failed to move the replica away from decommissioned broker.");
-      }
     }
     finish();
   }
@@ -297,18 +284,22 @@ public class ReplicaDistributionGoal extends AbstractGoal {
                                     Set<String> excludedTopics) {
     LOG.debug("Rebalancing broker {} [limits] lower: {} upper: {}.", broker.id(), _balanceLowerLimit, _balanceUpperLimit);
     int numReplicas = broker.replicas().size();
-    boolean requireLessReplicas = broker.isAlive() ? numReplicas > _balanceUpperLimit : numReplicas > 0;
-    boolean requireMoreReplicas = broker.isAlive() && numReplicas < _balanceLowerLimit;
+    int numOfflineReplicas = broker.currentOfflineReplicas().size();
+
+    // A broker with a bad disk may take new replicas and give away offline replicas.
+    boolean requireLessReplicas = numOfflineReplicas > 0 || (numReplicas > _balanceUpperLimit);
+    boolean requireMoreReplicas = broker.isAlive() && numReplicas - numOfflineReplicas < _balanceLowerLimit;
     if (broker.isAlive() && !requireMoreReplicas && !requireLessReplicas) {
-      // return if the broker is already under limit.
+      // return if the broker is already within the limit.
       return;
-    } else if (!clusterModel.newBrokers().isEmpty() && requireMoreReplicas && !broker.isNew()) {
-      // return if we have new brokers and the current broker is not a new broker but require more load.
+    } else if (!clusterModel.newBrokers().isEmpty() && requireMoreReplicas && !broker.isNew() && !requireLessReplicas) {
+      // return if we have new brokers and the current broker is not a new broker but requires: more replicas, but not
+      // less replicas -- i.e. hence, does not have offline replicas on it.
       return;
-    } else if (!clusterModel.deadBrokers().isEmpty() && requireLessReplicas && broker.isAlive()
-        && broker.immigrantReplicas().isEmpty()) {
+    } else if (!clusterModel.selfHealingEligibleReplicas().isEmpty() && requireLessReplicas
+               && broker.currentOfflineReplicas().isEmpty() && broker.immigrantReplicas().isEmpty()) {
       // return if the cluster is in self-healing mode and the broker requires less load, but does not have any
-      // immigrant replicas.
+      // offline or immigrant replicas.
       return;
     }
 
@@ -317,11 +308,13 @@ public class ReplicaDistributionGoal extends AbstractGoal {
       _brokerIdsAboveBalanceUpperLimit.add(broker.id());
       LOG.debug("Failed to sufficiently decrease replica count in broker {} with replica movements. Replicas: {}.",
                 broker.id(), broker.replicas().size());
-    } else if (requireMoreReplicas && rebalanceByMovingReplicasIn(broker, clusterModel, optimizedGoals, excludedTopics)) {
+    }
+    if (requireMoreReplicas && rebalanceByMovingReplicasIn(broker, clusterModel, optimizedGoals, excludedTopics)) {
       _brokerIdsUnderBalanceLowerLimit.add(broker.id());
       LOG.debug("Failed to sufficiently increase replica count in broker {} with replica movements. Replicas: {}.",
                 broker.id(), broker.replicas().size());
-    } else {
+    }
+    if (!_brokerIdsAboveBalanceUpperLimit.contains(broker.id()) && !_brokerIdsUnderBalanceLowerLimit.contains(broker.id())) {
       LOG.debug("Successfully balanced replica count for broker {} by moving replicas. Replicas: {}",
                 broker.id(), broker.replicas().size());
     }
@@ -334,18 +327,23 @@ public class ReplicaDistributionGoal extends AbstractGoal {
     // Get the eligible brokers.
     SortedSet<Broker> candidateBrokers = new TreeSet<>(Comparator.comparingInt((Broker b) -> b.replicas().size()).thenComparingInt(Broker::id));
 
-    candidateBrokers.addAll(_selfHealingDeadBrokersOnly ? clusterModel.healthyBrokers() : clusterModel
-        .healthyBrokers()
+    candidateBrokers.addAll(_fixOfflineReplicasOnly ? clusterModel.aliveBrokers() : clusterModel
+        .aliveBrokers()
         .stream()
         .filter(b -> b.replicas().size() < _balanceUpperLimit)
         .collect(Collectors.toSet()));
 
     BrokerAndSortedReplicas sourceBas = _brokerAndReplicasMap.get(broker.id());
-    // Get the replicas to rebalance. Replicas are sorted from smallest to largest disk usage.
+    // Get the replicas to rebalance. Replicas are sorted by (1) offline replicas then (2) immigrant replicas then
+    // (3) smallest to largest disk usage.
     List<Replica> replicasToMove = new ArrayList<>(sourceBas.sortedReplicas());
     // Now let's move things around.
+    boolean wasUnableToMoveOfflineReplica = false;
     for (Replica replica : replicasToMove) {
-      if (shouldExclude(replica, excludedTopics)) {
+      if (wasUnableToMoveOfflineReplica && !replica.isCurrentOffline() && broker.replicas().size() <= _balanceUpperLimit) {
+        // Was unable to move offline replicas from the broker, and remaining replica count is under the balance limit.
+        return false;
+      } else if (shouldExclude(replica, excludedTopics)) {
         continue;
       }
 
@@ -357,15 +355,16 @@ public class ReplicaDistributionGoal extends AbstractGoal {
         BrokerAndSortedReplicas destBas = _brokerAndReplicasMap.get(broker.id());
         destBas.sortedReplicas().add(replica);
         sourceBas.sortedReplicas().remove(replica);
-
-        if (broker.replicas().size() <= (broker.isAlive() ? _balanceUpperLimit : 0)) {
+        if (broker.replicas().size() <= (broker.currentOfflineReplicas().isEmpty() ? _balanceUpperLimit : 0)) {
           return false;
         }
         // Remove and reinsert the broker so the order is correct.
         candidateBrokers.remove(b);
-        if (b.replicas().size() < _balanceUpperLimit || _selfHealingDeadBrokersOnly) {
+        if (b.replicas().size() < _balanceUpperLimit || _fixOfflineReplicasOnly) {
           candidateBrokers.add(b);
         }
+      } else if (replica.isCurrentOffline()) {
+        wasUnableToMoveOfflineReplica = true;
       }
     }
     // All the replicas has been moved away from the broker.
@@ -377,13 +376,18 @@ public class ReplicaDistributionGoal extends AbstractGoal {
                                               Set<Goal> optimizedGoals,
                                               Set<String> excludedTopics) {
     PriorityQueue<Broker> eligibleBrokers = new PriorityQueue<>((b1, b2) -> {
-      int result = Double.compare(b2.replicas().size(), b1.replicas().size());
-      return result == 0 ? Integer.compare(b1.id(), b2.id()) : result;
+      // Brokers are sorted by (1) current offline replica count then (2) all replica count then (3) broker id.
+      int resultByOfflineReplicas = Integer.compare(b2.currentOfflineReplicas().size(), b1.currentOfflineReplicas().size());
+      if (resultByOfflineReplicas == 0) {
+        int resultByAllReplicas = Integer.compare(b2.replicas().size(), b1.replicas().size());
+        return resultByAllReplicas == 0 ? Integer.compare(b1.id(), b2.id()) : resultByAllReplicas;
+      }
+      return resultByOfflineReplicas;
     });
 
-    for (Broker healthyBroker : clusterModel.healthyBrokers()) {
-      if (healthyBroker.replicas().size() > _balanceLowerLimit) {
-        eligibleBrokers.add(healthyBroker);
+    for (Broker aliveBroker : clusterModel.aliveBrokers()) {
+      if (aliveBroker.replicas().size() > _balanceLowerLimit || !aliveBroker.currentOfflineReplicas().isEmpty()) {
+        eligibleBrokers.add(aliveBroker);
       }
     }
 
@@ -413,11 +417,16 @@ public class ReplicaDistributionGoal extends AbstractGoal {
           if (broker.replicas().size() >= (broker.isAlive() ? _balanceLowerLimit : 0)) {
             return false;
           }
-          // If the source broker has a lower number of replicas than the next broker in the eligible broker in the
-          // queue, we reenqueue the source broker and switch to the next broker.
-          if (!eligibleBrokers.isEmpty() && sourceBroker.replicas().size() < eligibleBrokers.peek().replicas().size()) {
-            eligibleBrokers.add(sourceBroker);
-            break;
+          // If the source broker has a lower number of offline replicas or an equal number of offline replicas, but
+          // more total replicas than the next broker in the eligible broker in the queue, we reenqueue the source broker
+          // and switch to the next broker.
+          if (!eligibleBrokers.isEmpty()) {
+            int result = Integer.compare(sourceBroker.currentOfflineReplicas().size(),
+                                         eligibleBrokers.peek().currentOfflineReplicas().size());
+            if (result == -1 || (result == 0 && sourceBroker.replicas().size() < eligibleBrokers.peek().replicas().size())) {
+              eligibleBrokers.add(sourceBroker);
+              break;
+            }
           }
         }
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionTarget.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionTarget.java
@@ -132,7 +132,7 @@ class ReplicaDistributionTarget {
     }
 
     // Update consumed warm broker credits. Credit is consumed because the broker was unable to move replicas.
-    if (isMoveSuccessful) {
+    if (!isMoveSuccessful) {
       _consumedWarmBrokerCredits++;
     }
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionTarget.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionTarget.java
@@ -51,11 +51,11 @@ class ReplicaDistributionTarget {
    *
    * @param numReplicasToBalance The number of replicas to balance. In case replicas to be balanced are for specific
    *                             topic, this number indicates the number of replicas of this topic in the cluster.
-   * @param healthyBrokers       Healthy brokers in the cluster -- i.e. brokers that are not dead.
+   * @param aliveBrokers       Alive brokers in the cluster -- i.e. brokers that are not dead.
    */
-  ReplicaDistributionTarget(int numReplicasToBalance, Set<Broker> healthyBrokers) {
-    _minNumReplicasPerBroker = numReplicasToBalance / healthyBrokers.size();
-    _warmBrokerCredits = numReplicasToBalance % healthyBrokers.size();
+  ReplicaDistributionTarget(int numReplicasToBalance, Set<Broker> aliveBrokers) {
+    _minNumReplicasPerBroker = numReplicasToBalance / aliveBrokers.size();
+    _warmBrokerCredits = numReplicasToBalance % aliveBrokers.size();
     _requiredNumReplicasByBrokerId = new HashMap<>();
     _secondaryEligibleBrokerIds = new HashSet<>();
     _consumedWarmBrokerCredits = 0;
@@ -69,7 +69,7 @@ class ReplicaDistributionTarget {
   }
 
   /**
-   * Move replicas residing in the given cluster and given healthy source broker having given set of topic partitions
+   * Move replicas residing in the given cluster and given alive source broker having given set of topic partitions
    * to eligible brokers. Replica movements are guaranteed not to violate the requirements of optimized goals.
    *
    * @param clusterModel           The state of the cluster.
@@ -108,30 +108,27 @@ class ReplicaDistributionTarget {
   }
 
   /**
-   * Move given self healing eligible replica residing in the given cluster in a dead or healthy broker to an eligible
+   * Move given self healing eligible replica residing in the given cluster in a dead or alive broker to an eligible
    * broker. Replica movements are guaranteed not to violate the requirements of optimized goals.
    *
    * @param clusterModel     The state of the cluster.
    * @param replicaToMove    Replica to move away from its current broker.
-   * @param numLocalReplicas Number of local replicas.
    * @param optimizedGoals   Goals that have already been optimized. The function ensures that their requirements won't
    *                         be violated.
    */
-  void moveSelfHealingEligibleReplicaToEligibleBroker(ClusterModel clusterModel,
-                                                      Replica replicaToMove,
-                                                      int numLocalReplicas,
-                                                      Set<Goal> optimizedGoals)
+  void moveSelfHealingEligibleReplicaToEligibleBroker(ClusterModel clusterModel, Replica replicaToMove, Set<Goal> optimizedGoals)
       throws OptimizationFailureException {
+    int numLocalReplicas = replicaToMove.broker().replicasOfTopicInBroker(replicaToMove.topicPartition().topic()).size();
     // Sanity check the number of replicas to move from the local to a remote broker to achieve the distribution
     // target. If the broker is dead, the replica must move to another broker.
-    if (replicaToMove.broker().isAlive() && numReplicasToMove(numLocalReplicas) == 0) {
+    if (!replicaToMove.isCurrentOffline() && numReplicasToMove(numLocalReplicas) == 0) {
       return;
     }
 
     // Attempt to move the replica to an eligible broker.
     boolean isMoveSuccessful = moveReplicaToEligibleBroker(clusterModel, replicaToMove, optimizedGoals);
-    if (!replicaToMove.broker().isAlive()) {
-      throw new OptimizationFailureException("Self healing failed to move the replica away from decommissioned broker.");
+    if (replicaToMove.isCurrentOffline()) {
+      throw new OptimizationFailureException("Self healing failed to move the offline replica away from broker.");
     }
 
     // Update consumed warm broker credits. Credit is consumed because the broker was unable to move replicas.
@@ -217,9 +214,9 @@ class ReplicaDistributionTarget {
   private boolean moveReplicaToEligibleBroker(ClusterModel clusterModel, Replica replicaToMove, Set<Goal> optimizedGoals) {
     boolean isMoveSuccessful = false;
     // Get eligible brokers to receive this replica.
-    for (int brokerId : replicaToMove.broker().isAlive()
-                        ? sortedCandidateBrokerIds()
-                        : clusterModel.healthyBrokers().stream().map(Broker::id).collect(Collectors.toList())) {
+    for (int brokerId : !replicaToMove.isCurrentOffline()
+                        ? sortedCandidateBrokerIds().stream().filter(id -> id != replicaToMove.originalBroker().id()).collect(Collectors.toList())
+                        : clusterModel.aliveBrokers().stream().map(Broker::id).collect(Collectors.toList())) {
       // filter out the broker that is not eligible.
       if (!isEligibleForReplica(clusterModel, replicaToMove, brokerId)) {
         continue;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ResourceDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ResourceDistributionGoal.java
@@ -5,6 +5,7 @@
 
 package com.linkedin.kafka.cruisecontrol.analyzer.goals;
 
+import com.linkedin.kafka.cruisecontrol.analyzer.AnalyzerUtils;
 import com.linkedin.kafka.cruisecontrol.common.Resource;
 import com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance;
 import com.linkedin.kafka.cruisecontrol.analyzer.BalancingConstraint;
@@ -38,7 +39,6 @@ import org.slf4j.LoggerFactory;
 
 import static com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance.ACCEPT;
 import static com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance.REPLICA_REJECT;
-import static com.linkedin.kafka.cruisecontrol.analyzer.ActionType.REPLICA_SWAP;
 import static com.linkedin.kafka.cruisecontrol.analyzer.ActionType.REPLICA_MOVEMENT;
 import static com.linkedin.kafka.cruisecontrol.analyzer.ActionType.LEADERSHIP_MOVEMENT;
 import static com.linkedin.kafka.cruisecontrol.analyzer.goals.ResourceDistributionGoal.ChangeType.ADD;
@@ -53,9 +53,9 @@ import static com.linkedin.kafka.cruisecontrol.analyzer.goals.ResourceDistributi
 public abstract class ResourceDistributionGoal extends AbstractGoal {
   private static final Logger LOG = LoggerFactory.getLogger(ResourceDistributionGoal.class);
   private static final double BALANCE_MARGIN = 0.9;
-  // Flag to indicate whether the self healing failed to relocate all replicas away from dead brokers in its initial
-  // attempt and currently omitting the resource balance limit to relocate remaining replicas.
-  private boolean _selfHealingDeadBrokersOnly;
+  // Flag to indicate whether the self healing failed to relocate all offline replicas away from dead brokers or broken
+  // disks in its initial attempt and currently omitting the resource balance limit to relocate remaining replicas.
+  private boolean _fixOfflineReplicasOnly;
   private double _balanceUpperThreshold;
   private double _balanceLowerThreshold;
 
@@ -188,10 +188,10 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
   protected boolean selfSatisfied(ClusterModel clusterModel, BalancingAction action) {
     Broker destinationBroker = clusterModel.broker(action.destinationBrokerId());
     Replica sourceReplica = clusterModel.broker(action.sourceBrokerId()).replica(action.topicPartition());
-    // If the source broker is dead and currently self healing dead brokers only, unless it is replica swap, the action
-    // must be executed.
-    if (!sourceReplica.broker().isAlive() && _selfHealingDeadBrokersOnly) {
-      return action.balancingAction() != REPLICA_SWAP;
+    // The action must be executed if currently fixing offline replicas only and the offline source replica is proposed
+    // to be moved to another broker.
+    if (_fixOfflineReplicasOnly && sourceReplica.broker().replica(action.topicPartition()).isCurrentOffline()) {
+      return action.balancingAction() == ActionType.REPLICA_MOVEMENT;
     }
 
     switch (action.balancingAction()) {
@@ -212,8 +212,7 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
   }
 
   /**
-   * (1) Initialize the current resource to be balanced or self healed. resource selection is based on the order of
-   * priority set in the _balancingConstraint.
+   * (1) Initialize the current resource to be balanced or self healed.
    * (2) Set the flag which indicates whether the self healing failed to relocate all replicas away from dead brokers
    * in its initial attempt. Since self healing has not been executed yet, this flag is false.
    *
@@ -222,11 +221,11 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
    */
   @Override
   protected void initGoalState(ClusterModel clusterModel, Set<String> excludedTopics) {
-    _selfHealingDeadBrokersOnly = false;
+    _fixOfflineReplicasOnly = false;
     _balanceUpperThreshold = computeBalanceUpperThreshold(clusterModel);
     _balanceLowerThreshold = computeBalanceLowerThreshold(clusterModel);
     clusterModel.trackSortedReplicas(sortName(),
-                                     ReplicaSortFunctionFactory.deprioritizeImmigrants(),
+                                     ReplicaSortFunctionFactory.deprioritizeOfflineReplicasThenImmigrants(),
                                      ReplicaSortFunctionFactory.sortByMetricGroupValue(resource().name()));
   }
 
@@ -251,7 +250,7 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
     Set<Integer> brokerIdsUnderBalanceLowerLimit = new HashSet<>();
     // Log broker Ids over balancing limit.
     // While proposals exclude the excludedTopics, the balance still considers utilization of the excludedTopic replicas.
-    for (Broker broker : clusterModel.healthyBrokers()) {
+    for (Broker broker : clusterModel.aliveBrokers()) {
       if (!isLoadUnderBalanceUpperLimit(broker)) {
         brokerIdsAboveBalanceUpperLimit.add(broker.id());
       }
@@ -271,36 +270,26 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
                (clusterModel.selfHealingEligibleReplicas().isEmpty()) ? "rebalance" : "self-healing");
       _succeeded = false;
     }
-    // Sanity check: No self-healing eligible replica should remain at a decommissioned broker.
-    for (Replica replica : clusterModel.selfHealingEligibleReplicas()) {
-      if (replica.broker().isAlive()) {
-        continue;
+    // Sanity check: No self-healing eligible replica should remain at a dead broker/disk.
+    try {
+      AnalyzerUtils.ensureNoOfflineReplicas(clusterModel);
+    } catch (OptimizationFailureException ofe) {
+      if (_fixOfflineReplicasOnly) {
+        throw ofe;
       }
-      if (_selfHealingDeadBrokersOnly) {
-        throw new OptimizationFailureException(
-            "Self healing failed to move the replica away from decommissioned brokers.");
-      }
-      _selfHealingDeadBrokersOnly = true;
-      LOG.warn("Omitting resource balance limit to relocate remaining replicas from dead brokers to healthy ones.");
+      _fixOfflineReplicasOnly = true;
+      LOG.warn("Omitting resource balance limit to relocate remaining replicas from dead brokers/disks.");
       return;
     }
-    // No dead broker contains replica.
-    _selfHealingDeadBrokersOnly = false;
 
-    // Sanity check: No self-healing eligible replica should remain at a decommissioned broker.
-    for (Replica replica : clusterModel.selfHealingEligibleReplicas()) {
-      if (!replica.broker().isAlive()) {
-        throw new OptimizationFailureException("Self healing failed to move the replica away from decommissioned broker.");
-      }
-    }
     finish();
     clusterModel.untrackSortedReplicas(sortName());
   }
 
   /**
    * (1) REBALANCE BY LEADERSHIP MOVEMENT:
-   * Perform leadership movement to ensure that the load on brokers for the outbound network load is under the balance
-   * limit.
+   * Perform leadership movement to ensure that the load on brokers for the outbound network and CPU load is under the
+   * balance limit.
    * <p>
    * (2) REBALANCE BY REPLICA MOVEMENT:
    * Perform optimization via replica movement for the given resource (without breaking the balance for already
@@ -319,28 +308,32 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
                                     ClusterModel clusterModel,
                                     Set<Goal> optimizedGoals,
                                     Set<String> excludedTopics) {
-    boolean requireLessLoad = !isLoadUnderBalanceUpperLimit(broker);
+    int numOfflineReplicas = broker.currentOfflineReplicas().size();
+
+    boolean requireLessLoad = numOfflineReplicas > 0 || !isLoadUnderBalanceUpperLimit(broker);
     boolean requireMoreLoad = !isLoadAboveBalanceLowerLimit(broker);
     if (broker.isAlive() && !requireMoreLoad && !requireLessLoad) {
-      // return if the broker is already under limit.
+      // return if the broker is already within the limit.
       return;
-    } else if (!clusterModel.deadBrokers().isEmpty() && requireLessLoad && broker.isAlive()
-        && broker.immigrantReplicas().isEmpty()) {
-      // return if the cluster is in self-healing mode and the broker requires less load but does not have any
-      // immigrant replicas.
+    } else if (!clusterModel.selfHealingEligibleReplicas().isEmpty() && requireLessLoad
+             && broker.currentOfflineReplicas().isEmpty() && broker.immigrantReplicas().isEmpty()) {
+      // return if the cluster is in self-healing mode and the broker requires less load, but does not have any
+      // offline or immigrant replicas.
       return;
     }
 
     // First try leadership movement
-    if (resource() == Resource.NW_OUT || resource() == Resource.CPU) {
+    if ((resource() == Resource.NW_OUT || resource() == Resource.CPU)
+        && !(_fixOfflineReplicasOnly && !broker.currentOfflineReplicas().isEmpty())) {
       if (requireLessLoad && !rebalanceByMovingLoadOut(broker, clusterModel, optimizedGoals,
                                                        LEADERSHIP_MOVEMENT, excludedTopics)) {
         LOG.debug("Successfully balanced {} for broker {} by moving out leaders.", resource(), broker.id());
-        return;
-      } else if (requireMoreLoad && !rebalanceByMovingLoadIn(broker, clusterModel, optimizedGoals,
-                                                             LEADERSHIP_MOVEMENT, excludedTopics)) {
+        requireLessLoad = false;
+      }
+      if (requireMoreLoad && !rebalanceByMovingLoadIn(broker, clusterModel, optimizedGoals,
+                                                      LEADERSHIP_MOVEMENT, excludedTopics)) {
         LOG.debug("Successfully balanced {} for broker {} by moving in leaders.", resource(), broker.id());
-        return;
+        requireMoreLoad = false;
       }
     }
 
@@ -350,9 +343,10 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
       if (rebalanceByMovingLoadOut(broker, clusterModel, optimizedGoals, REPLICA_MOVEMENT, excludedTopics)) {
         unbalanced = rebalanceBySwappingLoadOut(broker, clusterModel, optimizedGoals, excludedTopics);
       }
-    } else if (requireMoreLoad) {
+    }
+    if (requireMoreLoad) {
       if (rebalanceByMovingLoadIn(broker, clusterModel, optimizedGoals, REPLICA_MOVEMENT, excludedTopics)) {
-        unbalanced = rebalanceBySwappingLoadIn(broker, clusterModel, optimizedGoals, excludedTopics);
+        unbalanced = unbalanced || rebalanceBySwappingLoadIn(broker, clusterModel, optimizedGoals, excludedTopics);
       }
     }
 
@@ -376,7 +370,7 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
     // Sort the replicas initially to avoid sorting it every time.
 
     double clusterUtilization = clusterModel.load().expectedUtilizationFor(resource()) / clusterModel.capacityFor(resource());
-    for (Broker candidate : clusterModel.healthyBrokers()) {
+    for (Broker candidate : clusterModel.aliveBrokers()) {
       // Get candidate replicas on candidate broker to try moving load from -- sorted in the order of trial (descending load).
       if (utilizationPercentage(candidate) > clusterUtilization) {
         SortedSet<Replica> replicasToMoveIn = sortedCandidateReplicas(candidate, excludedTopics, 0, false);
@@ -423,7 +417,7 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
   /**
    * Get the sorted replicas in the given broker whose (1) topic is not an excluded topic AND (2) do not violate the given load
    * limit in ascending or descending order. Load limit requires the replica load to be (1) above the given limit in
-   * descending order, (2) below the given limit in ascending order.
+   * descending order, (2) below the given limit in ascending order. Offline replicas have priority over online replicas.
    *
    * @param broker Broker whose replicas will be considered.
    * @param excludedTopics Excluded topics for which the replicas will be remove from the returned candidate replicas.
@@ -437,6 +431,15 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
                                                      double loadLimit,
                                                      boolean isAscending) {
     SortedSet<Replica> candidateReplicas = new TreeSet<>((r1, r2) -> {
+      // Primary sort: by offline / online status
+      boolean isR1Offline = r1.isCurrentOffline();
+      boolean isR2Offline = r2.isCurrentOffline();
+
+      if (isR1Offline && !isR2Offline) {
+        return -1;
+      } else if (!isR1Offline && isR2Offline) {
+        return 1;
+      }
       int result = isAscending
                    ? Double.compare(r1.load().expectedUtilizationFor(resource()), r2.load().expectedUtilizationFor(resource()))
                    : Double.compare(r2.load().expectedUtilizationFor(resource()), r1.load().expectedUtilizationFor(resource()));
@@ -470,6 +473,15 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
     }
     // Get the replicas to rebalance.
     SortedSet<Replica> sourceReplicas = new TreeSet<>((r1, r2) -> {
+      // Primary sort: by offline / online status
+      boolean isR1Offline = r1.isCurrentOffline();
+      boolean isR2Offline = r2.isCurrentOffline();
+
+      if (isR1Offline && !isR2Offline) {
+        return -1;
+      } else if (!isR1Offline && isR2Offline) {
+        return 1;
+      }
       int result = Double.compare(r2.load().expectedUtilizationFor(resource()), r1.load().expectedUtilizationFor(resource()));
       return result == 0 ? r1.topicPartition().toString().compareTo(r2.topicPartition().toString()) : result;
     });
@@ -478,7 +490,7 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
 
     // Sort the replicas initially to avoid sorting it every time.
     PriorityQueue<CandidateBroker> candidateBrokerPQ = new PriorityQueue<>();
-    for (Broker candidate : clusterModel.healthyBrokersUnderThreshold(resource(), _balanceUpperThreshold)
+    for (Broker candidate : clusterModel.aliveBrokersUnderThreshold(resource(), _balanceUpperThreshold)
                                         .stream().filter(b -> !b.replicas().isEmpty()).collect(Collectors.toSet())) {
       // Get candidate replicas on candidate broker to try swapping with -- sorted in the order of trial (ascending load).
       double maxSourceReplicaLoad = sourceReplicas.first().load().expectedUtilizationFor(resource());
@@ -558,15 +570,25 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
     }
 
     // Get the replicas to rebalance.
-    SortedSet<Replica> sourceReplicas = new TreeSet<>(
-        Comparator.comparingDouble((Replica r) -> r.load().expectedUtilizationFor(resource()))
-                  .thenComparing(r -> r.topicPartition().toString()));
+    SortedSet<Replica> sourceReplicas = new TreeSet<>((r1, r2) -> {
+      // Primary sort: by offline / online status
+      boolean isR1Offline = r1.isCurrentOffline();
+      boolean isR2Offline = r2.isCurrentOffline();
+
+      if (isR1Offline && !isR2Offline) {
+        return -1;
+      } else if (!isR1Offline && isR2Offline) {
+        return 1;
+      }
+      int result = Double.compare(r1.load().expectedUtilizationFor(resource()), r2.load().expectedUtilizationFor(resource()));
+      return result == 0 ? r1.topicPartition().toString().compareTo(r2.topicPartition().toString()) : result;
+    });
 
     sourceReplicas.addAll(broker.replicas());
 
     // Sort the replicas initially to avoid sorting it every time.
     PriorityQueue<CandidateBroker> candidateBrokerPQ = new PriorityQueue<>();
-    for (Broker candidate : clusterModel.healthyBrokersOverThreshold(resource(), _balanceLowerThreshold)) {
+    for (Broker candidate : clusterModel.aliveBrokersOverThreshold(resource(), _balanceLowerThreshold)) {
       // Get candidate replicas on candidate broker to try swapping with -- sorted in the order of trial (descending load).
       double minSourceReplicaLoad = sourceReplicas.first().load().expectedUtilizationFor(resource());
       SortedSet<Replica> replicasToSwapWith = sortedCandidateReplicas(candidate, excludedTopics, minSourceReplicaLoad, false);
@@ -617,10 +639,10 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
     // Get the eligible brokers.
     SortedSet<Broker> candidateBrokers = new TreeSet<>(
         Comparator.comparingDouble(this::utilizationPercentage).thenComparingInt(Broker::id));
-    if (_selfHealingDeadBrokersOnly) {
-      candidateBrokers.addAll(clusterModel.healthyBrokers());
+    if (_fixOfflineReplicasOnly) {
+      candidateBrokers.addAll(clusterModel.aliveBrokers());
     } else {
-      candidateBrokers.addAll(clusterModel.healthyBrokersUnderThreshold(resource(), _balanceUpperThreshold));
+      candidateBrokers.addAll(clusterModel.aliveBrokersUnderThreshold(resource(), _balanceUpperThreshold));
     }
 
     // Get the replicas to rebalance.
@@ -640,8 +662,8 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
       if (shouldExclude(replica, excludedTopics)) {
         continue;
       }
-      // It does not make sense to move a replica without utilization from a live broker.
-      if (replica.load().expectedUtilizationFor(resource()) == 0.0 && broker.isAlive()) {
+      // It does not make sense to move an online replica without utilization from a live broker.
+      if (replica.load().expectedUtilizationFor(resource()) == 0.0 && !replica.isCurrentOffline()) {
         break;
       }
 
@@ -650,7 +672,7 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
       if (actionType == LEADERSHIP_MOVEMENT) {
         eligibleBrokers = new TreeSet<>(Comparator.comparingDouble(this::utilizationPercentage)
                                                   .thenComparingInt(Broker::id));
-        clusterModel.partition(replica.topicPartition()).followerBrokers().forEach(b -> {
+        clusterModel.partition(replica.topicPartition()).onlineFollowerBrokers().forEach(b -> {
           if (candidateBrokers.contains(b)) {
             eligibleBrokers.add(b);
           }
@@ -662,7 +684,7 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
       Broker b = maybeApplyBalancingAction(clusterModel, replica, eligibleBrokers, actionType, optimizedGoals);
       // Only check if we successfully moved something.
       if (b != null) {
-        if (isLoadUnderBalanceUpperLimit(broker)) {
+        if (isLoadUnderBalanceUpperLimit(broker) && !(_fixOfflineReplicasOnly && !broker.currentOfflineReplicas().isEmpty())) {
           return false;
         }
         // Remove and reinsert the broker so the order is correct.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoal.java
@@ -99,7 +99,7 @@ public class KafkaAssignerDiskUsageDistributionGoal implements Goal {
 
     // create a sorted set for all the brokers.
     SortedSet<BrokerAndSortedReplicas> allBrokers = new TreeSet<>(brokerComparator);
-    clusterModel.healthyBrokers().forEach(b -> allBrokers.add(new BrokerAndSortedReplicas(b, replicaComparator)));
+    clusterModel.aliveBrokers().forEach(b -> allBrokers.add(new BrokerAndSortedReplicas(b, replicaComparator)));
 
     boolean improved;
     int numIterations = 0;
@@ -135,7 +135,7 @@ public class KafkaAssignerDiskUsageDistributionGoal implements Goal {
     // Check if any broker is out of the allowed usage range.
     Set<Broker> brokersAboveUpperThreshold = new HashSet<>();
     Set<Broker> brokersUnderLowerThreshold = new HashSet<>();
-    for (Broker broker : clusterModel.healthyBrokers()) {
+    for (Broker broker : clusterModel.aliveBrokers()) {
       double diskUsage = diskUsage(broker);
       if (diskUsage < lowerThreshold) {
         brokersUnderLowerThreshold.add(broker);
@@ -161,7 +161,7 @@ public class KafkaAssignerDiskUsageDistributionGoal implements Goal {
   /**
    * Optimize the broker if the disk usage of the broker is not within the required range.
    *
-   * @param allBrokers a sorted set of all the healthy brokers in the cluster.
+   * @param allBrokers a sorted set of all the alive brokers in the cluster.
    * @param toOptimize the broker to optimize
    * @param clusterModel the cluster model
    * @param meanDiskUsage the average disk usage of the cluster

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AsyncKafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AsyncKafkaCruiseControl.java
@@ -39,6 +39,8 @@ import java.util.regex.Pattern;
  * <li>{@link KafkaCruiseControl#state(OperationProgress, Set)}</li>
  * <li>{@link KafkaCruiseControl#getOptimizationProposals(List, ModelCompletenessRequirements, OperationProgress,
  * boolean, boolean, Pattern)}</li>
+ * <li>{@link KafkaCruiseControl#fixOfflineReplicas(boolean, List, ModelCompletenessRequirements, OperationProgress,
+ * boolean, Integer, Integer, boolean, Pattern)}</li>
  * <li>{@link KafkaCruiseControl#rebalance(List, boolean, ModelCompletenessRequirements, OperationProgress,
  * boolean, Integer, Integer, boolean, Pattern)}</li>
  * </ul>

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AsyncKafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AsyncKafkaCruiseControl.java
@@ -98,6 +98,31 @@ public class AsyncKafkaCruiseControl extends KafkaCruiseControl {
   }
 
   /**
+   * @see KafkaCruiseControl#fixOfflineReplicas(boolean, List, ModelCompletenessRequirements, OperationProgress,
+   * boolean, Integer, Integer, boolean, Pattern)
+   */
+  public OperationFuture<GoalOptimizer.OptimizerResult> fixOfflineReplicas(boolean dryRun,
+                                                                           List<String> goals,
+                                                                           ModelCompletenessRequirements requirements,
+                                                                           boolean allowCapacityEstimation,
+                                                                           Integer concurrentPartitionMovements,
+                                                                           Integer concurrentLeaderMovements,
+                                                                           boolean skipHardGoalCheck,
+                                                                           Pattern excludedTopics) {
+    OperationFuture<GoalOptimizer.OptimizerResult> future = new OperationFuture<>("Fix offline replicas");
+    pending(future.operationProgress());
+    _sessionExecutor.submit(new FixOfflineReplicasRunnable(this, future, dryRun, goals,
+                                                           requirements,
+                                                           allowCapacityEstimation,
+                                                           concurrentPartitionMovements,
+                                                           concurrentLeaderMovements,
+                                                           skipHardGoalCheck,
+                                                           excludedTopics));
+
+    return future;
+  }
+
+  /**
    * @see KafkaCruiseControl#addBrokers(Collection, boolean, boolean, List, ModelCompletenessRequirements,
    * OperationProgress, boolean, Integer, Integer, boolean, Pattern)
    */

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/FixOfflineReplicasRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/FixOfflineReplicasRunnable.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.async;
+
+import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
+import com.linkedin.kafka.cruisecontrol.analyzer.GoalOptimizer;
+import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
+import java.util.List;
+import java.util.regex.Pattern;
+
+
+/**
+ * The async runnable for {@link KafkaCruiseControl#fixOfflineReplicas(boolean, List, ModelCompletenessRequirements,
+ * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean,
+ * Integer, Integer, boolean, Pattern)}
+ */
+class FixOfflineReplicasRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult> {
+  private final boolean _dryRun;
+  private final List<String> _goals;
+  private final ModelCompletenessRequirements _modelCompletenessRequirements;
+  private final boolean _allowCapacityEstimation;
+  private final Integer _concurrentPartitionMovements;
+  private final Integer _concurrentLeaderMovements;
+  private final boolean _skipHardGoalCheck;
+  private final Pattern _excludedTopics;
+
+  FixOfflineReplicasRunnable(KafkaCruiseControl kafkaCruiseControl,
+                             OperationFuture<GoalOptimizer.OptimizerResult> future,
+                             boolean dryRun,
+                             List<String> goals,
+                             ModelCompletenessRequirements modelCompletenessRequirements,
+                             boolean allowCapacityEstimation,
+                             Integer concurrentPartitionMovements,
+                             Integer concurrentLeaderMovements,
+                             boolean skipHardGoalCheck,
+                             Pattern excludedTopics) {
+    super(kafkaCruiseControl, future);
+    _dryRun = dryRun;
+    _goals = goals;
+    _modelCompletenessRequirements = modelCompletenessRequirements;
+    _allowCapacityEstimation = allowCapacityEstimation;
+    _concurrentPartitionMovements = concurrentPartitionMovements;
+    _concurrentLeaderMovements = concurrentLeaderMovements;
+    _skipHardGoalCheck = skipHardGoalCheck;
+    _excludedTopics = excludedTopics;
+  }
+
+  @Override
+  protected GoalOptimizer.OptimizerResult getResult() throws Exception {
+    return _kafkaCruiseControl.fixOfflineReplicas(_dryRun, _goals, _modelCompletenessRequirements,
+                                                  _future.operationProgress(), _allowCapacityEstimation,
+                                                  _concurrentPartitionMovements, _concurrentLeaderMovements,
+                                                  _skipHardGoalCheck, _excludedTopics);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionProposal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionProposal.java
@@ -33,7 +33,7 @@ public class ExecutionProposal {
    * @param tp the topic partition of this execution proposal
    * @param partitionSize the size of the partition.
    * @param oldLeader the old leader of the partition to determine if leader movement is needed.
-   * @param oldReplicas the old replicas for rollback. (Rollback is not supported until KAFKA-6034)
+   * @param oldReplicas the old replicas for rollback. (Rollback is not supported until KAFKA-6304)
    * @param newReplicas the new replicas of the partition in this order.
    */
   public ExecutionProposal(TopicPartition tp,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -614,7 +614,7 @@ public class Executor {
      *              still alive.
      * 3. DEAD: when any replica in the new replica list is dead. Or when a leader action times out.
      *
-     * Currently KafkaController does not support updates on the partitions that is being reassigned. (KAFKA-6034)
+     * Currently KafkaController does not support updates on the partitions that is being reassigned. (KAFKA-6304)
      * Therefore once a proposals is written to ZK, we cannot revoke it. So the actual behavior we are using is to
      * set the task state to:
      * 1. IN_PROGRESS: when the execution is stopped by the users. i.e. do nothing but let the task finish normally.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -230,8 +230,11 @@ public class ClusterModel implements Serializable {
   }
 
   /**
-   * Set broker alive status. If broker is not alive, add its replicas to self healing eligible replicas, if broker
-   * alive status is set to true, remove its replicas from self healing eligible replicas.
+   * Set the {@link Broker.State liveness state} of the given broker.
+   * <ul>
+   * <li>All currently offline replicas of a broker are considered to be self healing eligible.</li>
+   * <li>A broker with bad disks is also considered as an alive broker.</li>
+   * </ul>
    *
    * @param brokerId Id of the broker for which the alive status is set.
    * @param newState The new state of the broker.
@@ -687,7 +690,15 @@ public class ClusterModel implements Serializable {
 
   /**
    * Create a replica under given cluster/rack/broker. Add replica to rack and corresponding partition. Get the
-   * created replica. Set the replica s offline if it is on a dead broker.
+   * created replica. Set the replica as offline if it is on a dead broker.
+   *
+   * The {@link com.linkedin.kafka.cruisecontrol.monitor.LoadMonitor} uses {@link #createReplica(String, int,
+   * TopicPartition, int, boolean, boolean)} while setting the replica offline status, and it considers the broken disks,
+   * as well. Whereas, this method is used only by the unit tests. The relevant unit tests may use
+   * {@link Replica#markOriginalOffline()} to mark offline replicas on broken disks.
+   *
+   * The main reason for this separation is the lack of disk representation in the current broker model. Once the
+   * <a href="https://github.com/linkedin/cruise-control/pull/327">patch #327</a> is merged, we can simplify this logic.
    *
    * @param rackId         Rack id under which the replica will be created.
    * @param brokerId       Broker id under which the replica will be created.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Host.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Host.java
@@ -85,10 +85,11 @@ public class Host implements Serializable {
    * brokers in the rack for the requested resource.
    *
    * @param resource Resource for which capacity will be provided.
-   * @return Healthy host capacity of the resource.
+   * @return Alive host capacity of the resource.
    */
   public double capacityFor(Resource resource) {
     return _aliveBrokers > 0 ? _hostCapacity[resource.id()] : -1.0;
+    // TODO: Consider the capacity when there are broken disks.
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Partition.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Partition.java
@@ -81,6 +81,19 @@ public class Partition implements Serializable {
   }
 
   /**
+   * Get online follower replicas.
+   */
+  public List<Replica> onlineFollowers() {
+    List<Replica> onlineFollowers = new ArrayList<>();
+    for (Replica follower : followers()) {
+      if (!follower.isCurrentOffline()) {
+        onlineFollowers.add(follower);
+      }
+    }
+    return onlineFollowers;
+  }
+
+  /**
    * Get the leader replica.
    */
   public Replica leader() {
@@ -114,6 +127,19 @@ public class Partition implements Serializable {
       }
     });
     return followerBrokers;
+  }
+
+  /**
+   * Get the set of brokers that online followers reside in.
+   */
+  public List<Broker> onlineFollowerBrokers() {
+    List<Broker> onlineFollowerBrokers = new ArrayList<>();
+    _replicas.forEach(r -> {
+      if (!r.isLeader() && !r.isCurrentOffline()) {
+        onlineFollowerBrokers.add(r.broker());
+      }
+    });
+    return onlineFollowerBrokers;
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Rack.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Rack.java
@@ -130,7 +130,7 @@ public class Rack implements Serializable {
    * brokers in the rack for the requested resource.
    *
    * @param resource Resource for which capacity will be provided.
-   * @return Healthy rack capacity of the resource.
+   * @return Alive rack capacity of the resource.
    */
   public double capacityFor(Resource resource) {
     return _rackCapacity[resource.id()];

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Replica.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Replica.java
@@ -318,7 +318,7 @@ public class Replica implements Serializable, Comparable<Replica> {
     return String.format(
         "Replica[isLeader=%s,rack=%s,broker=%d,TopicPartition=%s,origBroker=%d,isOriginalOffline=%s,isCurrentOffline=%s]",
         _isLeader, _broker.rack().id(), _broker.id(), _tp,
-        _originalBroker == null ? -1 : _originalBroker.id(), _isOriginalOffline, isCurrentOffline());
+        _originalBroker == null ? -1 : _originalBroker.id(), isOriginalOffline(), isCurrentOffline());
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ReplicaSortFunctionFactory.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ReplicaSortFunctionFactory.java
@@ -24,7 +24,7 @@ public class ReplicaSortFunctionFactory {
   private static final Function<Replica, Integer> PRIORITIZE_IMMIGRANTS = r -> r.originalBroker() != r.broker() ? 0 : 1;
   /** De-prioritize the immigrant replicas */
   private static final Function<Replica, Integer> DEPRIORITIZE_IMMIGRANTS = r -> r.originalBroker() != r.broker() ? 1 : 0;
-  /** Prioritize the immigrant replicas */
+  /** Prioritize the offline replicas */
   private static final Function<Replica, Integer> PRIORITIZE_OFFLINE_REPLICAS = r -> r.isCurrentOffline() ? 0 : 1;
   /** Prioritize the immigrant replicas */
   private static final Function<Replica, Integer> DEPRIORITIZE_OFFLINE_REPLICAS = r -> r.isCurrentOffline() ? 1 : 0;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ReplicaSortFunctionFactory.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ReplicaSortFunctionFactory.java
@@ -20,10 +20,20 @@ public class ReplicaSortFunctionFactory {
   private ReplicaSortFunctionFactory() {
 
   }
-  /** Prioritize the immigrants replicas */
+  /** Prioritize the immigrant replicas */
   private static final Function<Replica, Integer> PRIORITIZE_IMMIGRANTS = r -> r.originalBroker() != r.broker() ? 0 : 1;
-  /** De-prioritize the immigrants replicas */
+  /** De-prioritize the immigrant replicas */
   private static final Function<Replica, Integer> DEPRIORITIZE_IMMIGRANTS = r -> r.originalBroker() != r.broker() ? 1 : 0;
+  /** Prioritize the immigrant replicas */
+  private static final Function<Replica, Integer> PRIORITIZE_OFFLINE_REPLICAS = r -> r.isCurrentOffline() ? 0 : 1;
+  /** Prioritize the immigrant replicas */
+  private static final Function<Replica, Integer> DEPRIORITIZE_OFFLINE_REPLICAS = r -> r.isCurrentOffline() ? 1 : 0;
+  /** Prioritize the (1) offline replicas, then (2) the immigrant replicas */
+  private static final Function<Replica, Integer> PRIORITIZE_OFFLINE_REPLICAS_THEN_IMMIGRANTS = r ->
+      r.isCurrentOffline() ? -1 : r.originalBroker() != r.broker() ? 0 : 1;
+  /** Deprioritize the (1) offline replicas, then (2) the immigrant replicas */
+  private static final Function<Replica, Integer> DEPRIORITIZE_OFFLINE_REPLICAS_THEN_IMMIGRANTS = r ->
+      r.isCurrentOffline() ? 1 : r.originalBroker() != r.broker() ? 0 : -1;
   /** Select leaders only */
   private static final Function<Replica, Boolean> SELECT_LEADERS = Replica::isLeader;
 
@@ -71,13 +81,47 @@ public class ReplicaSortFunctionFactory {
   }
 
   /**
+   * @return a priority function that prioritize the offline replicas.
+   */
+  public static Function<Replica, Integer> prioritizeOfflineReplicas() {
+    return PRIORITIZE_OFFLINE_REPLICAS;
+  }
+
+  /**
+   * @return a priority function that prioritize the offline replicas then immigrants.
+   */
+  public static Function<Replica, Integer> prioritizeOfflineReplicasThenImmigrants() {
+    return PRIORITIZE_OFFLINE_REPLICAS_THEN_IMMIGRANTS;
+  }
+
+  /**
    * This priority function can be used together with {@link SortedReplicas#reverselySortedReplicas()}
-   * to provide sorted replicas in descending order of score and prioritize the immigrants replicas.
+   * to provide sorted replicas in descending order of score and prioritize the immigrant replicas.
    *
    * @return a priority function that de-prioritize the immigrants replicas
    */
   public static Function<Replica, Integer> deprioritizeImmigrants() {
     return DEPRIORITIZE_IMMIGRANTS;
+  }
+
+  /**
+   * This priority function can be used together with {@link SortedReplicas#reverselySortedReplicas()}
+   * to provide sorted replicas in descending order of score and prioritize the offline replicas.
+   *
+   * @return a priority function that de-prioritize the offline replicas
+   */
+  public static Function<Replica, Integer> deprioritizeOfflineReplicas() {
+    return DEPRIORITIZE_OFFLINE_REPLICAS;
+  }
+
+  /**
+   * This priority function can be used together with {@link SortedReplicas#reverselySortedReplicas()}
+   * to provide sorted replicas in descending order of score and prioritize the offline replicas then immigrants.
+   *
+   * @return a priority function that de-prioritize the offline immigrants
+   */
+  public static Function<Replica, Integer> deprioritizeOfflineReplicasThenImmigrants() {
+    return DEPRIORITIZE_OFFLINE_REPLICAS_THEN_IMMIGRANTS;
   }
 
   // Selection functions

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -478,7 +478,7 @@ public class LoadMonitor {
       // Get the dead brokers and mark them as dead.
       deadBrokers(kafkaCluster).forEach(brokerId -> clusterModel.setBrokerState(brokerId, Broker.State.DEAD));
       // Get the alive brokers with bad disks and mark them accordingly.
-      for (Integer brokerId : brokersWithBadDisks(kafkaCluster)) {
+      for (Integer brokerId : brokersWithOfflineReplicas(kafkaCluster)) {
         if (clusterModel.broker(brokerId).isAlive()) {
           clusterModel.setBrokerState(brokerId, Broker.State.BAD_DISKS);
         }
@@ -688,7 +688,7 @@ public class LoadMonitor {
     return brokersWithPartitions;
   }
 
-  private Set<Integer> brokersWithBadDisks(Cluster kafkaCluster) {
+  private Set<Integer> brokersWithOfflineReplicas(Cluster kafkaCluster) {
     Set<Integer> brokersWithBadDisks = new HashSet<>();
     for (String topic : kafkaCluster.topics()) {
       for (PartitionInfo partition : kafkaCluster.partitionsForTopic(topic)) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -36,6 +36,7 @@ import com.linkedin.kafka.cruisecontrol.monitor.sampling.PartitionMetricSample;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.aggregator.SampleExtrapolation;
 import com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunner;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -50,6 +51,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
@@ -475,6 +477,12 @@ public class LoadMonitor {
 
       // Get the dead brokers and mark them as dead.
       deadBrokers(kafkaCluster).forEach(brokerId -> clusterModel.setBrokerState(brokerId, Broker.State.DEAD));
+      // Get the alive brokers with bad disks and mark them accordingly.
+      for (Integer brokerId : brokersWithBadDisks(kafkaCluster)) {
+        if (clusterModel.broker(brokerId).isAlive()) {
+          clusterModel.setBrokerState(brokerId, Broker.State.BAD_DISKS);
+        }
+      }
       LOG.debug("Generated cluster model in {} ms", System.currentTimeMillis() - start);
     } finally {
       ctx.stop();
@@ -591,7 +599,10 @@ public class LoadMonitor {
         } else {
           isLeader = replica.id() == partitionInfo.leader().id();
         }
-        clusterModel.createReplica(rack, replica.id(), tp, index, isLeader);
+        boolean isOffline = Arrays.stream(partitionInfo.offlineReplicas())
+                                  .anyMatch(offlineReplica -> offlineReplica.id() == replica.id());
+
+        clusterModel.createReplica(rack, replica.id(), tp, index, isLeader, isOffline);
         clusterModel.setReplicaLoad(rack,
                                     replica.id(),
                                     tp,
@@ -675,6 +686,18 @@ public class LoadMonitor {
     Set<Integer> brokersWithPartitions = brokersWithPartitions(kafkaCluster);
     kafkaCluster.nodes().forEach(node -> brokersWithPartitions.remove(node.id()));
     return brokersWithPartitions;
+  }
+
+  private Set<Integer> brokersWithBadDisks(Cluster kafkaCluster) {
+    Set<Integer> brokersWithBadDisks = new HashSet<>();
+    for (String topic : kafkaCluster.topics()) {
+      for (PartitionInfo partition : kafkaCluster.partitionsForTopic(topic)) {
+        if (partition.leader() != null) {
+          brokersWithBadDisks.addAll(Arrays.stream(partition.offlineReplicas()).map(Node::id).collect(Collectors.toSet()));
+        }
+      }
+    }
+    return brokersWithBadDisks;
   }
 
   private Map<TopicPartition, List<SampleExtrapolation>> partitionSampleExtrapolations(Map<PartitionEntity, ValuesAndExtrapolations> valuesAndExtrapolations) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/EndPoint.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/EndPoint.java
@@ -21,6 +21,7 @@ enum EndPoint {
   STATE,
   ADD_BROKER,
   REMOVE_BROKER,
+  FIX_OFFLINE_REPLICAS,
   REBALANCE,
   STOP_PROPOSAL_EXECUTION,
   PAUSE_SAMPLING,
@@ -39,6 +40,7 @@ enum EndPoint {
                                                                    USER_TASKS);
   private static final List<EndPoint> POST_ENDPOINT = Arrays.asList(ADD_BROKER,
                                                                     REMOVE_BROKER,
+                                                                    FIX_OFFLINE_REPLICAS,
                                                                     REBALANCE,
                                                                     STOP_PROPOSAL_EXECUTION,
                                                                     PAUSE_SAMPLING,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -830,6 +830,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
     boolean json = wantJSON(request);
     boolean skipHardGoalCheck;
     try {
+      // The parameters retrieved here are supported by either ADD_BROKER, REMOVE_BROKER, or FIX_OFFLINE_REPLICAS.
       brokerIds = brokerIds(request);
       dryrun = getDryRun(request);
       goals = getGoals(request);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -52,7 +52,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.linkedin.kafka.cruisecontrol.servlet.EndPoint.*;
 import static com.linkedin.kafka.cruisecontrol.servlet.KafkaCruiseControlServletUtils.*;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
@@ -279,6 +278,11 @@ public class KafkaCruiseControlServlet extends HttpServlet {
    *    POST /kafkacruisecontrol/demote_broker?brokerid=[id1,id2...]&amp;dryrun=[true/false]&amp;concurrent_leader_movements=[true/false]
    *    &amp;allow_capacity_estimation=[true/false]&amp;json=[true/false]&amp;excluded_topics=[pattern]
    *
+   * 8. Fix offline replicas
+   *    POST /kafkacruisecontrol/fix_offline_replicas?brokerid=[id1,id2...]&amp;dryrun=[true/false]&amp;goals=[goal1,goal2...]
+   *    &amp;allow_capacity_estimation=[true/false]&amp;concurrent_partition_movements_per_broker=[true/false]
+   *    &amp;concurrent_leader_movements=[true/false]&amp;json=[true/false]
+   *
    * <b>NOTE: All the timestamps are epoch time in second granularity.</b>
    * </pre>
    */
@@ -310,7 +314,8 @@ public class KafkaCruiseControlServlet extends HttpServlet {
           switch (endPoint) {
             case ADD_BROKER:
             case REMOVE_BROKER:
-              if (addOrRemoveBroker(request, response, endPoint)) {
+            case FIX_OFFLINE_REPLICAS:
+              if (addRemoveOrFixBroker(request, response, endPoint)) {
                 _userTaskManager.closeSession(request);
               }
               break;
@@ -777,6 +782,9 @@ public class KafkaCruiseControlServlet extends HttpServlet {
         case REMOVE_BROKER:
           sb.append(String.format("%n%nCluster load after removing broker %s:%n", brokerIds));
           break;
+        case FIX_OFFLINE_REPLICAS:
+          sb.append(String.format("%n%nCluster load after fixing offline replicas on broker %s:%n", brokerIds));
+          break;
         case DEMOTE_BROKER:
           sb.append(String.format("%n%nCluster load after demoting broker %s:%n", brokerIds));
           break;
@@ -809,7 +817,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
     return sb.toString();
   }
 
-  private boolean addOrRemoveBroker(HttpServletRequest request, HttpServletResponse response, EndPoint endPoint)
+  private boolean addRemoveOrFixBroker(HttpServletRequest request, HttpServletResponse response, EndPoint endPoint)
       throws Exception {
     List<Integer> brokerIds;
     Integer concurrentPartitionMovements;
@@ -843,32 +851,49 @@ public class KafkaCruiseControlServlet extends HttpServlet {
     // Get proposals asynchronously.
     GoalOptimizer.OptimizerResult optimizerResult;
     boolean allowCapacityEstimation = allowCapacityEstimation(request);
-    if (endPoint == ADD_BROKER) {
-      optimizerResult =
-          getAndMaybeReturnProgress(request, response,
-                                    () -> _asyncKafkaCruiseControl.addBrokers(brokerIds,
-                                                                              dryrun,
-                                                                              throttleAddedOrRemovedBrokers,
-                                                                              goalsAndRequirements.goals(),
-                                                                              goalsAndRequirements.requirements(),
-                                                                              allowCapacityEstimation,
-                                                                              concurrentPartitionMovements,
-                                                                              concurrentLeaderMovements,
-                                                                              skipHardGoalCheck,
-                                                                              excludedTopics));
-    } else {
-      optimizerResult =
-          getAndMaybeReturnProgress(request, response,
-                                    () -> _asyncKafkaCruiseControl.decommissionBrokers(brokerIds,
-                                                                                       dryrun,
-                                                                                       throttleAddedOrRemovedBrokers,
-                                                                                       goalsAndRequirements.goals(),
-                                                                                       goalsAndRequirements.requirements(),
-                                                                                       allowCapacityEstimation,
-                                                                                       concurrentPartitionMovements,
-                                                                                       concurrentLeaderMovements,
-                                                                                       skipHardGoalCheck,
-                                                                                       excludedTopics));
+    switch (endPoint) {
+      case ADD_BROKER:
+        optimizerResult =
+            getAndMaybeReturnProgress(
+                request, response, () -> _asyncKafkaCruiseControl.addBrokers(brokerIds,
+                                                                             dryrun,
+                                                                             throttleAddedOrRemovedBrokers,
+                                                                             goalsAndRequirements.goals(),
+                                                                             goalsAndRequirements.requirements(),
+                                                                             allowCapacityEstimation,
+                                                                             concurrentPartitionMovements,
+                                                                             concurrentLeaderMovements,
+                                                                             skipHardGoalCheck,
+                                                                             excludedTopics));
+        break;
+      case REMOVE_BROKER:
+        optimizerResult =
+            getAndMaybeReturnProgress(
+                request, response, () -> _asyncKafkaCruiseControl.decommissionBrokers(brokerIds,
+                                                                                      dryrun,
+                                                                                      throttleAddedOrRemovedBrokers,
+                                                                                      goalsAndRequirements.goals(),
+                                                                                      goalsAndRequirements.requirements(),
+                                                                                      allowCapacityEstimation,
+                                                                                      concurrentPartitionMovements,
+                                                                                      concurrentLeaderMovements,
+                                                                                      skipHardGoalCheck,
+                                                                                      excludedTopics));
+        break;
+      case FIX_OFFLINE_REPLICAS:
+        optimizerResult = getAndMaybeReturnProgress(
+            request, response, () -> _asyncKafkaCruiseControl.fixOfflineReplicas(dryrun,
+                                                                                 goalsAndRequirements.goals(),
+                                                                                 goalsAndRequirements.requirements(),
+                                                                                 allowCapacityEstimation,
+                                                                                 concurrentPartitionMovements,
+                                                                                 concurrentLeaderMovements,
+                                                                                 skipHardGoalCheck,
+                                                                                 excludedTopics));
+        break;
+      default:
+        // Should never reach here.
+        return false;
     }
     if (optimizerResult == null) {
       return false;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
@@ -134,6 +134,7 @@ class KafkaCruiseControlServletUtils {
 
     Set<String> fixOfflineReplicas = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     fixOfflineReplicas.addAll(addOrRemoveBroker);
+    fixOfflineReplicas.remove(KAFKA_ASSIGNER_MODE_PARAM);
 
     Set<String> demoteBroker = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     demoteBroker.add(BROKER_ID_PARAM);
@@ -358,12 +359,6 @@ class KafkaCruiseControlServletUtils {
 
   static List<String> getGoals(HttpServletRequest request) throws UnsupportedEncodingException {
     boolean isKafkaAssignerMode = getMode(request);
-    EndPoint endPoint = endPoint(request);
-    if (endPoint == FIX_OFFLINE_REPLICAS && isKafkaAssignerMode) {
-      throw new IllegalArgumentException(
-          String.format("The endpoint %s cannot be used in Kafka Assigner mode.", endPoint.name()));
-    }
-
     List<String> goals;
     String goalsString = urlDecode(request.getParameter(GOALS_PARAM));
     goals = goalsString == null ? new ArrayList<>() : Arrays.asList(goalsString.split(","));

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
@@ -110,30 +110,30 @@ class KafkaCruiseControlServletUtils {
     state.add(JSON_PARAM);
     state.add(SUBSTATES_PARAM);
 
-    Set<String> addOrRemoveBroker = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-    addOrRemoveBroker.add(DRY_RUN_PARAM);
-    addOrRemoveBroker.add(DATA_FROM_PARAM);
-    addOrRemoveBroker.add(GOALS_PARAM);
-    addOrRemoveBroker.add(KAFKA_ASSIGNER_MODE_PARAM);
-    addOrRemoveBroker.add(JSON_PARAM);
-    addOrRemoveBroker.add(ALLOW_CAPACITY_ESTIMATION_PARAM);
-    addOrRemoveBroker.add(CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER_PARAM);
-    addOrRemoveBroker.add(CONCURRENT_LEADER_MOVEMENTS_PARAM);
-    addOrRemoveBroker.add(SKIP_HARD_GOAL_CHECK_PARAM);
-    addOrRemoveBroker.add(EXCLUDED_TOPICS);
+    Set<String> addRemoveOrFixBroker = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    addRemoveOrFixBroker.add(DRY_RUN_PARAM);
+    addRemoveOrFixBroker.add(DATA_FROM_PARAM);
+    addRemoveOrFixBroker.add(GOALS_PARAM);
+    addRemoveOrFixBroker.add(KAFKA_ASSIGNER_MODE_PARAM);
+    addRemoveOrFixBroker.add(JSON_PARAM);
+    addRemoveOrFixBroker.add(ALLOW_CAPACITY_ESTIMATION_PARAM);
+    addRemoveOrFixBroker.add(CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER_PARAM);
+    addRemoveOrFixBroker.add(CONCURRENT_LEADER_MOVEMENTS_PARAM);
+    addRemoveOrFixBroker.add(SKIP_HARD_GOAL_CHECK_PARAM);
+    addRemoveOrFixBroker.add(EXCLUDED_TOPICS);
 
     Set<String> addBroker = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     addBroker.add(THROTTLE_ADDED_BROKER_PARAM);
     addBroker.add(BROKER_ID_PARAM);
-    addBroker.addAll(addOrRemoveBroker);
+    addBroker.addAll(addRemoveOrFixBroker);
 
     Set<String> removeBroker = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     removeBroker.add(THROTTLE_REMOVED_BROKER_PARAM);
     removeBroker.add(BROKER_ID_PARAM);
-    removeBroker.addAll(addOrRemoveBroker);
+    removeBroker.addAll(addRemoveOrFixBroker);
 
     Set<String> fixOfflineReplicas = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-    fixOfflineReplicas.addAll(addOrRemoveBroker);
+    fixOfflineReplicas.addAll(addRemoveOrFixBroker);
     fixOfflineReplicas.remove(KAFKA_ASSIGNER_MODE_PARAM);
 
     Set<String> demoteBroker = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/DeterministicClusterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/DeterministicClusterTest.java
@@ -43,7 +43,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static com.linkedin.kafka.cruisecontrol.analyzer.OptimizationVerifier.Verification.DEAD_BROKERS;
+import static com.linkedin.kafka.cruisecontrol.analyzer.OptimizationVerifier.Verification.BROKEN_BROKERS;
 import static com.linkedin.kafka.cruisecontrol.analyzer.OptimizationVerifier.Verification.NEW_BROKERS;
 import static com.linkedin.kafka.cruisecontrol.analyzer.OptimizationVerifier.Verification.REGRESSION;
 import static org.junit.Assert.assertTrue;
@@ -112,7 +112,7 @@ public class DeterministicClusterTest {
     Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
     props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(6L));
     BalancingConstraint balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
-    List<OptimizationVerifier.Verification> verifications = Arrays.asList(NEW_BROKERS, DEAD_BROKERS, REGRESSION);
+    List<OptimizationVerifier.Verification> verifications = Arrays.asList(NEW_BROKERS, BROKEN_BROKERS, REGRESSION);
 
     // ----------##TEST: BALANCE PERCENTAGES.
     balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);
@@ -177,7 +177,7 @@ public class DeterministicClusterTest {
     Map<Integer, String> kafkaAssignerGoals = new HashMap<>();
     kafkaAssignerGoals.put(0, KafkaAssignerEvenRackAwareGoal.class.getName());
     kafkaAssignerGoals.put(1, KafkaAssignerDiskUsageDistributionGoal.class.getName());
-    List<OptimizationVerifier.Verification> kafkaAssignerVerifications = Arrays.asList(DEAD_BROKERS, REGRESSION);
+    List<OptimizationVerifier.Verification> kafkaAssignerVerifications = Arrays.asList(BROKEN_BROKERS, REGRESSION);
     // Small cluster.
     p.add(params(balancingConstraint, DeterministicCluster.smallClusterModel(TestConstants.BROKER_CAPACITY),
                  kafkaAssignerGoals, kafkaAssignerVerifications, null));
@@ -207,7 +207,7 @@ public class DeterministicClusterTest {
       assertTrue("Deterministic Cluster Test failed to improve the existing state.",
           OptimizationVerifier.executeGoalsFor(_balancingConstraint, _cluster, _goalNameByPriority, _verifications));
     } catch (OptimizationFailureException optimizationFailureException) {
-      // This exception is thrown if rebalance fails due to healthy brokers having insufficient capacity.
+      // This exception is thrown if rebalance fails due to alive brokers having insufficient capacity.
       if (!optimizationFailureException.getMessage().contains("Insufficient healthy cluster capacity for resource")) {
         throw optimizationFailureException;
       }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/OptimizationVerifier.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/OptimizationVerifier.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Test fails for
- * (a) self healing if there are replicas on dead brokers after self healing.
+ * (a) self healing if there are replicas on dead brokers or broken disks after self healing.
  * (b) adding a new broker causes the replicas to move between old brokers.
  * (c) rebalance if rebalance causes a worse goal state. See {@link #executeGoalsFor} for details of pass / fail status.
  * <p>
@@ -56,7 +56,7 @@ class OptimizationVerifier {
    * A test fails if:
    * 1) Rebalance: During the optimization process, optimization of a goal leads to a worse cluster state (in terms of
    * the requirements of the same goal) than the cluster state just before starting the optimization.
-   * 2) Self Healing: There are replicas on dead brokers after self healing.
+   * 2) Self Healing: There are offline replicas on dead brokers or on broken disks of brokers after self healing.
    * 3) Adding a new broker causes the replicas to move among old brokers.
    *
    * @param constraint         Balancing constraint for the given cluster.
@@ -77,7 +77,7 @@ class OptimizationVerifier {
    * A test fails if:
    * 1) Rebalance: During the optimization process, optimization of a goal leads to a worse cluster state (in terms of
    * the requirements of the same goal) than the cluster state just before starting the optimization.
-   * 2) Self Healing: There are replicas on dead brokers after self healing.
+   * 2) Self Healing: There are offline replicas on dead brokers or on broken disks of brokers after self healing.
    * 3) Adding a new broker causes the replicas to move among old brokers.
    *
    * @param constraint         Balancing constraint for the given cluster.

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/OptimizationVerifier.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/OptimizationVerifier.java
@@ -140,8 +140,8 @@ class OptimizationVerifier {
             return false;
           }
           break;
-        case DEAD_BROKERS:
-          if (!clusterModel.deadBrokers().isEmpty() && !verifyDeadBrokers(clusterModel)) {
+        case BROKEN_BROKERS:
+          if (!clusterModel.brokenBrokers().isEmpty() && !verifyBrokenBrokers(clusterModel)) {
             return false;
           }
           break;
@@ -173,9 +173,9 @@ class OptimizationVerifier {
     }
   }
 
-  private static boolean verifyDeadBrokers(ClusterModel clusterModel) {
+  private static boolean verifyBrokenBrokers(ClusterModel clusterModel) {
     Set<Broker> deadBrokers = clusterModel.brokers();
-    deadBrokers.removeAll(clusterModel.healthyBrokers());
+    deadBrokers.removeAll(clusterModel.aliveBrokers());
     for (Broker deadBroker : deadBrokers) {
       if (deadBroker.replicas().size() > 0) {
         LOG.error("Failed to move {} replicas on dead broker {} to other brokers.", deadBroker.replicas().size(),
@@ -183,11 +183,19 @@ class OptimizationVerifier {
         return false;
       }
     }
+    Set<Broker> brokersHavingOfflineReplicasOnBadDisks = clusterModel.brokersHavingOfflineReplicasOnBadDisks();
+    if (!brokersHavingOfflineReplicasOnBadDisks.isEmpty()) {
+      for (Broker brokerHavingOfflineReplicasOnBadDisks : brokersHavingOfflineReplicasOnBadDisks) {
+        LOG.error("Failed to move offline replicas from broker with bad disk {}.",
+                  brokerHavingOfflineReplicasOnBadDisks.id());
+      }
+      return false;
+    }
     return true;
   }
 
   private static boolean verifyNewBrokers(ClusterModel clusterModel, BalancingConstraint constraint) {
-    for (Broker broker : clusterModel.healthyBrokers()) {
+    for (Broker broker : clusterModel.aliveBrokers()) {
       if (!broker.isNew()) {
         for (Replica replica : broker.replicas()) {
           if (replica.originalBroker() != broker) {
@@ -230,6 +238,6 @@ class OptimizationVerifier {
   }
 
   enum Verification {
-    GOAL_VIOLATION, DEAD_BROKERS, NEW_BROKERS, REGRESSION,
+    GOAL_VIOLATION, BROKEN_BROKERS, NEW_BROKERS, REGRESSION,
   }
 }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
@@ -27,7 +27,7 @@ import com.linkedin.kafka.cruisecontrol.common.Resource;
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.common.ClusterProperty;
-import com.linkedin.kafka.cruisecontrol.common.RandomCluster;
+import com.linkedin.kafka.cruisecontrol.model.RandomCluster;
 import com.linkedin.kafka.cruisecontrol.common.TestConstants;
 import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
@@ -47,7 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.linkedin.kafka.cruisecontrol.analyzer.OptimizationVerifier.Verification.NEW_BROKERS;
-import static com.linkedin.kafka.cruisecontrol.analyzer.OptimizationVerifier.Verification.DEAD_BROKERS;
+import static com.linkedin.kafka.cruisecontrol.analyzer.OptimizationVerifier.Verification.BROKEN_BROKERS;
 import static com.linkedin.kafka.cruisecontrol.analyzer.OptimizationVerifier.Verification.GOAL_VIOLATION;
 import static com.linkedin.kafka.cruisecontrol.analyzer.OptimizationVerifier.Verification.REGRESSION;
 import static org.junit.Assert.assertTrue;
@@ -88,9 +88,9 @@ public class RandomClusterTest {
     kafkaAssignerGoals.put(1, KafkaAssignerEvenRackAwareGoal.class.getName());
     kafkaAssignerGoals.put(2, KafkaAssignerDiskUsageDistributionGoal.class.getName());
 
-    List<OptimizationVerifier.Verification> verifications = Arrays.asList(NEW_BROKERS, DEAD_BROKERS, REGRESSION);
+    List<OptimizationVerifier.Verification> verifications = Arrays.asList(NEW_BROKERS, BROKEN_BROKERS, REGRESSION);
     List<OptimizationVerifier.Verification> kafkaAssignerVerifications =
-        Arrays.asList(GOAL_VIOLATION, DEAD_BROKERS, REGRESSION);
+        Arrays.asList(GOAL_VIOLATION, BROKEN_BROKERS, REGRESSION);
 
     Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
     props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(1500L));

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomGoalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomGoalTest.java
@@ -22,7 +22,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.common.ClusterProperty;
-import com.linkedin.kafka.cruisecontrol.common.RandomCluster;
+import com.linkedin.kafka.cruisecontrol.model.RandomCluster;
 import com.linkedin.kafka.cruisecontrol.common.TestConstants;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 
@@ -89,7 +89,7 @@ public class RandomGoalTest {
     balancingConstraint.setResourceBalancePercentage(TestConstants.LOW_BALANCE_PERCENTAGE);
     balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);
 
-    List<OptimizationVerifier.Verification> verifications = Arrays.asList(NEW_BROKERS, DEAD_BROKERS, REGRESSION);
+    List<OptimizationVerifier.Verification> verifications = Arrays.asList(NEW_BROKERS, BROKEN_BROKERS, REGRESSION);
 
     // Test: Single goal at a time.
     int goalPriority = 1;

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/ClusterProperty.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/ClusterProperty.java
@@ -8,6 +8,7 @@ public enum ClusterProperty {
   NUM_RACKS("numRacks"),
   NUM_BROKERS("numBrokers"),
   NUM_DEAD_BROKERS("numDeadBrokers"),
+  NUM_BROKERS_WITH_BAD_DISK("numBrokersWithBadDisk"),
   NUM_REPLICAS("numReplicas"),
   NUM_TOPICS("numTopics"),
   MIN_REPLICATION("minReplication"),

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/DeterministicCluster.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/DeterministicCluster.java
@@ -258,7 +258,7 @@ public class DeterministicCluster {
    *
    * @param numRacks                Number of racks in ToR architecture.
    * @param orderedRackIdsOfBrokers Specifies the rack id for each broker.
-   * @param brokerCapacity          Healthy broker capacity.
+   * @param brokerCapacity          Alive broker capacity.
    * @return Cluster with the specified number of racks and broker distribution.
    */
   public static ClusterModel getHomogeneousDeterministicCluster(int numRacks,

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/TestConstants.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/TestConstants.java
@@ -10,12 +10,12 @@ import java.util.Map;
 
 
 public class TestConstants {
-  static final long SEED_BASE = 3140;
-  static final long REPLICATION_SEED = 5234;
-  static final long LEADER_SEED = 72033;
-  static final long REPLICA_ASSIGNMENT_SEED = 1240;
-  static final long TOPIC_POPULARITY_SEED = 7234;
-  static final Map<Resource, Long> UTILIZATION_SEED_BY_RESOURCE;
+  public static final long SEED_BASE = 3140;
+  public static final long REPLICATION_SEED = 5234;
+  public static final long LEADER_SEED = 72033;
+  public static final long REPLICA_ASSIGNMENT_SEED = 1240;
+  public static final long TOPIC_POPULARITY_SEED = 7234;
+  public static final Map<Resource, Long> UTILIZATION_SEED_BY_RESOURCE;
   static {
     Map<Resource, Long> utilizationSeedByResource = new HashMap<>();
     utilizationSeedByResource.put(Resource.CPU, 100000L);
@@ -53,6 +53,7 @@ public class TestConstants {
     properties.put(ClusterProperty.NUM_RACKS, 10);
     properties.put(ClusterProperty.NUM_BROKERS, 40);
     properties.put(ClusterProperty.NUM_DEAD_BROKERS, 0);
+    properties.put(ClusterProperty.NUM_BROKERS_WITH_BAD_DISK, 0);
     properties.put(ClusterProperty.NUM_REPLICAS, 50001);
     properties.put(ClusterProperty.NUM_TOPICS, 3000);
     properties.put(ClusterProperty.MIN_REPLICATION, 3);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/RandomCluster.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/RandomCluster.java
@@ -378,14 +378,14 @@ public class RandomCluster {
       // Mark the remaining brokers as a broker with bad disk(s).
       int remainingBrokerWithBadDiskIndex = 0;
       for (Broker brokerToMark : cluster.brokers()) {
+        if (numBrokersWithBadDisk - markedBrokersContainingExcludedTopicReplicas == remainingBrokerWithBadDiskIndex) {
+          break;
+        }
         if (!brokerToMark.replicas().isEmpty() && brokerToMark.isAlive() && !brokerToMark.hasBadDisks()) {
           // Mark one (random) replica on this broker as offline.
           brokerToMark.replicas().iterator().next().markOriginalOffline();
           cluster.setBrokerState(remainingBrokerWithBadDiskIndex, Broker.State.BAD_DISKS);
           remainingBrokerWithBadDiskIndex++;
-        }
-        if (numBrokersWithBadDisk - markedBrokersContainingExcludedTopicReplicas == remainingBrokerWithBadDiskIndex) {
-          break;
         }
       }
       if (numBrokersWithBadDisk - markedBrokersContainingExcludedTopicReplicas != remainingBrokerWithBadDiskIndex) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/RandomCluster.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/RandomCluster.java
@@ -377,14 +377,19 @@ public class RandomCluster {
 
       // Mark the remaining brokers as a broker with bad disk(s).
       int remainingBrokerWithBadDiskIndex = 0;
-      while (numBrokersWithBadDisk - markedBrokersContainingExcludedTopicReplicas - remainingBrokerWithBadDiskIndex > 0) {
-        Broker brokerToMark = cluster.broker(remainingBrokerWithBadDiskIndex);
+      for (Broker brokerToMark : cluster.brokers()) {
         if (!brokerToMark.replicas().isEmpty() && brokerToMark.isAlive() && !brokerToMark.hasBadDisks()) {
           // Mark one (random) replica on this broker as offline.
           brokerToMark.replicas().iterator().next().markOriginalOffline();
           cluster.setBrokerState(remainingBrokerWithBadDiskIndex, Broker.State.BAD_DISKS);
           remainingBrokerWithBadDiskIndex++;
         }
+        if (numBrokersWithBadDisk - markedBrokersContainingExcludedTopicReplicas == remainingBrokerWithBadDiskIndex) {
+          break;
+        }
+      }
+      if (numBrokersWithBadDisk - markedBrokersContainingExcludedTopicReplicas != remainingBrokerWithBadDiskIndex) {
+        throw new IllegalArgumentException("Broken broker marking failed due to bad input.");
       }
     }
   }

--- a/semantic-build-versioning.gradle
+++ b/semantic-build-versioning.gradle
@@ -1,0 +1,8 @@
+
+preRelease {
+  startingVersion = 'RC.0'
+  // The bumping scheme is RC.0 -> RC.1 -> ... -> RC.n
+  bump = {
+    "RC.${((it - ~/^RC\./) as int) + 1}"
+  }
+}


### PR DESCRIPTION
This patch is part-1 out of multiple (4+) patches to add `JBOD` support. It adds the functionality to remove `offline` replicas to `alive` brokers. A replica is `offline` if it resides on (1) a dead broker or (2) a broken disk on an alive broker.
The patches that will follow this one will add support for:
* Specification and consideration of the capacity of each independent disk on each `JBOD` broker
* Moving replicas between disks within the same broker -- i.e. for operations such as rebalance and fixing offline replicas
* An anomaly detector to identify offline replicas and fix them if self-healing is enabled