### PR TITLE
Fix issues in proposals/remove_broker/user_tasks

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -164,7 +164,6 @@ public class KafkaCruiseControl {
     ModelCompletenessRequirements modelCompletenessRequirements =
         modelCompletenessRequirements(goalsByPriority.values()).weaker(requirements);
     try (AutoCloseable ignored = _loadMonitor.acquireForModelGeneration(operationProgress)) {
-      sanityCheckBrokerPresence(brokerIds);
       ClusterModel clusterModel = _loadMonitor.clusterModel(_time.milliseconds(), modelCompletenessRequirements,
                                                             operationProgress);
       brokerIds.forEach(id -> clusterModel.setBrokerState(id, Broker.State.DEAD));

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
@@ -331,7 +331,7 @@ public class GoalOptimizer implements Runnable {
                   _bestProposal == null ? "" : String.format(" Cached was excluding default topics: %s.",
                                                              _bestProposal.excludedTopics()));
         // Invalidate the cache and set the new caching rule regarding capacity estimation.
-        _bestProposal = null;
+        clearBestProposal();
         // Explicitly allow capacity estimation to exit the loop upon computing best proposals.
         while (!validCachedProposal()) {
           try {
@@ -347,6 +347,7 @@ public class GoalOptimizer implements Runnable {
                 // No precomputing thread is available, schedule a computing and wait for the cache update.
                 _proposalPrecomputingExecutor.submit(this::computeBestProposal);
               }
+              operationProgress.refer(_proposalPrecomputingProgress);
             }
             _cacheLock.wait();
           } finally {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -1103,13 +1103,13 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       responseString = new Gson().toJson(responseStructure);
     } else {
       StringBuilder sb = new StringBuilder();
-      sb.append(String.format("%n%40s%20s%20s%15s  %s", "USER TASK ID", "CLIENT ADDRESS", "START MS", "STATUS", "REQUEST URL"));
+      sb.append(String.format("%n%40s%40s%20s%15s  %s", "USER TASK ID", "CLIENT ADDRESS", "START MS", "STATUS", "REQUEST URL"));
       for (UserTaskManager.UserTaskInfo userTaskInfo : activeUserTasks) {
         Date date = new Date(userTaskInfo.startMs());
         DateFormat formatter = new SimpleDateFormat("HH:mm:ss.SSSZ");
         formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
         String dateFormatted = formatter.format(date);
-        sb.append(String.format("%n%40s%20s%20s%15s  %s", userTaskInfo.userTaskId().toString(),  userTaskInfo.clientIdentity(),
+        sb.append(String.format("%n%40s%40s%20s%15s  %s", userTaskInfo.userTaskId().toString(),  userTaskInfo.clientIdentity(),
             dateFormatted, "Active", userTaskInfo.requestWithParams()));
       }
 
@@ -1118,7 +1118,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
         DateFormat formatter = new SimpleDateFormat("HH:mm:ss.SSSZ");
         formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
         String dateFormatted = formatter.format(date);
-        sb.append(String.format("%n%40s%20s%20s%15s  %s", userTaskInfo.userTaskId().toString(),  userTaskInfo.clientIdentity(),
+        sb.append(String.format("%n%40s%40s%20s%15s  %s", userTaskInfo.userTaskId().toString(),  userTaskInfo.clientIdentity(),
             dateFormatted, "Completed", userTaskInfo.requestWithParams()));
 
       }


### PR DESCRIPTION
1. fix the issue in user_tasks endpoint that the return message does not reserve enough space for user identity field(which can be IPv6 address)
2.remove the invalid broker checking in remove_broker endpoint to handle the scenario that we want to use Cruise Control to remove a broker which has already died(since now shows in latest metadata)
3.fix the issue in proposals endpoint that sometimes the returned operation progress message does not reflect what is going on inside Cruise Control.