### PR TITLE
Fix for Executor state would stuck at STARTING_EXECUTION if CC metric sampler is stuck at SAMPLING state

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -92,6 +92,7 @@ public class LoadMonitor {
 
   private volatile ModelGeneration _cachedBrokerLoadGeneration;
   private volatile ClusterModel.BrokerStats _cachedBrokerLoadStats;
+  private volatile Boolean _awaitExecution;
 
   /**
    * Construct a load monitor.
@@ -330,6 +331,7 @@ public class LoadMonitor {
    */
   public void pauseMetricSampling() {
     _loadMonitorTaskRunner.pauseSampling();
+    _loadMonitorTaskRunner.setAwaitExecution(true);
   }
 
   /**
@@ -337,8 +339,8 @@ public class LoadMonitor {
    */
   public void resumeMetricSampling() {
     _loadMonitorTaskRunner.resumeSampling();
+    _loadMonitorTaskRunner.setAwaitExecution(false);
   }
-
   /**
    * Acquire the semaphore for the cluster model generation.
    * @param operationProgress the progress for the job.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricFetcherManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricFetcherManager.java
@@ -253,6 +253,8 @@ public class MetricFetcherManager {
         LOG.warn("Sampling scheduler thread is interrupted when waiting for sampling to finish.", e);
       } catch (ExecutionException e) {
         LOG.error("Sampling scheduler received Execution exception when waiting for sampling to finish", e);
+      } catch (TimeoutException e) {
+        LOG.error("Sampling scheduler received Timeout exception when waiting for sampling to finish", e);
       } catch (Exception e) {
         LOG.error("Sampling scheduler received Unknown exception when waiting for sampling to finish", e);
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/task/LoadMonitorTaskRunner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/task/LoadMonitorTaskRunner.java
@@ -45,6 +45,7 @@ public class LoadMonitorTaskRunner {
 
   private AtomicReference<LoadMonitorTaskRunnerState> _state;
   private volatile double _bootstrapProgress;
+  private volatile Boolean _awaitExecution;
 
   public enum LoadMonitorTaskRunnerState {
     NOT_STARTED, RUNNING, PAUSED, SAMPLING, BOOTSTRAPPING, TRAINING, LOADING
@@ -109,6 +110,7 @@ public class LoadMonitorTaskRunner {
 
     _state = new AtomicReference<>(NOT_STARTED);
     _bootstrapProgress = -1.0;
+    _awaitExecution = false;
   }
 
   /**
@@ -277,6 +279,16 @@ public class LoadMonitorTaskRunner {
     }
   }
 
+  /**
+   * Allow tasks to know if executor wishes to stop sampling b/c it wants to execute
+   */
+  public Boolean awaitingExecution() {
+    return _awaitExecution;
+  }
+
+  public void setAwaitExecution(Boolean state) {
+    _awaitExecution = state;
+  }
 
   boolean compareAndSetState(LoadMonitorTaskRunnerState expectedState, LoadMonitorTaskRunnerState newState) {
     return _state.compareAndSet(expectedState, newState);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/task/SamplingTask.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/task/SamplingTask.java
@@ -43,7 +43,7 @@ class SamplingTask implements Runnable {
 
   public void run() {
     long now = _time.milliseconds();
-    if (_loadMonitorTaskRunner.compareAndSetState(LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.RUNNING,
+    if (!_loadMonitorTaskRunner.awaitingExecution() && _loadMonitorTaskRunner.compareAndSetState(LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.RUNNING,
                                                   LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.SAMPLING)) {
       long samplingPeriodEndMs = now;
       try {


### PR DESCRIPTION
The fix added flag to indicate there's a pending Execution request. The LoadMonitor will not kick off consecutive sampling if it sees the flag is set. 
It's noticed that if MetadataClient.refreshMetadata() timeout (KafkaCruiseControlConfig.METADATA_MAX_AGE_CONFIG) is longer than sampling period for SamplingTask (KafkaCruiseControlConfig.METRIC_SAMPLING_INTERVAL_MS_CONFIG ). We need to make sure the timeout is no longer than the sampling period because the code will anyways throw TimeoutException if execution takes longer than sampling period. There's no need to wait longer than necessary. 