### PR TITLE
Use newline rather than literal %n

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -194,7 +194,7 @@ public class KafkaCruiseControl {
                                                    Map<Integer, String> capacityEstimationInfoByBrokerId) {
     if (!(allowCapacityEstimation || capacityEstimationInfoByBrokerId.isEmpty())) {
       StringBuilder sb = new StringBuilder();
-      sb.append("Allow capacity estimation or fix dependencies to capture broker capacities.%n");
+      sb.append(String.format("Allow capacity estimation or fix dependencies to capture broker capacities.%n"));
       for (Map.Entry<Integer, String> entry : capacityEstimationInfoByBrokerId.entrySet()) {
         sb.append(String.format("Broker: %d: info: %s%n", entry.getKey(), entry.getValue()));
       }


### PR DESCRIPTION
Previously, line 197 returns the string ending in literal "%n".

This results in output like  
```
java.lang.IllegalStateException: Allow capacity estimation or fix dependencies to capture broker capacities.%nBroker: 33882
```

It appears, however, that the intention is to use an OS-independent newline character, rather than %n literal.

Accordingly, surround the string containing "%n" in String.format() method, to return an OS-independent newline character.