### PR TITLE
Increase the default config values for history retention time of removal and demotion.

### DIFF
--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -198,10 +198,10 @@ failed.brokers.zk.path=/CruiseControlBrokerList
 completed.user.task.retention.time.ms=21600000
 
 # The maximum time in milliseconds to retain the demotion history of brokers.
-demotion.history.retention.time.ms=86400000
+demotion.history.retention.time.ms=1209600000
 
 # The maximum time in milliseconds to retain the removal history of brokers.
-removal.history.retention.time.ms=43200000
+removal.history.retention.time.ms=1209600000
 
 # The maximum number of completed user tasks for which the response and access details will be cached.
 max.cached.completed.user.tasks=100

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -760,16 +760,16 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 COMPLETED_USER_TASK_RETENTION_TIME_MS_DOC)
         .define(DEMOTION_HISTORY_RETENTION_TIME_MS_CONFIG,
                 ConfigDef.Type.LONG,
-                TimeUnit.HOURS.toMillis(24),
+                TimeUnit.HOURS.toMillis(336),
                 atLeast(0),
                 ConfigDef.Importance.MEDIUM,
                 DEMOTION_HISTORY_RETENTION_TIME_MS_DOC)
         .define(REMOVAL_HISTORY_RETENTION_TIME_MS_CONFIG,
-            ConfigDef.Type.LONG,
-            TimeUnit.HOURS.toMillis(12),
-            atLeast(0),
-            ConfigDef.Importance.MEDIUM,
-            REMOVAL_HISTORY_RETENTION_TIME_MS_DOC)
+                ConfigDef.Type.LONG,
+                TimeUnit.HOURS.toMillis(336),
+                atLeast(0),
+                ConfigDef.Importance.MEDIUM,
+                REMOVAL_HISTORY_RETENTION_TIME_MS_DOC)
         .define(MAX_CACHED_COMPLETED_USER_TASKS_CONFIG,
                 ConfigDef.Type.INT,
                 100,


### PR DESCRIPTION
Addresses the issue https://github.com/linkedin/cruise-control/issues/503.