### PR TITLE
Improve sample loading efficiency in Cruise Control booting up process.

### DIFF
--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregator.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregator.java
@@ -576,16 +576,18 @@ public class MetricSampleAggregator<G, E extends Entity<G>> extends LongGenerati
   }
 
   /**
-   * Get the length of time aggregator keeps sample in memory.
-   * It is used to determine the time length to look back(from current time) when loading the historical samples.
+   * Get the length of time aggregator keeps samples in memory.
    * @return length of time.
    */
   public long monitoringPeriodMs() {
     return _monitoringPeriodMs;
   }
 
+  /**
+   * The {@link MetricSample MetricSamples} type which the aggregator collects.
+   */
   protected enum SampleType {
     BROKER,
-    PARTITION;
+    PARTITION
   }
 }

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/RawMetricValues.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/RawMetricValues.java
@@ -185,7 +185,7 @@ public class RawMetricValues extends WindowIndexedArrays {
    *
    * @param startingWindowIndex the starting index of the windows to reset.
    * @param numWindowIndexesToReset the number of windows to reset.
-   * @return number of samples abandoned in window clearing process.
+   * @return number of samples abandoned in window clearing process. The abandoned samples are samples in the windows which get reset.
    */
   public synchronized int resetWindowIndexes(long startingWindowIndex, int numWindowIndexesToReset) {
     if (inValidRange(startingWindowIndex)
@@ -193,17 +193,17 @@ public class RawMetricValues extends WindowIndexedArrays {
       throw new IllegalStateException("Should never reset a window index that is in the valid range");
     }
     // We are not resetting all the data here. The data will be interpreted to 0 if count is 0.
-    int numAbandonedSample = 0;
+    int numAbandonedSamples = 0;
     for (long i = startingWindowIndex; i < startingWindowIndex + numWindowIndexesToReset; i++) {
       int index = arrayIndex(i);
-      numAbandonedSample += _counts[index];
+      numAbandonedSamples += _counts[index];
       _counts[index] = 0;
       _validity.clear(index);
       _extrapolations.clear(index);
     }
     LOG.trace("Resetting window index [{}, {}], abandon {} samples.", startingWindowIndex,
-        startingWindowIndex + numWindowIndexesToReset - 1, numAbandonedSample);
-    return numAbandonedSample;
+              startingWindowIndex + numWindowIndexesToReset - 1, numAbandonedSamples);
+    return numAbandonedSamples;
   }
 
   /**

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/RawMetricValues.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/RawMetricValues.java
@@ -185,14 +185,15 @@ public class RawMetricValues extends WindowIndexedArrays {
    *
    * @param startingWindowIndex the starting index of the windows to reset.
    * @param numWindowIndexesToReset the number of windows to reset.
+   * @return number of samples abandoned in window clearing process.
    */
-  public synchronized void resetWindowIndexes(long startingWindowIndex, int numWindowIndexesToReset) {
+  public synchronized int resetWindowIndexes(long startingWindowIndex, int numWindowIndexesToReset) {
     if (inValidRange(startingWindowIndex)
         || inValidRange(startingWindowIndex + numWindowIndexesToReset - 1)) {
       throw new IllegalStateException("Should never reset a window index that is in the valid range");
     }
     // We are not resetting all the data here. The data will be interpreted to 0 if count is 0.
-    long numAbandonedSample = 0;
+    int numAbandonedSample = 0;
     for (long i = startingWindowIndex; i < startingWindowIndex + numWindowIndexesToReset; i++) {
       int index = arrayIndex(i);
       numAbandonedSample += _counts[index];
@@ -200,8 +201,9 @@ public class RawMetricValues extends WindowIndexedArrays {
       _validity.clear(index);
       _extrapolations.clear(index);
     }
-    LOG.debug("Resetting window index [{}, {}], abandon {} samples.", startingWindowIndex,
+    LOG.trace("Resetting window index [{}, {}], abandon {} samples.", startingWindowIndex,
         startingWindowIndex + numWindowIndexesToReset - 1, numAbandonedSample);
+    return numAbandonedSample;
   }
 
   /**

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/RawMetricValues.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/RawMetricValues.java
@@ -191,15 +191,17 @@ public class RawMetricValues extends WindowIndexedArrays {
         || inValidRange(startingWindowIndex + numWindowIndexesToReset - 1)) {
       throw new IllegalStateException("Should never reset a window index that is in the valid range");
     }
-    LOG.debug("Resetting window index [{}, {}]", startingWindowIndex,
-              startingWindowIndex + numWindowIndexesToReset - 1);
     // We are not resetting all the data here. The data will be interpreted to 0 if count is 0.
+    long numAbandonedSample = 0;
     for (long i = startingWindowIndex; i < startingWindowIndex + numWindowIndexesToReset; i++) {
       int index = arrayIndex(i);
+      numAbandonedSample += _counts[index];
       _counts[index] = 0;
       _validity.clear(index);
       _extrapolations.clear(index);
     }
+    LOG.debug("Resetting window index [{}, {}], abandon {} samples.", startingWindowIndex,
+        startingWindowIndex + numWindowIndexesToReset - 1, numAbandonedSample);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
@@ -409,9 +409,9 @@ public class KafkaSampleStore implements SampleStore {
     }
 
     /**
-     * Config the sample loading consumers to consume from proper starting offsets. The sample store Kafka topic may contains datas
+     * Config the sample loading consumers to consume from proper starting offsets. The sample store Kafka topic may contain data
      * which are too old for {@link com.linkedin.cruisecontrol.monitor.sampling.aggregator.MetricSampleAggregator} to keep in memory,
-     * to prevent loading these stale datas, manually seek the consumers' staring offset to the offset at proper timestamp.
+     * to prevent loading these stale data, manually seek the consumers' staring offset to the offset at proper timestamp.
      */
     private void prepareConsumerOffset() {
       Map<TopicPartition, Long> beginningTimestamp = new HashMap<>(_consumer.assignment().size());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/SampleStore.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/SampleStore.java
@@ -77,5 +77,13 @@ public interface SampleStore extends CruiseControlConfigurable {
     public long brokerSampleCount() {
       return _brokerMetricSampleAggregator.numSamples();
     }
+
+    public long partitionSampleTimeLengthToLoadMs() {
+      return _partitionMetricSampleAggregator.sampleTimeLengthToLoadMs();
+    }
+
+    public long brokerSampleTimeLengthToLoadMs() {
+      return _brokerMetricSampleAggregator.sampleTimeLengthToLoadMs();
+    }
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/SampleStore.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/SampleStore.java
@@ -78,12 +78,12 @@ public interface SampleStore extends CruiseControlConfigurable {
       return _brokerMetricSampleAggregator.numSamples();
     }
 
-    public long partitionSampleTimeLengthToLoadMs() {
-      return _partitionMetricSampleAggregator.sampleTimeLengthToLoadMs();
+    public long partitionMonitoringPeriodMs() {
+      return _partitionMetricSampleAggregator.monitoringPeriodMs();
     }
 
-    public long brokerSampleTimeLengthToLoadMs() {
-      return _brokerMetricSampleAggregator.sampleTimeLengthToLoadMs();
+    public long brokerMonitoringPeriodMs() {
+      return _brokerMetricSampleAggregator.monitoringPeriodMs();
     }
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaBrokerMetricSampleAggregator.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaBrokerMetricSampleAggregator.java
@@ -42,6 +42,7 @@ public class KafkaBrokerMetricSampleAggregator extends MetricSampleAggregator<St
           KafkaMetricDef.brokerMetricDef());
     _maxAllowedExtrapoloationsPerBroker =
         config.getInt(KafkaCruiseControlConfig.MAX_ALLOWED_EXTRAPOLATIONS_PER_BROKER_CONFIG);
+    _metricSampleType = "Broker";
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaBrokerMetricSampleAggregator.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaBrokerMetricSampleAggregator.java
@@ -42,7 +42,7 @@ public class KafkaBrokerMetricSampleAggregator extends MetricSampleAggregator<St
           KafkaMetricDef.brokerMetricDef());
     _maxAllowedExtrapoloationsPerBroker =
         config.getInt(KafkaCruiseControlConfig.MAX_ALLOWED_EXTRAPOLATIONS_PER_BROKER_CONFIG);
-    _metricSampleType = "Broker";
+    _sampleType = SampleType.BROKER;
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregator.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregator.java
@@ -63,6 +63,7 @@ public class KafkaPartitionMetricSampleAggregator extends MetricSampleAggregator
     _metadata = metadata;
     _maxAllowedExtrapolationsPerPartition =
         config.getInt(KafkaCruiseControlConfig.MAX_ALLOWED_EXTRAPOLATIONS_PER_PARTITION_CONFIG);
+    _metricSampleType = "Partition";
 
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregator.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregator.java
@@ -63,7 +63,7 @@ public class KafkaPartitionMetricSampleAggregator extends MetricSampleAggregator
     _metadata = metadata;
     _maxAllowedExtrapolationsPerPartition =
         config.getInt(KafkaCruiseControlConfig.MAX_ALLOWED_EXTRAPOLATIONS_PER_PARTITION_CONFIG);
-    _metricSampleType = "Partition";
+    _sampleType = SampleType.PARTITION;
 
   }
 


### PR DESCRIPTION
Several bug fix and performance improvement in this path.
1. fix the bug in creating the broker metric sample topic(wrong config get picked up, result in wrong retention time of the topic)
2. fix the bug in loading partition/broker sample metric from corresponding topic(seek to the wrong beginning offset, result in doubling the Cruise Control boot up time)
3. improve the loading logic to reduce the contention between thread(to acquire the some lock) and burning CPU cycle(due to too short poll time)
4. improve the logging in sample loading process,  to help debugging if things goes wrong