### PR TITLE
Remove UserTaskManager#closeSession().

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -181,24 +181,16 @@ public class KafkaCruiseControlServlet extends HttpServlet {
               _successfulRequestExecutionTimer.get(endPoint).update(System.nanoTime() - requestExecutionStartTime, TimeUnit.NANOSECONDS);
               break;
             case LOAD:
-              if (getClusterLoad(request, response)) {
-                _userTaskManager.closeSession(request);
-              }
+              getClusterLoad(request, response);
               break;
             case PARTITION_LOAD:
-              if (getPartitionLoad(request, response)) {
-                _userTaskManager.closeSession(request);
-              }
+              getPartitionLoad(request, response);
               break;
             case PROPOSALS:
-              if (getProposals(request, response)) {
-                _userTaskManager.closeSession(request);
-              }
+              getProposals(request, response);
               break;
             case STATE:
-              if (getState(request, response)) {
-                _userTaskManager.closeSession(request);
-              }
+              getState(request, response);
               break;
             case KAFKA_CLUSTER_STATE:
               getKafkaClusterState(request, response);
@@ -224,7 +216,6 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       StringWriter sw = new StringWriter();
       ure.printStackTrace(new PrintWriter(sw));
       setErrorResponse(response, sw.toString(), errorMessage, SC_BAD_REQUEST, wantJSON(request));
-      _userTaskManager.closeSession(request);
     } catch (Exception e) {
       StringWriter sw = new StringWriter();
       PrintWriter pw = new PrintWriter(sw);
@@ -232,7 +223,6 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       String errorMessage = String.format("Error processing GET request '%s' due to '%s'.", request.getPathInfo(), e.getMessage());
       LOG.error(errorMessage, e);
       setErrorResponse(response, sw.toString(), errorMessage, SC_INTERNAL_SERVER_ERROR, wantJSON(request));
-      _userTaskManager.closeSession(request);
     } finally {
       try {
         response.getOutputStream().close();
@@ -305,14 +295,10 @@ public class KafkaCruiseControlServlet extends HttpServlet {
           switch (endPoint) {
             case ADD_BROKER:
             case REMOVE_BROKER:
-              if (addOrRemoveBroker(request, response, endPoint)) {
-                _userTaskManager.closeSession(request);
-              }
+              addOrRemoveBroker(request, response, endPoint);
               break;
             case REBALANCE:
-              if (rebalance(request, response)) {
-                _userTaskManager.closeSession(request);
-              }
+              rebalance(request, response);
               break;
             case STOP_PROPOSAL_EXECUTION:
               stopProposalExecution();
@@ -330,9 +316,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
               _successfulRequestExecutionTimer.get(endPoint).update(System.nanoTime() - requestExecutionStartTime, TimeUnit.NANOSECONDS);
               break;
             case DEMOTE_BROKER:
-              if (demoteBroker(request, response)) {
-                _userTaskManager.closeSession(request);
-              }
+              demoteBroker(request, response);
               break;
             default:
               throw new UserRequestException("Invalid URL for POST");
@@ -350,7 +334,6 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       StringWriter sw = new StringWriter();
       ure.printStackTrace(new PrintWriter(sw));
       setErrorResponse(response, sw.toString(), errorMessage, SC_BAD_REQUEST, wantJSON(request));
-      _userTaskManager.closeSession(request);
     } catch (Exception e) {
       StringWriter sw = new StringWriter();
       PrintWriter pw = new PrintWriter(sw);
@@ -358,7 +341,6 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       String errorMessage = String.format("Error processing POST request '%s' due to: '%s'.", request.getPathInfo(), e.getMessage());
       LOG.error(errorMessage, e);
       setErrorResponse(response, sw.toString(), errorMessage, SC_INTERNAL_SERVER_ERROR, wantJSON(request));
-      _userTaskManager.closeSession(request);
     } finally {
       try {
         response.getOutputStream().close();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
@@ -204,22 +204,6 @@ public class UserTaskManager implements Closeable {
     return (T) operationFutures.get(operationFutures.size() - 1);
   }
 
-  public void closeSession(HttpServletRequest request) {
-    SessionKey sessionKey = new SessionKey(request);
-    UUID userTaskId;
-    synchronized (_sessionToUserTaskIdMap) {
-      userTaskId = _sessionToUserTaskIdMap.remove(sessionKey);
-    }
-
-    if (userTaskId != null) {
-      LOG.info("Closing SessionKey {} and UserTaskId {}", sessionKey, userTaskId);
-      if (isActiveUserTasksDone(userTaskId)) {
-        LOG.info("Invalidate SessionKey {}", sessionKey);
-        sessionKey.httpSession().invalidate();
-      }
-    }
-  }
-
   private void expireOldSessions() {
     long now = _time.milliseconds();
     synchronized (_sessionToUserTaskIdMap) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManagerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManagerTest.java
@@ -219,37 +219,6 @@ public class UserTaskManagerTest {
   }
 
   @Test
-  public void testCloseSession() {
-    HttpSession mockHttpSession = EasyMock.mock(HttpSession.class);
-    mockHttpSession.invalidate();
-    EasyMock.expect(mockHttpSession.getLastAccessedTime()).andReturn(100L).anyTimes();
-
-    UserTaskManager.UUIDGenerator mockUUIDGenerator = EasyMock.mock(UserTaskManager.UUIDGenerator.class);
-    EasyMock.expect(mockUUIDGenerator.randomUUID()).andReturn(UUID.randomUUID()).anyTimes();
-
-    HttpServletRequest mockHttpServletRequest = prepareRequest(mockHttpSession, null);
-
-    OperationFuture<Integer> future = new OperationFuture<>("future");
-    UserTaskManager userTaskManager = new UserTaskManager(1000, 1, new MockTime(), mockUUIDGenerator);
-
-    HttpServletResponse mockHttpServletResponse = EasyMock.mock(HttpServletResponse.class);
-    mockHttpServletResponse.setHeader(EasyMock.anyString(), EasyMock.anyString());
-
-    EasyMock.replay(mockUUIDGenerator, mockHttpSession, mockHttpServletResponse);
-    // test-case: close session invalidates session
-    OperationFuture future1 =
-        userTaskManager.getOrCreateUserTask(mockHttpServletRequest, mockHttpServletResponse, () -> future, 0);
-    Assert.assertEquals(future, future1);
-
-    userTaskManager.closeSession(mockHttpServletRequest);
-
-    OperationFuture future2 = userTaskManager.getFuture(mockHttpServletRequest);
-    Assert.assertNull(future2);
-
-    userTaskManager.close();
-  }
-
-  @Test
   public void testMaximumActiveTasks() {
     HttpSession mockHttpSession1 = EasyMock.mock(HttpSession.class);
     EasyMock.expect(mockHttpSession1.getLastAccessedTime()).andReturn(100L).anyTimes();


### PR DESCRIPTION
Explicit calls to `closeSession()` has become redundant after the addition of `UserTaskManager`.