### PR TITLE
Allow missing broker produce request rate and consumer fetch request rate metrics from reporter

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsProcessor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsProcessor.java
@@ -553,6 +553,8 @@ public class CruiseControlMetricsProcessor {
         case BROKER_LOG_FLUSH_TIME_MS_MAX:
         case BROKER_LOG_FLUSH_TIME_MS_50TH:
         case BROKER_LOG_FLUSH_TIME_MS_999TH:
+        case BROKER_PRODUCE_REQUEST_RATE:
+        case BROKER_CONSUMER_FETCH_REQUEST_RATE:
           return true;
         default:
           return false;


### PR DESCRIPTION
In the scenario where there is no traffic for certain broker, the Cruise Control reporter on this broker will not report `BROKER_PRODUCE_REQUEST_RATE` and `BROKER_CONSUMER_FETCH_REQUEST_RATE` metrics and the metric processing logic inside Cruise Control will report warning like

` [MetricFetcher-0] [kafka-cruise-control] [] Skip generating broker metric sample for broker xxxx because the following required metrics are missing [BROKER_PRODUCE_REQUEST_RATE, BROKER_CONSUMER_FETCH_REQUEST_RATE]`

Given the behavior of reporter is reasonable here, this patch make these two broker metric optional. 