### PR TITLE
Add the possibility to create the metric reporter topic at launch

### DIFF
--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterConfig.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterConfig.java
@@ -12,10 +12,13 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CruiseControlMetricsReporterConfig extends AbstractConfig {
   private static final ConfigDef CONFIG;
   private static final Set<String> CONFIGS = new HashSet<>();
+  private static final Logger LOG = LoggerFactory.getLogger(CruiseControlMetricsReporterConfig.class);
   public static final String PREFIX = "cruise.control.metrics.reporter.";
   // Configurations
   public static final String CRUISE_CONTROL_METRICS_TOPIC_CONFIG = "cruise.control.metrics.topic";
@@ -33,9 +36,9 @@ public class CruiseControlMetricsReporterConfig extends AbstractConfig {
       + "metrics reporter should report the metrics.";
   // Default values
   public static final String DEFAULT_CRUISE_CONTROL_METRICS_TOPIC = "__CruiseControlMetrics";
-  public static final Integer DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS = 1;
+  public static final Integer DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS = -1;
   public static final boolean DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE = false;
-  public static final Short DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_REPLICATION_FACTOR = 1;
+  public static final Short DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_REPLICATION_FACTOR = -1;
   private static final long DEFAULT_CRUISE_CONTROL_METRICS_REPORTING_INTERVAL_MS = 60000;
   private static final String PRODUCER_ID = "CruiseControlMetricsReporter";
 

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterConfig.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterConfig.java
@@ -13,20 +13,29 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
-
 public class CruiseControlMetricsReporterConfig extends AbstractConfig {
   private static final ConfigDef CONFIG;
   private static final Set<String> CONFIGS = new HashSet<>();
   public static final String PREFIX = "cruise.control.metrics.reporter.";
-  // Two unique configurations
+  // Configurations
   public static final String CRUISE_CONTROL_METRICS_TOPIC_CONFIG = "cruise.control.metrics.topic";
   private static final String CRUISE_CONTROL_METRICS_TOPIC_DOC = "The topic to which Cruise Control metrics reporter "
       + "should send messages";
+  public static final String CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_CONFIG = "cruise.control.metrics.topic.auto.create";
+  private static final String CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_DOC = "Cruise Control metrics reporter will enforce " +
+      " the creation of the topic at launch";
+  public static final String CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS_CONFIG = "cruise.control.metrics.topic.num.partitions";
+  private static final String CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS_DOC = "The number of partitions of Cruise Control metrics topic";
+  public static final String CRUISE_CONTROL_METRICS_TOPIC_REPLICATION_FACTOR_CONFIG = "cruise.control.metrics.topic.replication.factor";
+  private static final String CRUISE_CONTROL_METRICS_TOPIC_REPLICATION_FACTOR_DOC = "The replication factor of Cruise Control metrics topic";
   public static final String CRUISE_CONTROL_METRICS_REPORTING_INTERVAL_MS_CONFIG = PREFIX + "metrics.reporting.interval.ms";
   private static final String CRUISE_CONTROL_METRICS_REPORTING_INTERVAL_MS_DOC = "The interval in milliseconds the "
       + "metrics reporter should report the metrics.";
   // Default values
   public static final String DEFAULT_CRUISE_CONTROL_METRICS_TOPIC = "__CruiseControlMetrics";
+  public static final Integer DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS = 1;
+  public static final boolean DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE = false;
+  public static final Short DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_REPLICATION_FACTOR = 1;
   private static final long DEFAULT_CRUISE_CONTROL_METRICS_REPORTING_INTERVAL_MS = 60000;
   private static final String PRODUCER_ID = "CruiseControlMetricsReporter";
 
@@ -36,21 +45,37 @@ public class CruiseControlMetricsReporterConfig extends AbstractConfig {
 
   static {
     ProducerConfig.configNames().forEach(name -> CONFIGS.add(PREFIX + name));
-    CONFIG = new ConfigDef().define(PREFIX + CommonClientConfigs.CLIENT_ID_CONFIG,
-                                    ConfigDef.Type.STRING,
-                                    PRODUCER_ID,
-                                    ConfigDef.Importance.LOW,
-                                    "The producer id for Cruise Control metrics reporter")
-                            .define(CRUISE_CONTROL_METRICS_TOPIC_CONFIG,
-                                    ConfigDef.Type.STRING,
-                                    DEFAULT_CRUISE_CONTROL_METRICS_TOPIC,
-                                    ConfigDef.Importance.HIGH,
-                                    CRUISE_CONTROL_METRICS_TOPIC_DOC)
-                            .define(CRUISE_CONTROL_METRICS_REPORTING_INTERVAL_MS_CONFIG,
-                                    ConfigDef.Type.LONG,
-                                    DEFAULT_CRUISE_CONTROL_METRICS_REPORTING_INTERVAL_MS,
-                                    ConfigDef.Importance.HIGH,
-                                    CRUISE_CONTROL_METRICS_REPORTING_INTERVAL_MS_DOC);
+    CONFIG = new ConfigDef()
+        .define(PREFIX + CommonClientConfigs.CLIENT_ID_CONFIG,
+                ConfigDef.Type.STRING,
+                PRODUCER_ID,
+                ConfigDef.Importance.LOW,
+                "The producer id for Cruise Control metrics reporter")
+        .define(CRUISE_CONTROL_METRICS_TOPIC_CONFIG,
+                ConfigDef.Type.STRING,
+                DEFAULT_CRUISE_CONTROL_METRICS_TOPIC,
+                ConfigDef.Importance.HIGH,
+                CRUISE_CONTROL_METRICS_TOPIC_DOC)
+        .define(CRUISE_CONTROL_METRICS_REPORTING_INTERVAL_MS_CONFIG,
+                ConfigDef.Type.LONG,
+                DEFAULT_CRUISE_CONTROL_METRICS_REPORTING_INTERVAL_MS,
+                ConfigDef.Importance.HIGH,
+                CRUISE_CONTROL_METRICS_REPORTING_INTERVAL_MS_DOC)
+        .define(CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_CONFIG,
+                ConfigDef.Type.BOOLEAN,
+                DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE,
+                ConfigDef.Importance.LOW,
+                CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_DOC)
+        .define(CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS_CONFIG,
+                ConfigDef.Type.INT,
+                DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS,
+                ConfigDef.Importance.LOW,
+                CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS_DOC)
+        .define(CRUISE_CONTROL_METRICS_TOPIC_REPLICATION_FACTOR_CONFIG,
+                ConfigDef.Type.SHORT,
+                DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_REPLICATION_FACTOR,
+                ConfigDef.Importance.LOW,
+                CRUISE_CONTROL_METRICS_TOPIC_REPLICATION_FACTOR_DOC);
   }
 
   public static String config(String baseConfigName) {

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsUtils.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsUtils.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+package com.linkedin.kafka.cruisecontrol.metricsreporter;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import java.util.Properties;
+
+public class CruiseControlMetricsUtils {
+
+  public static final long ADMIN_CLIENT_CLOSE_TIMEOUT_MS = 10000;
+
+  private CruiseControlMetricsUtils() {
+
+  }
+
+  private static void closeClientWithTimeout(Runnable clientCloseTask, long timeoutMs) {
+    Thread t = new Thread(clientCloseTask);
+    t.setDaemon(true);
+    t.start();
+    try {
+      t.join(timeoutMs);
+    } catch (InterruptedException e) {
+      // let it go
+    }
+    if (t.isAlive()) {
+      t.interrupt();
+    }
+  }
+
+  /**
+   * Create an instance of AdminClient using the given configurations.
+   *
+   * @param adminClientConfigs Configurations used for the AdminClient.
+   * @return A new instance of AdminClient.
+   */
+  public static AdminClient createAdminClient(Properties adminClientConfigs) {
+    return AdminClient.create(adminClientConfigs);
+  }
+
+  /**
+   * Close the given AdminClient with the default timeout of {@link #ADMIN_CLIENT_CLOSE_TIMEOUT_MS}.
+   *
+   * @param adminClient AdminClient to be closed
+   */
+  public static void closeAdminClientWithTimeout(AdminClient adminClient) {
+    closeAdminClientWithTimeout(adminClient, ADMIN_CLIENT_CLOSE_TIMEOUT_MS);
+  }
+
+  public static void closeAdminClientWithTimeout(AdminClient adminClient, long timeoutMs) {
+    closeClientWithTimeout(adminClient::close, timeoutMs);
+  }
+
+  /**
+   * Parse AdminClient configs based on the given {@link CruiseControlMetricsReporterConfig configs}.
+   *
+   * @param adminClientConfigs Configs that will be return with SSL configs.
+   * @param configs Configs to be used for parsing AdminClient SSL configs.
+   * @return AdminClient configs.
+   */
+  public static Properties addSslConfigs(Properties adminClientConfigs, CruiseControlMetricsReporterConfig configs) {
+    // Add security protocol (if specified).
+    try {
+      String securityProtocol = adminClientConfigs.get(AdminClientConfig.SECURITY_PROTOCOL_CONFIG).toString();
+
+      // Configure SSL configs (if security protocol is SSL)
+      if (securityProtocol.equals(SecurityProtocol.SSL.name)) {
+        setStringConfigIfExists(configs, adminClientConfigs, SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG);
+        setStringConfigIfExists(configs, adminClientConfigs, SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG);
+        setStringConfigIfExists(configs, adminClientConfigs, SslConfigs.SSL_KEYSTORE_TYPE_CONFIG);
+        setStringConfigIfExists(configs, adminClientConfigs, SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
+        setStringConfigIfExists(configs, adminClientConfigs, SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG);
+        setStringConfigIfExists(configs, adminClientConfigs, SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
+        setStringConfigIfExists(configs, adminClientConfigs, SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG);
+        setPasswordConfigIfExists(configs, adminClientConfigs, SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
+        setPasswordConfigIfExists(configs, adminClientConfigs, SslConfigs.SSL_KEY_PASSWORD_CONFIG);
+        setPasswordConfigIfExists(configs, adminClientConfigs, SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
+      }
+    } catch (ConfigException ce) {
+      // let it go.
+    }
+
+    return adminClientConfigs;
+  }
+
+  private static void setPasswordConfigIfExists(CruiseControlMetricsReporterConfig configs, Properties props, String name) {
+    try {
+      props.put(name, configs.getPassword(name));
+    } catch (ConfigException ce) {
+      // let it go.
+    }
+  }
+
+  private static void setStringConfigIfExists(CruiseControlMetricsReporterConfig configs, Properties props, String name) {
+    try {
+      props.put(name, configs.getString(name));
+    } catch (ConfigException ce) {
+      // let it go.
+    }
+  }
+}


### PR DESCRIPTION
I use this code to create topic "__CruiseControlMetrics" in cruisecontrolmetricsreporter.
It can deploy the topic with parameterized config in case of a non auto creation topic Cluster.