### PR TITLE
Add use_ready_default_goals parameter to enable user to control the use of a subset of default goals that are ready.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -650,7 +650,7 @@ public class KafkaCruiseControl {
    * Sanity check whether all hard goals are included in provided goal list.
    * There are two special scenarios where hard goal check is skipped.
    * <ul>
-   * <li> {@code goals} is null or empty list.</li>
+   * <li> {@code goals} is null or empty -- i.e. even if hard goals are excluded from the default goals, this check will pass</li>
    * <li> {@code goals} only has PreferredLeaderElectionGoal, denotes it is a PLE request.</li>
    * </ul>
    *
@@ -659,12 +659,13 @@ public class KafkaCruiseControl {
    */
   private void sanityCheckHardGoalPresence(List<String> goals, boolean skipHardGoalCheck) {
     if (goals != null && !goals.isEmpty() && !skipHardGoalCheck &&
-      !(goals.size() == 1 && goals.get(0).equals(PreferredLeaderElectionGoal.class.getSimpleName()))) {
+        !(goals.size() == 1 && goals.get(0).equals(PreferredLeaderElectionGoal.class.getSimpleName()))) {
       sanityCheckNonExistingGoal(goals, AnalyzerUtils.getCaseInsensitiveGoalsByName(_config));
       Set<String> hardGoals = _config.getList(KafkaCruiseControlConfig.HARD_GOALS_CONFIG).stream()
-                               .map(goalName -> goalName.substring(goalName.lastIndexOf(".") + 1)).collect(Collectors.toSet());
+          .map(goalName -> goalName.substring(goalName.lastIndexOf(".") + 1)).collect(Collectors.toSet());
       if (!goals.containsAll(hardGoals)) {
-        throw new IllegalArgumentException("Missing hard goals " + hardGoals + " in provided goal list " + goals + ".");
+        throw new IllegalArgumentException("Missing hard goals " + hardGoals + " in the provided goals: " + goals
+                                           + ". Add skip_hard_goal_check=true parameter to ignore this sanity check.");
       }
     }
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -30,7 +30,6 @@ import com.linkedin.kafka.cruisecontrol.monitor.metricdefinition.KafkaMetricDef;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -123,7 +122,7 @@ public class KafkaCruiseControl {
    * @param goals The goals to check
    * @return True if the given goals contain a Kafka Assigner goal, false otherwise.
    */
-  private boolean isKafkaAssignerMode(List<String> goals) {
+  private boolean isKafkaAssignerMode(Collection<String> goals) {
     return goals.stream().anyMatch(KAFKA_ASSIGNER_GOALS::contains);
   }
 
@@ -160,9 +159,9 @@ public class KafkaCruiseControl {
                                                            Pattern excludedTopics)
       throws KafkaCruiseControlException {
     sanityCheckHardGoalPresence(goals, skipHardGoalCheck);
-    Map<Integer, Goal> goalsByPriority = goalsByPriority(goals);
+    List<Goal> goalsByPriority = goalsByPriority(goals);
     ModelCompletenessRequirements modelCompletenessRequirements =
-        modelCompletenessRequirements(goalsByPriority.values()).weaker(requirements);
+        modelCompletenessRequirements(goalsByPriority).weaker(requirements);
     try (AutoCloseable ignored = _loadMonitor.acquireForModelGeneration(operationProgress)) {
       ClusterModel clusterModel = _loadMonitor.clusterModel(_time.milliseconds(), modelCompletenessRequirements,
                                                             operationProgress);
@@ -233,9 +232,9 @@ public class KafkaCruiseControl {
                                                   boolean skipHardGoalCheck,
                                                   Pattern excludedTopics) throws KafkaCruiseControlException {
     sanityCheckHardGoalPresence(goals, skipHardGoalCheck);
-    Map<Integer, Goal> goalsByPriority = goalsByPriority(goals);
+    List<Goal> goalsByPriority = goalsByPriority(goals);
     ModelCompletenessRequirements modelCompletenessRequirements =
-        modelCompletenessRequirements(goalsByPriority.values()).weaker(requirements);
+        modelCompletenessRequirements(goalsByPriority).weaker(requirements);
     try (AutoCloseable ignored = _loadMonitor.acquireForModelGeneration(operationProgress)) {
       sanityCheckBrokerPresence(brokerIds);
       ClusterModel clusterModel = _loadMonitor.clusterModel(_time.milliseconds(),
@@ -404,7 +403,7 @@ public class KafkaCruiseControl {
     } catch (KafkaCruiseControlException kcce) {
       throw kcce;
     } catch (Exception e) {
-        throw new KafkaCruiseControlException(e);
+      throw new KafkaCruiseControlException(e);
     }
   }
 
@@ -498,9 +497,9 @@ public class KafkaCruiseControl {
                                                                 Pattern excludedTopics) throws KafkaCruiseControlException {
     GoalOptimizer.OptimizerResult result;
     sanityCheckHardGoalPresence(goals, skipHardGoalCheck);
-    Map<Integer, Goal> goalsByPriority = goalsByPriority(goals);
+    List<Goal> goalsByPriority = goalsByPriority(goals);
     ModelCompletenessRequirements modelCompletenessRequirements =
-        modelCompletenessRequirements(goalsByPriority.values()).weaker(requirements);
+        modelCompletenessRequirements(goalsByPriority).weaker(requirements);
     // There are a few cases that we cannot use the cached best proposals:
     // 1. When users specified goals.
     // 2. When provided requirements contains a weaker requirement than what is used by the cached proposal.
@@ -534,7 +533,7 @@ public class KafkaCruiseControl {
   }
 
   private GoalOptimizer.OptimizerResult getOptimizationProposals(ClusterModel clusterModel,
-                                                                 Map<Integer, Goal> goalsByPriority,
+                                                                 List<Goal> goalsByPriority,
                                                                  OperationProgress operationProgress,
                                                                  boolean allowCapacityEstimation,
                                                                  Pattern requestedExcludedTopics)
@@ -556,8 +555,8 @@ public class KafkaCruiseControl {
    *                                  (if null, use num.concurrent.leader.movements).
    */
   private void executeProposals(Collection<ExecutionProposal> proposals,
-                               Collection<Integer> unthrottledBrokers,
-                               boolean isKafkaAssignerMode,
+                                Collection<Integer> unthrottledBrokers,
+                                boolean isKafkaAssignerMode,
                                 Integer concurrentPartitionMovements,
                                 Integer concurrentLeaderMovements) {
     // Set the execution mode, add execution proposals, and start execution.
@@ -610,7 +609,7 @@ public class KafkaCruiseControl {
 
   private ModelCompletenessRequirements modelCompletenessRequirements(Collection<Goal> overrides) {
     return overrides == null || overrides.isEmpty() ?
-        _goalOptimizer.defaultModelCompletenessRequirements() : MonitorUtils.combineLoadRequirementOptions(overrides);
+           _goalOptimizer.defaultModelCompletenessRequirements() : MonitorUtils.combineLoadRequirementOptions(overrides);
   }
 
   /**
@@ -620,7 +619,7 @@ public class KafkaCruiseControl {
    */
   public boolean meetCompletenessRequirements(List<String> goalNames) {
     sanityCheckHardGoalPresence(goalNames, false);
-    Collection<Goal> goals = goalsByPriority(goalNames).values();
+    Collection<Goal> goals = goalsByPriority(goalNames);
     MetadataClient.ClusterAndGeneration clusterAndGeneration = _loadMonitor.refreshClusterAndGeneration();
     return goals.stream().allMatch(g -> _loadMonitor.meetCompletenessRequirements(
         clusterAndGeneration, g.clusterModelCompletenessRequirements()));
@@ -630,20 +629,15 @@ public class KafkaCruiseControl {
    * Get a goals by priority based on the goal list.
    *
    * @param goals A list of goals.
-   * @return A map of goal priority to goal.
+   * @return A list of goals sorted by highest to lowest priority.
    */
-  private Map<Integer, Goal> goalsByPriority(List<String> goals) {
+  private List<Goal> goalsByPriority(List<String> goals) {
     if (goals == null || goals.isEmpty()) {
       return AnalyzerUtils.getGoalMapByPriority(_config);
     }
     Map<String, Goal> allGoals = AnalyzerUtils.getCaseInsensitiveGoalsByName(_config);
     sanityCheckNonExistingGoal(goals, allGoals);
-    Map<Integer, Goal> goalsByPriority = new HashMap<>();
-    int i = 0;
-    for (String goalName : goals) {
-      goalsByPriority.put(i++, allGoals.get(goalName));
-    }
-    return goalsByPriority;
+    return goals.stream().map(allGoals::get).collect(Collectors.toList());
   }
 
   /**
@@ -662,7 +656,7 @@ public class KafkaCruiseControl {
         !(goals.size() == 1 && goals.get(0).equals(PreferredLeaderElectionGoal.class.getSimpleName()))) {
       sanityCheckNonExistingGoal(goals, AnalyzerUtils.getCaseInsensitiveGoalsByName(_config));
       Set<String> hardGoals = _config.getList(KafkaCruiseControlConfig.HARD_GOALS_CONFIG).stream()
-          .map(goalName -> goalName.substring(goalName.lastIndexOf(".") + 1)).collect(Collectors.toSet());
+                                     .map(goalName -> goalName.substring(goalName.lastIndexOf(".") + 1)).collect(Collectors.toSet());
       if (!goals.containsAll(hardGoals)) {
         throw new IllegalArgumentException("Missing hard goals " + hardGoals + " in the provided goals: " + goals
                                            + ". Add skip_hard_goal_check=true parameter to ignore this sanity check.");

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUtils.java
@@ -203,15 +203,7 @@ public class AnalyzerUtils {
    * Get a priority to goal mapping. This is a default mapping.
    */
   public static SortedMap<Integer, Goal> getGoalMapByPriority(KafkaCruiseControlConfig config) {
-    List<String> defaultGoalsConfig = config.getList(KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG);
-    List<Goal> goals;
-    if (defaultGoalsConfig == null || defaultGoalsConfig.isEmpty()) {
-      // Default goals config not set or it is empty, use all the goals.
-      goals = config.getConfiguredInstances(KafkaCruiseControlConfig.GOALS_CONFIG, Goal.class);
-    } else {
-      // Use the provided default goals config.
-      goals = config.getConfiguredInstances(KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG, Goal.class);
-    }
+    List<Goal> goals = config.getConfiguredInstances(KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG, Goal.class);
     SortedMap<Integer, Goal> orderedGoals = new TreeMap<>();
     int i = 0;
     for (Goal goal: goals) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUtils.java
@@ -21,7 +21,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.apache.commons.math3.random.MersenneTwister;
@@ -200,16 +199,10 @@ public class AnalyzerUtils {
   }
 
   /**
-   * Get a priority to goal mapping. This is a default mapping.
+   * Get an list of goals sorted by highest to lowest default priority.
    */
-  public static SortedMap<Integer, Goal> getGoalMapByPriority(KafkaCruiseControlConfig config) {
-    List<Goal> goals = config.getConfiguredInstances(KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG, Goal.class);
-    SortedMap<Integer, Goal> orderedGoals = new TreeMap<>();
-    int i = 0;
-    for (Goal goal: goals) {
-      orderedGoals.put(i++, goal);
-    }
-    return orderedGoals;
+  public static List<Goal> getGoalMapByPriority(KafkaCruiseControlConfig config) {
+    return config.getConfiguredInstances(KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG, Goal.class);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -824,8 +824,7 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 HARD_GOALS_DOC)
         .define(DEFAULT_GOALS_CONFIG,
                 ConfigDef.Type.LIST,
-                "",
-                ConfigDef.Importance.MEDIUM,
+                ConfigDef.Importance.HIGH,
                 DEFAULT_GOALS_DOC)
         .define(ANOMALY_NOTIFIER_CLASS_CONFIG,
                 ConfigDef.Type.CLASS,
@@ -917,15 +916,27 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
   }
 
   /**
-   * Sanity check for case insensitive goal names.
+   * Sanity check for
+   * (1) {@link KafkaCruiseControlConfig#GOALS_CONFIG} is non-empty.
+   * (2) Case insensitive goal names.
+   * (3) {@link KafkaCruiseControlConfig#DEFAULT_GOALS_CONFIG} is non-empty.
    */
   private void sanityCheckGoalNames() {
     List<String> goalNames = getList(KafkaCruiseControlConfig.GOALS_CONFIG);
+    // Ensure that goals is non-empty.
+    if (goalNames.isEmpty()) {
+      throw new ConfigException("Attempt to configure goals configuration with an empty list of goals.");
+    }
+
     Set<String> caseInsensitiveGoalNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     for (String goalName: goalNames) {
       if (!caseInsensitiveGoalNames.add(goalName.replaceAll(".*\\.", ""))) {
         throw new ConfigException("Attempt to configure goals with case sensitive names.");
       }
+    }
+    // Ensure that default goals is non-empty.
+    if (getList(KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG).isEmpty()) {
+      throw new ConfigException("Attempt to configure default goals configuration with an empty list of goals.");
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -145,7 +145,7 @@ public class LoadMonitor {
     _clusterModelSemaphore = new Semaphore(Math.max(1, numPrecomputingThread), true);
 
     _defaultModelCompletenessRequirements =
-        MonitorUtils.combineLoadRequirementOptions(AnalyzerUtils.getGoalMapByPriority(config).values());
+        MonitorUtils.combineLoadRequirementOptions(AnalyzerUtils.getGoalMapByPriority(config));
 
     _loadMonitorTaskRunner =
         new LoadMonitorTaskRunner(config, _partitionMetricSampleAggregator, _brokerMetricSampleAggregator,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -140,6 +140,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
    * 5. Get an optimization proposal
    *    GET /kafkacruisecontrol/proposals?verbose=[ENABLE_VERBOSE]&amp;ignore_proposal_cache=[true/false]
    *    &amp;goals=[goal1,goal2...]&amp;data_from=[valid_windows/valid_partitions]&amp;excluded_topics=[pattern]
+   *    &amp;use_ready_default_goals=[true/false]
    *
    * 6. query the state of Kafka Cruise Control
    *    GET /kafkacruisecontrol/state
@@ -256,17 +257,17 @@ public class KafkaCruiseControlServlet extends HttpServlet {
    * 1. Decommission a broker.
    *    POST /kafkacruisecontrol/remove_broker?brokerid=[id1,id2...]&amp;dryrun=[true/false]&amp;throttle_removed_broker=[true/false]&amp;goals=[goal1,goal2...]
    *    &amp;allow_capacity_estimation=[true/false]&amp;concurrent_partition_movements_per_broker=[true/false]&amp;concurrent_leader_movements=[true/false]
-   *    &amp;json=[true/false]&amp;skip_hard_goal_check=[true/false]&amp;excluded_topics=[pattern]
+   *    &amp;json=[true/false]&amp;skip_hard_goal_check=[true/false]&amp;excluded_topics=[pattern]&amp;use_ready_default_goals=[true/false]
    *
    * 2. Add a broker
    *    POST /kafkacruisecontrol/add_broker?brokerid=[id1,id2...]&amp;dryrun=[true/false]&amp;throttle_added_broker=[true/false]&amp;goals=[goal1,goal2...]
    *    &amp;allow_capacity_estimation=[true/false]&amp;concurrent_partition_movements_per_broker=[true/false]&amp;concurrent_leader_movements=[true/false]
-   *    &amp;json=[true/false]&amp;skip_hard_goal_check=[true/false]&amp;excluded_topics=[pattern]
+   *    &amp;json=[true/false]&amp;skip_hard_goal_check=[true/false]&amp;excluded_topics=[pattern]&amp;use_ready_default_goals=[true/false]
    *
    * 3. Trigger a workload balance.
    *    POST /kafkacruisecontrol/rebalance?dryrun=[true/false]&amp;force=[true/false]&amp;goals=[goal1,goal2...]&amp;allow_capacity_estimation=[true/false]
    *    &amp;concurrent_partition_movements_per_broker=[true/false]&amp;concurrent_leader_movements=[true/false]&amp;json=[true/false]
-   *    &amp;skip_hard_goal_check=[true/false]&amp;excluded_topics=[pattern]
+   *    &amp;skip_hard_goal_check=[true/false]&amp;excluded_topics=[pattern]&amp;use_ready_default_goals=[true/false]
    *
    * 4. Stop the proposal execution.
    *    POST /kafkacruisecontrol/stop_proposal_execution?json=[true/false]

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
@@ -277,12 +277,13 @@ class KafkaCruiseControlServletUtils {
   }
 
   static boolean useReadyDefaultGoals(HttpServletRequest request) {
+    boolean useReadyDefaultGoals = getBooleanParam(request, USE_READY_DEFAULT_GOALS_PARAM, false);
     // Ensure that goals parameter is not specified.
-    if (request.getParameter(GOALS_PARAM) != null) {
+    if (useReadyDefaultGoals && request.getParameter(GOALS_PARAM) != null) {
       throw new UserRequestException("Cannot specify " + USE_READY_DEFAULT_GOALS_PARAM + " parameter when explicitly "
                                      + "specifying goals in request.");
     }
-    return getBooleanParam(request, USE_READY_DEFAULT_GOALS_PARAM, false);
+    return useReadyDefaultGoals;
   }
 
   static boolean getDryRun(HttpServletRequest request) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
@@ -54,6 +54,7 @@ class KafkaCruiseControlServletUtils {
   private static final String THROTTLE_ADDED_BROKER_PARAM = "throttle_added_broker";
   private static final String THROTTLE_REMOVED_BROKER_PARAM = "throttle_removed_broker";
   private static final String IGNORE_PROPOSAL_CACHE_PARAM = "ignore_proposal_cache";
+  private static final String USE_READY_DEFAULT_GOALS_PARAM = "use_ready_default_goals";
   private static final String CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER_PARAM = "concurrent_partition_movements_per_broker";
   private static final String CONCURRENT_LEADER_MOVEMENTS_PARAM = "concurrent_leader_movements";
   private static final String DEFAULT_PARTITION_LOAD_RESOURCE = "disk";
@@ -103,6 +104,7 @@ class KafkaCruiseControlServletUtils {
     proposals.add(JSON_PARAM);
     proposals.add(ALLOW_CAPACITY_ESTIMATION_PARAM);
     proposals.add(EXCLUDED_TOPICS);
+    proposals.add(USE_READY_DEFAULT_GOALS_PARAM);
 
     Set<String> state = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     state.add(VERBOSE_PARAM);
@@ -122,6 +124,7 @@ class KafkaCruiseControlServletUtils {
     addOrRemoveBroker.add(CONCURRENT_LEADER_MOVEMENTS_PARAM);
     addOrRemoveBroker.add(SKIP_HARD_GOAL_CHECK_PARAM);
     addOrRemoveBroker.add(EXCLUDED_TOPICS);
+    addOrRemoveBroker.add(USE_READY_DEFAULT_GOALS_PARAM);
 
     Set<String> addBroker = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     addBroker.add(THROTTLE_ADDED_BROKER_PARAM);
@@ -149,6 +152,7 @@ class KafkaCruiseControlServletUtils {
     rebalance.add(CONCURRENT_LEADER_MOVEMENTS_PARAM);
     rebalance.add(SKIP_HARD_GOAL_CHECK_PARAM);
     rebalance.add(EXCLUDED_TOPICS);
+    rebalance.add(USE_READY_DEFAULT_GOALS_PARAM);
 
     Set<String> kafkaClusterState = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     kafkaClusterState.add(VERBOSE_PARAM);
@@ -272,6 +276,15 @@ class KafkaCruiseControlServletUtils {
     return getBooleanParam(request, IGNORE_PROPOSAL_CACHE_PARAM, false);
   }
 
+  static boolean useReadyDefaultGoals(HttpServletRequest request) {
+    // Ensure that goals parameter is not specified.
+    if (request.getParameter(GOALS_PARAM) != null) {
+      throw new UserRequestException("Cannot specify " + USE_READY_DEFAULT_GOALS_PARAM + " parameter when explicitly "
+                                     + "specifying goals in request.");
+    }
+    return getBooleanParam(request, USE_READY_DEFAULT_GOALS_PARAM, false);
+  }
+
   static boolean getDryRun(HttpServletRequest request) {
     return getBooleanParam(request, DRY_RUN_PARAM, true);
   }
@@ -379,9 +392,9 @@ class KafkaCruiseControlServletUtils {
   }
 
   /**
-   * @param isPartitionMovement True if partition movement, false if leader movement.
+   * @param isPartitionMovement True if partition movement per broker, false if the total leader movement.
    */
-  static Integer concurrentMovementsPerBroker(HttpServletRequest request, boolean isPartitionMovement) {
+  static Integer concurrentMovements(HttpServletRequest request, boolean isPartitionMovement) {
     String concurrentMovementsPerBrokerString = isPartitionMovement
                                                 ? request.getParameter(CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER_PARAM)
                                                 : request.getParameter(CONCURRENT_LEADER_MOVEMENTS_PARAM);
@@ -432,8 +445,11 @@ class KafkaCruiseControlServletUtils {
     return Collections.unmodifiableList(brokerIds);
   }
 
+  /**
+   * Default: {@link DataFrom#VALID_WINDOWS}
+   */
   static DataFrom getDataFrom(HttpServletRequest request) {
-    DataFrom dataFrom = DataFrom.VALID_WINDOWS; // default to with available windows.
+    DataFrom dataFrom = DataFrom.VALID_WINDOWS;
     String dataFromString = request.getParameter(DATA_FROM_PARAM);
     if (dataFromString != null) {
       dataFrom = DataFrom.valueOf(dataFromString.toUpperCase());

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUnitTestUtils.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUnitTestUtils.java
@@ -40,6 +40,23 @@ public class KafkaCruiseControlUnitTestUtils {
     props.setProperty(BrokerCapacityConfigFileResolver.CAPACITY_CONFIG_FILE, capacityConfigFile);
     props.setProperty(KafkaCruiseControlConfig.MIN_SAMPLES_PER_PARTITION_METRICS_WINDOW_CONFIG, "2");
     props.setProperty(KafkaCruiseControlConfig.MIN_SAMPLES_PER_BROKER_METRICS_WINDOW_CONFIG, "2");
+    props.setProperty(
+        KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG,
+        "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal");
+
     return props;
   }
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/DeterministicClusterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/DeterministicClusterTest.java
@@ -56,7 +56,7 @@ import static org.junit.Assert.assertTrue;
 public class DeterministicClusterTest {
   private BalancingConstraint _balancingConstraint;
   private ClusterModel _cluster;
-  private Map<Integer, String> _goalNameByPriority;
+  private List<String> _goalNameByPriority;
   private List<OptimizationVerifier.Verification> _verifications;
 
   @Rule
@@ -71,7 +71,7 @@ public class DeterministicClusterTest {
    */
   public DeterministicClusterTest(BalancingConstraint balancingConstraint,
                                   ClusterModel cluster,
-                                  Map<Integer, String> goalNameByPriority,
+                                  List<String> goalNameByPriority,
                                   List<OptimizationVerifier.Verification> verifications,
                                   Class<? extends Throwable> expectedException) {
     _balancingConstraint = balancingConstraint;
@@ -92,22 +92,21 @@ public class DeterministicClusterTest {
   public static Collection<Object[]> data() {
     Collection<Object[]> p = new ArrayList<>();
 
-    Map<Integer, String> goalNameByPriority = new HashMap<>();
-    goalNameByPriority.put(1, RackAwareGoal.class.getName());
-    goalNameByPriority.put(2, ReplicaCapacityGoal.class.getName());
-    goalNameByPriority.put(3, DiskCapacityGoal.class.getName());
-    goalNameByPriority.put(4, NetworkInboundCapacityGoal.class.getName());
-    goalNameByPriority.put(5, NetworkOutboundCapacityGoal.class.getName());
-    goalNameByPriority.put(6, CpuCapacityGoal.class.getName());
-    goalNameByPriority.put(7, ReplicaDistributionGoal.class.getName());
-    goalNameByPriority.put(8, PotentialNwOutGoal.class.getName());
-    goalNameByPriority.put(9, DiskUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(10, NetworkInboundUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(11, NetworkOutboundUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(12, CpuUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(13, TopicReplicaDistributionGoal.class.getName());
-    goalNameByPriority.put(14, PreferredLeaderElectionGoal.class.getName());
-    goalNameByPriority.put(15, LeaderBytesInDistributionGoal.class.getName());
+    List<String> goalNameByPriority = Arrays.asList(RackAwareGoal.class.getName(),
+                                                    ReplicaCapacityGoal.class.getName(),
+                                                    DiskCapacityGoal.class.getName(),
+                                                    NetworkInboundCapacityGoal.class.getName(),
+                                                    NetworkOutboundCapacityGoal.class.getName(),
+                                                    CpuCapacityGoal.class.getName(),
+                                                    ReplicaDistributionGoal.class.getName(),
+                                                    PotentialNwOutGoal.class.getName(),
+                                                    DiskUsageDistributionGoal.class.getName(),
+                                                    NetworkInboundUsageDistributionGoal.class.getName(),
+                                                    NetworkOutboundUsageDistributionGoal.class.getName(),
+                                                    CpuUsageDistributionGoal.class.getName(),
+                                                    TopicReplicaDistributionGoal.class.getName(),
+                                                    PreferredLeaderElectionGoal.class.getName(),
+                                                    LeaderBytesInDistributionGoal.class.getName());
 
     Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
     props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(6L));
@@ -174,9 +173,8 @@ public class DeterministicClusterTest {
                    goalNameByPriority, verifications, null));
     }
 
-    Map<Integer, String> kafkaAssignerGoals = new HashMap<>();
-    kafkaAssignerGoals.put(0, KafkaAssignerEvenRackAwareGoal.class.getName());
-    kafkaAssignerGoals.put(1, KafkaAssignerDiskUsageDistributionGoal.class.getName());
+    List<String> kafkaAssignerGoals = Arrays.asList(KafkaAssignerEvenRackAwareGoal.class.getName(),
+                                                    KafkaAssignerDiskUsageDistributionGoal.class.getName());
     List<OptimizationVerifier.Verification> kafkaAssignerVerifications = Arrays.asList(DEAD_BROKERS, REGRESSION);
     // Small cluster.
     p.add(params(balancingConstraint, DeterministicCluster.smallClusterModel(TestConstants.BROKER_CAPACITY),
@@ -195,7 +193,7 @@ public class DeterministicClusterTest {
 
   private static Object[] params(BalancingConstraint balancingConstraint,
                                  ClusterModel cluster,
-                                 Map<Integer, String> goalNameByPriority,
+                                 List<String> goalNameByPriority,
                                  List<OptimizationVerifier.Verification> verifications,
                                  Class<? extends Throwable> expectedException) {
     return new Object[]{balancingConstraint, cluster, goalNameByPriority, verifications, expectedException};

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizerTest.java
@@ -21,6 +21,22 @@ public class GoalOptimizerTest {
     props.setProperty(KafkaCruiseControlConfig.BOOTSTRAP_SERVERS_CONFIG, "bootstrap.servers");
     props.setProperty(KafkaCruiseControlConfig.ZOOKEEPER_CONNECT_CONFIG, "connect:1234");
     props.setProperty(KafkaCruiseControlConfig.NUM_PROPOSAL_PRECOMPUTE_THREADS_CONFIG, "0");
+    props.setProperty(
+        KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG,
+        "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal");
     KafkaCruiseControlConfig config = new KafkaCruiseControlConfig(props);
 
     GoalOptimizer goalOptimizer = new GoalOptimizer(config, EasyMock.mock(LoadMonitor.class), new SystemTime(),

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalShuffleTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalShuffleTest.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
-import java.util.SortedMap;
 import java.util.StringJoiner;
 import org.apache.kafka.common.utils.SystemTime;
 import org.junit.Test;
@@ -43,10 +42,10 @@ public class GoalShuffleTest {
     _numPrecomputingThreadExpect = numPrecomputingThreadExpect;
   }
 
-  private void validateOriginalGoalOrder(List<SortedMap<Integer, Goal>> goalByPriorityForPrecomputing) {
+  private void validateOriginalGoalOrder(List<List<Goal>> goalByPriorityForPrecomputing) {
     // Check whether one of the generated goal priorities has the same order as set in config.
     boolean foundTheOriginalGoalPriorities = false;
-    for (SortedMap<Integer, Goal> goalByPriority : goalByPriorityForPrecomputing) {
+    for (List<Goal> goalByPriority : goalByPriorityForPrecomputing) {
       foundTheOriginalGoalPriorities = goalByPriority.get(0).name().equals(RackAwareGoal.class.getSimpleName())
                                        && goalByPriority.get(1).name().equals(ReplicaCapacityGoal.class.getSimpleName())
                                        && goalByPriority.get(2).name().equals(DiskCapacityGoal.class.getSimpleName());
@@ -73,18 +72,11 @@ public class GoalShuffleTest {
                                                     null,
                                                     new SystemTime(),
                                                     new MetricRegistry());
-    List<SortedMap<Integer, Goal>> goalByPriorityForPrecomputing = goalOptimizer.goalByPriorityForPrecomputing();
+    List<List<Goal>> goalByPriorityForPrecomputing = goalOptimizer.goalByPriorityForPrecomputing();
 
     // Check whether the correct number of goal priority is generated
     assertEquals(_numPrecomputingThreadExpect, goalByPriorityForPrecomputing.size());
     validateOriginalGoalOrder(goalByPriorityForPrecomputing);
-
-    // Check whether all generated goal priorities are valid.
-    for (SortedMap<Integer, Goal> aGoalByPriorityForPrecomputing : goalByPriorityForPrecomputing) {
-      for (int j = 0; j < 3; j++) {
-        assertTrue(aGoalByPriorityForPrecomputing.keySet().contains(j));
-      }
-    }
 
     // Check all generated goal priorities are unique.
     for (int i = 0; i < goalByPriorityForPrecomputing.size() - 1; i++) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalShuffleTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalShuffleTest.java
@@ -30,19 +30,17 @@ public class GoalShuffleTest {
 
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][]{{0, 1, false}, {1, 1, false}, {3, 3, false},  {6, 6, false}, {7, 6, false},
-                                        {0, 1, true}, {1, 1, true},  {16, 16, true}, {32, 32, true}});
+    return Arrays.asList(new Object[][]{{0, 1}, {1, 1}, {3, 3},  {6, 6}, {7, 6}});
   }
 
+  // Goal config is guaranteed to be non empty via KafkaCruiseControlConfig#sanityCheckGoalNames.
   private int _numPrecomputingThreadConfig;
   private int _numPrecomputingThreadExpect;
-  private boolean _emptyGoalConfig;
 
 
-  public GoalShuffleTest(int numPrecomputingThreadConfig, int numPrecomputingThreadExpect, boolean emptyGoalConfig) {
+  public GoalShuffleTest(int numPrecomputingThreadConfig, int numPrecomputingThreadExpect) {
     _numPrecomputingThreadConfig = numPrecomputingThreadConfig;
     _numPrecomputingThreadExpect = numPrecomputingThreadExpect;
-    _emptyGoalConfig = emptyGoalConfig;
   }
 
   private void validateOriginalGoalOrder(List<SortedMap<Integer, Goal>> goalByPriorityForPrecomputing) {
@@ -64,14 +62,10 @@ public class GoalShuffleTest {
   public void testGoalGetShuffled() {
     Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
     props.setProperty(KafkaCruiseControlConfig.NUM_PROPOSAL_PRECOMPUTE_THREADS_CONFIG, Long.toString(_numPrecomputingThreadConfig));
-    if (_emptyGoalConfig) {
-      props.setProperty(KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG, "");
-    } else {
-      props.setProperty(KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG, new StringJoiner(",").add(RackAwareGoal.class.getName())
-                                                                                            .add(ReplicaCapacityGoal.class.getName())
-                                                                                            .add(DiskCapacityGoal.class.getName())
-                                                                                            .toString());
-    }
+    props.setProperty(KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG, new StringJoiner(",").add(RackAwareGoal.class.getName())
+                                                                                          .add(ReplicaCapacityGoal.class.getName())
+                                                                                          .add(DiskCapacityGoal.class.getName())
+                                                                                          .toString());
     BalancingConstraint balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
     balancingConstraint.setResourceBalancePercentage(TestConstants.LOW_BALANCE_PERCENTAGE);
     balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterExpDistNewBrokerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterExpDistNewBrokerTest.java
@@ -26,7 +26,7 @@ public class RandomClusterExpDistNewBrokerTest extends RandomClusterTest {
    * @param verifications       The verifications to make.
    */
   public RandomClusterExpDistNewBrokerTest(Map<ClusterProperty, Number> modifiedProperties,
-                                           Map<Integer, String> goalNameByPriority,
+                                           List<String> goalNameByPriority,
                                            TestConstants.Distribution replicaDistribution,
                                            BalancingConstraint balancingConstraint,
                                            List<OptimizationVerifier.Verification> verifications) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterLinearDistNewBrokerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterLinearDistNewBrokerTest.java
@@ -31,7 +31,7 @@ public class RandomClusterLinearDistNewBrokerTest extends RandomClusterTest {
    * @param verifications The verifications to make.
    */
   public RandomClusterLinearDistNewBrokerTest(Map<ClusterProperty, Number> modifiedProperties,
-                                              Map<Integer, String> goalNameByPriority,
+                                              List<String> goalNameByPriority,
                                               TestConstants.Distribution replicaDistribution,
                                               BalancingConstraint balancingConstraint,
                                               List<OptimizationVerifier.Verification> verifications) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
@@ -67,26 +67,25 @@ public class RandomClusterTest {
   public static Collection<Object[]> data(TestConstants.Distribution distribution) {
     Collection<Object[]> p = new ArrayList<>();
 
-    Map<Integer, String> goalNameByPriority = new HashMap<>();
-    goalNameByPriority.put(1, RackAwareGoal.class.getName());
-    goalNameByPriority.put(2, ReplicaCapacityGoal.class.getName());
-    goalNameByPriority.put(3, DiskCapacityGoal.class.getName());
-    goalNameByPriority.put(4, NetworkInboundCapacityGoal.class.getName());
-    goalNameByPriority.put(5, NetworkOutboundCapacityGoal.class.getName());
-    goalNameByPriority.put(6, CpuCapacityGoal.class.getName());
-    goalNameByPriority.put(7, ReplicaDistributionGoal.class.getName());
-    goalNameByPriority.put(8, PotentialNwOutGoal.class.getName());
-    goalNameByPriority.put(9, DiskUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(10, NetworkInboundUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(11, NetworkOutboundUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(12, CpuUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(13, TopicReplicaDistributionGoal.class.getName());
-    goalNameByPriority.put(14, PreferredLeaderElectionGoal.class.getName());
-    goalNameByPriority.put(15, LeaderBytesInDistributionGoal.class.getName());
+    // Sorted by priority.
+    List<String> goalNameByPriority = Arrays.asList(RackAwareGoal.class.getName(),
+                                                    ReplicaCapacityGoal.class.getName(),
+                                                    DiskCapacityGoal.class.getName(),
+                                                    NetworkInboundCapacityGoal.class.getName(),
+                                                    NetworkOutboundCapacityGoal.class.getName(),
+                                                    CpuCapacityGoal.class.getName(),
+                                                    ReplicaDistributionGoal.class.getName(),
+                                                    PotentialNwOutGoal.class.getName(),
+                                                    DiskUsageDistributionGoal.class.getName(),
+                                                    NetworkInboundUsageDistributionGoal.class.getName(),
+                                                    NetworkOutboundUsageDistributionGoal.class.getName(),
+                                                    CpuUsageDistributionGoal.class.getName(),
+                                                    TopicReplicaDistributionGoal.class.getName(),
+                                                    PreferredLeaderElectionGoal.class.getName(),
+                                                    LeaderBytesInDistributionGoal.class.getName());
 
-    Map<Integer, String> kafkaAssignerGoals = new HashMap<>();
-    kafkaAssignerGoals.put(1, KafkaAssignerEvenRackAwareGoal.class.getName());
-    kafkaAssignerGoals.put(2, KafkaAssignerDiskUsageDistributionGoal.class.getName());
+    List<String> kafkaAssignerGoals = Arrays.asList(KafkaAssignerEvenRackAwareGoal.class.getName(),
+                                                    KafkaAssignerDiskUsageDistributionGoal.class.getName());
 
     List<OptimizationVerifier.Verification> verifications = Arrays.asList(NEW_BROKERS, DEAD_BROKERS, REGRESSION);
     List<OptimizationVerifier.Verification> kafkaAssignerVerifications =
@@ -139,7 +138,7 @@ public class RandomClusterTest {
   }
 
   private static Object[] params(Map<ClusterProperty, Number> modifiedProperties,
-                                 Map<Integer, String> goalNameByPriority,
+                                 List<String> goalNameByPriority,
                                  TestConstants.Distribution replicaDistribution,
                                  BalancingConstraint balancingConstraint,
                                  List<OptimizationVerifier.Verification> verifications) {
@@ -147,7 +146,7 @@ public class RandomClusterTest {
   }
 
   private Map<ClusterProperty, Number> _modifiedProperties;
-  private Map<Integer, String> _goalNameByPriority;
+  private List<String> _goalNameByPriority;
   private TestConstants.Distribution _replicaDistribution;
   private BalancingConstraint _balancingConstraint;
   private List<OptimizationVerifier.Verification> _verifications;
@@ -162,7 +161,7 @@ public class RandomClusterTest {
    * @param verifications       The verifications to make.
    */
   public RandomClusterTest(Map<ClusterProperty, Number> modifiedProperties,
-                           Map<Integer, String> goalNameByPriority,
+                           List<String> goalNameByPriority,
                            TestConstants.Distribution replicaDistribution,
                            BalancingConstraint balancingConstraint,
                            List<OptimizationVerifier.Verification> verifications) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterUniformDistNewBrokerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterUniformDistNewBrokerTest.java
@@ -26,10 +26,10 @@ public class RandomClusterUniformDistNewBrokerTest extends RandomClusterTest {
    * @param verifications       The verifications to make.
    */
   public RandomClusterUniformDistNewBrokerTest(Map<ClusterProperty, Number> modifiedProperties,
-      Map<Integer, String> goalNameByPriority,
-      TestConstants.Distribution replicaDistribution,
-      BalancingConstraint balancingConstraint,
-      List<OptimizationVerifier.Verification> verifications) {
+                                               List<String> goalNameByPriority,
+                                               TestConstants.Distribution replicaDistribution,
+                                               BalancingConstraint balancingConstraint,
+                                               List<OptimizationVerifier.Verification> verifications) {
     super(modifiedProperties, goalNameByPriority, replicaDistribution, balancingConstraint, verifications);
   }
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomGoalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomGoalTest.java
@@ -62,26 +62,25 @@ public class RandomGoalTest {
    * @return Parameters for the {@link OptimizationVerifier}.
    */
   @Parameters
-  public static Collection<Object[]> data() throws Exception {
+  public static Collection<Object[]> data() {
     int goalRepetition = 4;
     Collection<Object[]> p = new ArrayList<>();
 
-    List<String> goalsSortedByPriority = Arrays.asList(
-        RackAwareGoal.class.getName(),
-        ReplicaCapacityGoal.class.getName(),
-        DiskCapacityGoal.class.getName(),
-        NetworkInboundCapacityGoal.class.getName(),
-        NetworkOutboundCapacityGoal.class.getName(),
-        CpuCapacityGoal.class.getName(),
-        ReplicaDistributionGoal.class.getName(),
-        PotentialNwOutGoal.class.getName(),
-        DiskUsageDistributionGoal.class.getName(),
-        NetworkInboundUsageDistributionGoal.class.getName(),
-        NetworkOutboundUsageDistributionGoal.class.getName(),
-        CpuUsageDistributionGoal.class.getName(),
-        TopicReplicaDistributionGoal.class.getName(),
-        PreferredLeaderElectionGoal.class.getName(),
-        LeaderBytesInDistributionGoal.class.getName());
+    List<String> goalsSortedByPriority = Arrays.asList(RackAwareGoal.class.getName(),
+                                                       ReplicaCapacityGoal.class.getName(),
+                                                       DiskCapacityGoal.class.getName(),
+                                                       NetworkInboundCapacityGoal.class.getName(),
+                                                       NetworkOutboundCapacityGoal.class.getName(),
+                                                       CpuCapacityGoal.class.getName(),
+                                                       ReplicaDistributionGoal.class.getName(),
+                                                       PotentialNwOutGoal.class.getName(),
+                                                       DiskUsageDistributionGoal.class.getName(),
+                                                       NetworkInboundUsageDistributionGoal.class.getName(),
+                                                       NetworkOutboundUsageDistributionGoal.class.getName(),
+                                                       CpuUsageDistributionGoal.class.getName(),
+                                                       TopicReplicaDistributionGoal.class.getName(),
+                                                       PreferredLeaderElectionGoal.class.getName(),
+                                                       LeaderBytesInDistributionGoal.class.getName());
 
     Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
     props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(1500L));
@@ -92,37 +91,28 @@ public class RandomGoalTest {
     List<OptimizationVerifier.Verification> verifications = Arrays.asList(NEW_BROKERS, DEAD_BROKERS, REGRESSION);
 
     // Test: Single goal at a time.
-    int goalPriority = 1;
     for (String goalName: goalsSortedByPriority) {
-      Map<Integer, String> singletonGoalNameByPriority = Collections.singletonMap(goalPriority, goalName);
-      p.add(params(Collections.emptyMap(), singletonGoalNameByPriority, balancingConstraint, verifications));
-      goalPriority++;
+      p.add(params(Collections.emptyMap(), Collections.singletonList(goalName), balancingConstraint, verifications));
     }
 
     // Test: Consecutive repetition of the same goal (goalRepetition times each).
-    goalPriority = 1;
     for (String goalName : goalsSortedByPriority) {
-      Map<Integer, String> repeatedGoalNamesByPriority = new HashMap<>();
+      List<String> repeatedGoalNamesByPriority = new ArrayList<>();
       for (int i = 0; i < goalRepetition; i++) {
-        repeatedGoalNamesByPriority.put(goalPriority, goalName);
-        goalPriority++;
+        repeatedGoalNamesByPriority.add(goalName);
       }
       p.add(params(Collections.emptyMap(), repeatedGoalNamesByPriority, balancingConstraint, verifications));
     }
 
     // Test: Nested repetition of the same goal (goalRepetition times each).
-    goalPriority = 1;
-    Map<Integer, String> nonRepetitiveGoalNamesByPriority = new HashMap<>();
+    List<String> nonRepetitiveGoalNamesByPriority = new ArrayList<>();
     for (int i = 0; i < goalRepetition; i++) {
-      for (String goalName : goalsSortedByPriority) {
-        nonRepetitiveGoalNamesByPriority.put(goalPriority, goalName);
-        goalPriority++;
-      }
+      nonRepetitiveGoalNamesByPriority.addAll(goalsSortedByPriority);
     }
     p.add(params(Collections.emptyMap(), nonRepetitiveGoalNamesByPriority, balancingConstraint, verifications));
 
     // Test: No goal.
-    p.add(params(Collections.emptyMap(), Collections.emptyMap(), balancingConstraint, verifications));
+    p.add(params(Collections.emptyMap(), Collections.emptyList(), balancingConstraint, verifications));
 
     // Test shuffled soft goals.
     List<String> shuffledSoftGoalNames = new ArrayList<>(goalsSortedByPriority);
@@ -135,26 +125,21 @@ public class RandomGoalTest {
     shuffledSoftGoalNames.remove(NetworkOutboundCapacityGoal.class.getName());
     Collections.shuffle(shuffledSoftGoalNames, RANDOM);
 
-    goalPriority = 1;
-    Map<Integer, String> randomOrderedSoftGoalsByPriority = new HashMap<>();
-    for (String goalName : shuffledSoftGoalNames) {
-      randomOrderedSoftGoalsByPriority.put(goalPriority, goalName);
-      goalPriority++;
-    }
+    List<String> randomOrderedSoftGoalsByPriority = new ArrayList<>(shuffledSoftGoalNames);
     p.add(params(Collections.emptyMap(), randomOrderedSoftGoalsByPriority, balancingConstraint, verifications));
 
     return p;
   }
 
   private static Object[] params(Map<ClusterProperty, Number> modifiedProperties,
-                                 Map<Integer, String> goalNameByPriority,
+                                 List<String> goalNameByPriority,
                                  BalancingConstraint balancingConstraint,
                                  List<OptimizationVerifier.Verification> verifications) {
     return new Object[]{modifiedProperties, goalNameByPriority, balancingConstraint, verifications};
   }
 
   private Map<ClusterProperty, Number> _modifiedProperties;
-  private Map<Integer, String> _goalNameByPriority;
+  private List<String> _goalNameByPriority;
   private BalancingConstraint _balancingConstraint;
   private List<OptimizationVerifier.Verification> _verifications;
 
@@ -167,7 +152,7 @@ public class RandomGoalTest {
    * @param verifications the verifications to make.
    */
   public RandomGoalTest(Map<ClusterProperty, Number> modifiedProperties,
-                        Map<Integer, String> goalNameByPriority,
+                        List<String> goalNameByPriority,
                         BalancingConstraint balancingConstraint,
                         List<OptimizationVerifier.Verification> verifications) {
     _modifiedProperties = modifiedProperties;

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomSelfHealingTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomSelfHealingTest.java
@@ -61,30 +61,29 @@ public class RandomSelfHealingTest {
   public static Collection<Object[]> data() {
     Collection<Object[]> p = new ArrayList<>();
 
-    Map<Integer, String> goalNameByPriority = new HashMap<>();
-    goalNameByPriority.put(1, RackAwareGoal.class.getName());
-    goalNameByPriority.put(2, ReplicaCapacityGoal.class.getName());
-    goalNameByPriority.put(3, DiskCapacityGoal.class.getName());
-    goalNameByPriority.put(4, NetworkInboundCapacityGoal.class.getName());
-    goalNameByPriority.put(5, NetworkOutboundCapacityGoal.class.getName());
-    goalNameByPriority.put(6, CpuCapacityGoal.class.getName());
-    goalNameByPriority.put(7, ReplicaDistributionGoal.class.getName());
-    goalNameByPriority.put(8, PotentialNwOutGoal.class.getName());
-    goalNameByPriority.put(9, DiskUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(10, NetworkInboundUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(11, NetworkOutboundUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(12, CpuUsageDistributionGoal.class.getName());
-    goalNameByPriority.put(13, TopicReplicaDistributionGoal.class.getName());
+    // Sorted by priority.
+    List<String> goalNameByPriority = Arrays.asList(RackAwareGoal.class.getName(),
+                                                    ReplicaCapacityGoal.class.getName(),
+                                                    DiskCapacityGoal.class.getName(),
+                                                    NetworkInboundCapacityGoal.class.getName(),
+                                                    NetworkOutboundCapacityGoal.class.getName(),
+                                                    CpuCapacityGoal.class.getName(),
+                                                    ReplicaDistributionGoal.class.getName(),
+                                                    PotentialNwOutGoal.class.getName(),
+                                                    DiskUsageDistributionGoal.class.getName(),
+                                                    NetworkInboundUsageDistributionGoal.class.getName(),
+                                                    NetworkOutboundUsageDistributionGoal.class.getName(),
+                                                    CpuUsageDistributionGoal.class.getName(),
+                                                    TopicReplicaDistributionGoal.class.getName());
 
-    Map<Integer, String> kafkaAssignerGoals = new HashMap<>();
-    kafkaAssignerGoals.put(0, KafkaAssignerEvenRackAwareGoal.class.getName());
-    kafkaAssignerGoals.put(1, KafkaAssignerDiskUsageDistributionGoal.class.getName());
+    List<String> kafkaAssignerGoals = Arrays.asList(KafkaAssignerEvenRackAwareGoal.class.getName(),
+                                                    KafkaAssignerDiskUsageDistributionGoal.class.getName());
 
     Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
     props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(2000L));
-    BalancingConstraint balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
-    balancingConstraint.setResourceBalancePercentage(TestConstants.LOW_BALANCE_PERCENTAGE);
-    balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);
+    BalancingConstraint constraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
+    constraint.setResourceBalancePercentage(TestConstants.LOW_BALANCE_PERCENTAGE);
+    constraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);
 
     List<OptimizationVerifier.Verification> verifications = Arrays.asList(NEW_BROKERS, DEAD_BROKERS, REGRESSION);
     List<OptimizationVerifier.Verification> kafkaAssignerVerifications =
@@ -92,74 +91,59 @@ public class RandomSelfHealingTest {
 
     // -- TEST DECK #1: SINGLE DEAD BROKER.
     // Test: Single Goal.
-    Map<ClusterProperty, Number> singleDeadBroker = new HashMap<>();
-    singleDeadBroker.put(ClusterProperty.NUM_DEAD_BROKERS, 1);
+    Map<ClusterProperty, Number> singleDeadBroker = Collections.singletonMap(ClusterProperty.NUM_DEAD_BROKERS, 1);
     int testId = 0;
-    for (Map.Entry<Integer, String> entry : goalNameByPriority.entrySet()) {
-      p.add(params(testId++, singleDeadBroker, Collections.singletonMap(entry.getKey(), entry.getValue()),
-                   balancingConstraint, Collections.emptySet(), verifications, true));
-      p.add(params(testId++, singleDeadBroker, Collections.singletonMap(entry.getKey(), entry.getValue()),
-                   balancingConstraint, Collections.emptySet(), verifications, false));
-      p.add(params(testId++, singleDeadBroker, Collections.singletonMap(entry.getKey(), entry.getValue()),
-                   balancingConstraint, Collections.singleton("T0"), verifications, true));
-      p.add(params(testId++, singleDeadBroker, Collections.singletonMap(entry.getKey(), entry.getValue()),
-                   balancingConstraint, Collections.singleton("T0"), verifications, false));
+    List<String> testGoal;
+    for (int i = 0; i < goalNameByPriority.size(); i++) {
+      testGoal = goalNameByPriority.subList(i, i + 1);
+      p.add(params(testId++, singleDeadBroker, testGoal, constraint, Collections.emptySet(), verifications, true));
+      p.add(params(testId++, singleDeadBroker, testGoal, constraint, Collections.emptySet(), verifications, false));
+      p.add(params(testId++, singleDeadBroker, testGoal, constraint, Collections.singleton("T0"), verifications, true));
+      p.add(params(testId++, singleDeadBroker, testGoal, constraint, Collections.singleton("T0"), verifications, false));
     }
-    p.add(params(testId++, singleDeadBroker, Collections.singletonMap(0, KafkaAssignerEvenRackAwareGoal.class.getName()),
-                 balancingConstraint, Collections.emptySet(), kafkaAssignerVerifications, true));
-    p.add(params(testId++, singleDeadBroker, Collections.singletonMap(0, KafkaAssignerEvenRackAwareGoal.class.getName()),
-                 balancingConstraint, Collections.emptySet(), kafkaAssignerVerifications, false));
-    p.add(params(testId++, singleDeadBroker, Collections.singletonMap(0, KafkaAssignerEvenRackAwareGoal.class.getName()),
-                 balancingConstraint, Collections.singleton("T0"), kafkaAssignerVerifications, true));
-    p.add(params(testId++, singleDeadBroker, Collections.singletonMap(0, KafkaAssignerEvenRackAwareGoal.class.getName()),
-                 balancingConstraint, Collections.singleton("T0"), kafkaAssignerVerifications, false));
+    // In Kafka Assigner mode, the goal order is well-defined -- i.e. KafkaAssignerEvenRackAwareGoal is the first goal.
+    testGoal = Collections.singletonList(KafkaAssignerEvenRackAwareGoal.class.getName());
+    p.add(params(testId++, singleDeadBroker, testGoal, constraint, Collections.emptySet(), kafkaAssignerVerifications, true));
+    p.add(params(testId++, singleDeadBroker, testGoal, constraint, Collections.emptySet(), kafkaAssignerVerifications, false));
+    p.add(params(testId++, singleDeadBroker, testGoal, constraint, Collections.singleton("T0"), kafkaAssignerVerifications, true));
+    p.add(params(testId++, singleDeadBroker, testGoal, constraint, Collections.singleton("T0"), kafkaAssignerVerifications, false));
 
     props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(5100L));
-    balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
-    balancingConstraint.setResourceBalancePercentage(TestConstants.LOW_BALANCE_PERCENTAGE);
-    balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);
+    constraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
+    constraint.setResourceBalancePercentage(TestConstants.LOW_BALANCE_PERCENTAGE);
+    constraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);
 
     // Test: All Goals.
-    p.add(params(testId++, singleDeadBroker, goalNameByPriority, balancingConstraint, Collections.emptySet(),
-                 verifications, true));
-    p.add(params(testId++, singleDeadBroker, goalNameByPriority, balancingConstraint, Collections.singleton("T0"),
-                 verifications, true));
-    p.add(params(testId++, singleDeadBroker, kafkaAssignerGoals, balancingConstraint, Collections.emptySet(),
-                 kafkaAssignerVerifications, true));
-    p.add(params(testId++, singleDeadBroker, kafkaAssignerGoals, balancingConstraint, Collections.singleton("T0"),
-                 kafkaAssignerVerifications, true));
+    p.add(params(testId++, singleDeadBroker, goalNameByPriority, constraint, Collections.emptySet(), verifications, true));
+    p.add(params(testId++, singleDeadBroker, goalNameByPriority, constraint, Collections.singleton("T0"), verifications, true));
+    p.add(params(testId++, singleDeadBroker, kafkaAssignerGoals, constraint, Collections.emptySet(), kafkaAssignerVerifications, true));
+    p.add(params(testId++, singleDeadBroker, kafkaAssignerGoals, constraint, Collections.singleton("T0"), kafkaAssignerVerifications, true));
 
     // -- TEST DECK #2: MULTIPLE DEAD BROKERS.
     // Test: Single Goal.
-    Map<ClusterProperty, Number> multipleDeadBrokers = new HashMap<>();
-    multipleDeadBrokers.put(ClusterProperty.NUM_DEAD_BROKERS, 5);
-    for (Map.Entry<Integer, String> entry : goalNameByPriority.entrySet()) {
-      p.add(params(testId++, multipleDeadBrokers, Collections.singletonMap(entry.getKey(), entry.getValue()),
-                   balancingConstraint, Collections.emptySet(), verifications, true));
-      p.add(params(testId++, multipleDeadBrokers, Collections.singletonMap(entry.getKey(), entry.getValue()),
-                   balancingConstraint, Collections.singleton("T0"), verifications, true));
+    Map<ClusterProperty, Number> multipleDeadBrokers = Collections.singletonMap(ClusterProperty.NUM_DEAD_BROKERS, 5);
+    for (int i = 0; i < goalNameByPriority.size(); i++) {
+      testGoal = goalNameByPriority.subList(i, i + 1);
+      p.add(params(testId++, multipleDeadBrokers, testGoal, constraint, Collections.emptySet(), verifications, true));
+      p.add(params(testId++, multipleDeadBrokers, testGoal, constraint, Collections.singleton("T0"), verifications, true));
     }
-    p.add(params(testId++, multipleDeadBrokers, Collections.singletonMap(0, KafkaAssignerEvenRackAwareGoal.class.getName()),
-                 balancingConstraint, Collections.emptySet(), kafkaAssignerVerifications, true));
-    p.add(params(testId++, multipleDeadBrokers, Collections.singletonMap(0, KafkaAssignerEvenRackAwareGoal.class.getName()),
-                 balancingConstraint, Collections.singleton("T0"), kafkaAssignerVerifications, true));
+    // In Kafka Assigner mode, the goal order is well-defined -- i.e. KafkaAssignerEvenRackAwareGoal is the first goal.
+    testGoal = Collections.singletonList(KafkaAssignerEvenRackAwareGoal.class.getName());
+    p.add(params(testId++, multipleDeadBrokers, testGoal, constraint, Collections.emptySet(), kafkaAssignerVerifications, true));
+    p.add(params(testId++, multipleDeadBrokers, testGoal, constraint, Collections.singleton("T0"), kafkaAssignerVerifications, true));
 
     // Test: All Goals.
-    p.add(params(testId++, multipleDeadBrokers, goalNameByPriority, balancingConstraint, Collections.emptySet(),
-                 verifications, true));
-    p.add(params(testId++, multipleDeadBrokers, goalNameByPriority, balancingConstraint, Collections.singleton("T0"),
-                 verifications, true));
-    p.add(params(testId++, multipleDeadBrokers, kafkaAssignerGoals, balancingConstraint, Collections.emptySet(),
-                 kafkaAssignerVerifications, true));
-    p.add(params(testId++, multipleDeadBrokers, kafkaAssignerGoals, balancingConstraint, Collections.singleton("T0"),
-                 kafkaAssignerVerifications, true));
+    p.add(params(testId++, multipleDeadBrokers, goalNameByPriority, constraint, Collections.emptySet(), verifications, true));
+    p.add(params(testId++, multipleDeadBrokers, goalNameByPriority, constraint, Collections.singleton("T0"), verifications, true));
+    p.add(params(testId++, multipleDeadBrokers, kafkaAssignerGoals, constraint, Collections.emptySet(), kafkaAssignerVerifications, true));
+    p.add(params(testId++, multipleDeadBrokers, kafkaAssignerGoals, constraint, Collections.singleton("T0"), kafkaAssignerVerifications, true));
 
     return p;
   }
 
   private static Object[] params(int testId,
                                  Map<ClusterProperty, Number> modifiedProperties,
-                                 Map<Integer, String> goalNameByPriority,
+                                 List<String> goalNameByPriority,
                                  BalancingConstraint balancingConstraint,
                                  Collection<String> excludedTopics,
                                  List<OptimizationVerifier.Verification> verifications,
@@ -171,7 +155,7 @@ public class RandomSelfHealingTest {
 
   private int _testId;
   private Map<ClusterProperty, Number> _modifiedProperties;
-  private Map<Integer, String> _goalNameByPriority;
+  private List<String> _goalNameByPriority;
   private BalancingConstraint _balancingConstraint;
   private Set<String> _excludedTopics;
   private List<OptimizationVerifier.Verification> _verifications;
@@ -189,7 +173,7 @@ public class RandomSelfHealingTest {
    */
   public RandomSelfHealingTest(int testId,
                                Map<ClusterProperty, Number> modifiedProperties,
-                               Map<Integer, String> goalNameByPriority,
+                               List<String> goalNameByPriority,
                                BalancingConstraint balancingConstraint,
                                Collection<String> excludedTopics,
                                List<OptimizationVerifier.Verification> verifications,

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/CaseInsensitiveGoalConfigTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/CaseInsensitiveGoalConfigTest.java
@@ -57,6 +57,22 @@ public class CaseInsensitiveGoalConfigTest {
             + "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal,"
             + "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,"
             + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal");
+    caseInsensitiveGoalProps.setProperty(
+        KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG,
+        "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal");
 
     Object[] withCaseInsensitiveGoalParams = {caseInsensitiveGoalProps, null};
     params.add(withCaseInsensitiveGoalParams);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -283,6 +283,22 @@ public class ExecutorTest extends AbstractKafkaIntegrationTestHarness {
     props.setProperty(KafkaCruiseControlConfig.ZOOKEEPER_CONNECT_CONFIG, zookeeper().getConnectionString());
     props.setProperty(KafkaCruiseControlConfig.NUM_CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER_CONFIG, "10");
     props.setProperty(KafkaCruiseControlConfig.EXECUTION_PROGRESS_CHECK_INTERVAL_MS_CONFIG, "1000");
+    props.setProperty(
+        KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG,
+        "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal,"
+        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal");
     return props;
   }
 }


### PR DESCRIPTION
Fixes the issue https://github.com/linkedin/cruise-control/issues/363.
In endpoints that receive `goals` as input (e.g. `proposals`, `add_broker`, `remove_broker`, `rebalance`), if the following conditions are satisfied:
1) user does not provide `goals` parameter,
2) a strict subset of default goals are ready, but this strict subset excludes some `hard.goals` defined via `cruiescontrol.properties`, and
3) `NumValidWindows` is 0 (can be checked via `state` endpoint).

Then, in an effort to run the requested operation (such as `remove_broker`), Cruise Control implicitly attempts to execute with the ready goals -- i.e. a strict subset of default goals. This creates 3 issues: 
1. Lack of control over whether all the default goals or a subset of these goals are going to be used.
2. Lack of notification regarding  which goals are used in optimization,
3. Confusion regarding why the best proposal is not cached and the state endpoint is showing `isProposalReady` as `false` (note that in this scenario, the best proposals are not cached because the optimized goals are actually a subset of `default.goals`. Caching proposals requires the goals to be exactly the same as `default.goals`.)

This patch
* Adds `use_ready_default_goals` parameter (default: `false`) to resolve the above issues.
* Makes `default.goals` a required configuration.
* Uses a list rather than a map to represent goals with priorities.