### PR TITLE
Correctly display 'Cluster load after rebalance'

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -755,7 +755,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       }
       switch (endPoint) {
         case REBALANCE:
-          sb.append("%n%nCluster load after rebalance:%n");
+          sb.append(String.format("%n%nCluster load after rebalance:%n"));
           break;
         case ADD_BROKER:
           sb.append(String.format("%n%nCluster load after adding broker %s:%n", brokerIds));


### PR DESCRIPTION
Previously, the 'Cluster load after rebalance' prints literal '%n%n' in the response from `cruise-control`
```
STD:{cpu:       0.083 networkInbound:    5949.215 networkOutbound:    3737.438 disk:  218015.239 potentialNwOut:    2972.991 replicas:281.9897012875318 topicReplicas:0.38622891576356444%n%nCluster load after rebalance:%n
```

This is likely because String.format() is not used for this particular string, so '%n' does not resolve into a literal newline character.

Thus, use String.format() on the existing `"%n%nCluster load after rebalance:%n"` to preserve platform-independence while printing a newline, so that the response from `cruise-control` displays correctly.