### PR TITLE
Add per broker swap timeout for resource distribution goals.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ResourceDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ResourceDistributionGoal.java
@@ -489,7 +489,12 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
       candidateBrokerPQ.add(candidateBroker);
     }
 
-    while (!candidateBrokerPQ.isEmpty() && remainingPerBrokerSwapTimeMs(swapStartTimeMs) > 0) {
+    while (!candidateBrokerPQ.isEmpty()) {
+      if (remainingPerBrokerSwapTimeMs(swapStartTimeMs) <= 0) {
+        LOG.debug("Swap load out timeout for broker {}.", broker.id());
+        break;
+      }
+
       CandidateBroker cb = candidateBrokerPQ.poll();
       SortedSet<Replica> candidateReplicasToSwapWith = cb.replicas();
 
@@ -512,7 +517,7 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
           swappedOutReplica = sourceReplica;
           break;
         } else if (remainingPerBrokerSwapTimeMs(swapStartTimeMs) <= 0) {
-          LOG.debug("Swap load out timeout for broker {}.", broker.id());
+          LOG.debug("Swap load out timeout for source replica {}.", sourceReplica.toString());
           return true;
         }
       }
@@ -590,7 +595,11 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
       candidateBrokerPQ.add(candidateBroker);
     }
 
-    while (!candidateBrokerPQ.isEmpty() && remainingPerBrokerSwapTimeMs(swapStartTimeMs) > 0) {
+    while (!candidateBrokerPQ.isEmpty()) {
+      if (remainingPerBrokerSwapTimeMs(swapStartTimeMs) <= 0) {
+        LOG.debug("Swap load in timeout for broker {}.", broker.id());
+        break;
+      }
       CandidateBroker cb = candidateBrokerPQ.poll();
       SortedSet<Replica> candidateReplicasToSwapWith = cb.replicas();
 
@@ -617,7 +626,7 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
           swappedOutReplica = sourceReplica;
           break;
         } else if (remainingPerBrokerSwapTimeMs(swapStartTimeMs) <= 0) {
-          LOG.debug("Swap load in timeout for broker {}.", broker.id());
+          LOG.debug("Swap load in timeout for source replica {}.", sourceReplica.toString());
           return true;
         }
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ResourceDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ResourceDistributionGoal.java
@@ -53,6 +53,7 @@ import static com.linkedin.kafka.cruisecontrol.analyzer.goals.ResourceDistributi
 public abstract class ResourceDistributionGoal extends AbstractGoal {
   private static final Logger LOG = LoggerFactory.getLogger(ResourceDistributionGoal.class);
   private static final double BALANCE_MARGIN = 0.9;
+  private static final long PER_BROKER_SWAP_TIMEOUT_MS = 1000L;
   // Flag to indicate whether the self healing failed to relocate all replicas away from dead brokers in its initial
   // attempt and currently omitting the resource balance limit to relocate remaining replicas.
   private boolean _selfHealingDeadBrokersOnly;
@@ -465,6 +466,7 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
                                              ClusterModel clusterModel,
                                              Set<Goal> optimizedGoals,
                                              Set<String> excludedTopics) {
+    long swapStartTimeMs = System.currentTimeMillis();
     if (!broker.isAlive()) {
       return true;
     }
@@ -487,7 +489,7 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
       candidateBrokerPQ.add(candidateBroker);
     }
 
-    while (!candidateBrokerPQ.isEmpty()) {
+    while (!candidateBrokerPQ.isEmpty() && remainingPerBrokerSwapTimeMs(swapStartTimeMs) > 0) {
       CandidateBroker cb = candidateBrokerPQ.poll();
       SortedSet<Replica> candidateReplicasToSwapWith = cb.replicas();
 
@@ -509,6 +511,9 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
           swappedInReplica = swappedIn;
           swappedOutReplica = sourceReplica;
           break;
+        } else if (remainingPerBrokerSwapTimeMs(swapStartTimeMs) <= 0) {
+          LOG.debug("Swap load out timeout for broker {}.", broker.id());
+          return true;
         }
       }
 
@@ -516,6 +521,16 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
     }
 
     return true;
+  }
+
+  /**
+   * Get the remaining per broker swap time in milliseconds based on the given swap start time.
+   *
+   * @param swapStartTimeMs Per broker swap start time in milliseconds.
+   * @return Remaining per broker swap time in milliseconds.
+   */
+  private long remainingPerBrokerSwapTimeMs(long swapStartTimeMs) {
+    return PER_BROKER_SWAP_TIMEOUT_MS - (System.currentTimeMillis() - swapStartTimeMs);
   }
 
   /**
@@ -552,6 +567,7 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
                                             ClusterModel clusterModel,
                                             Set<Goal> optimizedGoals,
                                             Set<String> excludedTopics) {
+    long swapStartTimeMs = System.currentTimeMillis();
     if (!broker.isAlive() || broker.replicas().isEmpty()) {
       // Source broker is dead or has no replicas to swap.
       return true;
@@ -574,7 +590,7 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
       candidateBrokerPQ.add(candidateBroker);
     }
 
-    while (!candidateBrokerPQ.isEmpty()) {
+    while (!candidateBrokerPQ.isEmpty() && remainingPerBrokerSwapTimeMs(swapStartTimeMs) > 0) {
       CandidateBroker cb = candidateBrokerPQ.poll();
       SortedSet<Replica> candidateReplicasToSwapWith = cb.replicas();
 
@@ -600,6 +616,9 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
           swappedInReplica = swappedIn;
           swappedOutReplica = sourceReplica;
           break;
+        } else if (remainingPerBrokerSwapTimeMs(swapStartTimeMs) <= 0) {
+          LOG.debug("Swap load in timeout for broker {}.", broker.id());
+          return true;
         }
       }
 


### PR DESCRIPTION
This patch adds a hard-coded timeout for the per broker swap operations in resource distribution goals.
Future patches will remove this hardcoded value and make it configurable.