### PR TITLE
Add logDir information to cluster model and kafka cluster state.

### DIFF
--- a/config/capacityJBOD.json
+++ b/config/capacityJBOD.json
@@ -1,0 +1,35 @@
+{
+  "brokerCapacities":[
+    {
+      "brokerId": "-1",
+      "capacity": {
+        "DISK": {"/tmp/kafka-logs-1": "100000", "/tmp/kafka-logs-2": "100000", "/tmp/kafka-logs-3": "50000",
+          "/tmp/kafka-logs-4": "50000", "/tmp/kafka-logs-5": "150000", "/tmp/kafka-logs-6": "50000"},
+        "CPU": "100",
+        "NW_IN": "10000",
+        "NW_OUT": "10000"
+      },
+      "doc": "The default capacity for a broker with multiple logDirs each on a separate heterogeneous disk."
+    },
+    {
+      "brokerId": "0",
+      "capacity": {
+        "DISK": {"/tmp/kafka-logs": "500000"},
+        "CPU": "100",
+        "NW_IN": "50000",
+        "NW_OUT": "50000"
+      },
+      "doc": "This overrides the capacity for broker 0. This broker is not a JBOD broker."
+    },
+    {
+      "brokerId": "1",
+      "capacity": {
+        "DISK": {"/tmp/kafka-logs-1": "250000", "/tmp/kafka-logs-2": "250000"},
+        "CPU": "100",
+        "NW_IN": "50000",
+        "NW_OUT": "50000"
+      },
+      "doc": "This overrides the capacity for broker 1. This broker is a JBOD broker."
+    }
+  ]
+}

--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -79,8 +79,9 @@ num.broker.metrics.windows=20
 # The minimum broker metric samples required for a partition in each window
 min.samples.per.broker.metrics.window=1
 
-# The configuration for the BrokerCapacityConfigFileResolver
-capacity.config.file=config/capacity.json
+# The configuration for the BrokerCapacityConfigFileResolver (supports JBOD and non-JBOD broker capacities)
+#capacity.config.file=config/capacity.json
+capacity.config.file=config/capacityJBOD.json
 
 # Configurations for the analyzer
 # =======================================

--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -24,6 +24,6 @@ log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 log4j.logger.com.linkedin.kafka.cruisecontrol=INFO, kafkaCruiseControlAppender
 log4j.logger.com.linkedin.kafka.cruisecontrol.detector=INFO, kafkaCruiseControlAppender
 
-log4j.logger.LiKafkaCruiseControlPublicAccessLogger=DEBUG, requestAppender
+log4j.logger.CruiseControlPublicAccessLogger=INFO, requestAppender
 log4j.additivity.kafka.request.logger=false
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -652,7 +652,8 @@ public class KafkaCruiseControl {
    * Get the cluster state for Kafka.
    */
   public KafkaClusterState kafkaClusterState() {
-    return new KafkaClusterState(_loadMonitor.kafkaCluster(), _loadMonitor.topicConfigProvider());
+    String bootstrapServers = _config.getString(KafkaCruiseControlConfig.BOOTSTRAP_SERVERS_CONFIG);
+    return new KafkaClusterState(_loadMonitor.kafkaCluster(), _loadMonitor.topicConfigProvider(), bootstrapServers);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -6,10 +6,15 @@ package com.linkedin.kafka.cruisecontrol;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import kafka.zk.KafkaZkClient;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.DescribeLogDirsResult;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.SystemTime;
 
@@ -115,5 +120,30 @@ public class KafkaCruiseControlUtils {
   public static KafkaZkClient createKafkaZkClient(String connectString, String metricGroup, String metricType) {
     return KafkaZkClient.apply(connectString, false, ZK_SESSION_TIMEOUT, ZK_CONNECTION_TIMEOUT, Integer.MAX_VALUE,
                                new SystemTime(), metricGroup, metricType);
+  }
+
+  /**
+   * Describe LogDirs using the given bootstrap servers for the given brokers.
+   *
+   * @param bootstrapServers Bootstrap servers that the underlying AdminClient will use.
+   * @param brokers Brokers for which the logDirs will be described.
+   * @return DescribeLogDirsResult using the given bootstrap servers for the given brokers.
+   */
+  public static DescribeLogDirsResult describeLogDirs(String bootstrapServers, Collection<Integer> brokers) {
+    try (AdminClient adminClient = KafkaCruiseControlUtils.createAdminClient(bootstrapServers)) {
+      return adminClient.describeLogDirs(brokers);
+    }
+  }
+
+  /**
+   * Create an instance of AdminClient using the given bootstrap servers.
+   *
+   * @param bootstrapServers Bootstrap servers that the AdminClient will use.
+   * @return A new instance of AdminClient.
+   */
+  public static AdminClient createAdminClient(String bootstrapServers) {
+    Properties props = new Properties();
+    props.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    return AdminClient.create(props);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUtils.java
@@ -124,7 +124,7 @@ public class AnalyzerUtils {
         throw new OptimizationFailureException(String.format(
             "Self healing failed to move the replica %s away from %s broker %d for goal. There are still "
                 + "%d replicas on the broker.",
-            replica, replica.broker().getState(), replica.broker().id(), replica.broker().replicas().size()));
+            replica, replica.broker().state(), replica.broker().id(), replica.broker().replicas().size()));
       }
     }
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
@@ -142,7 +142,7 @@ public class ReplicaCapacityGoal extends AbstractGoal {
       for (String topic : excludedTopics) {
         excludedReplicasInBroker.addAll(broker.replicasOfTopicInBroker(topic));
       }
-      if (broker.getState() == Broker.State.BAD_DISKS) {
+      if (broker.state() == Broker.State.BAD_DISKS) {
         _isSelfHealingMode = true;
         excludedReplicasInBroker.removeAll(broker.currentOfflineReplicas());
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolver.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolver.java
@@ -13,13 +13,16 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
 
 /**
- * The broker capacity config resolver implementation based on files. The format of the file is JSON:
+ * The broker capacity config resolver implementation based on files. The format of the file is JSON. Depending on
+ * whether the JBOD configuration is used or not, this JSON file may specify disk capacity per logDir.
+ * Example capacity file without JBOD:
  * <pre>
  *   {
  *      "brokerCapacities":[
@@ -54,6 +57,42 @@ import java.util.Set;
  *   }
  * </pre>
  *
+ * Example capacity file with JBOD (provided logDirs must be absolute paths):
+ * <pre>
+ *   {
+ *      "brokerCapacities":[
+ *        {
+ *          "brokerId": "-1",
+ *          "capacity": {
+ *            "DISK": {"/tmp/kafka-logs-1": "400000", "/tmp/kafka-logs-2": "200000", "/tmp/kafka-logs-3": "200000",
+ *           "/tmp/kafka-logs-4": "200000", "/tmp/kafka-logs-5": "200000", "/tmp/kafka-logs-6": "200000"},
+ *            "CPU": "100",
+ *            "NW_IN": "100000",
+ *            "NW_OUT": "100000"
+ *          }
+ *        },
+ *        {
+ *          "brokerId": "0",
+ *          "capacity": {
+ *            "DISK": {"/tmp/kafka-logs-1": "350000", "/tmp/kafka-logs-2": "550000"},
+ *            "CPU": "100",
+ *            "NW_IN": "100000",
+ *            "NW_OUT": "100000"
+ *          }
+ *        },
+ *        {
+ *          "brokerId": "1",
+ *          "capacity": {
+ *            "DISK": {"/tmp/kafka-logs": "2000000"},
+ *            "CPU": "100",
+ *            "NW_IN": "100000",
+ *            "NW_OUT": "100000"
+ *          }
+ *        }
+ *      ]
+ *   }
+ * </pre>
+ *
  * The broker id -1 defines the default broker capacity estimate. A broker capacity is overridden if there is a capacity
  * defined for a particular broker id. In case a broker capacity is missing, the default estimate for a broker capacity
  * will be used.
@@ -68,7 +107,7 @@ import java.util.Set;
  */
 public class BrokerCapacityConfigFileResolver implements BrokerCapacityConfigResolver {
   public static final String CAPACITY_CONFIG_FILE = "capacity.config.file";
-  private static final int DEFAULT_CAPACITY_BROKER_ID = -1;
+  public static final int DEFAULT_CAPACITY_BROKER_ID = -1;
   private static Map<Integer, BrokerCapacityInfo> _capacitiesForBrokers;
 
   @Override
@@ -89,11 +128,62 @@ public class BrokerCapacityConfigFileResolver implements BrokerCapacityConfigRes
         return capacity;
       } else {
         String info = String.format("Missing broker id(%d) in capacity config file.", brokerId);
-        return new BrokerCapacityInfo(_capacitiesForBrokers.get(DEFAULT_CAPACITY_BROKER_ID).capacity(), info);
+        return new BrokerCapacityInfo(_capacitiesForBrokers.get(DEFAULT_CAPACITY_BROKER_ID).capacity(), info,
+                                      _capacitiesForBrokers.get(DEFAULT_CAPACITY_BROKER_ID).diskCapacityByLogDir());
       }
     } else {
       throw new IllegalArgumentException("The broker id(" + brokerId + ") should be non-negative.");
     }
+  }
+
+  private static boolean isJBOD(Map<Resource, Object> brokerCapacity) {
+    return brokerCapacity.get(Resource.DISK) instanceof Map;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<Resource, Double> getTotalCapacity(Map<Resource, Object> brokerCapacity) {
+    Map<Resource, Double> totalCapacity = new HashMap<>(brokerCapacity.size());
+    if (isJBOD(brokerCapacity)) {
+      for (Map.Entry<Resource, Object> entry : brokerCapacity.entrySet()) {
+        Resource resource = entry.getKey();
+        if (resource == Resource.DISK) {
+          double totalDiskCapacity = 0.0;
+          for (Map.Entry<String, String> diskEntry : ((Map<String, String>) brokerCapacity.get(resource)).entrySet()) {
+            if (!Paths.get(diskEntry.getKey()).isAbsolute()) {
+              throw new IllegalArgumentException("The logDir " + diskEntry.getKey() + " must be an absolute path.");
+            }
+
+            totalDiskCapacity += Double.parseDouble(diskEntry.getValue());
+          }
+          totalCapacity.put(resource, totalDiskCapacity);
+        } else {
+          totalCapacity.put(resource, Double.parseDouble((String) entry.getValue()));
+        }
+      }
+    } else {
+      brokerCapacity.forEach((key, value) -> totalCapacity.put(key, Double.parseDouble((String) value)));
+    }
+
+    return totalCapacity;
+  }
+
+  /**
+   * Get disk capacity by absolute logDir path if the capacity is specified per logDir, null otherwise.
+   *
+   * @param brokerCapacity Broker capacity for each resource.
+   * @return Disk capacity by absolute logDir path if the capacity is specified per logDir, null otherwise.
+   */
+  @SuppressWarnings("unchecked")
+  private static Map<String, Double> getDiskCapacityByLogDir(Map<Resource, Object> brokerCapacity) {
+    if (!isJBOD(brokerCapacity)) {
+      return null;
+    }
+
+    Map<String, String> stringDiskCapacityByLogDir = (Map<String, String>) brokerCapacity.get(Resource.DISK);
+    Map<String, Double> diskCapacityByLogDir = new HashMap<>(stringDiskCapacityByLogDir.size());
+    stringDiskCapacityByLogDir.forEach((key, value) -> diskCapacityByLogDir.put(key, Double.parseDouble(value)));
+
+    return diskCapacityByLogDir;
   }
 
   private void loadCapacities(String capacityConfigFile) throws FileNotFoundException {
@@ -102,12 +192,15 @@ public class BrokerCapacityConfigFileResolver implements BrokerCapacityConfigRes
       reader = new JsonReader(new InputStreamReader(new FileInputStream(capacityConfigFile), StandardCharsets.UTF_8));
       Gson gson = new Gson();
       Set<BrokerCapacity> brokerCapacities = ((BrokerCapacities) gson.fromJson(reader, BrokerCapacities.class)).brokerCapacities;
-      _capacitiesForBrokers = new HashMap<>();
+      _capacitiesForBrokers = new HashMap<>(brokerCapacities.size());
       for (BrokerCapacity bc : brokerCapacities) {
         boolean isDefault = bc.brokerId == DEFAULT_CAPACITY_BROKER_ID;
+        Map<Resource, Double> totalCapacity = getTotalCapacity(bc.capacity);
+        Map<String, Double> diskCapacityByLogDir = getDiskCapacityByLogDir(bc.capacity);
+
         BrokerCapacityInfo brokerCapacityInfo =
-            isDefault ? new BrokerCapacityInfo(bc.capacity, "The default broker capacity.")
-                      : new BrokerCapacityInfo(bc.capacity);
+            isDefault ? new BrokerCapacityInfo(totalCapacity, "The default broker capacity.", diskCapacityByLogDir)
+                      : new BrokerCapacityInfo(totalCapacity, diskCapacityByLogDir);
         _capacitiesForBrokers.put(bc.brokerId, brokerCapacityInfo);
       }
     } finally {
@@ -132,9 +225,9 @@ public class BrokerCapacityConfigFileResolver implements BrokerCapacityConfigRes
 
   private static class BrokerCapacity {
     private final int brokerId;
-    private final Map<Resource, Double> capacity;
+    private final Map<Resource, Object> capacity;
 
-    BrokerCapacity(int brokerId, Map<Resource, Double> capacity) {
+    BrokerCapacity(int brokerId, Map<Resource, Object> capacity) {
       this.brokerId = brokerId;
       this.capacity = capacity;
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityInfo.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityInfo.java
@@ -11,15 +11,49 @@ import java.util.Map;
 public class BrokerCapacityInfo {
   private final Map<Resource, Double> _capacity;
   private final String _estimationInfo;
+  private final Map<String, Double> _diskCapacityByLogDir;
 
-  public BrokerCapacityInfo(Map<Resource, Double> capacity, String estimationInfo) {
+  /**
+   * BrokerCapacityInfo with the given capacity, estimation, and per absolute logDir disk capacity information.
+   *
+   * @param capacity Capacity information for each resource.
+   * @param estimationInfo Description if there is any capacity estimation, null or empty string otherwise.
+   * @param diskCapacityByLogDir Disk capacity by absolute logDir.
+   */
+  public BrokerCapacityInfo(Map<Resource, Double> capacity, String estimationInfo,
+                            Map<String, Double> diskCapacityByLogDir) {
     _capacity = capacity;
     _estimationInfo = estimationInfo == null ? "" : estimationInfo;
+    _diskCapacityByLogDir = diskCapacityByLogDir;
   }
 
+  /**
+   * BrokerCapacityInfo with no capacity information specified per absolute logDir.
+   *
+   * @param capacity Capacity information for each resource.
+   * @param estimationInfo Description if there is any capacity estimation, null or empty string otherwise.
+   */
+  public BrokerCapacityInfo(Map<Resource, Double> capacity, String estimationInfo) {
+    this(capacity, estimationInfo, null);
+  }
+
+  /**
+   * BrokerCapacityInfo with no estimation.
+   *
+   * @param capacity Capacity information for each resource.
+   * @param diskCapacityByLogDir Disk capacity by absolute logDir.
+   */
+  public BrokerCapacityInfo(Map<Resource, Double> capacity, Map<String, Double> diskCapacityByLogDir) {
+    this(capacity, null, diskCapacityByLogDir);
+  }
+
+  /**
+   * BrokerCapacityInfo with no estimation, no capacity information specified per absolute logDir.
+   *
+   * @param capacity Capacity information for each resource.
+   */
   public BrokerCapacityInfo(Map<Resource, Double> capacity) {
-    _capacity = capacity;
-    _estimationInfo = "";
+    this(capacity, null, null);
   }
 
   /**
@@ -41,5 +75,12 @@ public class BrokerCapacityInfo {
    */
   public String estimationInfo() {
     return _estimationInfo;
+  }
+
+  /**
+   * @return Disk capacity by absolute logDir if the capacity is specified per logDir, null otherwise.
+   */
+  public Map<String, Double> diskCapacityByLogDir() {
+    return _diskCapacityByLogDir;
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/TopicConfigProvider.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/TopicConfigProvider.java
@@ -7,12 +7,14 @@ package com.linkedin.kafka.cruisecontrol.config;
 import com.linkedin.cruisecontrol.common.CruiseControlConfigurable;
 import java.util.Map;
 import java.util.Properties;
+import org.apache.kafka.common.annotation.InterfaceStability;
 
 
 /**
  * The interface for getting the topic configs of Kafka. Users should implement this interface so Cruise Control can
  * get relevant cluster configurations for presenting to user -- e.g. "min.insync.replicas".
  */
+@InterfaceStability.Evolving
 public interface TopicConfigProvider extends CruiseControlConfigurable, AutoCloseable {
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
@@ -172,7 +172,7 @@ public class Broker implements Serializable, Comparable<Broker> {
    * @return LogDir for the requested logDirIndex.
    */
   public String logDirForIndex(int index) {
-    if (index >= numLogDirs()) {
+    if (index >= numLogDirs() || index < 0) {
       throw new IllegalArgumentException("Index(" + index + ") is out of range(" + numLogDirs() + ") for broker:" + _id + ".");
     }
     return _logDirs[index];
@@ -185,7 +185,7 @@ public class Broker implements Serializable, Comparable<Broker> {
    * @return LogDir capacity for the requested logDirIndex.
    */
   public double logDirCapacityForIndex(int index) {
-    if (index >= numLogDirs()) {
+    if (index >= numLogDirs() || index < 0) {
       throw new IllegalArgumentException("Index(" + index + ") is out of range(" + numLogDirs() + ") for broker:" + _id + ".");
     }
     return _logDirCapacity[index];

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
@@ -38,6 +38,9 @@ public class Broker implements Serializable, Comparable<Broker> {
   private final int _id;
   private final Host _host;
   private final double[] _brokerCapacity;
+  // To reduce memory footprint, use arrays of logDirs and logDirCapacity rather than a map of diskCapacityByLogDir.
+  private final String[] _logDirs;
+  private final double[] _logDirCapacity;
   private final Set<Replica> _replicas;
   private final Set<Replica> _leaderReplicas;
   /** A map of cached sorted replicas using different user defined score functions. */
@@ -53,13 +56,25 @@ public class Broker implements Serializable, Comparable<Broker> {
   private State _state;
 
   /**
-   * Constructor for Broker class.
+   * Constructor for Broker class with no disk capacity specified per absolute logDir -- i.e. non-JBOD broker.
    *
    * @param host           The host this broker is on
    * @param id             The id of the broker.
    * @param brokerCapacity The capacity of the broker.
    */
   Broker(Host host, int id, Map<Resource, Double> brokerCapacity) {
+    this(host, id, brokerCapacity, null);
+  }
+
+  /**
+   * Constructor for Broker class.
+   *
+   * @param host           The host this broker is on
+   * @param id             The id of the broker.
+   * @param brokerCapacity The capacity of the broker.
+   * @param diskCapacityByLogDir Disk capacity by absolute logDir.
+   */
+  Broker(Host host, int id, Map<Resource, Double> brokerCapacity, Map<String, Double> diskCapacityByLogDir) {
     if (brokerCapacity == null) {
       throw new IllegalArgumentException("Attempt to create broker " + id + " on host " + host.name() + " with null capacity.");
     }
@@ -69,6 +84,20 @@ public class Broker implements Serializable, Comparable<Broker> {
     for (Map.Entry<Resource, Double> entry : brokerCapacity.entrySet()) {
       _brokerCapacity[entry.getKey().id()] = entry.getValue();
     }
+
+    if (diskCapacityByLogDir == null || diskCapacityByLogDir.isEmpty()) {
+      _logDirs = null;
+      _logDirCapacity = null;
+    } else {
+      _logDirs = new String[diskCapacityByLogDir.size()];
+      _logDirCapacity = new double[diskCapacityByLogDir.size()];
+      int logIndex = 0;
+      for (Map.Entry<String, Double> entry : diskCapacityByLogDir.entrySet()) {
+        _logDirs[logIndex] = entry.getKey();
+        _logDirCapacity[logIndex++] = entry.getValue();
+      }
+    }
+
     _replicas = new HashSet<>();
     _leaderReplicas = new HashSet<>();
     _topicReplicas = new HashMap<>();
@@ -85,7 +114,7 @@ public class Broker implements Serializable, Comparable<Broker> {
     return _host;
   }
 
-  public State getState() {
+  public State state() {
     return _state;
   }
 
@@ -114,6 +143,59 @@ public class Broker implements Serializable, Comparable<Broker> {
       return _brokerCapacity[resource.id()];
     }
     return -1.0;
+  }
+
+  /**
+   * Get logDir capacity for the requested logDir.
+   *
+   * @param logDir LogDir for which the capacity will be provided.
+   * @return The healthy capacity of the requested logDir. Note that if the broker is not alive or the disk is dead,
+   * this method still returns the healthy disk capacity.
+   */
+  public double logDirCapacityFor(String logDir) {
+    if (_logDirs == null) {
+      throw new IllegalStateException("No logDir capacity has been provided for broker:" + _id + ".");
+    }
+
+    for (int logDirIndex = 0; logDirIndex < _logDirs.length; logDirIndex++) {
+      if (logDir.equals(_logDirs[logDirIndex])) {
+        return _logDirCapacity[logDirIndex];
+      }
+    }
+    throw new IllegalArgumentException("Requested logDir:" + logDir + " does not exist in broker:" + _id + ".");
+  }
+
+  /**
+   * Get logDir for the requested logDirIndex.
+   *
+   * @param index Index of the queried logDir.
+   * @return LogDir for the requested logDirIndex.
+   */
+  public String logDirForIndex(int index) {
+    if (index >= numLogDirs()) {
+      throw new IllegalArgumentException("Index(" + index + ") is out of range(" + numLogDirs() + ") for broker:" + _id + ".");
+    }
+    return _logDirs[index];
+  }
+
+  /**
+   * Get logDir capacity for the requested logDirIndex.
+   *
+   * @param index Index of the queried logDir capacity.
+   * @return LogDir capacity for the requested logDirIndex.
+   */
+  public double logDirCapacityForIndex(int index) {
+    if (index >= numLogDirs()) {
+      throw new IllegalArgumentException("Index(" + index + ") is out of range(" + numLogDirs() + ") for broker:" + _id + ".");
+    }
+    return _logDirCapacity[index];
+  }
+
+  /**
+   * Get number of logDirs in the broker if provided, 0 otherwise.
+   */
+  public int numLogDirs() {
+    return _logDirs == null ? 0 : _logDirs.length;
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Host.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Host.java
@@ -119,8 +119,8 @@ public class Host implements Serializable {
   }
 
   // Model manipulation.
-  Broker createBroker(Integer brokerId, Map<Resource, Double> brokerCapacity) {
-    Broker broker = new Broker(this, brokerId, brokerCapacity);
+  Broker createBroker(Integer brokerId, Map<Resource, Double> brokerCapacity, Map<String, Double> diskCapacityByLogDir) {
+    Broker broker = new Broker(this, brokerId, brokerCapacity, diskCapacityByLogDir);
     _brokers.put(brokerId, broker);
     _aliveBrokers++;
     for (Map.Entry<Resource, Double> entry : brokerCapacity.entrySet()) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Rack.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Rack.java
@@ -244,14 +244,18 @@ public class Rack implements Serializable {
   /**
    * Create a broker under this rack, and get the created broker.
    *
-   * @param brokerId       Id of the broker to be created.
-   * @param hostName           The hostName of the broker
+   * @param brokerId Id of the broker to be created.
+   * @param hostName The hostName of the broker
    * @param brokerCapacity Capacity of the created broker.
+   * @param diskCapacityByLogDir Disk capacity by absolute logDir.
    * @return Created broker.
    */
-  Broker createBroker(int brokerId, String hostName, Map<Resource, Double> brokerCapacity) {
+  Broker createBroker(int brokerId,
+                      String hostName,
+                      Map<Resource, Double> brokerCapacity,
+                      Map<String, Double> diskCapacityByLogDir) {
     Host host = _hosts.computeIfAbsent(hostName, name -> new Host(name, this));
-    Broker broker = host.createBroker(brokerId, brokerCapacity);
+    Broker broker = host.createBroker(brokerId, brokerCapacity, diskCapacityByLogDir);
     _brokers.put(brokerId, broker);
     for (Map.Entry<Resource, Double> entry : brokerCapacity.entrySet()) {
       _rackCapacity[entry.getKey().id()] += entry.getValue();

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolverTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolverTest.java
@@ -32,7 +32,7 @@ public class BrokerCapacityConfigFileResolverTest {
     assertEquals(100000.0, configResolver.capacityForBroker("", "", 2)
                                          .capacity().get(Resource.NW_IN), 0.01);
     try {
-      configResolver.capacityForBroker("", "", -1);
+      configResolver.capacityForBroker("", "", BrokerCapacityConfigFileResolver.DEFAULT_CAPACITY_BROKER_ID);
       fail("Should have thrown exception for negative broker id");
     } catch (IllegalArgumentException e) {
       // let it go
@@ -40,5 +40,25 @@ public class BrokerCapacityConfigFileResolverTest {
 
     assertTrue(configResolver.capacityForBroker("", "", 2).isEstimated());
     assertTrue(configResolver.capacityForBroker("", "", 2).estimationInfo().length() > 0);
+  }
+
+  @Test
+  public void testParseConfigJBODFile() {
+    BrokerCapacityConfigResolver configResolver = new BrokerCapacityConfigFileResolver();
+    Map<String, String> configs = new HashMap<>();
+    String fileName = this.getClass().getClassLoader().getResource("testCapacityConfigJBOD.json").getFile();
+    configs.put(BrokerCapacityConfigFileResolver.CAPACITY_CONFIG_FILE, fileName);
+    configResolver.configure(configs);
+
+    assertEquals(2000000.0, configResolver.capacityForBroker("", "", 0)
+                                         .capacity().get(Resource.DISK), 0.01);
+    assertEquals(2200000.0, configResolver.capacityForBroker("", "", 3)
+                                         .capacity().get(Resource.DISK), 0.01);
+    assertEquals(200000.0, configResolver.capacityForBroker("", "", 3)
+                                         .diskCapacityByLogDir().get("/tmp/kafka-logs-4"), 0.01);
+
+    assertTrue(!configResolver.capacityForBroker("", "", 2).isEstimated());
+    assertTrue(configResolver.capacityForBroker("", "", 3).isEstimated());
+    assertTrue(configResolver.capacityForBroker("", "", 3).estimationInfo().length() > 0);
   }
 }

--- a/cruise-control/src/test/resources/testCapacityConfigJBOD.json
+++ b/cruise-control/src/test/resources/testCapacityConfigJBOD.json
@@ -1,0 +1,43 @@
+{
+  "brokerCapacities": [
+    {
+      "brokerId": "-1",
+      "capacity": {
+        "DISK": {"/tmp/kafka-logs-1": "400000", "/tmp/kafka-logs-2": "200000", "/tmp/kafka-logs-3": "200000",
+          "/tmp/kafka-logs-4": "200000", "/tmp/kafka-logs-5": "200000", "/tmp/kafka-logs-6": "200000",
+          "/tmp/kafka-logs-7": "200000", "/tmp/kafka-logs-8": "200000", "/tmp/kafka-logs-9": "200000",
+          "/tmp/kafka-logs-10": "200000"},
+        "CPU": "100",
+        "NW_IN": "100000",
+        "NW_OUT": "100000"
+      }
+    },
+    {
+      "brokerId": "0",
+      "capacity": {
+        "DISK": {"/tmp/kafka-logs": "2000000"},
+        "CPU": "200",
+        "NW_IN": "200000",
+        "NW_OUT": "200000"
+      }
+    },
+    {
+      "brokerId": "1",
+      "capacity": {
+        "DISK": {"/tmp/kafka-logs-1": "350000", "/tmp/kafka-logs-2": "550000"},
+        "CPU": "300",
+        "NW_IN": "300000",
+        "NW_OUT": "200000"
+      }
+    },
+    {
+      "brokerId": "2",
+      "capacity": {
+        "DISK": "2000000",
+        "CPU": "300",
+        "NW_IN": "300000",
+        "NW_OUT": "200000"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
* Add logDir information to cluster model and kafka cluster state.
* Fix a typo that prevents printing to `PublicAccessLogger`.