### PR TITLE
Fix the bug in MetricSampleAggregator sample window rolling out

### DIFF
--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregator.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregator.java
@@ -472,7 +472,7 @@ public class MetricSampleAggregator<G, E extends Entity<G>> extends LongGenerati
           // Reset all the data starting from previous oldest window. After this point the old samples cannot get
           // into the raw metric values. We only need to reset the index if the new index is at least _numWindows;
           if (numOldWindowIndexesToReset > 0) {
-            resetIndexes(prevOldestWindowIndex, numOldWindowIndexesToReset, _oldestWindowIndex);
+            resetIndexes(prevOldestWindowIndex, numOldWindowIndexesToReset);
           }
           // Set the generation of the old current window.
           _aggregatorState.updateWindowGeneration(_currentWindowIndex, generation());
@@ -489,12 +489,13 @@ public class MetricSampleAggregator<G, E extends Entity<G>> extends LongGenerati
     return false;
   }
 
-  private void resetIndexes(long prevOldestWindowIndex, int numIndexesToReset, long newOldestWindowIndex) {
+  private void resetIndexes(long prevOldestWindowIndex, int numIndexesToReset) {
+    long currentOldestWindowIndex = _oldestWindowIndex;
     for (RawMetricValues rawValues : _rawMetrics.values()) {
-      rawValues.updateOldestWindowIndex(newOldestWindowIndex);
+      rawValues.updateOldestWindowIndex(currentOldestWindowIndex);
       rawValues.resetWindowIndexes(prevOldestWindowIndex, numIndexesToReset);
     }
-    _aggregatorState.updateOldestWindowIndex(newOldestWindowIndex);
+    _aggregatorState.updateOldestWindowIndex(currentOldestWindowIndex);
     _aggregatorState.resetWindowIndexes(prevOldestWindowIndex, numIndexesToReset);
   }
 

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregator.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregator.java
@@ -472,7 +472,7 @@ public class MetricSampleAggregator<G, E extends Entity<G>> extends LongGenerati
           // Reset all the data starting from previous oldest window. After this point the old samples cannot get
           // into the raw metric values. We only need to reset the index if the new index is at least _numWindows;
           if (numOldWindowIndexesToReset > 0) {
-            resetIndexes(prevOldestWindowIndex, numOldWindowIndexesToReset);
+            resetIndexes(prevOldestWindowIndex, numOldWindowIndexesToReset, _oldestWindowIndex);
           }
           // Set the generation of the old current window.
           _aggregatorState.updateWindowGeneration(_currentWindowIndex, generation());
@@ -489,13 +489,13 @@ public class MetricSampleAggregator<G, E extends Entity<G>> extends LongGenerati
     return false;
   }
 
-  private void resetIndexes(long startingWindowIndex, int numIndexesToReset) {
+  private void resetIndexes(long prevOldestWindowIndex, int numIndexesToReset, long newOldestWindowIndex) {
     for (RawMetricValues rawValues : _rawMetrics.values()) {
-      rawValues.updateOldestWindowIndex(startingWindowIndex + numIndexesToReset);
-      rawValues.resetWindowIndexes(startingWindowIndex, numIndexesToReset);
+      rawValues.updateOldestWindowIndex(newOldestWindowIndex);
+      rawValues.resetWindowIndexes(prevOldestWindowIndex, numIndexesToReset);
     }
-    _aggregatorState.updateOldestWindowIndex(startingWindowIndex + numIndexesToReset);
-    _aggregatorState.resetWindowIndexes(startingWindowIndex, numIndexesToReset);
+    _aggregatorState.updateOldestWindowIndex(newOldestWindowIndex);
+    _aggregatorState.resetWindowIndexes(prevOldestWindowIndex, numIndexesToReset);
   }
 
   private void validateCompleteness(long from,

--- a/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregatorTest.java
+++ b/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregatorTest.java
@@ -161,6 +161,25 @@ public class MetricSampleAggregatorTest {
   }
 
   @Test
+  public void testAddSamplesWithLargeInterval() {
+    MetricSampleAggregator<String, IntegerEntity> aggregator =
+        new MetricSampleAggregator<>(NUM_WINDOWS, WINDOW_MS, MIN_SAMPLES_PER_WINDOW,
+            0, _metricDef);
+    CruiseControlUnitTestUtils.populateSampleAggregator(NUM_WINDOWS + 1, MIN_SAMPLES_PER_WINDOW,
+        aggregator, ENTITY1, 0, WINDOW_MS,
+        _metricDef);
+
+    CruiseControlUnitTestUtils.populateSampleAggregator(NUM_WINDOWS, MIN_SAMPLES_PER_WINDOW,
+        aggregator, ENTITY1, 4 * NUM_WINDOWS, WINDOW_MS,
+        _metricDef);
+    List<Long> availableWindows = aggregator.availableWindows();
+    assertEquals(NUM_WINDOWS, availableWindows.size());
+    for (int i = 0; i < NUM_WINDOWS; i++) {
+      assertEquals((i + 4 * NUM_WINDOWS) * WINDOW_MS, availableWindows.get(i).longValue());
+    }
+  }
+
+  @Test
   public void testAggregationOption1() throws NotEnoughValidWindowsException {
     MetricSampleAggregator<String, IntegerEntity> aggregator = prepareCompletenessTestEnv();
 

--- a/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregatorTest.java
+++ b/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregatorTest.java
@@ -165,13 +165,17 @@ public class MetricSampleAggregatorTest {
     MetricSampleAggregator<String, IntegerEntity> aggregator =
         new MetricSampleAggregator<>(NUM_WINDOWS, WINDOW_MS, MIN_SAMPLES_PER_WINDOW,
             0, _metricDef);
+    // Populate samples for time window indexed from 0 to NUM_WINDOWS to aggregator.
     CruiseControlUnitTestUtils.populateSampleAggregator(NUM_WINDOWS + 1, MIN_SAMPLES_PER_WINDOW,
         aggregator, ENTITY1, 0, WINDOW_MS,
         _metricDef);
 
+    // Populate samples for time window index from 4 * NUM_WINDOWS to 5 * NUM_WINDOWS - 1 to aggregator.
     CruiseControlUnitTestUtils.populateSampleAggregator(NUM_WINDOWS, MIN_SAMPLES_PER_WINDOW,
         aggregator, ENTITY1, 4 * NUM_WINDOWS, WINDOW_MS,
         _metricDef);
+    // If aggregator rolls out time window properly, time window indexed from 4 * NUM_WINDOW -1 to 5 * NUM_WINDOW -1 are
+    // currently in memory and time window indexed from 4 * NUM_WINDOW -1 to  5 * NUM_WINDOW - 2 should be returned from query.
     List<Long> availableWindows = aggregator.availableWindows();
     assertEquals(NUM_WINDOWS, availableWindows.size());
     for (int i = 0; i < NUM_WINDOWS; i++) {


### PR DESCRIPTION
There is bug in `MetricSampleAggregator` that the maximal number window can be rolled out is ceilinged by maximal number of window kept in memory. This cause issue in scenario where sampling is resumed after long time pause and more window needs to be rolled out. In case `SamplingTask` will keep failing and Cruise Control is hang(unable to execute any operation).