### PR TITLE
Allow missing log flush time 50th and 999th percentiles for broker sample creation.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsProcessor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsProcessor.java
@@ -551,6 +551,8 @@ public class CruiseControlMetricsProcessor {
         case BROKER_LOG_FLUSH_RATE:
         case BROKER_LOG_FLUSH_TIME_MS_MEAN:
         case BROKER_LOG_FLUSH_TIME_MS_MAX:
+        case BROKER_LOG_FLUSH_TIME_MS_50TH:
+        case BROKER_LOG_FLUSH_TIME_MS_999TH:
           return true;
         default:
           return false;


### PR DESCRIPTION
Fixes the issue https://github.com/linkedin/cruise-control/issues/449.