### PR TITLE
fix incorrect const string

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -135,7 +135,7 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
   /**
    * <code>broker.metrics.windows.ms</code>
    */
-  public static final String BROKER_METRICS_WINDOW_MS_CONFIG = "broker.metrics.windows.ms";
+  public static final String BROKER_METRICS_WINDOW_MS_CONFIG = "broker.metrics.window.ms";
   private static final String BROKER_METRICS_WINDOW_MS_DOC = "The size of the window in milliseconds to aggregate the"
       + " Kafka broker metrics.";
 


### PR DESCRIPTION
broker.metrics.windows.ms => broker.metrics.window.ms
this const string is different from its name, and also different from that in the sample config.