### PR TITLE
UserTaskManager should remove UserTaskInfo from CompletedTasks list w…

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
@@ -321,6 +321,7 @@ public class UserTaskManager implements Closeable {
                                                       OperationFuture operationFuture,
                                                       HttpServletRequest httpServletRequest) {
     if (_activeUserTaskIdToFuturesMap.containsKey(userTaskId)) {
+      _completedUserTaskIdToFuturesMap.remove(userTaskId);
       _activeUserTaskIdToFuturesMap.get(userTaskId).futures().add(operationFuture);
     } else {
       if (_activeUserTaskIdToFuturesMap.size() >= _maxActiveUserTasks) {


### PR DESCRIPTION
…hen adding a new Future.

When adding a new future to existing user operation, there is a bug where the UserTaskInfo
is not removed from the completed list when adding a new future and making it Active by
adding it to ActiveTasks list