### PR TITLE
Handle topics with dots to fix WARNs regarding missing topic and partition metrics.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ModelUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ModelUtils.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.model;
 
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
+import org.apache.kafka.common.TopicPartition;
 
 
 /**
@@ -86,5 +87,31 @@ public class ModelUtils {
         ModelParameters.getCoefficient(LinearRegressionModelParameters.ModelCoefficient.LEADER_BYTES_OUT);
     return leaderBytesInCoefficient * leaderPartitionBytesInRate
         + leaderBytesOutCoefficient * leaderPartitionBytesOutRate;
+  }
+
+
+  /**
+   * Removes any dots that potentially exist in the given string. This method useful for making topic names reported by
+   * Kafka metadata consistent with the topic names reported by the metrics reporter.
+   *
+   * Note that the reported metrics implicitly replaces the "." in topic names with "_".
+   *
+   * @param stringWithDots String that may contain dots.
+   * @return String whose dots have been removed from the given string.
+   */
+  public static String replaceDotsWithUnderscores(String stringWithDots) {
+    return !stringWithDots.contains(".") ? stringWithDots : stringWithDots.replace('.', '_');
+  }
+
+  /**
+   * Removes any dots that potentially exist in the given parameter.
+   *
+   * @param tp TopicPartition that may contain dots.
+   * @return TopicPartition whose dots have been removed from the given topic name.
+   */
+  public static TopicPartition partitionHandleDotInTopicName(TopicPartition tp) {
+    // In the reported metrics, the "." in the topic name will be replaced by "_".
+    return !tp.topic().contains(".") ? tp :
+           new TopicPartition(ModelUtils.replaceDotsWithUnderscores(tp.topic()), tp.partition());
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ModelUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ModelUtils.java
@@ -112,6 +112,6 @@ public class ModelUtils {
   public static TopicPartition partitionHandleDotInTopicName(TopicPartition tp) {
     // In the reported metrics, the "." in the topic name will be replaced by "_".
     return !tp.topic().contains(".") ? tp :
-           new TopicPartition(ModelUtils.replaceDotsWithUnderscores(tp.topic()), tp.partition());
+           new TopicPartition(replaceDotsWithUnderscores(tp.topic()), tp.partition());
   }
 }


### PR DESCRIPTION
Fixes issues including https://github.com/linkedin/cruise-control/issues/325, https://github.com/linkedin/cruise-control/issues/318, https://github.com/linkedin/cruise-control/issues/255, https://github.com/linkedin/cruise-control/issues/238.

Thanks to @craynic for helping us resolve the issue by sharing `TRACE`-level logs.