### PR TITLE
Increase the default config value for completed user task retention time

### DIFF
--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -195,7 +195,7 @@ metric.anomaly.analyzer.metrics=BROKER_PRODUCE_LOCAL_TIME_MS_MAX,BROKER_PRODUCE_
 failed.brokers.zk.path=/CruiseControlBrokerList
 
 # The maximum time in milliseconds to store the response and access details of a completed user task.
-completed.user.task.retention.time.ms=21600000
+completed.user.task.retention.time.ms=86400000
 
 # The maximum time in milliseconds to retain the demotion history of brokers.
 demotion.history.retention.time.ms=1209600000

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -754,7 +754,7 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 BROKER_METRICS_WINDOW_MS_DOC)
         .define(COMPLETED_USER_TASK_RETENTION_TIME_MS_CONFIG,
                 ConfigDef.Type.LONG,
-                TimeUnit.HOURS.toMillis(6),
+                TimeUnit.HOURS.toMillis(24),
                 atLeast(0),
                 ConfigDef.Importance.MEDIUM,
                 COMPLETED_USER_TASK_RETENTION_TIME_MS_DOC)


### PR DESCRIPTION
Addresses the issue https://github.com/linkedin/cruise-control/issues/513.