### PR TITLE
Improve goal violation anomaly detection and auto-fixing logic.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -1096,6 +1096,7 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
    * (1) {@link KafkaCruiseControlConfig#GOALS_CONFIG} is non-empty.
    * (2) Case insensitive goal names.
    * (3) {@link KafkaCruiseControlConfig#DEFAULT_GOALS_CONFIG} is non-empty.
+   * (4) {@link KafkaCruiseControlConfig#ANOMALY_DETECTION_GOALS_CONFIG} is a sublist of {@link KafkaCruiseControlConfig#GOALS_CONFIG}.
    */
   private void sanityCheckGoalNames() {
     List<String> goalNames = getList(KafkaCruiseControlConfig.GOALS_CONFIG);
@@ -1113,6 +1114,12 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
     // Ensure that default goals is non-empty.
     if (getList(KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG).isEmpty()) {
       throw new ConfigException("Attempt to configure default goals configuration with an empty list of goals.");
+    }
+
+    // Ensure that goals used for anomaly detection are supported goals.
+    List<String> anomalyDetectionGoalNames = getList(KafkaCruiseControlConfig.ANOMALY_DETECTION_GOALS_CONFIG);
+    if (anomalyDetectionGoalNames.stream().anyMatch(g -> !goalNames.contains(g))) {
+      throw new ConfigException("Attempt to configure anomaly detection goals with unsupported goals.");
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -1112,13 +1112,14 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
       }
     }
     // Ensure that default goals is non-empty.
-    if (getList(KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG).isEmpty()) {
+    List<String> defaultGoalNames = getList(KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG);
+    if (defaultGoalNames.isEmpty()) {
       throw new ConfigException("Attempt to configure default goals configuration with an empty list of goals.");
     }
 
     // Ensure that goals used for anomaly detection are supported goals.
     List<String> anomalyDetectionGoalNames = getList(KafkaCruiseControlConfig.ANOMALY_DETECTION_GOALS_CONFIG);
-    if (anomalyDetectionGoalNames.stream().anyMatch(g -> !goalNames.contains(g))) {
+    if (anomalyDetectionGoalNames.stream().anyMatch(g -> !defaultGoalNames.contains(g))) {
       throw new ConfigException("Attempt to configure anomaly detection goals with unsupported goals.");
     }
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -1021,18 +1021,7 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 new StringJoiner(",")
                     .add(RackAwareGoal.class.getName())
                     .add(ReplicaCapacityGoal.class.getName())
-                    .add(DiskCapacityGoal.class.getName())
-                    .add(NetworkInboundCapacityGoal.class.getName())
-                    .add(NetworkOutboundCapacityGoal.class.getName())
-                    .add(CpuCapacityGoal.class.getName())
-                    .add(ReplicaDistributionGoal.class.getName())
-                    .add(PotentialNwOutGoal.class.getName())
-                    .add(DiskUsageDistributionGoal.class.getName())
-                    .add(NetworkInboundUsageDistributionGoal.class.getName())
-                    .add(NetworkOutboundUsageDistributionGoal.class.getName())
-                    .add(CpuUsageDistributionGoal.class.getName())
-                    .add(LeaderBytesInDistributionGoal.class.getName())
-                    .add(TopicReplicaDistributionGoal.class.getName()).toString(),
+                    .add(DiskCapacityGoal.class.getName()).toString(),
                 ConfigDef.Importance.MEDIUM,
                 ANOMALY_DETECTION_GOALS_DOC)
         .define(FAILED_BROKERS_ZK_PATH_CONFIG,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorState.java
@@ -78,12 +78,12 @@ public class AnomalyDetectorState {
     Set<Map<String, Object>> recentAnomalies = new HashSet<>(_numCachedRecentAnomalyStates);
     for (Map.Entry<Long, Anomaly> entry: goalViolationsByTime.entrySet()) {
       GoalViolations goalViolations = (GoalViolations) entry.getValue();
-      Map<Boolean, List<String>> violatedGoals = goalViolations.violations();
-      Map<String, Object> anomalyDetails = new HashMap<>(2);
+      Map<Boolean, List<String>> violatedGoalsByFixability = goalViolations.violatedGoalsByFixability();
+      Map<String, Object> anomalyDetails = new HashMap<>(3);
       anomalyDetails.put(useDateFormat ? DETECTION_DATE : DETECTION_MS,
           useDateFormat ? getDateFormat(entry.getKey()) : entry.getKey());
-      anomalyDetails.put(FIXABLE_VIOLATED_GOALS, violatedGoals.getOrDefault(true, Collections.emptyList()));
-      anomalyDetails.put(UNFIXABLE_VIOLATED_GOALS, violatedGoals.getOrDefault(false, Collections.emptyList()));
+      anomalyDetails.put(FIXABLE_VIOLATED_GOALS, violatedGoalsByFixability.getOrDefault(true, Collections.emptyList()));
+      anomalyDetails.put(UNFIXABLE_VIOLATED_GOALS, violatedGoalsByFixability.getOrDefault(false, Collections.emptyList()));
       recentAnomalies.add(anomalyDetails);
     }
     return recentAnomalies;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorState.java
@@ -8,10 +8,12 @@ import com.linkedin.cruisecontrol.detector.Anomaly;
 import com.linkedin.kafka.cruisecontrol.detector.notifier.AnomalyType;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
@@ -22,7 +24,8 @@ public class AnomalyDetectorState {
   private static final String TIME_ZONE = "UTC";
   private static final String DETECTION_MS = "detectionMs";
   private static final String DETECTION_DATE = "detectionDate";
-  private static final String VIOLATED_GOALS = "violatedGoals";
+  private static final String FIXABLE_VIOLATED_GOALS = "fixableViolatedGoals";
+  private static final String UNFIXABLE_VIOLATED_GOALS = "unfixableViolatedGoals";
   private static final String FAILED_BROKERS_BY_TIME_MS = "failedBrokersByTimeMs";
   private static final String DESCRIPTION = "description";
   private static final String SELF_HEALING_ENABLED = "selfHealingEnabled";
@@ -75,11 +78,12 @@ public class AnomalyDetectorState {
     Set<Map<String, Object>> recentAnomalies = new HashSet<>(_numCachedRecentAnomalyStates);
     for (Map.Entry<Long, Anomaly> entry: goalViolationsByTime.entrySet()) {
       GoalViolations goalViolations = (GoalViolations) entry.getValue();
-      Set<String> violatedGoals = goalViolations.violations();
+      Map<Boolean, List<String>> violatedGoals = goalViolations.violations();
       Map<String, Object> anomalyDetails = new HashMap<>(2);
       anomalyDetails.put(useDateFormat ? DETECTION_DATE : DETECTION_MS,
           useDateFormat ? getDateFormat(entry.getKey()) : entry.getKey());
-      anomalyDetails.put(VIOLATED_GOALS, violatedGoals);
+      anomalyDetails.put(FIXABLE_VIOLATED_GOALS, violatedGoals.getOrDefault(true, Collections.emptyList()));
+      anomalyDetails.put(UNFIXABLE_VIOLATED_GOALS, violatedGoals.getOrDefault(false, Collections.emptyList()));
       recentAnomalies.add(anomalyDetails);
     }
     return recentAnomalies;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorState.java
@@ -15,7 +15,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.stream.Collectors;
 
 
 public class AnomalyDetectorState {
@@ -76,8 +75,7 @@ public class AnomalyDetectorState {
     Set<Map<String, Object>> recentAnomalies = new HashSet<>(_numCachedRecentAnomalyStates);
     for (Map.Entry<Long, Anomaly> entry: goalViolationsByTime.entrySet()) {
       GoalViolations goalViolations = (GoalViolations) entry.getValue();
-      Set<String> violatedGoals = goalViolations.violations().stream().map(GoalViolations.Violation::goalName)
-                                                .collect(Collectors.toSet());
+      Set<String> violatedGoals = goalViolations.violations();
       Map<String, Object> anomalyDetails = new HashMap<>(2);
       anomalyDetails.put(useDateFormat ? DETECTION_DATE : DETECTION_MS,
           useDateFormat ? getDateFormat(entry.getKey()) : entry.getKey());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
@@ -105,21 +105,21 @@ public class GoalViolationDetector implements Runnable {
       LOG.debug("Detecting if ready goals {} out of {} are violated.", readyGoals, _goals.values());
       GoalViolations goalViolations = new GoalViolations(_kafkaCruiseControl, _allowCapacityEstimation);
       ModelCompletenessRequirements requirements = new ModelCompletenessRequirements(0, 0, false);
-      for (Goal goal: readyGoals) {
+      for (Goal goal : readyGoals) {
         requirements = requirements.stronger(goal.clusterModelCompletenessRequirements());
       }
       ClusterModel clusterModel;
       try (AutoCloseable ignored = _loadMonitor.acquireForModelGeneration(new OperationProgress())) {
         clusterModel = _loadMonitor.clusterModel(_time.milliseconds(),
-            requirements,
-            new OperationProgress());
+                                                 requirements,
+                                                 new OperationProgress());
         _lastCheckedModelGeneration = clusterModel.generation();
       }  catch (Exception e) {
         LOG.error("Unexpected exception when generating cluster model.", e);
         return;
       }
 
-      for (Goal goal: readyGoals) {
+      for (Goal goal : readyGoals) {
         try {
           optimizeForGoal(clusterModel, goal, goalViolations);
         } catch (KafkaCruiseControlException kcce) {
@@ -130,6 +130,8 @@ public class GoalViolationDetector implements Runnable {
         _anomalies.add(goalViolations);
       }
       LOG.debug("Goal violation detection finished.");
+    } else {
+      LOG.debug("Skipping violation detection, because completeness requirement is not met for any goal in {}.", _goals.values());
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
@@ -128,7 +128,7 @@ public class GoalViolationDetector implements Runnable {
           LOG.debug("Skipping goal violation detection for {} because load completeness requirement is not met.", goal);
         }
       }
-      if (!goalViolations.violations().isEmpty()) {
+      if (!goalViolations.violatedGoalsByFixability().isEmpty()) {
         _anomalies.add(goalViolations);
       }
     } catch (NotEnoughValidWindowsException nevwe) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
@@ -9,9 +9,9 @@ import com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress;
 import com.linkedin.kafka.cruisecontrol.exception.KafkaCruiseControlException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.StringJoiner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,15 +24,13 @@ public class GoalViolations extends KafkaAnomaly {
   private static final Logger LOG = LoggerFactory.getLogger(GoalViolations.class);
   private final KafkaCruiseControl _kafkaCruiseControl;
   // The priority order of goals is maintained here.
-  private final List<String> _fixableViolatedGoals;
-  private final List<String> _unfixableViolatedGoals;
+  private final Map<Boolean, List<String>> _violatedGoals;
   private final boolean _allowCapacityEstimation;
 
   public GoalViolations(KafkaCruiseControl kafkaCruiseControl, boolean allowCapacityEstimation) {
     _kafkaCruiseControl = kafkaCruiseControl;
     _allowCapacityEstimation = allowCapacityEstimation;
-    _fixableViolatedGoals = new ArrayList<>();
-    _unfixableViolatedGoals = new ArrayList<>();
+    _violatedGoals = new HashMap<>();
   }
 
   /**
@@ -42,34 +40,28 @@ public class GoalViolations extends KafkaAnomaly {
    * @param fixable Whether the violated goal is fixable or not.
    */
   public void addViolation(String goalName, boolean fixable) {
-    if (fixable) {
-      _fixableViolatedGoals.add(goalName);
-    } else {
-      _unfixableViolatedGoals.add(goalName);
-    }
+      _violatedGoals.computeIfAbsent(fixable, k -> new ArrayList<>()).add(goalName);
   }
 
   /**
    * Get all the goal violations.
    */
-  public Set<String> violations() {
-    Set<String> allViolatedGoals = new HashSet<>(_unfixableViolatedGoals);
-    allViolatedGoals.addAll(_fixableViolatedGoals);
-    return allViolatedGoals;
+  public Map<Boolean, List<String>> violations() {
+    return _violatedGoals;
   }
 
   @Override
   public void fix() throws KafkaCruiseControlException {
-    if (_unfixableViolatedGoals.isEmpty()) {
+    if (_violatedGoals.get(false) == null) {
       try {
         // Fix the fixable goal violations with rebalance operation.
         _kafkaCruiseControl.rebalance(Collections.emptyList(), false, null, new OperationProgress(), _allowCapacityEstimation,
                                       null, null, false, null, null);
       } catch (IllegalStateException e) {
-        LOG.warn("Got exception when trying to fix the cluster for violated goals {} " + e.getMessage(), _fixableViolatedGoals);
+        LOG.warn("Got exception when trying to fix the cluster for violated goals {} " + e.getMessage(), _violatedGoals.get(true));
       }
     } else {
-      LOG.info("Skip fixing goal violations due to unfixable goal violations {} detected.", _unfixableViolatedGoals);
+      LOG.info("Skip fixing goal violations due to unfixable goal violations {} detected.", _violatedGoals.get(false));
     }
   }
 
@@ -78,11 +70,11 @@ public class GoalViolations extends KafkaAnomaly {
     StringBuilder sb = new StringBuilder();
     sb.append("{unfixable goal violations: {");
     StringJoiner joiner = new StringJoiner(",");
-    _unfixableViolatedGoals.forEach(joiner::add);
+    _violatedGoals.getOrDefault(false, Collections.emptyList()).forEach(joiner::add);
     sb.append(joiner.toString());
     sb.append("}, fixable goal violations: {");
     joiner = new StringJoiner(",");
-    _fixableViolatedGoals.forEach(joiner::add);
+    _violatedGoals.getOrDefault(true, Collections.emptyList()).forEach(joiner::add);
     sb.append("}}");
     return sb.toString();
   }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -143,7 +143,7 @@ public class AnomalyDetectorTest {
     EasyMock.expect(mockKafkaCruiseControl.state(EasyMock.anyObject(), EasyMock.anyObject()))
             .andReturn(new CruiseControlState(ExecutorState.noTaskInProgress(), null, null,
                                               null));
-    EasyMock.expect(mockKafkaCruiseControl.rebalance(EasyMock.eq(Collections.emptyList()),
+    EasyMock.expect(mockKafkaCruiseControl.rebalance(EasyMock.eq(Collections.singletonList("RackAwareGoal")),
                                                      EasyMock.eq(false),
                                                      EasyMock.eq(null),
                                                      EasyMock.anyObject(OperationProgress.class),
@@ -170,7 +170,9 @@ public class AnomalyDetectorTest {
 
     try {
       anomalyDetector.startDetection();
-      anomalies.add(new GoalViolations(mockKafkaCruiseControl, true));
+      GoalViolations violations = new GoalViolations(mockKafkaCruiseControl, true);
+      violations.addViolation("RackAwareGoal", true);
+      anomalies.add(violations);
       while (!anomalies.isEmpty()) {
         // Just wait for the anomalies to be drained.
       }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -143,7 +143,7 @@ public class AnomalyDetectorTest {
     EasyMock.expect(mockKafkaCruiseControl.state(EasyMock.anyObject(), EasyMock.anyObject()))
             .andReturn(new CruiseControlState(ExecutorState.noTaskInProgress(), null, null,
                                               null));
-    EasyMock.expect(mockKafkaCruiseControl.rebalance(EasyMock.eq(Collections.singletonList("RackAwareGoal")),
+    EasyMock.expect(mockKafkaCruiseControl.rebalance(EasyMock.eq(Collections.emptyList()),
                                                      EasyMock.eq(false),
                                                      EasyMock.eq(null),
                                                      EasyMock.anyObject(OperationProgress.class),


### PR DESCRIPTION
Patch for issue [455](https://github.com/linkedin/cruise-control/issues/451).
Improvement made to goal violation anomaly detection and auto-fixing logic.

* remove caching unneeded proposal for each goal violation
* distinguish fixable and unfixable goal violation and handle them differently
* filter all the support goal to check based on readiness of each goal