### PR TITLE
Fix the concurrency bug in cached broker load stats retrieval.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -482,21 +482,14 @@ public class LoadMonitor {
 
   /**
    * Get the cached load.
-   * @return the cached load, null if the load is stale or does not meet requirement.
+   * @return The cached load, or null if (1) load or metadata is stale or (2) cached load violates capacity requirements.
    */
-  public BrokerStats cachedBrokerLoadStats(boolean allowCapacityEstimation) {
-    BrokerStats brokerStats;
-    ModelGeneration brokerLoadGeneration;
-    synchronized (this) {
-      brokerStats = _cachedBrokerLoadStats;
-      brokerLoadGeneration = _cachedBrokerLoadGeneration;
-    }
-    if (brokerLoadGeneration != null
-        && (allowCapacityEstimation || !brokerStats.isBrokerStatsEstimated())
-        && _partitionMetricSampleAggregator.generation() == brokerLoadGeneration.loadGeneration()) {
-      if (brokerLoadGeneration.clusterGeneration() == _metadataClient.refreshMetadata().generation()) {
-        return brokerStats;
-      }
+  public synchronized BrokerStats cachedBrokerLoadStats(boolean allowCapacityEstimation) {
+    if (_cachedBrokerLoadGeneration != null
+        && (allowCapacityEstimation || !_cachedBrokerLoadStats.isBrokerStatsEstimated())
+        && _partitionMetricSampleAggregator.generation() == _cachedBrokerLoadGeneration.loadGeneration()
+        && _metadataClient.refreshMetadata().generation() == _cachedBrokerLoadGeneration.clusterGeneration()) {
+      return _cachedBrokerLoadStats;
     }
     return null;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/ModelGeneration.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/ModelGeneration.java
@@ -32,7 +32,7 @@ public class ModelGeneration implements Serializable {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || !(o instanceof ModelGeneration)) {
+    if (!(o instanceof ModelGeneration)) {
       return false;
     }
 


### PR DESCRIPTION
The value of `_cachedBrokerLoadStats` and ` _cachedBrokerLoadGeneration` should be protected while reading them.