### PR TITLE
Fixes crash when using dynamic reconfig

### DIFF
--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
@@ -81,8 +81,8 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
   public void configure(Map<String, ?> configs) {
     Properties producerProps = CruiseControlMetricsReporterConfig.parseProducerConfigs(configs);
     if (!producerProps.containsKey(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG)) {
-      String port = (String) configs.get("port");
-      String bootstrapServers = "localhost:" + (port == null ? "9092" : port);
+      Object port = configs.get("port");
+      String bootstrapServers = "localhost:" + (port == null ? "9092" : String.valueOf(port));
       producerProps.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
       LOG.info("Using default value of {} for {}", bootstrapServers,
                CruiseControlMetricsReporterConfig.config(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG));


### PR DESCRIPTION
When dynamically setting metric.reporters to use cruise control, the Kafka brokers refuse to reload the new config because the 'port' property is actually an Integer which doesn't get properly cast to a string.