### PR TITLE
Add parameter to dynamically specify the topics to exclude from replica movements.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AddBrokerRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AddBrokerRunnable.java
@@ -9,10 +9,13 @@ import com.linkedin.kafka.cruisecontrol.analyzer.GoalOptimizer;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Pattern;
+
 
 /**
  * The async runnable for {@link KafkaCruiseControl#addBrokers(Collection, boolean, boolean, List,
- * ModelCompletenessRequirements, com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean, Integer, Integer, boolean)}
+ * ModelCompletenessRequirements, com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean, Integer,
+ * Integer, boolean, Pattern)}
  */
 class AddBrokerRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult> {
   private final Collection<Integer> _brokerIds;
@@ -24,6 +27,7 @@ class AddBrokerRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult>
   private final Integer _concurrentPartitionMovements;
   private final Integer _concurrentLeaderMovements;
   private final boolean _skipHardGoalCheck;
+  private final Pattern _excludedTopics;
 
   AddBrokerRunnable(KafkaCruiseControl kafkaCruiseControl,
                     OperationFuture<GoalOptimizer.OptimizerResult> future,
@@ -35,7 +39,8 @@ class AddBrokerRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult>
                     boolean allowCapacityEstimation,
                     Integer concurrentPartitionMovements,
                     Integer concurrentLeaderMovements,
-                    boolean skipHardGoalCheck) {
+                    boolean skipHardGoalCheck,
+                    Pattern excludedTopics) {
     super(kafkaCruiseControl, future);
     _brokerIds = brokerIds;
     _dryRun = dryRun;
@@ -46,6 +51,7 @@ class AddBrokerRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult>
     _concurrentPartitionMovements = concurrentPartitionMovements;
     _concurrentLeaderMovements = concurrentLeaderMovements;
     _skipHardGoalCheck = skipHardGoalCheck;
+    _excludedTopics = excludedTopics;
   }
 
   @Override
@@ -53,6 +59,6 @@ class AddBrokerRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult>
     return _kafkaCruiseControl.addBrokers(_brokerIds, _dryRun, _throttleAddedBrokers, _goals,
                                           _modelCompletenessRequirements, _future.operationProgress(),
                                           _allowCapacityEstimation, _concurrentPartitionMovements,
-                                          _concurrentLeaderMovements, _skipHardGoalCheck);
+                                          _concurrentLeaderMovements, _skipHardGoalCheck, _excludedTopics);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DecommissionBrokersRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DecommissionBrokersRunnable.java
@@ -9,11 +9,13 @@ import com.linkedin.kafka.cruisecontrol.analyzer.GoalOptimizer;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Pattern;
+
 
 /**
  * The async runnable for {@link KafkaCruiseControl#decommissionBrokers(Collection, boolean, boolean, List,
  * ModelCompletenessRequirements, com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean,
- * Integer, Integer, boolean)}
+ * Integer, Integer, boolean, Pattern)}
  */
 class DecommissionBrokersRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult> {
   private final Collection<Integer> _brokerIds;
@@ -25,6 +27,7 @@ class DecommissionBrokersRunnable extends OperationRunnable<GoalOptimizer.Optimi
   private final Integer _concurrentPartitionMovements;
   private final Integer _concurrentLeaderMovements;
   private final boolean _skipHardGoalCheck;
+  private final Pattern _excludedTopics;
 
   DecommissionBrokersRunnable(KafkaCruiseControl kafkaCruiseControl,
                               OperationFuture<GoalOptimizer.OptimizerResult> future,
@@ -36,7 +39,8 @@ class DecommissionBrokersRunnable extends OperationRunnable<GoalOptimizer.Optimi
                               boolean allowCapacityEstimation,
                               Integer concurrentPartitionMovements,
                               Integer concurrentLeaderMovements,
-                              boolean skipHardGoalCheck) {
+                              boolean skipHardGoalCheck,
+                              Pattern excludedTopics) {
     super(kafkaCruiseControl, future);
     _brokerIds = brokerIds;
     _dryRun = dryRun;
@@ -47,6 +51,7 @@ class DecommissionBrokersRunnable extends OperationRunnable<GoalOptimizer.Optimi
     _concurrentPartitionMovements = concurrentPartitionMovements;
     _concurrentLeaderMovements = concurrentLeaderMovements;
     _skipHardGoalCheck = skipHardGoalCheck;
+    _excludedTopics = excludedTopics;
   }
 
   @Override
@@ -54,6 +59,6 @@ class DecommissionBrokersRunnable extends OperationRunnable<GoalOptimizer.Optimi
     return _kafkaCruiseControl.decommissionBrokers(_brokerIds, _dryRun, _throttleRemovedBrokers, _goals,
                                                    _modelCompletenessRequirements, _future.operationProgress(),
                                                    _allowCapacityEstimation, _concurrentPartitionMovements,
-                                                   _concurrentLeaderMovements, _skipHardGoalCheck);
+                                                   _concurrentLeaderMovements, _skipHardGoalCheck, _excludedTopics);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DemoteBrokerRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DemoteBrokerRunnable.java
@@ -7,6 +7,7 @@ package com.linkedin.kafka.cruisecontrol.async;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
 import com.linkedin.kafka.cruisecontrol.analyzer.GoalOptimizer;
 import java.util.Collection;
+import java.util.regex.Pattern;
 
 
 public class DemoteBrokerRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult> {
@@ -14,23 +15,26 @@ public class DemoteBrokerRunnable extends OperationRunnable<GoalOptimizer.Optimi
   private final boolean _dryRun;
   private final boolean _allowCapacityEstimation;
   private final Integer _concurrentLeaderMovements;
+  private final Pattern _excludedTopics;
 
   DemoteBrokerRunnable(KafkaCruiseControl kafkaCruiseControl,
                        OperationFuture<GoalOptimizer.OptimizerResult> future,
                        Collection<Integer> brokerIds,
                        boolean dryRun,
                        boolean allowCapacityEstimation,
-                       Integer concurrentLeaderMovements) {
+                       Integer concurrentLeaderMovements,
+                       Pattern excludedTopics) {
     super(kafkaCruiseControl, future);
     _brokerIds = brokerIds;
     _dryRun = dryRun;
     _allowCapacityEstimation = allowCapacityEstimation;
     _concurrentLeaderMovements = concurrentLeaderMovements;
+    _excludedTopics = excludedTopics;
   }
 
   @Override
   protected GoalOptimizer.OptimizerResult getResult() throws Exception {
     return _kafkaCruiseControl.demoteBrokers(_brokerIds, _dryRun, _future.operationProgress(),
-                                             _allowCapacityEstimation, _concurrentLeaderMovements);
+                                             _allowCapacityEstimation, _concurrentLeaderMovements, _excludedTopics);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetOptimizationProposalsRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetOptimizationProposalsRunnable.java
@@ -8,37 +8,43 @@ import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
 import com.linkedin.kafka.cruisecontrol.analyzer.GoalOptimizer;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 import java.util.List;
+import java.util.regex.Pattern;
+
 
 /**
  * The async runnable for {@link KafkaCruiseControl#getOptimizationProposals(
  * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean)} and
  * {@link KafkaCruiseControl#getOptimizationProposals(List, ModelCompletenessRequirements,
- * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean, boolean)}
+ * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean, boolean, Pattern)}
  */
 class GetOptimizationProposalsRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult> {
   private final List<String> _goals;
   private final ModelCompletenessRequirements _modelCompletenessRequirements;
   private final boolean _allowCapacityEstimation;
+  private final Pattern _excludedTopics;
 
   GetOptimizationProposalsRunnable(KafkaCruiseControl kafkaCruiseControl,
                                    OperationFuture<GoalOptimizer.OptimizerResult> future,
                                    List<String> goals,
                                    ModelCompletenessRequirements modelCompletenessRequirements,
-                                   boolean allowCapacityEstimation) {
+                                   boolean allowCapacityEstimation,
+                                   Pattern excludedTopics) {
     super(kafkaCruiseControl, future);
     _goals = goals;
     _modelCompletenessRequirements = modelCompletenessRequirements;
     _allowCapacityEstimation = allowCapacityEstimation;
+    _excludedTopics = excludedTopics;
   }
 
   @Override
   protected GoalOptimizer.OptimizerResult getResult() throws Exception {
-    if (_goals != null) {
+    if (_goals != null || _excludedTopics != null) {
       return _kafkaCruiseControl.getOptimizationProposals(_goals,
                                                           _modelCompletenessRequirements,
                                                           _future.operationProgress(),
                                                           _allowCapacityEstimation,
-                                                          true);
+                                                          true,
+                                                          _excludedTopics);
     } else {
       return _kafkaCruiseControl.getOptimizationProposals(_future.operationProgress(), _allowCapacityEstimation);
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/RebalanceRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/RebalanceRunnable.java
@@ -8,10 +8,12 @@ import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
 import com.linkedin.kafka.cruisecontrol.analyzer.GoalOptimizer;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 import java.util.List;
+import java.util.regex.Pattern;
+
 
 /**
  * The async runnable for {@link KafkaCruiseControl#rebalance(List, boolean, ModelCompletenessRequirements,
- * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean, Integer, Integer, boolean)}
+ * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean, Integer, Integer, boolean, Pattern)}
  */
 class RebalanceRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult> {
   private final List<String> _goals;
@@ -21,6 +23,7 @@ class RebalanceRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult>
   private final Integer _concurrentPartitionMovements;
   private final Integer _concurrentLeaderMovements;
   private final boolean _skipHardGoalCheck;
+  private final Pattern _excludedTopics;
 
   RebalanceRunnable(KafkaCruiseControl kafkaCruiseControl,
                     OperationFuture<GoalOptimizer.OptimizerResult> future,
@@ -30,7 +33,8 @@ class RebalanceRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult>
                     boolean allowCapacityEstimation,
                     Integer concurrentPartitionMovements,
                     Integer concurrentLeaderMovements,
-                    boolean skipHardGoalCheck) {
+                    boolean skipHardGoalCheck,
+                    Pattern excludedTopics) {
     super(kafkaCruiseControl, future);
     _goals = goals;
     _dryRun = dryRun;
@@ -39,6 +43,7 @@ class RebalanceRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult>
     _concurrentPartitionMovements = concurrentPartitionMovements;
     _concurrentLeaderMovements = concurrentLeaderMovements;
     _skipHardGoalCheck = skipHardGoalCheck;
+    _excludedTopics = excludedTopics;
   }
 
   @Override
@@ -50,6 +55,7 @@ class RebalanceRunnable extends OperationRunnable<GoalOptimizer.OptimizerResult>
                                          _allowCapacityEstimation,
                                          _concurrentPartitionMovements,
                                          _concurrentLeaderMovements,
-                                         _skipHardGoalCheck);
+                                         _skipHardGoalCheck,
+                                         _excludedTopics);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailures.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailures.java
@@ -43,7 +43,7 @@ public class BrokerFailures extends KafkaAnomaly {
     if (_failedBrokers != null && !_failedBrokers.isEmpty()) {
       _kafkaCruiseControl.decommissionBrokers(_failedBrokers.keySet(), false, false,
                                              Collections.emptyList(), null, new OperationProgress(),
-                                              _allowCapacityEstimation, null, null, false);
+                                              _allowCapacityEstimation, null, null, false, null);
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
@@ -48,7 +48,7 @@ public class GoalViolations extends KafkaAnomaly {
     try {
       _kafkaCruiseControl.rebalance(
           Collections.emptyList(), false, null, new OperationProgress(), _allowCapacityEstimation,
-          null, null, false);
+          null, null, false, null);
     } catch (IllegalStateException e) {
       LOG.warn("Got exception when trying to fix the cluster. " + e.getMessage());
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/EndPoint.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/EndPoint.java
@@ -29,19 +29,19 @@ enum EndPoint {
   DEMOTE_BROKER;
 
   private static final List<EndPoint> GET_ENDPOINT = Arrays.asList(BOOTSTRAP,
-      TRAIN,
-      LOAD,
-      PARTITION_LOAD,
-      PROPOSALS,
-      STATE,
-      KAFKA_CLUSTER_STATE);
+                                                                   TRAIN,
+                                                                   LOAD,
+                                                                   PARTITION_LOAD,
+                                                                   PROPOSALS,
+                                                                   STATE,
+                                                                   KAFKA_CLUSTER_STATE);
   private static final List<EndPoint> POST_ENDPOINT = Arrays.asList(ADD_BROKER,
-      REMOVE_BROKER,
-      REBALANCE,
-      STOP_PROPOSAL_EXECUTION,
-      PAUSE_SAMPLING,
-      RESUME_SAMPLING,
-      DEMOTE_BROKER);
+                                                                    REMOVE_BROKER,
+                                                                    REBALANCE,
+                                                                    STOP_PROPOSAL_EXECUTION,
+                                                                    PAUSE_SAMPLING,
+                                                                    RESUME_SAMPLING,
+                                                                    DEMOTE_BROKER);
   private static final List<EndPoint> CACHED_VALUES = Collections.unmodifiableList(Arrays.asList(values()));
 
   public static List<EndPoint> getEndpoint() {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
@@ -60,6 +60,7 @@ class KafkaCruiseControlServletUtils {
   private static final String SUBSTATES_PARAM = "substates";
   private static final String MIN_VALID_PARTITION_RATIO_PARAM = "min_valid_partition_ratio";
   private static final String SKIP_HARD_GOAL_CHECK_PARAM = "skip_hard_goal_check";
+  private static final String EXCLUDED_TOPICS = "excluded_topics";
 
   static final Map<EndPoint, Set<String>> VALID_ENDPOINT_PARAM_NAMES;
   static {
@@ -101,6 +102,7 @@ class KafkaCruiseControlServletUtils {
     proposals.add(KAFKA_ASSIGNER_MODE_PARAM);
     proposals.add(JSON_PARAM);
     proposals.add(ALLOW_CAPACITY_ESTIMATION_PARAM);
+    proposals.add(EXCLUDED_TOPICS);
 
     Set<String> state = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     state.add(VERBOSE_PARAM);
@@ -119,6 +121,7 @@ class KafkaCruiseControlServletUtils {
     addOrRemoveBroker.add(CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER_PARAM);
     addOrRemoveBroker.add(CONCURRENT_LEADER_MOVEMENTS_PARAM);
     addOrRemoveBroker.add(SKIP_HARD_GOAL_CHECK_PARAM);
+    addOrRemoveBroker.add(EXCLUDED_TOPICS);
 
     Set<String> addBroker = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     addBroker.add(THROTTLE_ADDED_BROKER_PARAM);
@@ -134,6 +137,7 @@ class KafkaCruiseControlServletUtils {
     demoteBroker.add(JSON_PARAM);
     demoteBroker.add(ALLOW_CAPACITY_ESTIMATION_PARAM);
     demoteBroker.add(CONCURRENT_LEADER_MOVEMENTS_PARAM);
+    demoteBroker.add(EXCLUDED_TOPICS);
 
     Set<String> rebalance = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     rebalance.add(DRY_RUN_PARAM);
@@ -145,6 +149,7 @@ class KafkaCruiseControlServletUtils {
     rebalance.add(CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER_PARAM);
     rebalance.add(CONCURRENT_LEADER_MOVEMENTS_PARAM);
     rebalance.add(SKIP_HARD_GOAL_CHECK_PARAM);
+    rebalance.add(EXCLUDED_TOPICS);
 
     Set<String> kafkaClusterState = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     kafkaClusterState.add(VERBOSE_PARAM);
@@ -387,6 +392,11 @@ class KafkaCruiseControlServletUtils {
     }
 
     return concurrentMovementsPerBroker;
+  }
+
+  static Pattern excludedTopics(HttpServletRequest request) {
+    String excludedTopicsString = request.getParameter(EXCLUDED_TOPICS);
+    return excludedTopicsString != null ? Pattern.compile(excludedTopicsString) : null;
   }
 
   /**

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -148,7 +148,8 @@ public class AnomalyDetectorTest {
                                                      EasyMock.eq(true),
                                                      EasyMock.eq(null),
                                                      EasyMock.eq(null),
-                                                     EasyMock.eq(false)))
+                                                     EasyMock.eq(false),
+                                                     EasyMock.eq(null)))
             .andReturn(null);
     EasyMock.expect(mockKafkaCruiseControl.meetCompletenessRequirements(EasyMock.anyObject())).andReturn(true);
 


### PR DESCRIPTION
`topics.excluded.from.partition.movement` parameter enables users to specify the topics to exclude from partition movements -- unless the replica from the excluded topic is offline. However, users cannot specify the value of this config dynamically.

This patch adds `EXCLUDED_TOPICS` parameter to the following endpoints to dynamically specify the topics to exclude from replica movements:
- `PROPOSALS`,
- `ADD_BROKER`,
- `REMOVE_BROKER`,
- `REBALANCE`,
- `DEMOTE`