### PR TITLE
Fix Replica Distribution, Potential NwOut, and TopicReplica Distribution Goals.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -233,12 +233,12 @@ public class KafkaCruiseControl {
                                                   Integer concurrentLeaderMovements,
                                                   boolean skipHardGoalCheck,
                                                   Pattern excludedTopics) throws KafkaCruiseControlException {
+    sanityCheckHardGoalPresence(goals, skipHardGoalCheck);
+    Map<Integer, Goal> goalsByPriority = goalsByPriority(goals);
+    ModelCompletenessRequirements modelCompletenessRequirements =
+        modelCompletenessRequirements(goalsByPriority.values()).weaker(requirements);
     try (AutoCloseable ignored = _loadMonitor.acquireForModelGeneration(operationProgress)) {
       sanityCheckBrokerPresence(brokerIds);
-      sanityCheckHardGoalPresence(goals, skipHardGoalCheck);
-      Map<Integer, Goal> goalsByPriority = goalsByPriority(goals);
-      ModelCompletenessRequirements modelCompletenessRequirements =
-          modelCompletenessRequirements(goalsByPriority.values()).weaker(requirements);
       ClusterModel clusterModel = _loadMonitor.clusterModel(_time.milliseconds(),
                                                             modelCompletenessRequirements,
                                                             operationProgress);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/PotentialNwOutGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/PotentialNwOutGoal.java
@@ -263,7 +263,8 @@ public class PotentialNwOutGoal extends AbstractGoal {
                                     ClusterModel clusterModel,
                                     Set<Goal> optimizedGoals,
                                     Set<String> excludedTopics) {
-    double capacityLimit = broker.capacityFor(Resource.NW_OUT) * _balancingConstraint.capacityThreshold(Resource.NW_OUT);
+    double capacityThreshold = _balancingConstraint.capacityThreshold(Resource.NW_OUT);
+    double capacityLimit = broker.capacityFor(Resource.NW_OUT) * capacityThreshold;
     boolean estimatedMaxPossibleNwOutOverLimit = !broker.replicas().isEmpty() &&
         clusterModel.potentialLeadershipLoadFor(broker.id()).expectedUtilizationFor(Resource.NW_OUT) > capacityLimit;
     if (!estimatedMaxPossibleNwOutOverLimit) {
@@ -300,7 +301,8 @@ public class PotentialNwOutGoal extends AbstractGoal {
         // Update brokersUnderEstimatedMaxPossibleNwOut (for destination broker).
         double updatedDestBrokerPotentialNwOut =
             clusterModel.potentialLeadershipLoadFor(destinationBrokerId).expectedUtilizationFor(Resource.NW_OUT);
-        if (!_selfHealingDeadBrokersOnly && updatedDestBrokerPotentialNwOut > capacityLimit) {
+        double destCapacityLimit = destinationBroker.capacityFor(Resource.NW_OUT) * capacityThreshold;
+        if (!_selfHealingDeadBrokersOnly && updatedDestBrokerPotentialNwOut > destCapacityLimit) {
           candidateBrokers.remove(clusterModel.broker(destinationBrokerId));
         }
       }
@@ -326,8 +328,7 @@ public class PotentialNwOutGoal extends AbstractGoal {
     double capacityThreshold = _balancingConstraint.capacityThreshold(Resource.NW_OUT);
 
     for (Broker healthyBroker : clusterModel.healthyBrokers()) {
-      // We use the hosts capacity instead of the broker capacity.
-      double capacityLimit = healthyBroker.host().capacityFor(Resource.NW_OUT) * capacityThreshold;
+      double capacityLimit = healthyBroker.capacityFor(Resource.NW_OUT) * capacityThreshold;
       if (clusterModel.potentialLeadershipLoadFor(healthyBroker.id()).expectedUtilizationFor(Resource.NW_OUT) < capacityLimit) {
         brokersUnderEstimatedMaxPossibleNwOut.add(healthyBroker);
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionTarget.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionTarget.java
@@ -135,7 +135,7 @@ class ReplicaDistributionTarget {
     }
 
     // Update consumed warm broker credits. Credit is consumed because the broker was unable to move replicas.
-    if (isMoveSuccessful) {
+    if (!isMoveSuccessful) {
       _consumedWarmBrokerCredits++;
     }
   }


### PR DESCRIPTION
* Ensure that Potential NwOut Goal uses the capacity of the correct broker -- i.e. destination, not the source.
* Ensure correct destination broker id while updating the global sorted broker set in Replica Distribution Goal.
* Ensure correct warm credit adjustment for TopicReplica Distribution Goal.