### PR TITLE
Fix the bug that Cruise Control returns in accurate valid partition ratio in State endpoint.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregator.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregator.java
@@ -227,7 +227,7 @@ public class KafkaPartitionMetricSampleAggregator extends MetricSampleAggregator
                                  AggregationOptions.Granularity.ENTITY_GROUP,
                                  true);
     MetricSampleCompleteness<String, PartitionEntity> completeness = completeness(-1, Long.MAX_VALUE, options);
-    return windowIndexesToWindows(completeness.validEntityGroupRatioByWindowIndex(), _windowMs);
+    return windowIndexesToWindows(completeness.validEntityRatioWithGroupGranularityByWindowIndex(), _windowMs);
   }
 
   private Set<PartitionEntity> allPartitions(Cluster cluster) {


### PR DESCRIPTION
fix for issue[404](https://github.com/linkedin/cruise-control/issues/404)