### PR TITLE
Improve the detection of wrong broker ID in decommission broker request.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -234,6 +234,7 @@ public class KafkaCruiseControl {
                                                   boolean skipHardGoalCheck,
                                                   Pattern excludedTopics) throws KafkaCruiseControlException {
     try (AutoCloseable ignored = _loadMonitor.acquireForModelGeneration(operationProgress)) {
+      sanityCheckBrokerPresence(brokerIds);
       sanityCheckHardGoalPresence(goals, skipHardGoalCheck);
       Map<Integer, Goal> goalsByPriority = goalsByPriority(goals);
       ModelCompletenessRequirements modelCompletenessRequirements =
@@ -671,7 +672,7 @@ public class KafkaCruiseControl {
   }
 
   /**
-   * Sanity check whether the provided brokers to be decommissioned/demoted exist in cluster or not.
+   * Sanity check whether the provided brokers exist in cluster or not.
    * @param brokerIds A list of broker id.
    */
   private void sanityCheckBrokerPresence(Collection<Integer> brokerIds) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -831,9 +831,6 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       concurrentLeaderMovements = concurrentMovementsPerBroker(request, false);
       skipHardGoalCheck = skipHardGoalCheck(request);
       excludedTopics = excludedTopics(request);
-      if (brokerIds.isEmpty()) {
-        throw new IllegalArgumentException("Target broker ID is not provided.");
-      }
     } catch (Exception e) {
       handleParameterParseException(e, response, e.getMessage(), json);
       // Close session

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -831,6 +831,9 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       concurrentLeaderMovements = concurrentMovementsPerBroker(request, false);
       skipHardGoalCheck = skipHardGoalCheck(request);
       excludedTopics = excludedTopics(request);
+      if (brokerIds.isEmpty()) {
+        throw new IllegalArgumentException("Target broker ID is not provided.");
+      }
     } catch (Exception e) {
       handleParameterParseException(e, response, e.getMessage(), json);
       // Close session

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
@@ -423,6 +423,9 @@ class KafkaCruiseControlServletUtils {
     if (brokersString != null) {
       brokerIds = Arrays.stream(brokersString.split(",")).map(Integer::parseInt).collect(Collectors.toList());
     }
+    if (brokerIds.isEmpty()) {
+      throw new IllegalArgumentException("Target broker ID is not provided.");
+    }
     return Collections.unmodifiableList(brokerIds);
   }
 


### PR DESCRIPTION
Currently we check the user provided broker ID after cluster model is generated, which is a expensive process. The patch moves this check before cluster model generation, thus fail faster for broker ids missing from the cluster in remove broker request.