### PR TITLE
Keep and expose a history of recently removed brokers in the executor substate of the state endpoint.

### DIFF
--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -200,6 +200,9 @@ completed.user.task.retention.time.ms=21600000
 # The maximum time in milliseconds to retain the demotion history of brokers.
 demotion.history.retention.time.ms=86400000
 
+# The maximum time in milliseconds to retain the removal history of brokers.
+removal.history.retention.time.ms=43200000
+
 # The maximum number of completed user tasks for which the response and access details will be cached.
 max.cached.completed.user.tasks=100
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -22,6 +22,9 @@ import org.apache.kafka.common.config.ConfigException;
  * Util class for convenience.
  */
 public class KafkaCruiseControlUtils {
+  public static final int ZK_SESSION_TIMEOUT = 30000;
+  public static final int ZK_CONNECTION_TIMEOUT = 30000;
+  public static final boolean IS_ZK_SECURITY_ENABLED = false;
   public static final String DATA_FORMAT = "YYYY-MM-dd_HH:mm:ss z";
   public static final String TIME_ZONE = "UTC";
 
@@ -56,6 +59,10 @@ public class KafkaCruiseControlUtils {
       throw new ConfigException(String.format("Configuration %s must be provided.", configName));
     }
     return value;
+  }
+
+  public static ZkUtils createZkUtils(String zkConnect) {
+    return ZkUtils.apply(zkConnect, ZK_SESSION_TIMEOUT, ZK_CONNECTION_TIMEOUT, IS_ZK_SECURITY_ENABLED);
   }
 
   public static void closeZkUtilsWithTimeout(ZkUtils zkUtils, long timeoutMs) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -548,6 +548,13 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
       + " demotion history of brokers.";
 
   /**
+   * <code>removal.history.retention.time.ms</code>
+   */
+  public static final String REMOVAL_HISTORY_RETENTION_TIME_MS_CONFIG = "removal.history.retention.time.ms";
+  private static final String REMOVAL_HISTORY_RETENTION_TIME_MS_DOC = "The maximum time in milliseconds to retain the"
+      + " removal history of brokers.";
+
+  /**
    * <code>max.cached.completed.user.tasks</code>
    */
   public static final String MAX_CACHED_COMPLETED_USER_TASKS_CONFIG = "max.cached.completed.user.tasks";
@@ -757,6 +764,12 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 atLeast(0),
                 ConfigDef.Importance.MEDIUM,
                 DEMOTION_HISTORY_RETENTION_TIME_MS_DOC)
+        .define(REMOVAL_HISTORY_RETENTION_TIME_MS_CONFIG,
+            ConfigDef.Type.LONG,
+            TimeUnit.HOURS.toMillis(12),
+            atLeast(0),
+            ConfigDef.Importance.MEDIUM,
+            REMOVAL_HISTORY_RETENTION_TIME_MS_DOC)
         .define(MAX_CACHED_COMPLETED_USER_TASKS_CONFIG,
                 ConfigDef.Type.INT,
                 100,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorState.java
@@ -17,6 +17,7 @@ public class ExecutorState {
   private static final String TRIGGERED_USER_TASK_ID = "triggeredUserTaskId";
   private static final String STATE = "state";
   private static final String RECENTLY_DEMOTED_BROKERS = "recentlyDemotedBrokers";
+  private static final String RECENTLY_REMOVED_BROKERS = "recentlyRemovedBrokers";
   private static final String PENDING_LEADERSHIP_MOVEMENT = "pendingLeadershipMovement";
   private static final String NUM_FINISHED_LEADERSHIP_MOVEMENTS = "numFinishedLeadershipMovements";
   private static final String NUM_TOTAL_LEADERSHIP_MOVEMENTS = "numTotalLeadershipMovements";
@@ -58,6 +59,7 @@ public class ExecutorState {
   private final int _maximumConcurrentLeaderMovements;
   private final String _uuid;
   private final Set<Integer> _recentlyDemotedBrokers;
+  private final Set<Integer> _recentlyRemovedBrokers;
 
   private ExecutorState(State state,
                         int numFinishedPartitionMovements,
@@ -66,7 +68,8 @@ public class ExecutorState {
                         long finishedDataMovementInMB,
                         int maximumConcurrentPartitionMovementsPerBroker,
                         int maximumConcurrentLeaderMovements,
-                        Set<Integer> recentlyDemotedBrokers) {
+                        Set<Integer> recentlyDemotedBrokers,
+                        Set<Integer> recentlyRemovedBrokers) {
     this(state,
          numFinishedPartitionMovements,
          numFinishedLeadershipMovements,
@@ -74,7 +77,9 @@ public class ExecutorState {
          finishedDataMovementInMB,
          maximumConcurrentPartitionMovementsPerBroker,
          maximumConcurrentLeaderMovements,
-         null, recentlyDemotedBrokers);
+         null,
+         recentlyDemotedBrokers,
+         recentlyRemovedBrokers);
   }
 
   private ExecutorState(State state,
@@ -85,7 +90,8 @@ public class ExecutorState {
                         int maximumConcurrentPartitionMovementsPerBroker,
                         int maximumConcurrentLeaderMovements,
                         String uuid,
-                        Set<Integer> recentlyDemotedBrokers) {
+                        Set<Integer> recentlyDemotedBrokers,
+                        Set<Integer> recentlyRemovedBrokers) {
     _state = state;
     _numFinishedPartitionMovements = numFinishedPartitionMovements;
     _numFinishedLeadershipMovements = numFinishedLeadershipMovements;
@@ -101,13 +107,15 @@ public class ExecutorState {
     _maximumConcurrentLeaderMovements = maximumConcurrentLeaderMovements;
     _uuid = uuid;
     _recentlyDemotedBrokers = recentlyDemotedBrokers;
+    _recentlyRemovedBrokers = recentlyRemovedBrokers;
   }
 
   /**
    * @param recentlyDemotedBrokers Recently demoted broker IDs.
+   * @param recentlyRemovedBrokers Recently removed broker IDs.
    * @return Executor state when no task is in progress.
    */
-  public static ExecutorState noTaskInProgress(Set<Integer> recentlyDemotedBrokers) {
+  public static ExecutorState noTaskInProgress(Set<Integer> recentlyDemotedBrokers, Set<Integer> recentlyRemovedBrokers) {
     return new ExecutorState(State.NO_TASK_IN_PROGRESS,
                              0,
                              0,
@@ -121,15 +129,19 @@ public class ExecutorState {
                              0L,
                              0,
                              0,
-                             recentlyDemotedBrokers);
+                             recentlyDemotedBrokers,
+                             recentlyRemovedBrokers);
   }
 
   /**
    * @param uuid UUID of the current execution.
    * @param recentlyDemotedBrokers Recently demoted broker IDs.
+   * @param recentlyRemovedBrokers Recently removed broker IDs.
    * @return Executor state when the execution has started.
    */
-  public static ExecutorState executionStarted(String uuid, Set<Integer> recentlyDemotedBrokers) {
+  public static ExecutorState executionStarted(String uuid,
+                                               Set<Integer> recentlyDemotedBrokers,
+                                               Set<Integer> recentlyRemovedBrokers) {
     return new ExecutorState(State.STARTING_EXECUTION,
                              0,
                              0,
@@ -144,7 +156,8 @@ public class ExecutorState {
                              0,
                              0,
                              uuid,
-                             recentlyDemotedBrokers);
+                             recentlyDemotedBrokers,
+                             recentlyRemovedBrokers);
   }
 
   /**
@@ -155,6 +168,7 @@ public class ExecutorState {
    * @param maximumConcurrentLeaderMovements Maximum concurrent leader movements.
    * @param uuid UUID of the current execution.
    * @param recentlyDemotedBrokers Recently demoted broker IDs.
+   * @param recentlyRemovedBrokers Recently removed broker IDs.
    * @return Executor state when replica movement is in progress.
    */
   public static ExecutorState replicaMovementInProgress(int finishedPartitionMovements,
@@ -163,11 +177,12 @@ public class ExecutorState {
                                                         int maximumConcurrentPartitionMovementsPerBroker,
                                                         int maximumConcurrentLeaderMovements,
                                                         String uuid,
-                                                        Set<Integer> recentlyDemotedBrokers) {
+                                                        Set<Integer> recentlyDemotedBrokers,
+                                                        Set<Integer> recentlyRemovedBrokers) {
     return new ExecutorState(State.REPLICA_MOVEMENT_TASK_IN_PROGRESS,
                              finishedPartitionMovements, 0, executionTasksSummary,
                              finishedDataMovementInMB, maximumConcurrentPartitionMovementsPerBroker,
-                             maximumConcurrentLeaderMovements, uuid, recentlyDemotedBrokers);
+                             maximumConcurrentLeaderMovements, uuid, recentlyDemotedBrokers, recentlyRemovedBrokers);
   }
 
   /**
@@ -183,6 +198,7 @@ public class ExecutorState {
    * @param maximumConcurrentLeaderMovements Maximum concurrent leader movements.
    * @param uuid UUID of the current execution.
    * @param recentlyDemotedBrokers Recently demoted broker IDs.
+   * @param recentlyRemovedBrokers Recently removed broker IDs.
    * @return Executor state when replica movement is in progress.
    */
   public static ExecutorState replicaMovementInProgress(int finishedPartitionMovements,
@@ -196,7 +212,8 @@ public class ExecutorState {
                                                         int maximumConcurrentPartitionMovementsPerBroker,
                                                         int maximumConcurrentLeaderMovements,
                                                         String uuid,
-                                                        Set<Integer> recentlyDemotedBrokers) {
+                                                        Set<Integer> recentlyDemotedBrokers,
+                                                        Set<Integer> recentlyRemovedBrokers) {
     return replicaMovementInProgress(finishedPartitionMovements,
                                      new ExecutionTaskManager.ExecutionTasksSummary(remainingPartitionMovements,
                                                                                     Collections.emptySet(),
@@ -209,7 +226,8 @@ public class ExecutorState {
                                      maximumConcurrentPartitionMovementsPerBroker,
                                      maximumConcurrentLeaderMovements,
                                      uuid,
-                                     recentlyDemotedBrokers);
+                                     recentlyDemotedBrokers,
+                                     recentlyRemovedBrokers);
   }
 
   /**
@@ -219,6 +237,7 @@ public class ExecutorState {
    * @param maximumConcurrentLeaderMovements Maximum concurrent leader movements.
    * @param uuid UUID of the current execution.
    * @param recentlyDemotedBrokers Recently demoted broker IDs.
+   * @param recentlyRemovedBrokers Recently removed broker IDs.
    * @return Executor state when leader movement is in progress.
    */
   public static ExecutorState leaderMovementInProgress(int finishedLeadershipMovements,
@@ -226,7 +245,8 @@ public class ExecutorState {
                                                        int maximumConcurrentPartitionMovementsPerBroker,
                                                        int maximumConcurrentLeaderMovements,
                                                        String uuid,
-                                                       Set<Integer> recentlyDemotedBrokers) {
+                                                       Set<Integer> recentlyDemotedBrokers,
+                                                       Set<Integer> recentlyRemovedBrokers) {
     return new ExecutorState(State.LEADER_MOVEMENT_TASK_IN_PROGRESS,
                              0,
                              finishedLeadershipMovements,
@@ -241,7 +261,8 @@ public class ExecutorState {
                              maximumConcurrentPartitionMovementsPerBroker,
                              maximumConcurrentLeaderMovements,
                              uuid,
-                             recentlyDemotedBrokers);
+                             recentlyDemotedBrokers,
+                             recentlyRemovedBrokers);
   }
 
   /**
@@ -253,6 +274,7 @@ public class ExecutorState {
    * @param maximumConcurrentLeaderMovements Maximum concurrent leader movements.
    * @param uuid UUID of the current execution.
    * @param recentlyDemotedBrokers Recently demoted broker IDs.
+   * @param recentlyRemovedBrokers Recently removed broker IDs.
    * @return Executor state when stopping the ongoing execution.
    */
   public static ExecutorState stopping(int finishedPartitionMovements,
@@ -262,7 +284,8 @@ public class ExecutorState {
                                        int maximumConcurrentPartitionMovementsPerBroker,
                                        int maximumConcurrentLeaderMovements,
                                        String uuid,
-                                       Set<Integer> recentlyDemotedBrokers) {
+                                       Set<Integer> recentlyDemotedBrokers,
+                                       Set<Integer> recentlyRemovedBrokers) {
     return new ExecutorState(State.STOPPING_EXECUTION,
                              finishedPartitionMovements,
                              finishedLeadershipMovements,
@@ -271,7 +294,8 @@ public class ExecutorState {
                              maximumConcurrentPartitionMovementsPerBroker,
                              maximumConcurrentLeaderMovements,
                              uuid,
-                             recentlyDemotedBrokers);
+                             recentlyDemotedBrokers,
+                             recentlyRemovedBrokers);
   }
 
   public State state() {
@@ -334,6 +358,10 @@ public class ExecutorState {
     return _recentlyDemotedBrokers;
   }
 
+  public Set<Integer> recentlyRemovedBrokers() {
+    return _recentlyRemovedBrokers;
+  }
+
   /*
    * Return an object that can be further used
    * to encode into JSON
@@ -343,6 +371,9 @@ public class ExecutorState {
     execState.put(STATE, _state);
     if (_recentlyDemotedBrokers != null && !_recentlyDemotedBrokers.isEmpty()) {
       execState.put(RECENTLY_DEMOTED_BROKERS, _recentlyDemotedBrokers);
+    }
+    if (_recentlyRemovedBrokers != null && !_recentlyRemovedBrokers.isEmpty()) {
+      execState.put(RECENTLY_REMOVED_BROKERS, _recentlyRemovedBrokers);
     }
     switch (_state) {
       case NO_TASK_IN_PROGRESS:
@@ -409,6 +440,7 @@ public class ExecutorState {
       default:
         execState.put(ERROR, "ILLEGAL_STATE_EXCEPTION");
         execState.remove(RECENTLY_DEMOTED_BROKERS);
+        execState.remove(RECENTLY_REMOVED_BROKERS);
         break;
     }
 
@@ -418,29 +450,32 @@ public class ExecutorState {
   public String getPlaintext() {
     String recentlyDemotedBrokers = (_recentlyDemotedBrokers != null && !_recentlyDemotedBrokers.isEmpty())
                                     ? String.format(", %s: %s", RECENTLY_DEMOTED_BROKERS, _recentlyDemotedBrokers) : "";
+    String recentlyRemovedBrokers = (_recentlyRemovedBrokers != null && !_recentlyRemovedBrokers.isEmpty())
+                                    ? String.format(", %s: %s", RECENTLY_REMOVED_BROKERS, _recentlyRemovedBrokers) : "";
 
     switch (_state) {
       case NO_TASK_IN_PROGRESS:
-        return String.format("{%s: %s%s}", STATE, _state, recentlyDemotedBrokers);
+        return String.format("{%s: %s%s%s}", STATE, _state, recentlyDemotedBrokers, recentlyRemovedBrokers);
       case STARTING_EXECUTION:
-        return String.format("{%s: %s, %s: %s%s}", STATE, _state, TRIGGERED_USER_TASK_ID,
-                             _uuid == null ? "Initiated-by-AnomalyDetector" : _uuid, recentlyDemotedBrokers);
+        return String.format("{%s: %s, %s: %s%s%s}", STATE, _state, TRIGGERED_USER_TASK_ID,
+                             _uuid == null ? "Initiated-by-AnomalyDetector" : _uuid, recentlyDemotedBrokers, recentlyRemovedBrokers);
       case LEADER_MOVEMENT_TASK_IN_PROGRESS:
         return String.format("{%s: %s, finished/total leadership movements: %d/%d, "
-                             + "maximum concurrent leadership movements: %d, %s: %s%s}", STATE, _state, _numFinishedLeadershipMovements,
+                             + "maximum concurrent leadership movements: %d, %s: %s%s%s}", STATE, _state, _numFinishedLeadershipMovements,
                              numTotalLeadershipMovements(), _maximumConcurrentLeaderMovements, TRIGGERED_USER_TASK_ID,
-                             _uuid == null ? "Initiated-by-AnomalyDetector" : _uuid, recentlyDemotedBrokers);
+                             _uuid == null ? "Initiated-by-AnomalyDetector" : _uuid, recentlyDemotedBrokers, recentlyRemovedBrokers);
       case REPLICA_MOVEMENT_TASK_IN_PROGRESS:
       case STOPPING_EXECUTION:
         return String.format("{%s: %s, in-progress/aborting partitions: %d/%d, completed/total bytes(MB): %d/%d, "
                              + "finished/aborted/dead/total partitions: %d/%d/%d/%d, finished leadership movements: %d/%d, "
-                             + "maximum concurrent leadership/per-broker partition movements: %d/%d, %s: %s%s}",
+                             + "maximum concurrent leadership/per-broker partition movements: %d/%d, %s: %s%s%s}",
                              STATE, _state, _inProgressPartitionMovements.size(), _abortingPartitionMovements.size(),
                              _finishedDataMovementInMB, totalDataToMoveInMB(), _numFinishedPartitionMovements,
                              _abortedPartitionMovements.size(), _deadPartitionMovements.size(),
                              numTotalPartitionMovements(), _numFinishedLeadershipMovements, numTotalLeadershipMovements(),
                              _maximumConcurrentLeaderMovements, _maximumConcurrentPartitionMovementsPerBroker,
-                             TRIGGERED_USER_TASK_ID, _uuid == null ? "Initiated-by-AnomalyDetector" : _uuid, recentlyDemotedBrokers);
+                             TRIGGERED_USER_TASK_ID, _uuid == null ? "Initiated-by-AnomalyDetector" : _uuid,
+                             recentlyDemotedBrokers, recentlyRemovedBrokers);
       default:
         throw new IllegalStateException("This should never happen");
     }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUnitTestUtils.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUnitTestUtils.java
@@ -12,14 +12,8 @@ import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.monitor.metricdefinition.KafkaMetricDef;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.NoopSampler;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import kafka.utils.ZkUtils;
-import org.I0Itec.zkclient.ZkClient;
-import org.I0Itec.zkclient.ZkConnection;
-import org.I0Itec.zkclient.exception.ZkMarshallingError;
-import org.I0Itec.zkclient.serialize.ZkSerializer;
 
 
 /**
@@ -43,6 +37,7 @@ public class KafkaCruiseControlUnitTestUtils {
     props.setProperty(KafkaCruiseControlConfig.MIN_SAMPLES_PER_BROKER_METRICS_WINDOW_CONFIG, "2");
     props.setProperty(KafkaCruiseControlConfig.COMPLETED_USER_TASK_RETENTION_TIME_MS_CONFIG, Long.toString(TimeUnit.HOURS.toMillis(6)));
     props.setProperty(KafkaCruiseControlConfig.DEMOTION_HISTORY_RETENTION_TIME_MS_CONFIG, Long.toString(TimeUnit.HOURS.toMillis(24)));
+    props.setProperty(KafkaCruiseControlConfig.REMOVAL_HISTORY_RETENTION_TIME_MS_CONFIG, Long.toString(TimeUnit.HOURS.toMillis(12)));
     props.setProperty(
         KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG,
         "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,"
@@ -61,25 +56,6 @@ public class KafkaCruiseControlUnitTestUtils {
         + "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal");
 
     return props;
-  }
-
-  public static ZkUtils zkUtils(String zkConnect) {
-    ZkConnection zkConnection = new ZkConnection(zkConnect, 30000);
-    ZkClient zkClient = new ZkClient(zkConnection, 30000, new ZKStringSerializer());
-    return new ZkUtils(zkClient, zkConnection, false);
-  }
-
-  private static class ZKStringSerializer implements ZkSerializer {
-
-    @Override
-    public byte[] serialize(Object data) throws ZkMarshallingError {
-      return ((String) data).getBytes(StandardCharsets.UTF_8);
-    }
-
-    @Override
-    public Object deserialize(byte[] bytes) throws ZkMarshallingError {
-      return bytes == null ? null : new String(bytes, StandardCharsets.UTF_8);
-    }
   }
 
   /**

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -73,7 +73,7 @@ public class AnomalyDetectorTest {
 
     // The following state are used to test the delayed check when executor is busy.
     EasyMock.expect(mockKafkaCruiseControl.state(EasyMock.anyObject(), EasyMock.anyObject()))
-            .andReturn(new CruiseControlState(ExecutorState.noTaskInProgress(null), null, null,
+            .andReturn(new CruiseControlState(ExecutorState.noTaskInProgress(null, null), null, null,
                                               null));
 
     EasyMock.replay(mockAnomalyNotifier);
@@ -141,7 +141,7 @@ public class AnomalyDetectorTest {
 
     // The following state are used to test the delayed check when executor is busy.
     EasyMock.expect(mockKafkaCruiseControl.state(EasyMock.anyObject(), EasyMock.anyObject()))
-            .andReturn(new CruiseControlState(ExecutorState.noTaskInProgress(null), null, null,
+            .andReturn(new CruiseControlState(ExecutorState.noTaskInProgress(null, null), null, null,
                                               null));
     EasyMock.expect(mockKafkaCruiseControl.rebalance(EasyMock.eq(Collections.emptyList()),
                                                      EasyMock.eq(false),
@@ -231,6 +231,7 @@ public class AnomalyDetectorTest {
                                                         1,
                                                         1,
                                                         1,
+                                                        null,
                                                         null,
                                                         null),
                 null, null, null));

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/task/LoadMonitorTaskRunnerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/task/LoadMonitorTaskRunnerTest.java
@@ -6,6 +6,7 @@ package com.linkedin.kafka.cruisecontrol.monitor.task;
 
 import com.codahale.metrics.MetricRegistry;
 import com.linkedin.cruisecontrol.metricdef.MetricInfo;
+import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils;
 import com.linkedin.kafka.cruisecontrol.common.Resource;
 import com.linkedin.kafka.clients.utils.tests.AbstractKafkaIntegrationTestHarness;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUnitTestUtils;
@@ -65,7 +66,7 @@ public class LoadMonitorTaskRunnerTest extends AbstractKafkaIntegrationTestHarne
   @Before
   public void setUp() {
     super.setUp();
-    ZkUtils zkUtils = KafkaCruiseControlUnitTestUtils.zkUtils(zookeeper().getConnectionString());
+    ZkUtils zkUtils = KafkaCruiseControlUtils.createZkUtils(zookeeper().getConnectionString());
     for (int i = 0; i < NUM_TOPICS; i++) {
       AdminUtils.createTopic(zkUtils, "topic-" + i, NUM_PARTITIONS, 1, new Properties(), RackAwareMode.Safe$.MODULE$);
     }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletDataFromTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletDataFromTest.java
@@ -144,7 +144,7 @@ public class KafkaCruiseControlServletDataFromTest {
    * Generate the KCC state.
    */
   private CruiseControlState getState(int numReadyGoals, int totalGoals, int numValidWindows) {
-    ExecutorState executorState = ExecutorState.noTaskInProgress(null);
+    ExecutorState executorState = ExecutorState.noTaskInProgress(null, null);
     LoadMonitorState loadMonitorState = LoadMonitorState.running(numValidWindows, new TreeMap<>(),
                                                                  1, 10,
                                                                  Collections.emptyMap(),


### PR DESCRIPTION
Adds the feature explained in https://github.com/linkedin/cruise-control/issues/476.