### PR TITLE
Disable hard goal enforcement in kafka assigner mode.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -650,8 +650,7 @@ public class KafkaCruiseControl {
    * Sanity check whether all hard goals are included in provided goal list.
    * There are two special scenarios where hard goal check is skipped.
    * <ul>
-   * <li> {@code goals} is null or empty list, according to {@link KafkaCruiseControl#goalsByPriority(List)} either default
-   * goals or all goals(if default.goals config is not set) will be picked up.</li>
+   * <li> {@code goals} is null or empty list.</li>
    * <li> {@code goals} only has PreferredLeaderElectionGoal, denotes it is a PLE request.</li>
    * </ul>
    *
@@ -661,8 +660,8 @@ public class KafkaCruiseControl {
   private void sanityCheckHardGoalPresence(List<String> goals, boolean skipHardGoalCheck) {
     if (goals != null && !goals.isEmpty() && !skipHardGoalCheck &&
       !(goals.size() == 1 && goals.get(0).equals(PreferredLeaderElectionGoal.class.getSimpleName()))) {
-      List<String> hardGoals = _config.getList(KafkaCruiseControlConfig.HARD_GOALS_CONFIG).stream()
-                               .map(goalName -> goalName.substring(goalName.lastIndexOf(".") + 1)).collect(Collectors.toList());
+      Set<String> hardGoals = _config.getList(KafkaCruiseControlConfig.HARD_GOALS_CONFIG).stream()
+                               .map(goalName -> goalName.substring(goalName.lastIndexOf(".") + 1)).collect(Collectors.toSet());
       if (!goals.containsAll(hardGoals)) {
         throw new IllegalArgumentException("Missing hard goals " + hardGoals + " in provided goal list " + goals + ".");
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
@@ -434,8 +434,11 @@ class KafkaCruiseControlServletUtils {
     return dataFrom;
   }
 
+  /**
+   * Skip hard goal check in kafka_assigner mode,
+   */
   static boolean skipHardGoalCheck(HttpServletRequest request) {
-    return getBooleanParam(request, SKIP_HARD_GOAL_CHECK_PARAM, false);
+    return getMode(request) || getBooleanParam(request, SKIP_HARD_GOAL_CHECK_PARAM, false);
   }
 
   enum DataFrom {


### PR DESCRIPTION
Currently `skip_hard_goal_check` parameter on `add_broker`, `remove_broker`, and `rebalance` endpoints must be set to `true` to avoid hard goal enforcement. 

For `kafka_assigner` mode,  ` skip_hard_goal_check=true` should be true by default.