### PR TITLE
Make Cruise Control to better manage JBOD Kafka cluster.

### DIFF
--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -40,6 +40,7 @@ num.metric.fetchers=1
 
 # The metric sampler class
 metric.sampler.class=com.linkedin.kafka.cruisecontrol.monitor.sampling.CruiseControlMetricsReporterSampler
+
 # Configurations for CruiseControlMetricsReporterSampler
 metric.reporter.topic.pattern=__CruiseControlMetrics
 
@@ -93,7 +94,7 @@ capacity.config.file=config/capacityJBOD.json
 default.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal
 
 # The list of supported goals
-goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerDiskUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerEvenRackAwareGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.PreferredLeaderElectionGoal
+goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerDiskUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerEvenRackAwareGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.PreferredLeaderElectionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.IntraBrokerDiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.IntraBrokerDiskUsageDistributionGoal
 
 # The list of supported hard goals
 hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
@@ -166,6 +167,9 @@ zookeeper.connect=localhost:2181/
 
 # The max number of partitions to move in/out on a given broker at a given time.
 num.concurrent.partition.movements.per.broker=10
+
+# The max number of partitions to move between disks within a given broker at a given time.
+num.concurrent.intra.broker.partition.movements=2
 
 # The max number of leadership movement within the whole cluster at a given time.
 num.concurrent.leader.movements=1000

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -37,6 +37,7 @@ public class KafkaCruiseControlUtils {
   public static final int ZK_CONNECTION_TIMEOUT = 30000;
   public static final long KAFKA_ZK_CLIENT_CLOSE_TIMEOUT_MS = 10000;
   public static final long ADMIN_CLIENT_CLOSE_TIMEOUT_MS = 10000;
+  public static final long LOGDIR_RESPONSE_TIMEOUT_MS = 10000;
   public static final String DATE_FORMAT = "YYYY-MM-dd_HH:mm:ss z";
   public static final String DATE_FORMAT2 = "dd/MM/yyyy HH:mm:ss";
   public static final String TIME_ZONE = "UTC";

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/ActionType.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/ActionType.java
@@ -14,19 +14,23 @@ import java.util.List;
  *
  * <ul>
  * <li>{@link #INTER_BROKER_REPLICA_MOVEMENT}: Move a replica from a source broker to a destination broker.</li>
+ * <li>{@link #INTRA_BROKER_REPLICA_MOVEMENT}: Move a replica from a source disk to a destination disk.</li>
  * <li>{@link #LEADERSHIP_MOVEMENT}: Move leadership of a leader from a source broker to a follower of the same
  * partition residing in a destination broker.</li>
  * <li>{@link #REPLICA_ADDITION}: Add a new replica to the cluster.</li>
  * <li>{@link #REPLICA_DELETION}: Remove an existing replica from the cluster.</li>
  * <li>{@link #INTER_BROKER_REPLICA_SWAP}: Swap places of replicas residing in source and destination brokers.</li>
+ * <li>{@link #INTRA_BROKER_REPLICA_SWAP}: Swap places of replicas residing in source and destination disks.</li>
  * </ul>
  */
 public enum ActionType {
   INTER_BROKER_REPLICA_MOVEMENT("REPLICA"),
+  INTRA_BROKER_REPLICA_MOVEMENT("INTRA_BROKER_REPLICA"),
   LEADERSHIP_MOVEMENT("LEADER"),
   REPLICA_ADDITION("ADDITION"),
   REPLICA_DELETION("DELETE"),
-  INTER_BROKER_REPLICA_SWAP("SWAP");
+  INTER_BROKER_REPLICA_SWAP("SWAP"),
+  INTRA_BROKER_REPLICA_SWAP("INTRA_BROKER_SWAP");
 
   private static final List<ActionType> CACHED_VALUES = Collections.unmodifiableList(Arrays.asList(values()));
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskCapacityGoal.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ *
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.goals;
+
+import com.linkedin.kafka.cruisecontrol.analyzer.OptimizationOptions;
+import com.linkedin.kafka.cruisecontrol.common.Resource;
+import com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance;
+import com.linkedin.kafka.cruisecontrol.analyzer.BalancingConstraint;
+import com.linkedin.kafka.cruisecontrol.analyzer.BalancingAction;
+import com.linkedin.kafka.cruisecontrol.exception.OptimizationFailureException;
+import com.linkedin.kafka.cruisecontrol.model.Broker;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
+import com.linkedin.kafka.cruisecontrol.model.Disk;
+import com.linkedin.kafka.cruisecontrol.model.Replica;
+import com.linkedin.kafka.cruisecontrol.model.ReplicaSortFunctionFactory;
+import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance.ACCEPT;
+import static com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance.REPLICA_REJECT;
+
+/**
+ * Class for achieving the following hard goal:
+ * HARD GOAL: Generate replica movement proposals between disks of the same broker to push the load on each disk of broker
+ * under the capacity limit.
+ */
+public class IntraBrokerDiskCapacityGoal extends AbstractGoal {
+  private static final Logger LOG = LoggerFactory.getLogger(IntraBrokerDiskCapacityGoal.class);
+  private static final int MIN_NUM_VALID_WINDOWS = 1;
+  private static final Resource RESOURCE = Resource.DISK;
+
+  /**
+   * Constructor for Capacity Goal.
+   */
+  public IntraBrokerDiskCapacityGoal() {
+
+  }
+
+  /**
+   * Package private for unit test.
+   */
+  IntraBrokerDiskCapacityGoal(BalancingConstraint constraint) {
+    _balancingConstraint = constraint;
+  }
+
+  @Override
+  public boolean isHardGoal() {
+    return true;
+  }
+
+  /**
+   * Sanity checks: For each alive broker in the cluster, the load for {@link Resource#DISK} less than the limiting capacity
+   * determined by the total capacity of alive disks multiplied by the capacity threshold.
+   *
+   * @param clusterModel The state of the cluster.
+   * @param optimizationOptions Options to take into account during optimization -- e.g. excluded topics.
+   */
+  @Override
+  protected void initGoalState(ClusterModel clusterModel, OptimizationOptions optimizationOptions)
+      throws OptimizationFailureException {
+    // While proposals exclude the excludedTopics, the existingUtilization still considers replicas of the excludedTopics.
+    for (Broker broker : clusterModel.aliveBrokers()) {
+      double existingUtilization = broker.load().expectedUtilizationFor(RESOURCE);
+      double allowedCapacity = broker.capacityFor(RESOURCE) * _balancingConstraint.capacityThreshold(RESOURCE);
+      if (allowedCapacity < existingUtilization) {
+        throw new OptimizationFailureException("Insufficient disk capacity at broker " + broker.id() + ", existing broker utilization "
+                                               + existingUtilization + " exceeds allowed capacity " + allowedCapacity);
+      }
+    }
+  }
+
+  /**
+   * Get brokers in the cluster so that the rebalance process will go over to apply balancing actions to replicas
+   * they contain.
+   * Note this goal moves replica between disks within broker, therefore it is unable to heal dead broker.
+   *
+   * @param clusterModel The state of the cluster.
+   * @return A collection of brokers that the rebalance process will go over to apply balancing actions to replicas
+   *         they contain.
+   */
+  @Override
+  protected SortedSet<Broker> brokersToBalance(ClusterModel clusterModel) {
+    return new TreeSet<>(clusterModel.aliveBrokers());
+  }
+
+  /**
+   * Check whether the given action is acceptable by this goal. An action is acceptable by a goal if it satisfies
+   * requirements of the goal. For this goal:
+   * ## Leadership Movement: always accept.
+   * ## Replica Movement/Swap: accept if action will not make disk load exceed disk capacity limit.
+   *
+   * @param action Action to be checked for acceptance.
+   * @param clusterModel The state of the cluster.
+   * @return {@link ActionAcceptance#ACCEPT} if the action is acceptable by this goal,
+   *         {@link ActionAcceptance#REPLICA_REJECT} otherwise.
+   */
+  @Override
+  public ActionAcceptance actionAcceptance(BalancingAction action, ClusterModel clusterModel) {
+    // Currently disk-granularity goals do not work with broker-granularity goals.
+    if (action.sourceBrokerLogdir() ==  null || action.destinationBrokerLogdir() == null) {
+      throw new IllegalArgumentException(this.getClass().getSimpleName() + " does not support balancing action not "
+                                         + "specifying logdir.");
+    }
+    Replica sourceReplica = clusterModel.broker(action.sourceBrokerId()).replica(action.topicPartition());
+    Disk destinationDisk = clusterModel.broker(action.destinationBrokerId()).disk(action.destinationBrokerLogdir());
+
+    switch (action.balancingAction()) {
+      case INTRA_BROKER_REPLICA_SWAP:
+        Replica destinationReplica = clusterModel.broker(action.destinationBrokerId()).replica(action.destinationTopicPartition());
+        return isSwapAcceptableForCapacity(sourceReplica, destinationReplica) ? ACCEPT : REPLICA_REJECT;
+      case INTRA_BROKER_REPLICA_MOVEMENT:
+        return isMovementAcceptableForCapacity(sourceReplica, destinationDisk) ? ACCEPT : REPLICA_REJECT;
+      case LEADERSHIP_MOVEMENT:
+        return ACCEPT;
+      default:
+        throw new IllegalArgumentException("Unsupported balancing action " + action.balancingAction() + " is provided.");
+    }
+  }
+
+  /**
+   * Check if requirements of this goal are not violated if this action is applied to the given cluster state,
+   * false otherwise.
+   *
+   * @param  clusterModel The state of the cluster.
+   * @param  action Action containing information about potential modification to the given cluster model.
+   * @return True if requirements of this goal are not violated if this action is applied to the given cluster state,
+   *         false otherwise.
+   */
+  @Override
+  protected boolean selfSatisfied(ClusterModel clusterModel, BalancingAction action) {
+    Replica sourceReplica = clusterModel.broker(action.sourceBrokerId()).replica(action.topicPartition());
+    Disk destinationDisk = clusterModel.broker(action.destinationBrokerId()).disk(action.destinationBrokerLogdir());
+    return sourceReplica.load().expectedUtilizationFor(RESOURCE) > 0
+           && isMovementAcceptableForCapacity(sourceReplica, destinationDisk);
+  }
+
+  /**
+   * Perform optimization via replica movement cross disks on broker to ensure balance: The load on each alive disk
+   * is under the disk's the capacity limit.
+   * Note the optimization from this goal cannot be applied to offline replicas because Kafka does not support moving
+   * replicas on bad disks to good disks within the same broker.
+   *
+   * @param broker         Broker to be balanced.
+   * @param clusterModel   The state of the cluster.
+   * @param optimizedGoals Optimized goals.
+   * @param optimizationOptions Options to take into account during optimization -- e.g. excluded topics.
+   */
+  @Override
+  protected void rebalanceForBroker(Broker broker,
+                                    ClusterModel clusterModel,
+                                    Set<Goal> optimizedGoals,
+                                    OptimizationOptions optimizationOptions) {
+    LOG.debug("balancing broker {}, optimized goals = {}.", broker, optimizedGoals);
+
+    // Get alive disk over capacity limit.
+    List<Disk> disksOverUtilized  =  broker.disks().stream().filter(Disk::isAlive)
+                                           .filter(this::isUtilizationOverLimit).collect(Collectors.toList());
+    if (disksOverUtilized.isEmpty()) {
+      return;
+    }
+    Set<String> excludedTopics = optimizationOptions.excludedTopics();
+    List<Disk> candidateDisks = new ArrayList<>(broker.disks());
+    candidateDisks.removeAll(disksOverUtilized);
+    candidateDisks.sort(new Comparator<Disk>() {
+      @Override
+      public int compare(Disk disk1, Disk disk2) {
+        double allowanceForDisk1 = disk1.capacity() * _balancingConstraint.capacityThreshold(RESOURCE) - disk1.utilization();
+        double allowanceForDisk2 = disk2.capacity() * _balancingConstraint.capacityThreshold(RESOURCE) - disk2.utilization();
+        return ((Double) (allowanceForDisk2 - allowanceForDisk1)).intValue();
+      }
+    });
+
+    for (Disk disk : disksOverUtilized) {
+      disk.trackSortedReplicas(name(),
+                               ReplicaSortFunctionFactory.selectOnlineReplicas(),
+                               ReplicaSortFunctionFactory.deprioritizeDiskImmigrants(),
+                               ReplicaSortFunctionFactory.sortByMetricGroupValue(RESOURCE.name()));
+      for (Replica replica : disk.trackedSortedReplicas(name()).reverselySortedReplicas()) {
+        if (shouldExclude(replica, excludedTopics)) {
+          continue;
+        }
+        Disk d = maybeMoveReplicaBetweenDisks(clusterModel, replica, candidateDisks, optimizedGoals);
+        if (d == null) {
+          LOG.debug("Failed to move replica {} to any disk {} in broker {}", replica, candidateDisks, replica.broker());
+        }
+        if (!isUtilizationOverLimit(disk)) {
+          break;
+        }
+      }
+      disk.untrackSortedReplicas(name());
+    }
+  }
+
+  /**
+   * Update goal state.
+   * Sanity check: After completion of balancing the resource, confirm that the utilization is under the capacity and finish.
+   *
+   * @param clusterModel The state of the cluster.
+   * @param excludedTopics The topics that should be excluded from the optimization action.
+   */
+  @Override
+  protected void updateGoalState(ClusterModel clusterModel, Set<String> excludedTopics) throws OptimizationFailureException {
+    for (Broker broker : brokersToBalance(clusterModel)) {
+      for (Disk disk : broker.disks()) {
+        if (disk.isAlive() && isUtilizationOverLimit(disk)) {
+            // The utilization of the host for the resource is over the capacity limit.
+            throw new OptimizationFailureException(String.format(
+                "Optimization for goal %s failed because utilization for disk %s on broker %d is still above capacity limit.",
+                name(), disk, broker.id()));
+        }
+      }
+    }
+    finish();
+  }
+
+  @Override
+  public ClusterModelStatsComparator clusterModelStatsComparator() {
+    return new ClusterModelStatsComparator() {
+      @Override
+      public int compare(ClusterModelStats stats1, ClusterModelStats stats2) {
+        // This goal does not care about stats. The optimization would have already failed if the goal is not met.
+        return 0;
+      }
+
+      @Override
+      public String explainLastComparison() {
+        return null;
+      }
+    };
+  }
+
+  @Override
+  public ModelCompletenessRequirements clusterModelCompletenessRequirements() {
+    // We only need the latest snapshot and include all the topics.
+    return new ModelCompletenessRequirements(MIN_NUM_VALID_WINDOWS, _minMonitoredPartitionPercentage, true);
+  }
+
+  /**
+   * Get the name of this goal. Name of a goal provides an identification for the goal in human readable format.
+   */
+  public String name() {
+    return this.getClass().getSimpleName();
+  }
+
+  /**
+   * Check whether the combined replica utilization is above the given disk capacity limits.
+   *
+   * @param disk Disk to be checked for capacity limit violation.
+   * @return True if utilization is over the limit, false otherwise.
+   */
+  private boolean isUtilizationOverLimit(Disk disk) {
+    return disk.utilization() > disk.capacity() * _balancingConstraint.capacityThreshold(RESOURCE);
+  }
+
+  /**
+   * Check whether the movement of source replica to destination disk is acceptable for this goal.
+   *
+   * @param sourceReplica   Source replica.
+   * @param destinationDisk Destination disk.
+   * @return True if movement is acceptable for this goal, false otherwise.
+   */
+  private boolean isMovementAcceptableForCapacity(Replica sourceReplica, Disk destinationDisk) {
+    double replicaUtilization = sourceReplica.load().expectedUtilizationFor(RESOURCE);
+    return isUtilizationUnderLimitAfterAddingLoad(destinationDisk, replicaUtilization);
+  }
+
+  /**
+   * Check whether the swap between source and destination replicas is acceptable for this goal.
+   *
+   * @param sourceReplica Source replica.
+   * @param destinationReplica Destination replica.
+   * @return True if the swap for the current resource between source and destination replicas is acceptable for this
+   *         goal, false otherwise.
+   */
+  private boolean isSwapAcceptableForCapacity(Replica sourceReplica, Replica destinationReplica) {
+    double sourceReplicaUtilization = sourceReplica.load().expectedUtilizationFor(RESOURCE);
+    double destinationReplicaUtilization = destinationReplica.load().expectedUtilizationFor(RESOURCE);
+    double sourceUtilizationDelta = destinationReplicaUtilization - sourceReplicaUtilization;
+    return sourceUtilizationDelta > 0 ? isUtilizationUnderLimitAfterAddingLoad(sourceReplica.disk(), sourceUtilizationDelta)
+                                      : isUtilizationUnderLimitAfterAddingLoad(destinationReplica.disk(), - sourceUtilizationDelta);
+  }
+
+  /**
+   * Check whether the additional load on the destination disk makes the disk go out of the capacity limit.
+   *
+   * @param destinationDisk Destination disk.
+   * @param utilizationToAdd Utilization to add.
+   * @return True if utilization is less than the capacity limit, false otherwise.
+   */
+  private boolean isUtilizationUnderLimitAfterAddingLoad(Disk destinationDisk, double utilizationToAdd) {
+    double capacityLimit = destinationDisk.capacity() * _balancingConstraint.capacityThreshold(RESOURCE);
+    return destinationDisk.utilization() + utilizationToAdd < capacityLimit;
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskUsageDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskUsageDistributionGoal.java
@@ -1,0 +1,560 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ *
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.goals;
+
+import com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance;
+import com.linkedin.kafka.cruisecontrol.analyzer.BalancingAction;
+import com.linkedin.kafka.cruisecontrol.analyzer.BalancingConstraint;
+import com.linkedin.kafka.cruisecontrol.analyzer.OptimizationOptions;
+import com.linkedin.kafka.cruisecontrol.common.Resource;
+import com.linkedin.kafka.cruisecontrol.model.Broker;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
+import com.linkedin.kafka.cruisecontrol.model.Disk;
+import com.linkedin.kafka.cruisecontrol.model.Replica;
+import com.linkedin.kafka.cruisecontrol.model.ReplicaSortFunctionFactory;
+import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance.*;
+import static com.linkedin.kafka.cruisecontrol.analyzer.goals.GoalUtils.averageDiskUtilizationPercentage;
+import static com.linkedin.kafka.cruisecontrol.analyzer.goals.GoalUtils.diskUtilizationPercentage;
+import static java.lang.Math.abs;
+
+
+/**
+ * Class for achieving the following soft goal:
+ * SOFT GOAL: For each broker rebalance disk usage to push each disk's utilization percentage within range around the
+ *  utilization percentage of the whole broker.
+ */
+public class IntraBrokerDiskUsageDistributionGoal extends AbstractGoal {
+  private static final Logger LOG = LoggerFactory.getLogger(IntraBrokerDiskUsageDistributionGoal.class);
+  private static final double BALANCE_MARGIN = 0.9;
+  private static final long PER_DISK_SWAP_TIMEOUT_MS = 500L;
+  private static final Resource RESOURCE = Resource.DISK;
+  private final Map<Broker, Double> _balanceUpperThresholdByBroker;
+  private final Map<Broker, Double> _balanceLowerThresholdByBroker;
+
+  /**
+   * Constructor for Resource Distribution Goal.
+   */
+  public IntraBrokerDiskUsageDistributionGoal() {
+    super();
+    _balanceLowerThresholdByBroker = new HashMap<>();
+    _balanceUpperThresholdByBroker = new HashMap<>();
+  }
+
+  /**
+   * Package private for unit test.
+   */
+  IntraBrokerDiskUsageDistributionGoal(BalancingConstraint constraint) {
+    _balancingConstraint = constraint;
+    _balanceLowerThresholdByBroker = new HashMap<>();
+    _balanceUpperThresholdByBroker = new HashMap<>();
+  }
+
+  @Override
+  public boolean isHardGoal() {
+    return false;
+  }
+
+  /**
+   * Initialize the utilization thresholds.
+   * To avoid churns, we add a balance margin to the user specified rebalance threshold. e.g. when user sets the
+   * threshold to be resourceBalancePercentage, we use (resourceBalancePercentage-1)*balanceMargin instead.
+   * @param clusterModel The state of the cluster.
+   * @param optimizationOptions Options to take into account during optimization -- e.g. excluded topics.
+   */
+  @Override
+  protected void initGoalState(ClusterModel clusterModel, OptimizationOptions optimizationOptions) {
+    double balancePercentageWithMargin = (_balancingConstraint.resourceBalancePercentage(RESOURCE) - 1) * BALANCE_MARGIN;
+    for (Broker broker : brokersToBalance(clusterModel)) {
+      double averageDiskUtilization = averageDiskUtilizationPercentage(broker);
+      _balanceUpperThresholdByBroker.put(broker, averageDiskUtilization * (1 + balancePercentageWithMargin));
+      _balanceLowerThresholdByBroker.put(broker, averageDiskUtilization * Math.max(0, (1 - balancePercentageWithMargin)));
+    }
+  }
+
+  /**
+   * Update goal state.
+   * Sanity check: After completion of balancing the resource, check whether there are disks whose utilization percentage is
+   * out of range, finish and mark optimization status accordingly.
+   *
+   * @param clusterModel The state of the cluster.
+   * @param excludedTopics The topics that should be excluded from the optimization action.
+   */
+  @Override
+  protected void updateGoalState(ClusterModel clusterModel, Set<String> excludedTopics) {
+    List<String> disksAboveBalanceUpperLimit = new ArrayList<>();
+    List<String> disksBelowBalanceLowerLimit = new ArrayList<>();
+    for (Broker broker : brokersToBalance(clusterModel)) {
+      double upperLimit = _balanceUpperThresholdByBroker.get(broker);
+      double lowerLimit = _balanceLowerThresholdByBroker.get(broker);
+      for (Disk disk : broker.disks()) {
+        if (disk.isAlive()) {
+          if (diskUtilizationPercentage(disk) > upperLimit) {
+            disksAboveBalanceUpperLimit.add(broker.toString() + ":" + disk.logDir());
+          }
+          if (diskUtilizationPercentage(disk) < lowerLimit) {
+            disksBelowBalanceLowerLimit.add(broker.toString() + ":" + disk.logDir());
+          }
+        }
+      }
+    }
+    if (!disksAboveBalanceUpperLimit.isEmpty()) {
+      LOG.warn("Disks {} are above balance upper limit after optimization.", disksAboveBalanceUpperLimit);
+      _succeeded = false;
+    }
+    if (!disksBelowBalanceLowerLimit.isEmpty()) {
+      LOG.warn("Disks {} are below balance lower limit after optimization.", disksBelowBalanceLowerLimit);
+      _succeeded = false;
+    }
+    finish();
+  }
+
+  /**
+   * Get brokers in the cluster so that the rebalance process will go over to apply balancing actions to replicas
+   * they contain.
+   * Note this goal moves replica between disks within broker, therefore it is unable to heal dead broker.
+   *
+   * @param clusterModel The state of the cluster.
+   * @return A collection of brokers that the rebalance process will go over to apply balancing actions to replicas
+   *         they contain.
+   */
+  @Override
+  protected SortedSet<Broker> brokersToBalance(ClusterModel clusterModel) {
+    return new TreeSet<>(clusterModel.aliveBrokers());
+  }
+
+  /**
+   * Check whether given action is acceptable by this goal. An action is acceptable by this goal if it satisfies the
+   * following:
+   * (1) If source and destination disks were within the limit before the action, the corresponding limits cannot be
+   * violated after the action.
+   * (2) The action cannot increase the utilization difference between disks.
+   *
+   * @param action Action to be checked for acceptance.
+   * @param clusterModel The state of the cluster.
+   * @return {@link ActionAcceptance#ACCEPT} if the action is acceptable by this goal,
+   *         {@link ActionAcceptance#REPLICA_REJECT} otherwise.
+   */
+  @Override
+  public ActionAcceptance actionAcceptance(BalancingAction action, ClusterModel clusterModel) {
+    double sourceUtilizationDelta = sourceUtilizationDelta(action, clusterModel);
+    Broker broker = clusterModel.broker(action.sourceBrokerId());
+    Disk sourceDisk = broker.disk(action.sourceBrokerLogdir());
+    Disk destinationDisk = broker.disk(action.destinationBrokerLogdir());
+    if (sourceUtilizationDelta == 0) {
+      // No change in terms of load.
+      return ACCEPT;
+    }
+    if (isChangeViolatingLimit(sourceUtilizationDelta, sourceDisk, destinationDisk)) {
+      return REPLICA_REJECT;
+    }
+    return isGettingMoreBalanced(sourceDisk, destinationDisk, sourceUtilizationDelta) ? ACCEPT : REPLICA_REJECT;
+  }
+
+  /**
+   * Check if requirements of this goal are not violated if this action is applied to the given cluster state, false otherwise.
+   *
+   * @param  clusterModel The state of the cluster.
+   * @param  action Action containing information about potential modification to the given cluster model.
+   * @return True if requirements of this goal are not violated if this action is applied to the given cluster state,
+   *         false otherwise.
+   */
+  @Override
+  protected boolean selfSatisfied(ClusterModel clusterModel, BalancingAction action) {
+    double sourceUtilizationDelta = sourceUtilizationDelta(action, clusterModel);
+    return sourceUtilizationDelta != 0 && actionAcceptance(action, clusterModel) == ACCEPT;
+  }
+
+  private double sourceUtilizationDelta(BalancingAction action, ClusterModel clusterModel) {
+    // Currently disk-granularity goals do not work with broker-granularity goals.
+    if (action.sourceBrokerLogdir() == null || action.destinationBrokerLogdir() == null) {
+      throw new IllegalArgumentException(this.getClass().getSimpleName() + " does not support balancing action not "
+                                         + "specifying logdir.");
+    }
+
+    Broker broker = clusterModel.broker(action.sourceBrokerId());
+    Replica sourceReplica = broker.replica(action.topicPartition());
+    switch (action.balancingAction()) {
+      case INTRA_BROKER_REPLICA_SWAP:
+        Replica destinationReplica = broker.replica(action.destinationTopicPartition());
+        return destinationReplica.load().expectedUtilizationFor(RESOURCE)
+               - sourceReplica.load().expectedUtilizationFor(RESOURCE);
+      case LEADERSHIP_MOVEMENT:
+        return 0;
+      case INTRA_BROKER_REPLICA_MOVEMENT:
+        return - sourceReplica.load().expectedUtilizationFor(RESOURCE);
+      default:
+        throw new IllegalArgumentException("Unsupported balancing action " + action.balancingAction() + " is provided.");
+    }
+  }
+
+  private boolean isChangeViolatingLimit(double sourceUtilizationDelta, Disk sourceDisk, Disk destinationDisk) {
+    double balanceUpperThreshold = _balanceUpperThresholdByBroker.get(sourceDisk.broker());
+    double balanceLowerThreshold = _balanceLowerThresholdByBroker.get(sourceDisk.broker());
+    double sourceDiskAllowance = sourceUtilizationDelta > 0 ? sourceDisk.capacity() * balanceUpperThreshold - sourceDisk.utilization() :
+                                                              sourceDisk.utilization() - sourceDisk.capacity() * balanceLowerThreshold;
+    double destinationDiskAllowance = sourceUtilizationDelta > 0 ? destinationDisk.utilization() - destinationDisk.capacity() * balanceLowerThreshold :
+                                                                   destinationDisk.capacity() * balanceUpperThreshold - destinationDisk.utilization();
+    if ((sourceDiskAllowance >= 0 && sourceDiskAllowance < abs(sourceUtilizationDelta)) ||
+        (destinationDiskAllowance >= 0 && destinationDiskAllowance < abs(sourceUtilizationDelta))) {
+      return true;
+    }
+    return false;
+  }
+
+  private boolean isGettingMoreBalanced(Disk sourceDisk, Disk destinationDisk, double sourceUtilizationDelta) {
+    double prevDiff = diskUtilizationPercentage(sourceDisk)  - diskUtilizationPercentage(destinationDisk);
+    double nextDiff = prevDiff + sourceUtilizationDelta / sourceDisk.capacity() + sourceUtilizationDelta / destinationDisk.capacity();
+    return abs(nextDiff) < abs(prevDiff);
+  }
+
+  /**
+   * (1) REBALANCE BY REPLICA MOVEMENT:
+   * Perform optimization via replica movement between disks to ensure balance: The load on disks are within range.
+   * (2) REBALANCE BY REPLICA SWAP:
+   * Swap replicas to ensure balance without violating optimized goal requirements.
+   * Note the optimization from this goal cannot be applied to offline replicas because Kafka does not support moving
+   * replicas on bad disks to good disks within the same broker.
+   *
+   * @param broker              Broker to be balanced.
+   * @param clusterModel        The state of the cluster.
+   * @param optimizedGoals      Optimized goals.
+   * @param optimizationOptions Options to take into account during optimization -- e.g. excluded topics.
+   */
+  @Override
+  protected void rebalanceForBroker(Broker broker,
+                                    ClusterModel clusterModel,
+                                    Set<Goal> optimizedGoals,
+                                    OptimizationOptions optimizationOptions) {
+    double upperLimit = _balanceUpperThresholdByBroker.get(broker);
+    double lowerLimit = _balanceLowerThresholdByBroker.get(broker);
+    for (Disk disk : broker.disks()) {
+      if (!disk.isAlive()) {
+        continue;
+      }
+      if (diskUtilizationPercentage(disk) > upperLimit) {
+        if (rebalanceByMovingLoadOut(disk, clusterModel, optimizedGoals, optimizationOptions)) {
+          rebalanceBySwappingLoadOut(disk, clusterModel, optimizedGoals, optimizationOptions);
+        }
+      }
+      if (diskUtilizationPercentage(disk) < lowerLimit) {
+        if (rebalanceByMovingLoadIn(disk, clusterModel, optimizedGoals, optimizationOptions)) {
+          rebalanceBySwappingLoadIn(disk, clusterModel, optimizedGoals, optimizationOptions);
+        }
+      }
+    }
+  }
+
+  /**
+   * Try to balance the underloaded disk by moving in replicas from other disks of the same broker.
+   *
+   * @param disk                 The disk to balance.
+   * @param clusterModel         The current cluster model.
+   * @param optimizedGoals       Optimized goals.
+   * @param optimizationOptions  Options to take into account during optimization -- e.g. excluded topics.
+   * @return True if the disk to balance is still underloaded, false otherwise.
+   */
+  private boolean rebalanceByMovingLoadIn(Disk disk,
+                                          ClusterModel clusterModel,
+                                          Set<Goal> optimizedGoals,
+                                          OptimizationOptions optimizationOptions) {
+    Broker broker = disk.broker();
+    double brokerUtilization = averageDiskUtilizationPercentage(broker);
+    Set<String> excludedTopics = optimizationOptions.excludedTopics();
+
+    PriorityQueue<Disk> candidateDiskPQ = new PriorityQueue<>(
+        (d1, d2) -> Double.compare(diskUtilizationPercentage(d2), diskUtilizationPercentage(d1)));
+    for (Disk candidateDisk : broker.disks()) {
+      // Get candidate disk on broker to try moving load from -- sorted in the order of trial (descending load).
+      if (candidateDisk.isAlive() && diskUtilizationPercentage(candidateDisk) > brokerUtilization) {
+        candidateDiskPQ.add(candidateDisk);
+      }
+    }
+
+    while (!candidateDiskPQ.isEmpty()) {
+      Disk candidateDisk = candidateDiskPQ.poll();
+      candidateDisk.trackSortedReplicas(name(),
+                                        ReplicaSortFunctionFactory.selectOnlineReplicas(),
+                                        ReplicaSortFunctionFactory.deprioritizeDiskImmigrants(),
+                                        ReplicaSortFunctionFactory.sortByMetricGroupValue(RESOURCE.name()));
+      for (Iterator<Replica> iterator = candidateDisk.trackedSortedReplicas(name()).reverselySortedReplicas().iterator();
+          iterator.hasNext(); ) {
+        Replica replica = iterator.next();
+        if (excludedTopics.contains(replica.topicPartition().topic())) {
+          continue;
+        }
+        Disk d = maybeMoveReplicaBetweenDisks(clusterModel, replica, Collections.singleton(disk), optimizedGoals);
+        // Only need to check status if the action is taken. This will also handle the case that the source disk
+        // has nothing to move in. In that case we will never re-enqueue that source disk.
+        if (d != null) {
+          if (diskUtilizationPercentage(disk) > _balanceLowerThresholdByBroker.get(broker)) {
+            candidateDisk.untrackSortedReplicas(name());
+            return false;
+          }
+          iterator.remove();
+          // If the source disk has a lower utilization than the next disk in the candidate disk priority queue,
+          // we re-enqueue the source disk and switch to the next disk.
+          if (!candidateDiskPQ.isEmpty() && diskUtilizationPercentage(candidateDisk) < diskUtilizationPercentage(candidateDiskPQ.peek())) {
+            candidateDiskPQ.add(candidateDisk);
+            break;
+          }
+        }
+      }
+      candidateDisk.untrackSortedReplicas(name());
+    }
+    return true;
+  }
+
+  /**
+   * Try to balance the overloaded disk by moving out replicas to other disks of the same broker.
+   *
+   * @param disk                 The disk to balance.
+   * @param clusterModel         The current cluster model.
+   * @param optimizedGoals       Optimized goals.
+   * @param optimizationOptions  Options to take into account during optimization -- e.g. excluded topics.
+   * @return True if the disk to balance is still overloaded, false otherwise.
+   */
+  private boolean rebalanceByMovingLoadOut(Disk disk,
+                                           ClusterModel clusterModel,
+                                           Set<Goal> optimizedGoals,
+                                           OptimizationOptions optimizationOptions) {
+    Broker broker = disk.broker();
+    double brokerUtilization = averageDiskUtilizationPercentage(broker);
+    Set<String> excludedTopics = optimizationOptions.excludedTopics();
+    disk.trackSortedReplicas(name(),
+                             ReplicaSortFunctionFactory.selectOnlineReplicas(),
+                             ReplicaSortFunctionFactory.deprioritizeDiskImmigrants(),
+                             ReplicaSortFunctionFactory.sortByMetricGroupValue(RESOURCE.name()));
+
+    PriorityQueue<Disk> candidateDiskPQ = new PriorityQueue<>(
+        (d1, d2) -> Double.compare(diskUtilizationPercentage(d1), diskUtilizationPercentage(d2)));
+    for (Disk candidateDisk : broker.disks()) {
+      // Get candidate disk on broker to try moving load to -- sorted in the order of trial (ascending load).
+      if (candidateDisk.isAlive() && diskUtilizationPercentage(candidateDisk) < brokerUtilization) {
+        candidateDiskPQ.add(candidateDisk);
+      }
+    }
+
+    while (!candidateDiskPQ.isEmpty()) {
+      Disk candidateDisk = candidateDiskPQ.poll();
+      for (Iterator<Replica> iterator = disk.trackedSortedReplicas(name()).reverselySortedReplicas().iterator();
+          iterator.hasNext(); ) {
+        Replica replica = iterator.next();
+        if (excludedTopics.contains(replica.topicPartition().topic())) {
+          continue;
+        }
+        Disk d = maybeMoveReplicaBetweenDisks(clusterModel, replica, Collections.singleton(candidateDisk), optimizedGoals);
+        // Only need to check status if the action is taken. This will also handle the case that no replica can be
+        // move to destination disk. In that case we will never re-enqueue that destination disk.
+        if (d != null) {
+          if (diskUtilizationPercentage(disk) < _balanceUpperThresholdByBroker.get(broker)) {
+            disk.untrackSortedReplicas(name());
+            return false;
+          }
+          iterator.remove();
+          // If the destination disk has a higher utilization than the next disk in the candidate disk priority queue,
+          // we re-enqueue the destination disk and switch to the next disk.
+          if (!candidateDiskPQ.isEmpty() && diskUtilizationPercentage(candidateDisk) > diskUtilizationPercentage(candidateDiskPQ.peek())) {
+            candidateDiskPQ.add(candidateDisk);
+            break;
+          }
+        }
+      }
+    }
+    disk.untrackSortedReplicas(name());
+    return true;
+  }
+
+  /**
+   * Try to balance the overloaded disk by swapping its replicas with replicas from other disks of the same broker.
+   *
+   * @param disk                 The disk to balance.
+   * @param clusterModel         The current cluster model.
+   * @param optimizedGoals       Optimized goals.
+   * @param optimizationOptions  Options to take into account during optimization -- e.g. excluded topics.
+   */
+  private void rebalanceBySwappingLoadOut(Disk disk,
+                                         ClusterModel clusterModel,
+                                         Set<Goal> optimizedGoals,
+                                         OptimizationOptions optimizationOptions) {
+    long swapStartTimeMs = System.currentTimeMillis();
+    Broker broker = disk.broker();
+    Set<String> excludedTopics = optimizationOptions.excludedTopics();
+    disk.trackSortedReplicas(name(),
+                             ReplicaSortFunctionFactory.selectOnlineReplicas(),
+                             ReplicaSortFunctionFactory.sortByMetricGroupValue(RESOURCE.name()));
+
+    PriorityQueue<Disk> candidateDiskPQ = new PriorityQueue<>(
+        (d1, d2) -> Double.compare(diskUtilizationPercentage(d1), diskUtilizationPercentage(d2)));
+    for (Disk candidateDisk : broker.disks()) {
+      // Get candidate disk on broker to try to swap replica with -- sorted in the order of trial (ascending load).
+      if (candidateDisk.isAlive() && diskUtilizationPercentage(candidateDisk) < _balanceUpperThresholdByBroker.get(broker)) {
+        candidateDiskPQ.add(candidateDisk);
+      }
+    }
+
+    while (!candidateDiskPQ.isEmpty()) {
+      Disk candidateDisk = candidateDiskPQ.poll();
+      candidateDisk.trackSortedReplicas(name(),
+                                        ReplicaSortFunctionFactory.selectOnlineReplicas(),
+                                        ReplicaSortFunctionFactory.sortByMetricGroupValue(RESOURCE.name()));
+      for (Iterator<Replica> iterator = disk.trackedSortedReplicas(name()).reverselySortedReplicas().iterator();
+          iterator.hasNext(); ) {
+        Replica sourceReplica = iterator.next();
+        if (shouldExclude(sourceReplica, excludedTopics)) {
+          continue;
+        }
+        // Try swapping the source with the candidate replicas. Get the swapped in replica if successful, null otherwise.
+        Replica swappedIn = maybeSwapReplicaBetweenDisks(clusterModel,
+                                                         sourceReplica,
+                                                         candidateDisk.trackedSortedReplicas(name()).sortedReplicas(),
+                                                         optimizedGoals,
+                                                         excludedTopics);
+        if (swappedIn != null) {
+          if (diskUtilizationPercentage(disk) < _balanceUpperThresholdByBroker.get(broker)) {
+            // Successfully balanced this broker by swapping in.
+            disk.untrackSortedReplicas(name());
+            candidateDisk.untrackSortedReplicas(name());
+            return;
+          }
+          break;
+        }
+      }
+      candidateDisk.untrackSortedReplicas(name());
+      if (remainingPerDiskSwapTimeMs(swapStartTimeMs) <= 0) {
+        LOG.debug("Swap load out timeout for disk {}.", disk.logDir());
+        break;
+      }
+      if (diskUtilizationPercentage(candidateDisk) < _balanceUpperThresholdByBroker.get(broker)) {
+        candidateDiskPQ.add(candidateDisk);
+      }
+    }
+    disk.untrackSortedReplicas(name());
+  }
+
+  /**
+   * Try to balance the underloaded disk by swapping its replicas with replicas from other disks of the same broker.
+   *
+   * @param disk                 The disk to balance.
+   * @param clusterModel         The current cluster model.
+   * @param optimizedGoals       Optimized goals.
+   * @param optimizationOptions  Options to take into account during optimization -- e.g. excluded topics.
+   */
+  private void rebalanceBySwappingLoadIn(Disk disk,
+                                        ClusterModel clusterModel,
+                                        Set<Goal> optimizedGoals,
+                                        OptimizationOptions optimizationOptions) {
+    long swapStartTimeMs = System.currentTimeMillis();
+    Broker broker = disk.broker();
+    Set<String> excludedTopics = optimizationOptions.excludedTopics();
+    disk.trackSortedReplicas(name(),
+                             ReplicaSortFunctionFactory.selectOnlineReplicas(),
+                             ReplicaSortFunctionFactory.sortByMetricGroupValue(RESOURCE.name()));
+
+    PriorityQueue<Disk> candidateDiskPQ = new PriorityQueue<>(
+        (d1, d2) -> Double.compare(diskUtilizationPercentage(d2), diskUtilizationPercentage(d1)));
+    for (Disk candidateDisk : broker.disks()) {
+      // Get candidate disk on broker to try to swap replica with -- sorted in the order of trial (descending load).
+      if (candidateDisk.isAlive() && diskUtilizationPercentage(candidateDisk) > _balanceLowerThresholdByBroker.get(broker)) {
+        candidateDiskPQ.add(candidateDisk);
+      }
+    }
+
+    while (!candidateDiskPQ.isEmpty()) {
+      Disk candidateDisk = candidateDiskPQ.poll();
+      candidateDisk.trackSortedReplicas(name(),
+                                        ReplicaSortFunctionFactory.selectOnlineReplicas(),
+                                        ReplicaSortFunctionFactory.sortByMetricGroupValue(RESOURCE.name()));
+      for (Iterator<Replica> iterator = disk.trackedSortedReplicas(name()).sortedReplicas().iterator();
+          iterator.hasNext(); ) {
+        Replica sourceReplica = iterator.next();
+        if (shouldExclude(sourceReplica, excludedTopics)) {
+          continue;
+        }
+        // Try swapping the source with the candidate replicas. Get the swapped in replica if successful, null otherwise.
+        Replica swappedIn = maybeSwapReplicaBetweenDisks(clusterModel,
+                                                         sourceReplica,
+                                                         candidateDisk.trackedSortedReplicas(name()).reverselySortedReplicas(),
+                                                         optimizedGoals,
+                                                         excludedTopics);
+        if (swappedIn != null) {
+          if (diskUtilizationPercentage(disk) > _balanceLowerThresholdByBroker.get(broker)) {
+            // Successfully balanced this broker by swapping in.
+            disk.untrackSortedReplicas(name());
+            candidateDisk.untrackSortedReplicas(name());
+            return;
+          }
+          break;
+        }
+      }
+      candidateDisk.untrackSortedReplicas(name());
+      if (remainingPerDiskSwapTimeMs(swapStartTimeMs) <= 0) {
+        LOG.debug("Swap load out timeout for disk {}.", disk.logDir());
+        break;
+      }
+      if (diskUtilizationPercentage(candidateDisk) > _balanceLowerThresholdByBroker.get(broker)) {
+        candidateDiskPQ.add(candidateDisk);
+      }
+    }
+    disk.untrackSortedReplicas(name());
+  }
+
+  /**
+   * Get the remaining per disk swap time in milliseconds based on the given swap start time.
+   *
+   * @param swapStartTimeMs Per disk swap start time in milliseconds.
+   * @return Remaining per disk swap time in milliseconds.
+   */
+  private long remainingPerDiskSwapTimeMs(long swapStartTimeMs) {
+    return PER_DISK_SWAP_TIMEOUT_MS - (System.currentTimeMillis() - swapStartTimeMs);
+  }
+
+
+  @Override
+  public ClusterModelStatsComparator clusterModelStatsComparator() {
+    return new ClusterModelStatsComparator() {
+      @Override
+      public int compare(ClusterModelStats stats1, ClusterModelStats stats2) {
+        if (stats1.numUnbalancedDisks() > stats2.numUnbalancedDisks() ||
+            stats1.diskUtilizationStandardDeviation() > stats2.diskUtilizationStandardDeviation()) {
+          return -1;
+        }
+        return 1;
+      }
+
+      @Override
+      public String explainLastComparison() {
+        return null;
+      }
+    };
+  }
+
+  @Override
+  public ModelCompletenessRequirements clusterModelCompletenessRequirements() {
+    return new ModelCompletenessRequirements(_numWindows, _minMonitoredPartitionPercentage, false);
+  }
+
+  /**
+   * Get the name of this goal. Name of a goal provides an identification for the goal in human readable format.
+   */
+  public String name() {
+    return this.getClass().getSimpleName();
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ResourceDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ResourceDistributionGoal.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 
 import static com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance.ACCEPT;
 import static com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance.REPLICA_REJECT;
-import static com.linkedin.kafka.cruisecontrol.analyzer.ActionType.INTER_BROKER_REPLICA_SWAP;
 import static com.linkedin.kafka.cruisecontrol.analyzer.ActionType.INTER_BROKER_REPLICA_MOVEMENT;
 import static com.linkedin.kafka.cruisecontrol.analyzer.ActionType.LEADERSHIP_MOVEMENT;
 import static com.linkedin.kafka.cruisecontrol.analyzer.goals.GoalUtils.utilizationPercentage;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AsyncKafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AsyncKafkaCruiseControl.java
@@ -39,19 +39,19 @@ import java.util.concurrent.Executors;
  * com.linkedin.kafka.cruisecontrol.executor.strategy.ReplicaMovementStrategy, String, boolean, boolean)}</li>
  * <li>{@link KafkaCruiseControl#demoteBrokers(Set, boolean, OperationProgress, boolean, Integer, boolean, boolean,
  * com.linkedin.kafka.cruisecontrol.executor.strategy.ReplicaMovementStrategy, String, boolean)}</li>
- * <li>{@link KafkaCruiseControl#clusterModel(long, ModelCompletenessRequirements, OperationProgress, boolean)}</li>
+ * <li>{@link KafkaCruiseControl#clusterModel(long, ModelCompletenessRequirements, OperationProgress, boolean, boolean)}</li>
  * <li>{@link KafkaCruiseControl#clusterModel(long, long, Double, OperationProgress, boolean)}</li>
  * <li>{@link KafkaCruiseControl#getProposals(OperationProgress, boolean)}</li>
  * <li>{@link KafkaCruiseControl#state(OperationProgress, Set)}</li>
  * <li>{@link KafkaCruiseControl#getProposals(java.util.List, ModelCompletenessRequirements, OperationProgress,
- * boolean, boolean, java.util.regex.Pattern, boolean, boolean, boolean, boolean, Set)}</li>
+ * boolean, boolean, java.util.regex.Pattern, boolean, boolean, boolean, boolean, Set, boolean)}</li>
  * <li>{@link KafkaCruiseControl#fixOfflineReplicas(boolean, java.util.List, ModelCompletenessRequirements, OperationProgress,
  * boolean, Integer, Integer, boolean, java.util.regex.Pattern,
  * com.linkedin.kafka.cruisecontrol.executor.strategy.ReplicaMovementStrategy, String, boolean, boolean)}</li>
  * <li>{@link KafkaCruiseControl#rebalance(java.util.List, boolean, ModelCompletenessRequirements, OperationProgress,
- * boolean, Integer, Integer, boolean, java.util.regex.Pattern,
+ * boolean, Integer, Integer, Integer, boolean, java.util.regex.Pattern,
  * com.linkedin.kafka.cruisecontrol.executor.strategy.ReplicaMovementStrategy, String, boolean, boolean, boolean,
- * boolean, Set)}</li>
+ * boolean, Set, boolean)}</li>
  * </ul>
  *
  * The other operations are non-blocking by default.
@@ -131,7 +131,7 @@ public class AsyncKafkaCruiseControl extends KafkaCruiseControl {
   }
 
   /**
-   * @see KafkaCruiseControl#clusterModel(long, ModelCompletenessRequirements, OperationProgress, boolean)
+   * @see KafkaCruiseControl#clusterModel(long, ModelCompletenessRequirements, OperationProgress, boolean, boolean)
    */
   public OperationFuture getBrokerStats(ClusterLoadParameters parameters) {
     OperationFuture future = new OperationFuture("Get broker stats");
@@ -142,7 +142,7 @@ public class AsyncKafkaCruiseControl extends KafkaCruiseControl {
 
   /**
    * @see KafkaCruiseControl#getProposals(java.util.List, ModelCompletenessRequirements, OperationProgress,
-   * boolean, boolean, java.util.regex.Pattern, boolean, boolean, boolean, boolean, Set)
+   * boolean, boolean, java.util.regex.Pattern, boolean, boolean, boolean, boolean, Set, boolean)
    */
   public OperationFuture getProposals(ProposalsParameters parameters) {
     OperationFuture future = new OperationFuture("Get customized proposals");
@@ -153,9 +153,9 @@ public class AsyncKafkaCruiseControl extends KafkaCruiseControl {
 
   /**
    * @see KafkaCruiseControl#rebalance(java.util.List, boolean, ModelCompletenessRequirements, OperationProgress,
-   * boolean, Integer, Integer, boolean, java.util.regex.Pattern,
+   * boolean, Integer, Integer, Integer, boolean, java.util.regex.Pattern,
    * com.linkedin.kafka.cruisecontrol.executor.strategy.ReplicaMovementStrategy, String, boolean, boolean, boolean,
-   * boolean, Set)
+   * boolean, Set, boolean)
    */
   public OperationFuture rebalance(RebalanceParameters parameters, String uuid) {
     OperationFuture future = new OperationFuture("Rebalance");

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/FixOfflineReplicasRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/FixOfflineReplicasRunnable.java
@@ -24,7 +24,7 @@ class FixOfflineReplicasRunnable extends OperationRunnable {
   private final List<String> _goals;
   private final ModelCompletenessRequirements _modelCompletenessRequirements;
   private final boolean _allowCapacityEstimation;
-  private final Integer _concurrentPartitionMovements;
+  private final Integer _concurrentInterBrokerPartitionMovements;
   private final Integer _concurrentLeaderMovements;
   private final boolean _skipHardGoalCheck;
   private final Pattern _excludedTopics;
@@ -44,7 +44,7 @@ class FixOfflineReplicasRunnable extends OperationRunnable {
     _goals = parameters.goals();
     _modelCompletenessRequirements = parameters.modelCompletenessRequirements();
     _allowCapacityEstimation = parameters.allowCapacityEstimation();
-    _concurrentPartitionMovements = parameters.concurrentPartitionMovements();
+    _concurrentInterBrokerPartitionMovements = parameters.concurrentInterBrokerPartitionMovements();
     _concurrentLeaderMovements = parameters.concurrentLeaderMovements();
     _skipHardGoalCheck = parameters.skipHardGoalCheck();
     _excludedTopics = parameters.excludedTopics();
@@ -59,7 +59,7 @@ class FixOfflineReplicasRunnable extends OperationRunnable {
   protected OptimizationResult getResult() throws Exception {
     return new OptimizationResult(_kafkaCruiseControl.fixOfflineReplicas(_dryRun, _goals, _modelCompletenessRequirements,
                                                                          _future.operationProgress(), _allowCapacityEstimation,
-                                                                         _concurrentPartitionMovements, _concurrentLeaderMovements,
+                                                                         _concurrentInterBrokerPartitionMovements, _concurrentLeaderMovements,
                                                                          _skipHardGoalCheck, _excludedTopics, _replicaMovementStrategy,
                                                                          _uuid, _excludeRecentlyDemotedBrokers,
                                                                          _excludeRecentlyRemovedBrokers),

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetProposalsRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetProposalsRunnable.java
@@ -19,7 +19,7 @@ import java.util.regex.Pattern;
  * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean)} and
  * {@link KafkaCruiseControl#getProposals(List, ModelCompletenessRequirements,
  * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean, boolean, Pattern, boolean, boolean,
- * boolean, boolean, java.util.Set)}
+ * boolean, boolean, java.util.Set, boolean)}
  */
 class GetProposalsRunnable extends OperationRunnable {
   private final List<String> _goals;
@@ -31,6 +31,7 @@ class GetProposalsRunnable extends OperationRunnable {
   private final boolean _ignoreProposalCache;
   private final Set<Integer> _destinationBrokerIds;
   private final KafkaCruiseControlConfig _config;
+  private final boolean _isRebalanceDiskMode;
 
   GetProposalsRunnable(KafkaCruiseControl kafkaCruiseControl,
                        OperationFuture future,
@@ -46,6 +47,7 @@ class GetProposalsRunnable extends OperationRunnable {
     _ignoreProposalCache = parameters.ignoreProposalCache();
     _destinationBrokerIds = parameters.destinationBrokerIds();
     _config = config;
+    _isRebalanceDiskMode = parameters.isRebalanceDiskMode();
   }
 
   @Override
@@ -60,7 +62,8 @@ class GetProposalsRunnable extends OperationRunnable {
                                                                    _excludeRecentlyRemovedBrokers,
                                                                    _ignoreProposalCache,
                                                                    false,
-                                                                   _destinationBrokerIds),
+                                                                   _destinationBrokerIds,
+                                                                   _isRebalanceDiskMode),
                                   _config);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/RebalanceRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/RebalanceRunnable.java
@@ -17,8 +17,8 @@ import java.util.regex.Pattern;
 
 /**
  * The async runnable for {@link KafkaCruiseControl#rebalance(List, boolean, ModelCompletenessRequirements,
- * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean, Integer, Integer, boolean, Pattern,
- * ReplicaMovementStrategy, String, boolean, boolean, boolean, boolean, Set)}
+ * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean, Integer, Integer, Integer, boolean,
+ * Pattern, ReplicaMovementStrategy, String, boolean, boolean, boolean, boolean, Set, boolean)}
  */
 class RebalanceRunnable extends OperationRunnable {
   private final List<String> _goals;
@@ -26,6 +26,7 @@ class RebalanceRunnable extends OperationRunnable {
   private final ModelCompletenessRequirements _modelCompletenessRequirements;
   private final boolean _allowCapacityEstimation;
   private final Integer _concurrentInterBrokerPartitionMovements;
+  private final Integer _concurrentIntraBrokerPartitionMovements;
   private final Integer _concurrentLeaderMovements;
   private final boolean _skipHardGoalCheck;
   private final Pattern _excludedTopics;
@@ -36,6 +37,7 @@ class RebalanceRunnable extends OperationRunnable {
   private final boolean _ignoreProposalCache;
   private final Set<Integer> _destinationBrokerIds;
   private final KafkaCruiseControlConfig _config;
+  private final boolean _isRebalanceDiskMode;
 
   RebalanceRunnable(KafkaCruiseControl kafkaCruiseControl,
                     OperationFuture future,
@@ -48,6 +50,7 @@ class RebalanceRunnable extends OperationRunnable {
     _modelCompletenessRequirements = parameters.modelCompletenessRequirements();
     _allowCapacityEstimation = parameters.allowCapacityEstimation();
     _concurrentInterBrokerPartitionMovements = parameters.concurrentInterBrokerPartitionMovements();
+    _concurrentIntraBrokerPartitionMovements = parameters.concurrentIntraBrokerPartitionMovements();
     _concurrentLeaderMovements = parameters.concurrentLeaderMovements();
     _skipHardGoalCheck = parameters.skipHardGoalCheck();
     _excludedTopics = parameters.excludedTopics();
@@ -58,6 +61,7 @@ class RebalanceRunnable extends OperationRunnable {
     _ignoreProposalCache = parameters.ignoreProposalCache();
     _destinationBrokerIds = parameters.destinationBrokerIds();
     _config = config;
+    _isRebalanceDiskMode =  parameters.isRebalanceDiskMode();
   }
 
   @Override
@@ -68,6 +72,7 @@ class RebalanceRunnable extends OperationRunnable {
                                                                 _future.operationProgress(),
                                                                 _allowCapacityEstimation,
                                                                 _concurrentInterBrokerPartitionMovements,
+                                                                _concurrentIntraBrokerPartitionMovements,
                                                                 _concurrentLeaderMovements,
                                                                 _skipHardGoalCheck,
                                                                 _excludedTopics,
@@ -77,7 +82,8 @@ class RebalanceRunnable extends OperationRunnable {
                                                                 _excludeRecentlyRemovedBrokers,
                                                                 _ignoreProposalCache,
                                                                 false,
-                                                                _destinationBrokerIds),
+                                                                _destinationBrokerIds,
+                                                                _isRebalanceDiskMode),
                                   _config);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -452,6 +452,15 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
       "given point. This is to avoid overwhelming the cluster by inter-broker partition movements.";
 
   /**
+   * <code>num.concurrent.intra.broker.partition.movements</code>
+   */
+  public static final String NUM_CONCURRENT_INTRA_BROKER_PARTITION_MOVEMENTS_CONFIG = "num.concurrent.intra.broker.partition.movements";
+  private static final String NUM_CONCURRENT_INTRA_BROKER_PARTITION_MOVEMENTS_DOC = "The maximum number of partitions " +
+      "the executor will move across disks within a broker at the same time. e.g. setting the value to 10 means that the " +
+      "executor will at most allow 10 partitions to move across disks within a broker at any given point. This is to avoid " +
+      "overwhelming the cluster by intra-broker partition movements.";
+
+  /**
    * <code>num.concurrent.leader.movements</code>
    */
   public static final String NUM_CONCURRENT_LEADER_MOVEMENTS_CONFIG =
@@ -1101,6 +1110,12 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 atLeast(1),
                 ConfigDef.Importance.MEDIUM,
                 NUM_CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER_DOC)
+        .define(NUM_CONCURRENT_INTRA_BROKER_PARTITION_MOVEMENTS_CONFIG,
+                ConfigDef.Type.INT,
+                2,
+                atLeast(1),
+                ConfigDef.Importance.MEDIUM,
+                NUM_CONCURRENT_INTRA_BROKER_PARTITION_MOVEMENTS_DOC)
         .define(NUM_CONCURRENT_LEADER_MOVEMENTS_CONFIG,
                 ConfigDef.Type.INT,
                 1000,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
@@ -17,6 +17,7 @@ import com.linkedin.kafka.cruisecontrol.exception.OptimizationFailureException;
 import com.linkedin.kafka.cruisecontrol.executor.ExecutionProposal;
 import com.linkedin.kafka.cruisecontrol.executor.ExecutorState;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
 import com.linkedin.kafka.cruisecontrol.monitor.LoadMonitor;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelGeneration;
 import com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunner;
@@ -224,8 +225,8 @@ public class GoalViolationDetector implements Runnable {
       LOG.info("Skipping goal violation detection because the cluster model does not have any topic.");
       return false;
     }
-    Map<TopicPartition, List<Integer>> initReplicaDistribution = clusterModel.getReplicaDistribution();
-    Map<TopicPartition, Integer> initLeaderDistribution = clusterModel.getLeaderDistribution();
+    Map<TopicPartition, List<ReplicaPlacementInfo>> initReplicaDistribution = clusterModel.getReplicaDistribution();
+    Map<TopicPartition, ReplicaPlacementInfo> initLeaderDistribution = clusterModel.getLeaderDistribution();
     try {
       goal.optimize(clusterModel, new HashSet<>(), new OptimizationOptions(excludedTopics(clusterModel),
                                                                            excludedBrokersForLeadership,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
@@ -81,6 +81,7 @@ public class GoalViolations extends KafkaAnomaly {
                                                                                    _allowCapacityEstimation,
                                                                                    null,
                                                                                    null,
+                                                                                   null,
                                                                                    false,
                                                                                    null,
                                                                                    null,
@@ -89,7 +90,8 @@ public class GoalViolations extends KafkaAnomaly {
                                                                                    _excludeRecentlyRemovedBrokers,
                                                                                    false,
                                                                                    true,
-                                                                                   Collections.emptySet()),
+                                                                                   Collections.emptySet(),
+                                                                                   false),
                                                      null);
         // Ensure that only the relevant response is cached to avoid memory pressure.
         _optimizationResult.discardIrrelevantAndCacheJsonAndPlaintext();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorAdminUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorAdminUtils.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.executor;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.TopicPartitionReplica;
+import org.apache.kafka.common.errors.KafkaStorageException;
+import org.apache.kafka.common.errors.LogDirNotFoundException;
+import org.apache.kafka.common.errors.ReplicaNotAvailableException;
+import org.apache.kafka.common.protocol.Errors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.LOGDIR_RESPONSE_TIMEOUT_MS;
+import static org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult.ReplicaLogDirInfo;
+import static org.apache.kafka.common.requests.DescribeLogDirsResponse.LogDirInfo;
+
+public class ExecutorAdminUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(ExecutorAdminUtils.class);
+
+  private ExecutorAdminUtils() {
+
+  }
+
+  /**
+   * Fetch the logdir information for subject replicas in intra-broker replica movement tasks.
+   *
+   * @param tasks The tasks to check.
+   * @param adminClient The adminClient to send describeReplicaLogDirs request.
+   * @return Replica logdir information by task.
+   */
+  static Map<ExecutionTask, ReplicaLogDirInfo> getLogdirInfoForExecutionTask(Collection<ExecutionTask> tasks,
+                                                                              AdminClient adminClient) {
+    Set<TopicPartitionReplica> replicasToCheck = new HashSet<>(tasks.size());
+    Map<ExecutionTask, ReplicaLogDirInfo> logdirInfoByTask = new HashMap<>(tasks.size());
+    Map<TopicPartitionReplica, ExecutionTask> taskByReplica = new HashMap<>(tasks.size());
+    tasks.forEach(t -> {
+      TopicPartitionReplica tpr = new TopicPartitionReplica(t.proposal().topic(), t.proposal().partitionId(), t.brokerId());
+      replicasToCheck.add(tpr);
+      taskByReplica.put(tpr, t);
+    });
+    Map<TopicPartitionReplica, KafkaFuture<ReplicaLogDirInfo>> logDirsByReplicas = adminClient.describeReplicaLogDirs(replicasToCheck).values();
+    for (Map.Entry<TopicPartitionReplica, KafkaFuture<ReplicaLogDirInfo>> entry : logDirsByReplicas.entrySet()) {
+      try {
+        ReplicaLogDirInfo info = entry.getValue().get(LOGDIR_RESPONSE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        logdirInfoByTask.put(taskByReplica.get(entry.getKey()), info);
+      } catch (InterruptedException | ExecutionException | TimeoutException e) {
+        LOG.warn("Encounter exception {} when fetching logdir information for replica {}", e.getMessage(), entry.getKey());
+      }
+    }
+    return logdirInfoByTask;
+  }
+
+  /**
+   * Execute intra-broker replica movement tasks by sending alterReplicaLogDirs request.
+   *
+   * @param tasksToExecute The tasks to execute.
+   * @param adminClient The adminClient to send alterReplicaLogDirs request.
+   * @param executionTaskManager The task manager to do bookkeeping for task execution state.
+   */
+  static void executeIntraBrokerReplicaMovements(List<ExecutionTask> tasksToExecute,
+                                                 AdminClient adminClient,
+                                                 ExecutionTaskManager executionTaskManager) {
+    Map<TopicPartitionReplica, String> replicaAssignment = new HashMap<>(tasksToExecute.size());
+    Map<TopicPartitionReplica, ExecutionTask> replicaToTask = new HashMap<>(tasksToExecute.size());
+    tasksToExecute.forEach(t -> {
+      TopicPartitionReplica tpr = new TopicPartitionReplica(t.proposal().topic(), t.proposal().partitionId(), t.brokerId());
+      replicaAssignment.put(tpr, t.proposal().replicasToMoveBetweenDisksByBroker().get(t.brokerId()).logdir());
+      replicaToTask.put(tpr, t);
+    });
+    for (Map.Entry<TopicPartitionReplica, KafkaFuture<Void>> entry: adminClient.alterReplicaLogDirs(replicaAssignment).values().entrySet()) {
+      try {
+        entry.getValue().get(LOGDIR_RESPONSE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      } catch (InterruptedException | ExecutionException | TimeoutException |
+               LogDirNotFoundException | KafkaStorageException | ReplicaNotAvailableException e) {
+        LOG.warn("Encounter exception {} when trying to execute task {}, mark task dead.", e.getMessage(), replicaToTask.get(entry.getKey()));
+        executionTaskManager.markTaskAborting(replicaToTask.get(entry.getKey()));
+        executionTaskManager.markTaskDead(replicaToTask.get(entry.getKey()));
+      }
+    }
+  }
+
+  /**
+   * Check whether there is ongoing intra-broker replica movement.
+   * @param brokersToCheck List of broker to check.
+   * @param adminClient The adminClient to send describeLogDirs request.
+   * @return True if there is ongoing intra-broker replica movement.
+   */
+  static boolean isOngoingIntraBrokerReplicaMovement(Collection<Integer> brokersToCheck, AdminClient adminClient) {
+    Map<Integer, KafkaFuture<Map<String, LogDirInfo>>> logDirsByBrokerId = adminClient.describeLogDirs(brokersToCheck).values();
+    for (Map.Entry<Integer, KafkaFuture<Map<String, LogDirInfo>>> entry : logDirsByBrokerId.entrySet()) {
+      try {
+        Map<String, LogDirInfo> logInfos = entry.getValue().get(LOGDIR_RESPONSE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        for (LogDirInfo info : logInfos.values()) {
+          if (info.error == Errors.NONE) {
+            if (info.replicaInfos.values().stream().anyMatch(i -> i.isFuture)) {
+              return true;
+            }
+          }
+        }
+      } catch (InterruptedException | TimeoutException | ExecutionException e) {
+        //Let it go.
+      }
+    }
+    return false;
+  }
+}
+

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/strategy/AbstractReplicaMovementStrategy.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/strategy/AbstractReplicaMovementStrategy.java
@@ -6,6 +6,7 @@ package com.linkedin.kafka.cruisecontrol.executor.strategy;
 
 import com.linkedin.kafka.cruisecontrol.executor.ExecutionProposal;
 import com.linkedin.kafka.cruisecontrol.executor.ExecutionTask;
+import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
@@ -60,16 +61,15 @@ public abstract class AbstractReplicaMovementStrategy implements ReplicaMovement
       ExecutionProposal proposal = task.proposal();
 
       // Add the task to source broker's execution plan
-      int sourceBroker = proposal.oldLeader();
-      SortedSet<ExecutionTask> sourceBrokerTaskSet = tasksByBrokerId.computeIfAbsent(sourceBroker,
+      SortedSet<ExecutionTask> sourceBrokerTaskSet = tasksByBrokerId.computeIfAbsent(proposal.oldLeader().brokerId(),
                                                                                      k -> new TreeSet<>(taskComparator(cluster)));
       if (!sourceBrokerTaskSet.add(task)) {
         throw new IllegalStateException("Replica movement strategy " + this.getClass().getSimpleName() + " is unable to determine order of all tasks.");
       }
 
       // Add the task to destination brokers' execution plan
-      for (int destinationBroker : proposal.replicasToAdd()) {
-        SortedSet<ExecutionTask> destinationBrokerTaskSet = tasksByBrokerId.computeIfAbsent(destinationBroker,
+      for (ReplicaPlacementInfo destinationBroker : proposal.replicasToAdd()) {
+        SortedSet<ExecutionTask> destinationBrokerTaskSet = tasksByBrokerId.computeIfAbsent(destinationBroker.brokerId(),
                                                                                             k -> new TreeSet<>(taskComparator(cluster)));
         if (!destinationBrokerTaskSet.add(task)) {
           throw new IllegalStateException("Replica movement strategy " + this.getClass().getSimpleName() + " is unable to determine order of all tasks.");

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Disk.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Disk.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.model;
+
+import com.linkedin.cruisecontrol.monitor.sampling.aggregator.AggregatedMetricValues;
+import com.linkedin.kafka.cruisecontrol.common.Resource;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import org.apache.kafka.common.TopicPartition;
+
+/**
+ * A class that holds the disk information of a broker, including its liveness, capacity and load. It is created as part
+ * of a broker structure. A disk object represent an independent disk Kafka broker uses to host data and is managed by
+ * Kafka LogManager.
+ *
+ */
+public class Disk implements Comparable<Disk> {
+  private static final double DEAD_DISK_CAPACITY = -1.0;
+
+  public enum State {
+    ALIVE, DEAD
+  }
+
+  private final String _logDir;
+  private double _capacity;
+  private final Set<Replica> _replicas;
+  private State _state;
+  private final Broker _broker;
+  // Utilization is only relevant for alive disk.
+  private double _utilization;
+  // A map of cached sorted replicas using different user defined score functions.
+  private final Map<String, SortedReplicas> _sortedReplicas;
+
+  /**
+   * Constructor for Disk class.
+   *
+   * @param logDir         The log directory maps to disk.
+   * @param broker         The broker of the disk.
+   * @param diskCapacity   The capacity of the disk. If disk is dead, the capacity value is expected to be negative.
+   */
+  Disk(String logDir, Broker broker, double diskCapacity) {
+    _logDir = logDir;
+    _broker = broker;
+    _replicas = new HashSet<>();
+    _utilization = 0;
+    _sortedReplicas = new HashMap<>();
+
+    if (diskCapacity < 0) {
+      _capacity = DEAD_DISK_CAPACITY;
+      _state = State.DEAD;
+    } else {
+      _capacity = diskCapacity;
+      _state = State.ALIVE;
+    }
+  }
+
+  public String logDir() {
+    return _logDir;
+  }
+
+  public double capacity() {
+    return _capacity;
+  }
+
+  public Disk.State state() {
+    return _state;
+  }
+
+  public boolean isAlive() {
+    return _state == State.ALIVE;
+  }
+
+  public Set<Replica> replicas() {
+    return Collections.unmodifiableSet(_replicas);
+  }
+
+  public Broker broker() {
+    return _broker;
+  }
+
+  public double utilization() {
+    return _utilization;
+  }
+
+  /**
+   * Set Disk status.
+   *
+   * @param newState The new state of the broker.
+   */
+  public void setState(Disk.State newState) {
+    _state = newState;
+    if (_state == State.DEAD) {
+      _capacity = DEAD_DISK_CAPACITY;
+    }
+  }
+
+  /**
+   * Add replica to the disk.
+   *
+   * @param replica Replica to be added to the current disk.
+   */
+  void addReplica(Replica replica) {
+    if (_replicas.contains(replica)) {
+      throw new IllegalStateException(String.format("Disk %s already has replica %s", _logDir, replica.topicPartition()));
+    }
+    _utilization += replica.load().expectedUtilizationFor(Resource.DISK);
+    _replicas.add(replica);
+    replica.setDisk(this);
+    _sortedReplicas.values().forEach(sr -> sr.add(replica));
+  }
+
+  /**
+   * Add replica load to the disk. This is used in cluster model initialization. When first adding replica to disk in
+   * {@link ClusterModel#createReplica(String, int, TopicPartition, int, boolean, boolean, String)}, the replica is load
+   * is not initiated, therefore later in
+   * {@link ClusterModel#setReplicaLoad(String, int, TopicPartition, AggregatedMetricValues, List)}, disk needs to refresh
+   * its utilization with initiated replica load.
+   *
+   * @param replica The replica whose load is initiated.
+   */
+  void addReplicaLoad(Replica replica) {
+    _utilization += replica.load().expectedUtilizationFor(Resource.DISK);
+  }
+
+  /**
+   * Remove replica from the disk.
+   *
+   * @param replica Replica to be removed from the current disk.
+   */
+  void removeReplica(Replica replica) {
+    if (!_replicas.contains(replica)) {
+      throw new IllegalStateException(String.format("Disk %s does not has replica %s", _logDir, replica.topicPartition()));
+    }
+    _utilization -= replica.load().expectedUtilizationFor(Resource.DISK);
+    _replicas.remove(replica);
+    _sortedReplicas.values().forEach(sr -> sr.remove(replica));
+  }
+
+  /**
+   * Track the sorted replicas using the given score function. The sort first uses the priority function to
+   * sort the replicas, then use the score function to sort the replicas. The priority function is useful
+   * to priorities a particular type of replicas, e.g leader replicas, immigrant replicas, etc.
+   *
+   * @param sortName the name of the tracked sorted replicas.
+   * @param selectionFunc the selection function to decide which replicas to include.
+   * @param priorityFunc the priority function to sort replicas.
+   * @param scoreFunc the score function to sort replicas.
+   */
+  public void trackSortedReplicas(String sortName,
+                                  Function<Replica, Boolean> selectionFunc,
+                                  Function<Replica, Integer> priorityFunc,
+                                  Function<Replica, Double> scoreFunc) {
+    _sortedReplicas.putIfAbsent(sortName, new SortedReplicas(_broker, this, selectionFunc, priorityFunc, scoreFunc, true));
+  }
+
+  public void trackSortedReplicas(String sortName,
+                                  Function<Replica, Boolean> selectionFunc,
+                                  Function<Replica, Double> scoreFunc) {
+    _sortedReplicas.putIfAbsent(sortName, new SortedReplicas(_broker, this, selectionFunc, (r1) -> 0, scoreFunc, true));
+  }
+
+  /**
+   * Untrack the sorted replicas for the given sort name. This helps release memory.
+   *
+   * @param sortName the name of the tracked sorted replicas.
+   */
+  public void untrackSortedReplicas(String sortName) {
+    _sortedReplicas.remove(sortName);
+  }
+
+  /**
+   * Get the tracked sorted replicas using the given sort name.
+   *
+   * @param sortName the sort name.
+   * @return the {@link SortedReplicas} for the given sort name.
+   */
+  public SortedReplicas trackedSortedReplicas(String sortName) {
+    SortedReplicas sortedReplicas = _sortedReplicas.get(sortName);
+    if (sortedReplicas == null) {
+      throw new IllegalStateException("The sort name " + sortName + "  is not found. Make sure trackSortedReplicas() " +
+          "has been called for the sort name");
+    }
+    return sortedReplicas;
+  }
+
+  @Override
+  public int compareTo(Disk d) {
+    int result = _broker.compareTo(d.broker());
+    if (result == 0) {
+      return _logDir.compareTo(d.logDir());
+    }
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof  Disk)) {
+      return false;
+    }
+    return compareTo((Disk) o) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_broker, _logDir);
+  }
+
+  /**
+   * Output writing string representation of this class to the stream.
+   * @param out the output stream.
+   */
+  public void writeTo(OutputStream out) throws IOException {
+    String disk = String.format("<Disk logdir=\"%s\" state=\"%s\">%n", _logDir, _state);
+    out.write(disk.getBytes(StandardCharsets.UTF_8));
+    for (Replica replica : _replicas) {
+      replica.writeTo(out);
+    }
+    out.write("</Disk>%n".getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Override
+  public String toString() {
+    return String.format("Disk[logdir=%s,state=%s,capacity=%f,replicaCount=%d]", _logDir, _state, _capacity, _replicas.size());
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Rack.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Rack.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import org.apache.kafka.common.TopicPartition;
 
+import static com.linkedin.kafka.cruisecontrol.common.Resource.DISK;
 
 /**
  * A class that holds the information of the rack, including its topology, liveness and load for brokers, and
@@ -281,6 +282,18 @@ public class Rack implements Serializable {
       }
       _rackCapacity[r.id()] = capacity;
     }
+  }
+
+  /**
+   * Mark specified disk dead and update the capacity.
+   *
+   * @param brokerId The id of broker which host the disk.
+   * @param logdir Log directory of the disk.
+   */
+  void markDiskDead(int brokerId, String logdir) {
+    Broker broker = broker(brokerId);
+    double capacityLost = broker.host().markDiskDead(brokerId, logdir);
+    _rackCapacity[DISK.id()] -= capacityLost;
   }
 
   /*

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Replica.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Replica.java
@@ -39,16 +39,18 @@ public class Replica implements Serializable, Comparable<Replica> {
   private boolean _isOriginalOffline;
   private Broker _broker;
   private boolean _isLeader;
+  private final Disk _originalDisk;
+  private Disk _disk;
 
   /**
-   * The constructor for an online replica.
+   * The constructor for an online replica without disk information.
    *
    * @param tp Topic partition information of the replica.
    * @param broker The broker of the replica.
    * @param isLeader A flag to represent whether the replica is the isLeader or not.
    */
   Replica(TopicPartition tp, Broker broker, boolean isLeader) {
-    this(tp, broker, isLeader, false);
+    this(tp, broker, isLeader, false, null);
   }
 
   /**
@@ -58,14 +60,17 @@ public class Replica implements Serializable, Comparable<Replica> {
    * @param broker The broker of the replica.
    * @param isLeader A flag to represent whether the replica is the isLeader or not.
    * @param isOriginalOffline True if the replica is offline in its original location, false otherwise.
+   * @param disk The disk of the replica. If replica placement over disk information is not populated, this parameter is null.
    */
-  Replica(TopicPartition tp, Broker broker, boolean isLeader, boolean isOriginalOffline) {
+  Replica(TopicPartition tp, Broker broker, boolean isLeader, boolean isOriginalOffline, Disk disk) {
     _tp = tp;
     _load = new Load();
     _originalBroker = broker;
     _broker = broker;
     _isLeader = isLeader;
     _isOriginalOffline = isOriginalOffline;
+    _originalDisk = disk;
+    _disk = disk;
   }
 
   /**
@@ -138,6 +143,31 @@ public class Replica implements Serializable, Comparable<Replica> {
    */
   void setBroker(Broker broker) {
     _broker = broker;
+  }
+
+  /**
+   * Set disk that the replica resides in.
+   *
+   * @param disk Disk that the replica resides in.
+   */
+  void setDisk(Disk disk) {
+    _disk = disk;
+  }
+
+  /**
+   * Get disk that the replica originally resides in. If the replica-over-disk placement information is not populated in
+   * {@link ClusterModel}, null will be returned.
+   */
+  public Disk originalDisk() {
+    return _originalDisk;
+  }
+
+  /**
+   * Get disk that the replica resides in. If the replica-over-disk placement information is not populated in
+   * {@link ClusterModel}, null will be returned.
+   */
+  public Disk disk() {
+    return _disk;
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ReplicaPlacementInfo.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ReplicaPlacementInfo.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.model;
+
+import java.util.Objects;
+
+
+public class ReplicaPlacementInfo {
+  private int _brokerId;
+  private String _logdir;
+
+  public ReplicaPlacementInfo(int brokerId, String logdir) {
+    _brokerId = brokerId;
+    _logdir = logdir;
+  }
+
+  public ReplicaPlacementInfo(Integer brokerId) {
+    this(brokerId, null);
+  }
+
+  public Integer brokerId() {
+    return _brokerId;
+  }
+
+  public String logdir() {
+    return _logdir;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof ReplicaPlacementInfo)) {
+      return false;
+    }
+    ReplicaPlacementInfo info = (ReplicaPlacementInfo) o;
+    return _brokerId == info._brokerId && Objects.equals(_logdir, info._logdir);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_brokerId, _logdir);
+  }
+
+  @Override
+  public String toString() {
+    if (_logdir == null) {
+      return String.format("{Broker: %d}", _brokerId);
+    } else {
+      return String.format("{Broker: %d, Logdir: %s}", _brokerId, _logdir);
+    }
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ReplicaSortFunctionFactory.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ReplicaSortFunctionFactory.java
@@ -34,8 +34,14 @@ public class ReplicaSortFunctionFactory {
   /** Deprioritize the (1) offline replicas, then (2) the immigrant replicas */
   private static final Function<Replica, Integer> DEPRIORITIZE_OFFLINE_REPLICAS_THEN_IMMIGRANTS = r ->
       r.isCurrentOffline() ? 1 : r.originalBroker() != r.broker() ? 0 : -1;
+  /** Prioritize the disk immigrant replicas */
+  private static final Function<Replica, Integer> PRIORITIZE_DISK_IMMIGRANTS = r -> r.originalDisk() != r.disk() ? 0 : 1;
+  /** De-prioritize the disk immigrant replicas */
+  private static final Function<Replica, Integer> DEPRIORITIZE_DISK_IMMIGRANTS = r -> r.originalDisk() != r.disk() ? 1 : 0;
   /** Select leaders only */
   private static final Function<Replica, Boolean> SELECT_LEADERS = Replica::isLeader;
+  /** Select online replicas only */
+  private static final Function<Replica, Boolean> SELECT_ONLINE_REPLICAS = r -> !r.isCurrentOffline();
 
   // Score functions
   /**
@@ -124,11 +130,35 @@ public class ReplicaSortFunctionFactory {
     return DEPRIORITIZE_OFFLINE_REPLICAS_THEN_IMMIGRANTS;
   }
 
+  /**
+   * @return a priority function that prioritize the immigrant replicas to the disk.
+   */
+  public static Function<Replica, Integer> prioritizeDiskImmigrants() {
+    return PRIORITIZE_DISK_IMMIGRANTS;
+  }
+
+  /**
+   * This priority function can be used together with {@link SortedReplicas#reverselySortedReplicas()}
+   * to provide sorted replicas in descending order of score and prioritize the immigrant replicas for the disk.
+   *
+   * @return a priority function that de-prioritize the immigrant replicas to the disk.
+   */
+  public static Function<Replica, Integer> deprioritizeDiskImmigrants() {
+    return DEPRIORITIZE_DISK_IMMIGRANTS;
+  }
+
   // Selection functions
   /**
    * @return a selection function that only includes leaders.
    */
   public static Function<Replica, Boolean> selectLeaders() {
     return SELECT_LEADERS;
+  }
+
+  /**
+   * @return a selection function that only includes online replicas.
+   */
+  public static Function<Replica, Boolean> selectOnlineReplicas() {
+    return SELECT_ONLINE_REPLICAS;
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AddedOrRemovedBrokerParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AddedOrRemovedBrokerParameters.java
@@ -29,8 +29,8 @@ public abstract class AddedOrRemovedBrokerParameters extends GoalBasedOptimizati
     super.initParameters();
     _brokerIds = ParameterUtils.brokerIds(_request);
     _dryRun = ParameterUtils.getDryRun(_request);
-    _concurrentInterBrokerPartitionMovements = ParameterUtils.concurrentMovements(_request, true);
-    _concurrentLeaderMovements = ParameterUtils.concurrentMovements(_request, false);
+    _concurrentInterBrokerPartitionMovements = ParameterUtils.concurrentMovements(_request, true, false);
+    _concurrentLeaderMovements = ParameterUtils.concurrentMovements(_request, false, false);
     _skipHardGoalCheck = ParameterUtils.skipHardGoalCheck(_request);
     _replicaMovementStrategy = ParameterUtils.getReplicaMovementStrategy(_request, _config);
     boolean twoStepVerificationEnabled = _config.getBoolean(KafkaCruiseControlConfig.TWO_STEP_VERIFICATION_ENABLED_CONFIG);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AdminParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AdminParameters.java
@@ -20,13 +20,15 @@ import javax.servlet.http.HttpServletRequest;
  * <pre>
  *    POST /kafkacruisecontrol/admin?json=[true/false]&amp;disable_self_healing_for=[Set-of-{@link AnomalyType}]
  *    &amp;enable_self_healing_for=[Set-of-{@link AnomalyType}]&amp;concurrent_partition_movements_per_broker=[POSITIVE-INTEGER]
- *    &amp;concurrent_leader_movements=[POSITIVE-INTEGER]&amp;review_id=[id]
+ *    &amp;concurrent_intra_broker_partition_movements=[POSITIVE-INTEGER]&amp;concurrent_leader_movements=[POSITIVE-INTEGER]
+ *    &amp;review_id=[id]
  * </pre>
  */
 public class AdminParameters extends AbstractParameters {
   private Set<AnomalyType> _disableSelfHealingFor;
   private Set<AnomalyType> _enableSelfHealingFor;
   private Integer _concurrentInterBrokerPartitionMovements;
+  private Integer _concurrentIntraBrokerPartitionMovements;
   private Integer _concurrentLeaderMovements;
   private Integer _reviewId;
   private final boolean _twoStepVerificationEnabled;
@@ -42,8 +44,9 @@ public class AdminParameters extends AbstractParameters {
     Map<Boolean, Set<AnomalyType>> selfHealingFor = ParameterUtils.selfHealingFor(_request);
     _enableSelfHealingFor = selfHealingFor.get(true);
     _disableSelfHealingFor = selfHealingFor.get(false);
-    _concurrentInterBrokerPartitionMovements = ParameterUtils.concurrentMovements(_request, true);
-    _concurrentLeaderMovements = ParameterUtils.concurrentMovements(_request, false);
+    _concurrentInterBrokerPartitionMovements = ParameterUtils.concurrentMovements(_request, true, false);
+    _concurrentIntraBrokerPartitionMovements = ParameterUtils.concurrentMovements(_request, false, true);
+    _concurrentLeaderMovements = ParameterUtils.concurrentMovements(_request, false, false);
     _reviewId = ParameterUtils.reviewId(_request, _twoStepVerificationEnabled);
   }
 
@@ -66,6 +69,10 @@ public class AdminParameters extends AbstractParameters {
 
   public Integer concurrentInterBrokerPartitionMovements() {
     return _concurrentInterBrokerPartitionMovements;
+  }
+
+  public Integer concurrentIntraBrokerPartitionMovements() {
+    return _concurrentIntraBrokerPartitionMovements;
   }
 
   public Integer concurrentLeaderMovements() {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ClusterLoadParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ClusterLoadParameters.java
@@ -16,12 +16,14 @@ import javax.servlet.http.HttpServletRequest;
  * <pre>
  * Get the cluster load
  *    GET /kafkacruisecontrol/load?time=[TIMESTAMP]&amp;allow_capacity_estimation=[true/false]&amp;json=[true/false]
+ *    &amp;populate_disk_info=[true/false]
  * </pre>
  */
 public class ClusterLoadParameters extends AbstractParameters {
   private long _time;
   private ModelCompletenessRequirements _requirements;
   private boolean _allowCapacityEstimation;
+  private boolean _populateDiskInfo;
 
   public ClusterLoadParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
     super(request, config);
@@ -33,6 +35,7 @@ public class ClusterLoadParameters extends AbstractParameters {
     _time = ParameterUtils.time(_request);
     _requirements = new ModelCompletenessRequirements(1, 0.0, true);
     _allowCapacityEstimation = ParameterUtils.allowCapacityEstimation(_request);
+    _populateDiskInfo = ParameterUtils.populateDiskInfo(_request);
   }
 
   public long time() {
@@ -45,5 +48,9 @@ public class ClusterLoadParameters extends AbstractParameters {
 
   public boolean allowCapacityEstimation() {
     return _allowCapacityEstimation;
+  }
+
+  public boolean populateDiskInfo() {
+    return _populateDiskInfo;
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/DemoteBrokerParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/DemoteBrokerParameters.java
@@ -43,7 +43,7 @@ public class DemoteBrokerParameters extends KafkaOptimizationParameters {
     super.initParameters();
     _brokerIds = ParameterUtils.brokerIds(_request);
     _dryRun = ParameterUtils.getDryRun(_request);
-    _concurrentLeaderMovements = ParameterUtils.concurrentMovements(_request, false);
+    _concurrentLeaderMovements = ParameterUtils.concurrentMovements(_request, false, false);
     _allowCapacityEstimation = ParameterUtils.allowCapacityEstimation(_request);
     _skipUrpDemotion = ParameterUtils.skipUrpDemotion(_request);
     _excludeFollowerDemotion = ParameterUtils.excludeFollowerDemotion(_request);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/FixOfflineReplicasParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/FixOfflineReplicasParameters.java
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class FixOfflineReplicasParameters extends GoalBasedOptimizationParameters {
   private boolean _dryRun;
-  private Integer _concurrentPartitionMovements;
+  private Integer _concurrentInterBrokerPartitionMovements;
   private Integer _concurrentLeaderMovements;
   private boolean _skipHardGoalCheck;
   private ReplicaMovementStrategy _replicaMovementStrategy;
@@ -40,8 +40,8 @@ public class FixOfflineReplicasParameters extends GoalBasedOptimizationParameter
   protected void initParameters() throws UnsupportedEncodingException {
     super.initParameters();
     _dryRun = ParameterUtils.getDryRun(_request);
-    _concurrentPartitionMovements = ParameterUtils.concurrentMovements(_request, true);
-    _concurrentLeaderMovements = ParameterUtils.concurrentMovements(_request, false);
+    _concurrentInterBrokerPartitionMovements = ParameterUtils.concurrentMovements(_request, true, false);
+    _concurrentLeaderMovements = ParameterUtils.concurrentMovements(_request, false, false);
     _skipHardGoalCheck = ParameterUtils.skipHardGoalCheck(_request);
     _replicaMovementStrategy = ParameterUtils.getReplicaMovementStrategy(_request, _config);
     boolean twoStepVerificationEnabled = _config.getBoolean(KafkaCruiseControlConfig.TWO_STEP_VERIFICATION_ENABLED_CONFIG);
@@ -61,8 +61,8 @@ public class FixOfflineReplicasParameters extends GoalBasedOptimizationParameter
     return _dryRun;
   }
 
-  public Integer concurrentPartitionMovements() {
-    return _concurrentPartitionMovements;
+  public Integer concurrentInterBrokerPartitionMovements() {
+    return _concurrentInterBrokerPartitionMovements;
   }
 
   public Integer concurrentLeaderMovements() {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ProposalsParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ProposalsParameters.java
@@ -18,12 +18,13 @@ import javax.servlet.http.HttpServletRequest;
  *    &amp;goals=[goal1,goal2...]&amp;data_from=[valid_windows/valid_partitions]&amp;excluded_topics=[pattern]
  *    &amp;use_ready_default_goals=[true/false]&amp;allow_capacity_estimation=[true/false]&amp;json=[true/false]
  *    &amp;exclude_recently_demoted_brokers=[true/false]&amp;exclude_recently_removed_brokers=[true/false]
- *    &amp;destination_broker_ids=[id1,id2...]&amp;kafka_assigner=[true/false]
+ *    &amp;destination_broker_ids=[id1,id2...]&amp;kafka_assigner=[true/false]&amp;rebalance_disk=[true/false]
  * </pre>
  */
 public class ProposalsParameters extends GoalBasedOptimizationParameters {
   private Set<Integer> _destinationBrokerIds;
   private boolean _ignoreProposalCache;
+  private boolean _isRebalanceDiskMode;
 
   public ProposalsParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
     super(request, config);
@@ -34,6 +35,7 @@ public class ProposalsParameters extends GoalBasedOptimizationParameters {
     super.initParameters();
     _destinationBrokerIds = ParameterUtils.destinationBrokerIds(_request);
     _ignoreProposalCache = ParameterUtils.ignoreProposalCache(_request);
+    _isRebalanceDiskMode = ParameterUtils.isRebalanceDiskMode(_request);
   }
 
   public Set<Integer> destinationBrokerIds() {
@@ -42,5 +44,9 @@ public class ProposalsParameters extends GoalBasedOptimizationParameters {
 
   public boolean ignoreProposalCache() {
     return _ignoreProposalCache;
+  }
+
+  public boolean isRebalanceDiskMode() {
+    return _isRebalanceDiskMode;
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RebalanceParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RebalanceParameters.java
@@ -20,22 +20,25 @@ import javax.servlet.http.HttpServletRequest;
  * Trigger a workload balance.
  *    POST /kafkacruisecontrol/rebalance?dryRun=[true/false]&amp;goals=[goal1,goal2...]
  *    &amp;allow_capacity_estimation=[true/false]&amp;concurrent_partition_movements_per_broker=[POSITIVE-INTEGER]
- *    &amp;concurrent_leader_movements=[POSITIVE-INTEGER]&amp;json=[true/false]&amp;skip_hard_goal_check=[true/false]
- *    &amp;excluded_topics=[pattern]&amp;use_ready_default_goals=[true/false]&amp;verbose=[true/false]
- *    &amp;exclude_recently_demoted_brokers=[true/false]&amp;exclude_recently_removed_brokers=[true/false]
- *    &amp;replica_movement_strategies=[strategy1,strategy2...]&amp;ignore_proposal_cache=[true/false]
- *    &amp;destination_broker_ids=[id1,id2...]&amp;kafka_assigner=[true/false]&amp;review_id=[id]
+ *    &amp;concurrent_intra_broker_partition_movements=[POSITIVE-INTEGER]&amp;concurrent_leader_movements=[POSITIVE-INTEGER]
+ *    &amp;json=[true/false]&amp;skip_hard_goal_check=[true/false]&amp;excluded_topics=[pattern]
+ *    &amp;use_ready_default_goals=[true/false]&amp;verbose=[true/false]&amp;exclude_recently_demoted_brokers=[true/false]
+ *    &amp;exclude_recently_removed_brokers=[true/false]&amp;replica_movement_strategies=[strategy1,strategy2...]
+ *    &amp;ignore_proposal_cache=[true/false]&amp;destination_broker_ids=[id1,id2...]&amp;kafka_assigner=[true/false]
+ *    &amp;rebalance_disk=[true/false]&amp;review_id=[id]
  * </pre>
  */
 public class RebalanceParameters extends GoalBasedOptimizationParameters {
   private boolean _dryRun;
   private Integer _concurrentInterBrokerPartitionMovements;
+  private Integer _concurrentIntraBrokerPartitionMovements;
   private Integer _concurrentLeaderMovements;
   private boolean _skipHardGoalCheck;
   private ReplicaMovementStrategy _replicaMovementStrategy;
   private boolean _ignoreProposalCache;
   private Set<Integer> _destinationBrokerIds;
   private Integer _reviewId;
+  private boolean _isRebalanceDiskMode;
 
   public RebalanceParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
     super(request, config);
@@ -45,14 +48,16 @@ public class RebalanceParameters extends GoalBasedOptimizationParameters {
   protected void initParameters() throws UnsupportedEncodingException {
     super.initParameters();
     _dryRun = ParameterUtils.getDryRun(_request);
-    _concurrentInterBrokerPartitionMovements = ParameterUtils.concurrentMovements(_request, true);
-    _concurrentLeaderMovements = ParameterUtils.concurrentMovements(_request, false);
+    _concurrentInterBrokerPartitionMovements = ParameterUtils.concurrentMovements(_request, true, false);
+    _concurrentIntraBrokerPartitionMovements = ParameterUtils.concurrentMovements(_request, false, true);
+    _concurrentLeaderMovements = ParameterUtils.concurrentMovements(_request, false, false);
     _skipHardGoalCheck = ParameterUtils.skipHardGoalCheck(_request);
     _replicaMovementStrategy = ParameterUtils.getReplicaMovementStrategy(_request, _config);
     _ignoreProposalCache = ParameterUtils.ignoreProposalCache(_request);
     _destinationBrokerIds = ParameterUtils.destinationBrokerIds(_request);
     boolean twoStepVerificationEnabled = _config.getBoolean(KafkaCruiseControlConfig.TWO_STEP_VERIFICATION_ENABLED_CONFIG);
     _reviewId = ParameterUtils.reviewId(_request, twoStepVerificationEnabled);
+    _isRebalanceDiskMode =  ParameterUtils.isRebalanceDiskMode(_request);
   }
 
   @Override
@@ -70,6 +75,10 @@ public class RebalanceParameters extends GoalBasedOptimizationParameters {
 
   public Integer concurrentInterBrokerPartitionMovements() {
     return _concurrentInterBrokerPartitionMovements;
+  }
+
+  public Integer concurrentIntraBrokerPartitionMovements() {
+    return _concurrentIntraBrokerPartitionMovements;
   }
 
   public Integer concurrentLeaderMovements() {
@@ -90,5 +99,9 @@ public class RebalanceParameters extends GoalBasedOptimizationParameters {
 
   public boolean ignoreProposalCache() {
     return _ignoreProposalCache;
+  }
+
+  public boolean isRebalanceDiskMode() {
+    return _isRebalanceDiskMode;
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlState.java
@@ -32,6 +32,7 @@ import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTask.State;
 
 public class CruiseControlState extends AbstractCruiseControlResponse {
   private static final String INTER_BROKER_PARTITION_MOVEMENTS = "inter-broker partition movements";
+  private static final String INTRA_BROKER_PARTITION_MOVEMENTS = "intra-broker partition movements";
   private static final String LEADERSHIP_MOVEMENTS = "leadership movements";
   private static final String MONITOR_STATE = "MonitorState";
   private static final String EXECUTOR_STATE = "ExecutorState";
@@ -124,9 +125,10 @@ public class CruiseControlState extends AbstractCruiseControlResponse {
 
   private void writeVerboseExecutorState(StringBuilder sb) {
     if (_executorState != null) {
-      Map<TaskType, Map<State, Set<ExecutionTask>>> filteredTasksByState = _executorState.executionTasksSummary().filteredTasksByState();
-      filteredTasksByState.forEach((type, taskMap) -> {
+      Map<TaskType, Map<State, Set<ExecutionTask>>> taskSnapshot = _executorState.executionTasksSummary().filteredTasksByState();
+      taskSnapshot.forEach((type, taskMap) -> {
         String taskTypeString = type == TaskType.INTER_BROKER_REPLICA_ACTION ? INTER_BROKER_PARTITION_MOVEMENTS :
+                                type == TaskType.INTRA_BROKER_REPLICA_ACTION ? INTRA_BROKER_PARTITION_MOVEMENTS :
                                                                                LEADERSHIP_MOVEMENTS;
         sb.append(String.format("%n%n%s %s:%n",
                                 _executorState.state() == ExecutorState.State.STOPPING_EXECUTION ? "Cancelled" : "Pending",

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/KafkaClusterState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/KafkaClusterState.java
@@ -36,13 +36,13 @@ import org.apache.kafka.common.requests.DescribeLogDirsResponse.LogDirInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.describeLogDirs;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.LOGDIR_RESPONSE_TIMEOUT_MS;
 import static com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils.JSON_VERSION;
 import static com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils.VERSION;
-import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.describeLogDirs;
 
 public class KafkaClusterState extends AbstractCruiseControlResponse {
   private static final Logger LOG = LoggerFactory.getLogger(KafkaClusterState.class);
-  private static final long LOGDIR_RESPONSE_TIMEOUT_MS = 10000;
   private static final String TOPIC = "topic";
   private static final String PARTITION = "partition";
   private static final String LEADER = "leader";

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/stats/SingleBrokerStats.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/stats/SingleBrokerStats.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.servlet.response.stats;
 
 import com.linkedin.kafka.cruisecontrol.model.Broker;
+import java.util.HashMap;
 import java.util.Map;
 
 
@@ -12,21 +13,29 @@ public class SingleBrokerStats {
   private static final String HOST = "Host";
   private static final String BROKER = "Broker";
   private static final String BROKER_STATE = "BrokerState";
+  private static final String DISK_STATE = "DiskState";
+  private static final String DISK_MB = "DiskMB";
+  private static final String DISK_PCT = "DiskPct";
   private final String _host;
   private final int _id;
   private final Broker.State _state;
   private final BasicStats _basicStats;
   private final boolean _isEstimated;
+  private final Map<String, Double> _utilByDisk;
+  private final Map<String, Double> _capacityByDisk;
 
   SingleBrokerStats(String host, int id, Broker.State state, double diskUtil, double cpuUtil, double leaderBytesInRate,
                     double followerBytesInRate, double bytesOutRate, double potentialBytesOutRate, int numReplicas,
-                    int numLeaders, boolean isEstimated, double capacity) {
+                    int numLeaders, boolean isEstimated, double capacity, Map<String, Double> utilByDisk,
+                    Map<String, Double> capacityByDisk) {
     _host = host;
     _id = id;
     _state = state;
     _basicStats = new BasicStats(diskUtil, cpuUtil, leaderBytesInRate, followerBytesInRate, bytesOutRate,
                                  potentialBytesOutRate, numReplicas, numLeaders, capacity);
     _isEstimated = isEstimated;
+    _utilByDisk = utilByDisk;
+    _capacityByDisk = capacityByDisk;
   }
 
   public String host() {
@@ -45,6 +54,27 @@ public class SingleBrokerStats {
     return _basicStats;
   }
 
+  /**
+   * If {@link com.linkedin.kafka.cruisecontrol.config.BrokerCapacityConfigResolver} does not report the per-disk capacity
+   * for the broker,this method will return empty map.
+   */
+  Map<String, Double> utilByDisk() {
+    return _utilByDisk;
+  }
+
+  /**
+   * If {@link com.linkedin.kafka.cruisecontrol.config.BrokerCapacityConfigResolver} does not report the per-disk capacity
+   * for the broker,this method will return empty map.
+   */
+  Map<String, Double> capacityByDisk() {
+    return _capacityByDisk;
+  }
+
+  Double utilPctFor(String logdir) {
+    return _capacityByDisk.getOrDefault(logdir, 0.0) > 0 ? _utilByDisk.get(logdir) * 100 / _capacityByDisk.get(logdir) :
+                                                                     null;
+  }
+
   public boolean isEstimated() {
     return _isEstimated;
   }
@@ -58,6 +88,18 @@ public class SingleBrokerStats {
     entry.put(HOST, _host);
     entry.put(BROKER, _id);
     entry.put(BROKER_STATE, _state);
+    if (!_capacityByDisk.isEmpty()) {
+      Map<String, Object>  diskStates = new HashMap<>(_capacityByDisk.size());
+      for (Map.Entry<String, Double> e : _capacityByDisk.entrySet()) {
+        String logdir = e.getKey();
+        Double util = _utilByDisk.get(logdir);
+        Map<String, Object> diskEntry = new HashMap<>(2);
+        diskEntry.put(DISK_PCT, util == null ? "DEAD" : utilPctFor(logdir));
+        diskEntry.put(DISK_MB, util == null ? "DEAD" : util);
+        diskStates.put(logdir, diskEntry);
+      }
+      entry.put(DISK_STATE, diskStates);
+    }
     return entry;
   }
 }

--- a/cruise-control/src/main/scala/com/linkedin/kafka/cruisecontrol/executor/ExecutorUtils.scala
+++ b/cruise-control/src/main/scala/com/linkedin/kafka/cruisecontrol/executor/ExecutorUtils.scala
@@ -36,8 +36,8 @@ object ExecutorUtils {
       val newReplicaAssignment = scala.collection.mutable.Map(inProgressReplicaReassignment.toSeq: _*)
       reassignmentTasks.foreach({ task =>
         val tp = task.proposal.topicPartition()
-        val oldReplicas = asScalaBuffer(task.proposal.oldReplicas()).map(_.toInt)
-        val newReplicas = asScalaBuffer(task.proposal().newReplicas()).map(_.toInt)
+        val oldReplicas = asScalaBuffer(task.proposal.oldReplicas()).map(_.brokerId.toInt)
+        val newReplicas = asScalaBuffer(task.proposal().newReplicas()).map(_.brokerId.toInt)
 
         val inProgressReplicasOpt = newReplicaAssignment.get(tp)
         var addTask = true

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/ExcludedBrokersForLeadershipTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/ExcludedBrokersForLeadershipTest.java
@@ -29,6 +29,7 @@ import com.linkedin.kafka.cruisecontrol.executor.ExecutionProposal;
 import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 
+import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -227,8 +228,8 @@ public class ExcludedBrokersForLeadershipTest {
   @Test
   public void test() throws Exception {
     if (_exceptionClass == null) {
-      Map<TopicPartition, List<Integer>> initReplicaDistribution = _clusterModel.getReplicaDistribution();
-      Map<TopicPartition, Integer> initLeaderDistribution = _clusterModel.getLeaderDistribution();
+      Map<TopicPartition, List<ReplicaPlacementInfo>> initReplicaDistribution = _clusterModel.getReplicaDistribution();
+      Map<TopicPartition, ReplicaPlacementInfo> initLeaderDistribution = _clusterModel.getLeaderDistribution();
 
       Set<Integer> excludedBrokersForLeadership = _optimizationOptions.excludedBrokersForLeadership();
       if (_expectedToOptimize) {
@@ -243,8 +244,8 @@ public class ExcludedBrokersForLeadershipTest {
         Set<ExecutionProposal> goalProposals =
             AnalyzerUtils.getDiff(initReplicaDistribution, initLeaderDistribution, _clusterModel);
         for (ExecutionProposal proposal : goalProposals) {
-          if (proposal.hasLeaderAction() && excludedBrokersForLeadership.contains(proposal.newLeader())
-              && _clusterModel.broker(proposal.oldLeader()).isAlive()) {
+          if (proposal.hasLeaderAction() && excludedBrokersForLeadership.contains(proposal.newLeader().brokerId())
+              && _clusterModel.broker(proposal.oldLeader().brokerId()).isAlive()) {
             fail(String.format("Leadership move in %s from an online replica to an excluded broker for leadership %s.",
                                proposal, excludedBrokersForLeadership));
           }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/ExcludedBrokersForReplicaMoveTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/ExcludedBrokersForReplicaMoveTest.java
@@ -28,6 +28,7 @@ import com.linkedin.kafka.cruisecontrol.executor.ExecutionProposal;
 import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 
+import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,7 +52,6 @@ import static com.linkedin.kafka.cruisecontrol.common.DeterministicCluster.unbal
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
-
 
 /**
  * Unit test for testing goals with excluded brokers for replica move under fixed cluster properties.
@@ -218,12 +218,12 @@ public class ExcludedBrokersForReplicaMoveTest {
   private boolean violatesExcludedBrokersForReplicaMove(Set<Integer> excludedBrokersForReplicaMove,
                                                         ExecutionProposal proposal) {
     int numOfflineOldReplicas =
-        (int) proposal.oldReplicas().stream().filter(brokerId -> !_clusterModel.broker(brokerId).isAlive()).count();
+        (int) proposal.oldReplicas().stream().filter(r -> !_clusterModel.broker(r.brokerId()).isAlive()).count();
 
     int numNewReplicasOnExcludedBrokers = 0;
     for (int i = 0; i < proposal.newReplicas().size(); i++) {
-      int oldBroker = proposal.oldReplicas().get(i);
-      int newBroker = proposal.newReplicas().get(i);
+      int oldBroker = proposal.oldReplicas().get(i).brokerId();
+      int newBroker = proposal.newReplicas().get(i).brokerId();
       if (oldBroker != newBroker && excludedBrokersForReplicaMove.contains(newBroker)) {
         numNewReplicasOnExcludedBrokers++;
       }
@@ -235,8 +235,8 @@ public class ExcludedBrokersForReplicaMoveTest {
   @Test
   public void test() throws Exception {
     if (_exceptionClass == null) {
-      Map<TopicPartition, List<Integer>> initReplicaDistribution = _clusterModel.getReplicaDistribution();
-      Map<TopicPartition, Integer> initLeaderDistribution = _clusterModel.getLeaderDistribution();
+      Map<TopicPartition, List<ReplicaPlacementInfo>> initReplicaDistribution = _clusterModel.getReplicaDistribution();
+      Map<TopicPartition, ReplicaPlacementInfo> initLeaderDistribution = _clusterModel.getLeaderDistribution();
 
       Set<Integer> excludedBrokersForReplicaMove = _optimizationOptions.excludedBrokersForReplicaMove();
       if (_expectedToOptimize) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/ExcludedTopicsTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/ExcludedTopicsTest.java
@@ -29,6 +29,7 @@ import com.linkedin.kafka.cruisecontrol.executor.ExecutionProposal;
 import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 
+import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -247,8 +248,8 @@ public class ExcludedTopicsTest {
   @Test
   public void test() throws Exception {
     if (_exceptionClass == null) {
-      Map<TopicPartition, List<Integer>> initReplicaDistribution = _clusterModel.getReplicaDistribution();
-      Map<TopicPartition, Integer> initLeaderDistribution = _clusterModel.getLeaderDistribution();
+      Map<TopicPartition, List<ReplicaPlacementInfo>> initReplicaDistribution = _clusterModel.getReplicaDistribution();
+      Map<TopicPartition, ReplicaPlacementInfo> initLeaderDistribution = _clusterModel.getLeaderDistribution();
 
       Set<String> excludedTopics = _optimizationOptions.excludedTopics();
       if (_expectedToOptimize) {
@@ -265,10 +266,10 @@ public class ExcludedTopicsTest {
 
         for (ExecutionProposal proposal : goalProposals) {
           if (excludedTopics.contains(proposal.topic())) {
-            for (int brokerId : proposal.replicasToRemove()) {
-              if (_clusterModel.broker(brokerId).isAlive()) {
+            for (ReplicaPlacementInfo r : proposal.replicasToRemove()) {
+              if (_clusterModel.broker(r.brokerId()).isAlive()) {
                 fail(String.format("Proposal %s contains excluded topic %s, but the broker %d is still alive.",
-                                   proposal, proposal.topic(), brokerId));
+                                   proposal, proposal.topic(), r.brokerId()));
               }
             }
           }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/IntraBrokerRebalanceTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/IntraBrokerRebalanceTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer;
+
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.IntraBrokerDiskCapacityGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.IntraBrokerDiskUsageDistributionGoal;
+import com.linkedin.kafka.cruisecontrol.common.ClusterProperty;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
+import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUnitTestUtils;
+import com.linkedin.kafka.cruisecontrol.common.TestConstants;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import com.linkedin.kafka.cruisecontrol.model.RandomCluster;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static com.linkedin.kafka.cruisecontrol.analyzer.OptimizationVerifier.Verification.*;
+import static com.linkedin.kafka.cruisecontrol.common.DeterministicCluster.*;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Unit test for testing with intra-broker rebalance goals using various random clusters.
+ */
+@RunWith(Parameterized.class)
+public class IntraBrokerRebalanceTest {
+
+  private int _testId;
+  private Map<ClusterProperty, Number> _modifiedProperties;
+  private List<String> _goalNameByPriority;
+  private BalancingConstraint _balancingConstraint;
+  private Set<String> _excludedTopics;
+  private List<OptimizationVerifier.Verification> _verifications;
+
+  /**
+   * Constructor of Self Healing Test.
+   *
+   * @param testId Test id.
+   * @param modifiedProperties Modified cluster properties over the {@link TestConstants#BASE_PROPERTIES}.
+   * @param goalNameByPriority Goal name by priority.
+   * @param balancingConstraint Balancing constraint.
+   * @param excludedTopics Excluded topics.
+   * @param verifications the verifications to make.
+   */
+  public IntraBrokerRebalanceTest(int testId,
+                                  Map<ClusterProperty, Number> modifiedProperties,
+                                  List<String> goalNameByPriority,
+                                  BalancingConstraint balancingConstraint,
+                                  Collection<String> excludedTopics,
+                                  List<OptimizationVerifier.Verification> verifications) {
+    _testId = testId;
+    _modifiedProperties = modifiedProperties;
+    _goalNameByPriority = goalNameByPriority;
+    _balancingConstraint = balancingConstraint;
+    _excludedTopics = new HashSet<>(excludedTopics);
+    _verifications = verifications;
+  }
+
+  @Test
+  public void test() throws Exception {
+    // Create cluster properties by applying modified properties to base properties.
+    Map<ClusterProperty, Number> clusterProperties = new HashMap<>(TestConstants.BASE_PROPERTIES);
+    clusterProperties.putAll(_modifiedProperties);
+
+    ClusterModel clusterModel = RandomCluster.generate(clusterProperties);
+    RandomCluster.populate(clusterModel, clusterProperties, TestConstants.Distribution.UNIFORM, true,
+                          true, _excludedTopics);
+
+    assertTrue("Goals failed to optimize cluster.",
+               OptimizationVerifier.executeGoalsFor(_balancingConstraint, clusterModel, _goalNameByPriority,
+                                                    _excludedTopics, _verifications));
+
+  }
+
+  private static Object[] params(int testId,
+                                 Map<ClusterProperty, Number> modifiedProperties,
+                                 List<String> goalNameByPriority,
+                                 BalancingConstraint balancingConstraint,
+                                 Collection<String> excludedTopics,
+                                 List<OptimizationVerifier.Verification> verifications) {
+    return new Object[]{testId, modifiedProperties, goalNameByPriority, balancingConstraint, excludedTopics, verifications};
+  }
+
+  /**
+   * Populate parameters for the {@link OptimizationVerifier}.
+   *
+   * @return Parameters for the {@link OptimizationVerifier}.
+   */
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    Collection<Object[]> p = new ArrayList<>();
+    List<String> goalNameByPriority = Arrays.asList(IntraBrokerDiskCapacityGoal.class.getName(),
+                                                    IntraBrokerDiskUsageDistributionGoal.class.getName());
+    Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
+    props.setProperty(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(2000L));
+    BalancingConstraint balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
+    balancingConstraint.setResourceBalancePercentage(TestConstants.LOW_BALANCE_PERCENTAGE);
+    balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);
+    List<OptimizationVerifier.Verification> verifications = Arrays.asList(GOAL_VIOLATION, REGRESSION);
+
+    int testId = 0;
+    // -- TEST DECK #1: HEALTHY CLUSTER.
+    List<String> testGoal;
+    Map<ClusterProperty, Number> jbodCluster = new HashMap<>();
+    jbodCluster.put(ClusterProperty.POPULATE_REPLICA_PLACEMENT_INFO, 1);
+    // Test: Single Goal.
+    for (int i = 0; i < goalNameByPriority.size(); i++) {
+      testGoal = goalNameByPriority.subList(i, i + 1);
+      p.add(params(testId++, jbodCluster, testGoal, balancingConstraint, Collections.emptySet(), verifications));
+    }
+    // Test: Multiple Goals.
+    p.add(params(testId++, jbodCluster, goalNameByPriority, balancingConstraint, Collections.emptySet(), verifications));
+
+    // -- TEST DECK #2: CLUSTER WITH DEAD&BROKER BROKER.
+    Set<String> excludedTopics = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(T1, T2)));
+    // Test: Single Goal.
+    for (int i = 0; i < goalNameByPriority.size(); i++) {
+      testGoal = goalNameByPriority.subList(i, i + 1);
+      p.add(params(testId++, jbodCluster, testGoal, balancingConstraint, excludedTopics, verifications));
+    }
+    // Test: Multiple Goals.
+    p.add(params(testId++, jbodCluster, goalNameByPriority, balancingConstraint, excludedTopics, verifications));
+
+    // -- TEST DECK #3: CLUSTER WITH EXCLUDED TOPIC.
+    Map<ClusterProperty, Number> unhealthyCluster = new HashMap<>();
+    unhealthyCluster.put(ClusterProperty.POPULATE_REPLICA_PLACEMENT_INFO, 1);
+    unhealthyCluster.put(ClusterProperty.NUM_BROKERS_WITH_BAD_DISK, 5);
+    unhealthyCluster.put(ClusterProperty.NUM_DEAD_BROKERS, 5);
+    // Test: Single Goal.
+    for (int i = 0; i < goalNameByPriority.size(); i++) {
+      testGoal = goalNameByPriority.subList(i, i + 1);
+      p.add(params(testId++, unhealthyCluster, testGoal, balancingConstraint, Collections.emptySet(), verifications));
+    }
+    // Test: Multiple Goal.
+    p.add(params(testId++, unhealthyCluster, goalNameByPriority, balancingConstraint, Collections.emptySet(), verifications));
+
+    return p;
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
@@ -201,7 +201,7 @@ public class RandomClusterTest {
       }
 
       BrokerCapacityInfo brokerCapacityInfo = new BrokerCapacityInfo(brokerCapacity);
-      clusterWithNewBroker.createBroker(b.rack().id(), Integer.toString(b.id()), b.id(), brokerCapacityInfo);
+      clusterWithNewBroker.createBroker(b.rack().id(), Integer.toString(b.id()), b.id(), brokerCapacityInfo, false);
     }
 
     for (Map.Entry<String, List<Partition>> entry : clusterModel.getPartitionsByTopic().entrySet()) {
@@ -227,7 +227,8 @@ public class RandomClusterTest {
       clusterWithNewBroker.createBroker(Integer.toString(i),
                                         Integer.toString(i + clusterModel.brokers().size() - 1),
                                         i + clusterModel.brokers().size() - 1,
-                                        commonBrokerCapacityInfo);
+                                        commonBrokerCapacityInfo,
+                                        false);
       clusterWithNewBroker.setBrokerState(i + clusterModel.brokers().size() - 1, Broker.State.NEW);
     }
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoalTest.java
@@ -227,10 +227,10 @@ public class KafkaAssignerDiskUsageDistributionGoalTest {
     BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY);
     int i = 0;
     for (; i < 2; i++) {
-      clusterModel.createBroker("r0", "h" + i, i, commonBrokerCapacityInfo);
+      clusterModel.createBroker("r0", "h" + i, i, commonBrokerCapacityInfo, false);
     }
     for (int j = 1; j < numRacks; j++, i++) {
-      clusterModel.createBroker("r" + j, "h" + i, i, commonBrokerCapacityInfo);
+      clusterModel.createBroker("r" + j, "h" + i, i, commonBrokerCapacityInfo, false);
     }
 
     clusterModel.createReplica("r0", 0, T0P0, 0, true);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/ClusterProperty.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/ClusterProperty.java
@@ -16,7 +16,8 @@ public enum ClusterProperty {
   MEAN_CPU("meanCpu"),
   MEAN_DISK("meanDisk"),
   MEAN_NW_IN("meanNwIn"),
-  MEAN_NW_OUT("meanNwOut");
+  MEAN_NW_OUT("meanNwOut"),
+  POPULATE_REPLICA_PLACEMENT_INFO("populateReplicaPlacementInfo");
 
   private final String _clusterProperty;
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/DeterministicCluster.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/DeterministicCluster.java
@@ -371,7 +371,7 @@ public class DeterministicCluster {
     BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(brokerCapacity);
     // Create brokers and assign a broker to each rack.
     rackByBroker.forEach(
-        (key, value) -> cluster.createBroker(value.toString(), Integer.toString(key), key, commonBrokerCapacityInfo));
+        (key, value) -> cluster.createBroker(value.toString(), Integer.toString(key), key, commonBrokerCapacityInfo, false));
     return cluster;
   }
 }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/TestConstants.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/TestConstants.java
@@ -66,6 +66,7 @@ public class TestConstants {
     properties.put(ClusterProperty.MEAN_DISK, 100.0);
     properties.put(ClusterProperty.MEAN_NW_IN, 100.0);
     properties.put(ClusterProperty.MEAN_NW_OUT, 100.0);
+    properties.put(ClusterProperty.POPULATE_REPLICA_PLACEMENT_INFO, 0);
     BASE_PROPERTIES = Collections.unmodifiableMap(properties);
 
   }
@@ -81,4 +82,8 @@ public class TestConstants {
     capacity.put(Resource.NW_OUT, TestConstants.MEDIUM_BROKER_CAPACITY);
     BROKER_CAPACITY = Collections.unmodifiableMap(capacity);
   }
+
+  // Broker capacity config file for test.
+  public static final String JBOD_BROKER_CAPACITY_CONFIG_FILE = "testCapacityConfigJBOD.json";
+  public static final String DEFAULT_BROKER_CAPACITY_CONFIG_FILE = "DefaultCapacityConfig.json";
 }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -151,6 +151,7 @@ public class AnomalyDetectorTest {
                                                      EasyMock.eq(true),
                                                      EasyMock.eq(null),
                                                      EasyMock.eq(null),
+                                                     EasyMock.eq(null),
                                                      EasyMock.eq(false),
                                                      EasyMock.eq(null),
                                                      EasyMock.eq(null),
@@ -159,7 +160,8 @@ public class AnomalyDetectorTest {
                                                      EasyMock.eq(true),
                                                      EasyMock.eq(false),
                                                      EasyMock.eq(true),
-                                                     EasyMock.eq(Collections.emptySet())))
+                                                     EasyMock.eq(Collections.emptySet()),
+                                                     EasyMock.eq(false)))
             .andReturn(null);
     EasyMock.expect(mockKafkaCruiseControl.meetCompletenessRequirements(EasyMock.anyObject())).andReturn(true);
 
@@ -231,6 +233,7 @@ public class AnomalyDetectorTest {
             .andReturn(new CruiseControlState(
                 ExecutorState.operationInProgress(ExecutorState.State.INTER_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS,
                                                   null,
+                                                  1,
                                                   1,
                                                   1,
                                                   null,

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionProposalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionProposalTest.java
@@ -4,20 +4,25 @@
 
 package com.linkedin.kafka.cruisecontrol.executor;
 
+import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
 import java.util.Arrays;
 import java.util.Collections;
 import org.apache.kafka.common.TopicPartition;
+import org.junit.Assert;
 import org.junit.Test;
-
 
 /**
  * Unit test for execution proposals.
  */
 public class ExecutionProposalTest {
   private static final TopicPartition TP = new TopicPartition("topic", 0);
-  private final Integer _r0 =  0;
-  private final Integer _r1 =  1;
-  private final Integer _r2 =  2;
+  private final ReplicaPlacementInfo _r0 =  new ReplicaPlacementInfo(0);
+  private final ReplicaPlacementInfo _r1 =  new ReplicaPlacementInfo(1);
+  private final ReplicaPlacementInfo _r2 =  new ReplicaPlacementInfo(2);
+
+  private final ReplicaPlacementInfo _r0d0 =  new ReplicaPlacementInfo(0, "tmp0");
+  private final ReplicaPlacementInfo _r0d1 =  new ReplicaPlacementInfo(0, "tmp1");
+  private final ReplicaPlacementInfo _r1d1 =  new ReplicaPlacementInfo(1, "tmp1");
 
   @Test (expected = IllegalArgumentException.class)
   public void testNullNewReplicaList() {
@@ -36,6 +41,17 @@ public class ExecutionProposalTest {
 
   @Test (expected = IllegalArgumentException.class)
   public void testOldLeaderMissingFromOldReplicas() {
-    new ExecutionProposal(TP, 0, _r2, Arrays.asList(_r0, _r1), Arrays.asList(_r2, _r2));
+    new ExecutionProposal(TP, 0, _r2, Arrays.asList(_r0, _r1), Arrays.asList(_r1, _r2));
+  }
+
+  @Test
+  public void testIntraBrokerReplicaMovements() {
+    ExecutionProposal p = new ExecutionProposal(TP, 0, _r0d0, Arrays.asList(_r0d0, _r1d1), Arrays.asList(_r0d1, _r1d1));
+    Assert.assertEquals(1, p.replicasToMoveBetweenDisksByBroker().size());
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testMingleReplicaMovements() {
+    new ExecutionProposal(TP, 0, _r0d0, Arrays.asList(_r0d0, _r1), Arrays.asList(_r0d1, _r2));
   }
 }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskManagerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskManagerTest.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.executor;
 
 import com.codahale.metrics.MetricRegistry;
+import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -42,8 +43,8 @@ public class ExecutionTaskManagerTest {
   @Test
   public void testStateChangeSequences() {
     TopicPartition tp = new TopicPartition("topic", 0);
-    ExecutionTaskManager taskManager = new ExecutionTaskManager(1, 1,
-                                                                null, new MetricRegistry(), new SystemTime());
+    ExecutionTaskManager taskManager = new ExecutionTaskManager(1, 1, 1,
+                                                                null, null, new MetricRegistry(), new SystemTime());
 
     List<List<ExecutionTask.State>> testSequences = new ArrayList<>();
     // Completed successfully.
@@ -55,9 +56,9 @@ public class ExecutionTaskManagerTest {
     // Cannot rollback.
     testSequences.add(Arrays.asList(IN_PROGRESS, DEAD));
 
-    Integer r0 = 0;
-    Integer r1 = 1;
-    Integer r2 = 2;
+    ReplicaPlacementInfo r0 = new ReplicaPlacementInfo(0);
+    ReplicaPlacementInfo r1 = new ReplicaPlacementInfo(1);
+    ReplicaPlacementInfo r2 = new ReplicaPlacementInfo(2);
     for (List<ExecutionTask.State> sequence : testSequences) {
       taskManager.clear();
       // Make sure the proposal does not involve leader movement.
@@ -70,6 +71,7 @@ public class ExecutionTaskManagerTest {
                                         generateExpectedCluster(proposal, tp),
                                         null);
       taskManager.setRequestedInterBrokerPartitionMovementConcurrency(null);
+      taskManager.setRequestedIntraBrokerPartitionMovementConcurrency(null);
       taskManager.setRequestedLeadershipMovementConcurrency(null);
       List<ExecutionTask> tasks = taskManager.getInterBrokerReplicaMovementTasks();
       assertEquals(1, tasks.size());

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlannerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlannerTest.java
@@ -8,11 +8,17 @@ import com.linkedin.kafka.cruisecontrol.executor.strategy.BaseReplicaMovementStr
 import com.linkedin.kafka.cruisecontrol.executor.strategy.PostponeUrpReplicaMovementStrategy;
 import com.linkedin.kafka.cruisecontrol.executor.strategy.PrioritizeLargeReplicaMovementStrategy;
 import com.linkedin.kafka.cruisecontrol.executor.strategy.PrioritizeSmallReplicaMovementStrategy;
+import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult;
 import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
@@ -22,20 +28,25 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.kafka.common.TopicPartitionReplica;
+import org.easymock.EasyMock;
 import org.junit.Test;
 
+import static org.apache.kafka.common.KafkaFuture.completedFuture;
+import static org.easymock.EasyMock.anyObject;
 import static org.junit.Assert.assertEquals;
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC1;
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC2;
+import static org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult.ReplicaLogDirInfo;
 
 /**
  * Unit test class for execution task planner
  */
 public class ExecutionTaskPlannerTest {
-  private Integer _r0 = 0;
-  private Integer _r1 = 1;
-  private Integer _r2 = 2;
-  private Integer _r3 = 3;
+  private ReplicaPlacementInfo _r0 = new ReplicaPlacementInfo(0);
+  private ReplicaPlacementInfo _r1 = new ReplicaPlacementInfo(1);
+  private ReplicaPlacementInfo _r2 = new ReplicaPlacementInfo(2);
+  private ReplicaPlacementInfo _r3 = new ReplicaPlacementInfo(3);
 
   private final ExecutionProposal _leaderMovement1 =
       new ExecutionProposal(new TopicPartition(TOPIC1, 0), 0, _r1, Arrays.asList(_r1, _r0), Arrays.asList(_r0, _r1));
@@ -55,10 +66,10 @@ public class ExecutionTaskPlannerTest {
   private final ExecutionProposal _partitionMovement4 =
       new ExecutionProposal(new TopicPartition(TOPIC2, 3), 1, _r3, Arrays.asList(_r3, _r2), Arrays.asList(_r2, _r0));
 
-  private final List<Node> _expectedNodes = new ArrayList<>(Arrays.asList(new Node(0, "null", -1),
-                                                                          new Node(1, "null", -1),
-                                                                          new Node(2, "null", -1),
-                                                                          new Node(3, "null", -1)));
+  private final List<Node> _expectedNodes = Arrays.asList(new Node(0, "null", -1),
+                                                          new Node(1, "null", -1),
+                                                          new Node(2, "null", -1),
+                                                          new Node(3, "null", -1));
 
   @Test
   public void testGetLeaderMovementTasks() {
@@ -67,7 +78,7 @@ public class ExecutionTaskPlannerTest {
     proposals.add(_leaderMovement2);
     proposals.add(_leaderMovement3);
     proposals.add(_leaderMovement4);
-    ExecutionTaskPlanner planner = new ExecutionTaskPlanner(Collections.emptyList());
+    ExecutionTaskPlanner planner = new ExecutionTaskPlanner(null, Collections.emptyList());
 
     Set<PartitionInfo> partitions = new HashSet<>();
     for (ExecutionProposal proposal : proposals) {
@@ -103,11 +114,14 @@ public class ExecutionTaskPlannerTest {
     proposals.add(_partitionMovement3);
     proposals.add(_partitionMovement4);
     // Test different execution strategies.
-    ExecutionTaskPlanner basePlanner = new ExecutionTaskPlanner(null);
-    ExecutionTaskPlanner postponeUrpPlanner = new ExecutionTaskPlanner(Collections.singletonList(PostponeUrpReplicaMovementStrategy.class.getName()));
-    ExecutionTaskPlanner prioritizeLargeMovementPlanner = new ExecutionTaskPlanner(Arrays.asList(PrioritizeLargeReplicaMovementStrategy.class.getName(),
+    ExecutionTaskPlanner basePlanner = new ExecutionTaskPlanner(null, null);
+    ExecutionTaskPlanner postponeUrpPlanner = new ExecutionTaskPlanner(null,
+                                                                       Collections.singletonList(PostponeUrpReplicaMovementStrategy.class.getName()));
+    ExecutionTaskPlanner prioritizeLargeMovementPlanner = new ExecutionTaskPlanner(null,
+                                                                                   Arrays.asList(PrioritizeLargeReplicaMovementStrategy.class.getName(),
                                                                                                  BaseReplicaMovementStrategy.class.getName()));
-    ExecutionTaskPlanner prioritizeSmallMovementPlanner = new ExecutionTaskPlanner(Arrays.asList(PrioritizeSmallReplicaMovementStrategy.class.getName(),
+    ExecutionTaskPlanner prioritizeSmallMovementPlanner = new ExecutionTaskPlanner(null,
+                                                                                   Arrays.asList(PrioritizeSmallReplicaMovementStrategy.class.getName(),
                                                                                                  BaseReplicaMovementStrategy.class.getName()));
 
     Set<PartitionInfo> partitions = new HashSet<>();
@@ -116,11 +130,7 @@ public class ExecutionTaskPlannerTest {
     partitions.add(generatePartitionInfo(_partitionMovement3, true));
     partitions.add(generatePartitionInfo(_partitionMovement4, false));
 
-    Cluster expectedCluster = new Cluster(null,
-                                          _expectedNodes,
-                                          partitions,
-                                          Collections.<String>emptySet(),
-                                          Collections.<String>emptySet());
+    Cluster expectedCluster = new Cluster(null, _expectedNodes, partitions, Collections.<String>emptySet(), Collections.<String>emptySet());
 
     Map<Integer, Integer> readyBrokers = new HashMap<>();
     readyBrokers.put(0, 8);
@@ -159,7 +169,7 @@ public class ExecutionTaskPlannerTest {
     proposals.add(_partitionMovement2);
     proposals.add(_partitionMovement3);
     proposals.add(_partitionMovement4);
-    ExecutionTaskPlanner planner = new ExecutionTaskPlanner(null);
+    ExecutionTaskPlanner planner = new ExecutionTaskPlanner(null, null);
 
     Set<PartitionInfo> partitions = new HashSet<>();
     partitions.add(generatePartitionInfo(_partitionMovement1, true));
@@ -167,11 +177,7 @@ public class ExecutionTaskPlannerTest {
     partitions.add(generatePartitionInfo(_partitionMovement3, true));
     partitions.add(generatePartitionInfo(_partitionMovement4, false));
 
-    Cluster expectedCluster = new Cluster(null,
-                                          _expectedNodes,
-                                          partitions,
-                                          Collections.<String>emptySet(),
-                                          Collections.<String>emptySet());
+    Cluster expectedCluster = new Cluster(null, _expectedNodes, partitions, Collections.<String>emptySet(), Collections.<String>emptySet());
 
     Map<Integer, Integer> readyBrokers = new HashMap<>();
     readyBrokers.put(0, 8);
@@ -201,6 +207,67 @@ public class ExecutionTaskPlannerTest {
     assertEquals("First task should be partitionMovement4", _partitionMovement4, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task should be partitionMovement2", _partitionMovement2, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task should be partitionMovement1", _partitionMovement1, partitionMovementTasks.get(2).proposal());
+
+  }
+
+  @Test
+  public void testGetIntraBrokerPartitionMovementTasks() {
+    ReplicaPlacementInfo r0d0 = new ReplicaPlacementInfo(0, "d0");
+    ReplicaPlacementInfo r0d1 = new ReplicaPlacementInfo(0, "d1");
+    ReplicaPlacementInfo r1d0 = new ReplicaPlacementInfo(1, "d0");
+    ReplicaPlacementInfo r1d1 = new ReplicaPlacementInfo(1, "d1");
+
+    List<ExecutionProposal> proposals = Collections.singletonList(new ExecutionProposal(new TopicPartition(TOPIC2, 0),
+                                                                                        4,
+                                                                                        r0d0,
+                                                                                        Arrays.asList(r0d0, r1d1),
+                                                                                        Arrays.asList(r1d0, r0d1)));
+
+    TopicPartitionReplica tpr0 = new TopicPartitionReplica(TOPIC2, 0, 0);
+    TopicPartitionReplica tpr1 = new TopicPartitionReplica(TOPIC2, 0, 1);
+
+    //Mock adminClient
+    AdminClient mockAdminClient = EasyMock.mock(AdminClient.class);
+    try {
+      // Reflectively set constructors from package private to public.
+      Constructor<DescribeReplicaLogDirsResult> constructor1 = DescribeReplicaLogDirsResult.class.getDeclaredConstructor(Map.class);
+      constructor1.setAccessible(true);
+      Constructor<ReplicaLogDirInfo> constructor2 =
+          ReplicaLogDirInfo.class.getDeclaredConstructor(String.class, long.class, String.class, long.class);
+      constructor2.setAccessible(true);
+
+      Map<TopicPartitionReplica, KafkaFuture<ReplicaLogDirInfo>> futureByReplica = new HashMap<>();
+      futureByReplica.put(tpr0, completedFuture(constructor2.newInstance("d0", 0L, null, -1L)));
+      futureByReplica.put(tpr1, completedFuture(constructor2.newInstance("d1", 0L, null, -1L)));
+
+      EasyMock.expect(mockAdminClient.describeReplicaLogDirs(anyObject()))
+              .andReturn(constructor1.newInstance(futureByReplica))
+              .anyTimes();
+      EasyMock.replay(mockAdminClient);
+    } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+      // Let it go.
+    }
+
+    Set<PartitionInfo> partitions = new HashSet<>();
+    Node[] isrArray = generateExpectedReplicas(proposals.get(0));
+    partitions.add(new PartitionInfo(proposals.get(0).topicPartition().topic(),
+                                     proposals.get(0).topicPartition().partition(),
+                                     isrArray[0], isrArray, isrArray));
+
+    Cluster expectedCluster = new Cluster(null,
+                                          _expectedNodes,
+                                          partitions,
+                                          Collections.<String>emptySet(),
+                                          Collections.<String>emptySet());
+
+
+    ExecutionTaskPlanner planner = new ExecutionTaskPlanner(mockAdminClient, Collections.emptyList());
+    planner.addExecutionProposals(proposals, expectedCluster, null);
+    assertEquals(1, planner.remainingLeadershipMovements().size());
+    assertEquals(2, planner.remainingIntraBrokerReplicaMovements().size());
+    planner.clear();
+    assertEquals(0, planner.remainingLeadershipMovements().size());
+    assertEquals(0, planner.remainingIntraBrokerReplicaMovements().size());
   }
 
   @Test
@@ -208,7 +275,7 @@ public class ExecutionTaskPlannerTest {
     List<ExecutionProposal> proposals = new ArrayList<>();
     proposals.add(_leaderMovement1);
     proposals.add(_partitionMovement1);
-    ExecutionTaskPlanner planner = new ExecutionTaskPlanner(Collections.emptyList());
+    ExecutionTaskPlanner planner = new ExecutionTaskPlanner(null, Collections.emptyList());
 
     Set<PartitionInfo> partitions = new HashSet<>();
 
@@ -232,8 +299,8 @@ public class ExecutionTaskPlannerTest {
   private Node[] generateExpectedReplicas(ExecutionProposal proposal) {
     int i = 0;
     Node[] expectedProposalReplicas = new Node[proposal.oldReplicas().size()];
-    for (Integer oldId: proposal.oldReplicas()) {
-      expectedProposalReplicas[i++] = new Node(oldId, "null", -1);
+    for (ReplicaPlacementInfo oldId: proposal.oldReplicas()) {
+      expectedProposalReplicas[i++] = new Node(oldId.brokerId(), "null", -1);
     }
     return expectedProposalReplicas;
   }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -10,6 +10,7 @@ import com.linkedin.kafka.cruisecontrol.common.MetadataClient;
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityConfigFileResolver;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaIntegrationTestHarness;
+import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
 import com.linkedin.kafka.cruisecontrol.monitor.LoadMonitor;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.NoopSampler;
 import java.util.Arrays;
@@ -46,7 +47,6 @@ import static org.junit.Assert.fail;
 
 
 public class ExecutorTest extends CCKafkaIntegrationTestHarness {
-  private static final long ZK_UTILS_CLOSE_TIMEOUT_MS = 10000L;
   private static final int PARTITION = 0;
   private static final TopicPartition TP0 = new TopicPartition(TOPIC0, PARTITION);
   private static final TopicPartition TP1 = new TopicPartition(TOPIC1, PARTITION);
@@ -80,14 +80,18 @@ public class ExecutorTest extends CCKafkaIntegrationTestHarness {
       int initialLeader1 = topicDescriptions.get(TOPIC1).partitions().get(0).leader().id();
 
       ExecutionProposal proposal0 =
-          new ExecutionProposal(TP0, 0, initialLeader0,
-                                Collections.singletonList(initialLeader0),
-                                Collections.singletonList(initialLeader0 == 0 ? 1 : 0));
+          new ExecutionProposal(TP0, 0, new ReplicaPlacementInfo(initialLeader0),
+                                Collections.singletonList(new ReplicaPlacementInfo(initialLeader0)),
+                                Collections.singletonList(initialLeader0 == 0 ? new ReplicaPlacementInfo(1) :
+                                                                                new ReplicaPlacementInfo(0)));
       ExecutionProposal proposal1 =
-          new ExecutionProposal(TP1, 0, initialLeader1,
-                                Arrays.asList(initialLeader1, initialLeader1 == 0 ? 1 : 0),
-                                Arrays.asList(initialLeader1 == 0 ? 1 : 0, initialLeader1));
-
+          new ExecutionProposal(TP1, 0, new ReplicaPlacementInfo(initialLeader1),
+                               Arrays.asList(new ReplicaPlacementInfo(initialLeader1),
+                                             initialLeader1 == 0 ? new ReplicaPlacementInfo(1) :
+                                                                   new ReplicaPlacementInfo(0)),
+                               Arrays.asList(initialLeader1 == 0 ? new ReplicaPlacementInfo(1) :
+                                                                   new ReplicaPlacementInfo(0),
+                                             new ReplicaPlacementInfo(initialLeader1)));
       Collection<ExecutionProposal> proposals = Arrays.asList(proposal0, proposal1);
       executeAndVerifyProposals(kafkaZkClient, proposals, proposals);
     } finally {
@@ -106,21 +110,31 @@ public class ExecutorTest extends CCKafkaIntegrationTestHarness {
       int initialLeader1 = topicDescriptions.get(TOPIC1).partitions().get(0).leader().id();
 
       ExecutionProposal proposal0 =
-          new ExecutionProposal(TP0, 0, initialLeader0,
-                                Collections.singletonList(initialLeader0),
-                                Collections.singletonList(initialLeader0 == 0 ? 1 : 0));
+          new ExecutionProposal(TP0, 0, new ReplicaPlacementInfo(initialLeader0),
+                                Collections.singletonList(new ReplicaPlacementInfo(initialLeader0)),
+                                Collections.singletonList(initialLeader0 == 0 ? new ReplicaPlacementInfo(1) :
+                                                                                new ReplicaPlacementInfo(0)));
       ExecutionProposal proposal1 =
-          new ExecutionProposal(TP1, 0, initialLeader1,
-                                Arrays.asList(initialLeader1, initialLeader1 == 0 ? 1 : 0),
-                                Arrays.asList(initialLeader1 == 0 ? 1 : 0, initialLeader1));
+          new ExecutionProposal(TP1, 0, new ReplicaPlacementInfo(initialLeader1),
+                                Arrays.asList(new ReplicaPlacementInfo(initialLeader1),
+                                              initialLeader1 == 0 ? new ReplicaPlacementInfo(1) :
+                                                                    new ReplicaPlacementInfo(0)),
+                                Arrays.asList(initialLeader1 == 0 ? new ReplicaPlacementInfo(1) :
+                                                                    new ReplicaPlacementInfo(0),
+                                              new ReplicaPlacementInfo(initialLeader1)));
       ExecutionProposal proposal2 =
-          new ExecutionProposal(TP2, 0, initialLeader0,
-                                Collections.singletonList(initialLeader0),
-                                Collections.singletonList(initialLeader0 == 0 ? 1 : 0));
+          new ExecutionProposal(TP2, 0, new ReplicaPlacementInfo(initialLeader0),
+                                Collections.singletonList(new ReplicaPlacementInfo(initialLeader0)),
+                                Collections.singletonList(initialLeader0 == 0 ? new ReplicaPlacementInfo(1) :
+                                                                                new ReplicaPlacementInfo(0)));
       ExecutionProposal proposal3 =
-          new ExecutionProposal(TP3, 0, initialLeader1,
-                                Arrays.asList(initialLeader1, initialLeader1 == 0 ? 1 : 0),
-                                Arrays.asList(initialLeader1 == 0 ? 1 : 0, initialLeader1));
+          new ExecutionProposal(TP3, 0, new ReplicaPlacementInfo(initialLeader1),
+                                Arrays.asList(new ReplicaPlacementInfo(initialLeader1),
+                                              initialLeader1 == 0 ? new ReplicaPlacementInfo(1) :
+                                                                    new ReplicaPlacementInfo(0)),
+                                Arrays.asList(initialLeader1 == 0 ? new ReplicaPlacementInfo(1) :
+                                                                    new ReplicaPlacementInfo(0),
+                                              new ReplicaPlacementInfo(initialLeader1)));
 
       Collection<ExecutionProposal> proposalsToExecute = Arrays.asList(proposal0, proposal1, proposal2, proposal3);
       Collection<ExecutionProposal> proposalsToCheck = Arrays.asList(proposal0, proposal1);
@@ -142,13 +156,18 @@ public class ExecutorTest extends CCKafkaIntegrationTestHarness {
 
       _brokers.get(initialLeader0 == 0 ? 1 : 0).shutdown();
       ExecutionProposal proposal0 =
-          new ExecutionProposal(TP0, 0, initialLeader0,
-                                Collections.singletonList(initialLeader0),
-                                Collections.singletonList(initialLeader0 == 0 ? 1 : 0));
+          new ExecutionProposal(TP0, 0, new ReplicaPlacementInfo(initialLeader0),
+                                Collections.singletonList(new ReplicaPlacementInfo(initialLeader0)),
+                                Collections.singletonList(initialLeader0 == 0 ? new ReplicaPlacementInfo(1) :
+                                                                                new ReplicaPlacementInfo(0)));
       ExecutionProposal proposal1 =
-          new ExecutionProposal(TP1, 0, initialLeader1,
-                                Arrays.asList(initialLeader1, initialLeader1 == 0 ? 1 : 0),
-                                Arrays.asList(initialLeader1 == 0 ? 1 : 0, initialLeader1));
+          new ExecutionProposal(TP1, 0, new ReplicaPlacementInfo(initialLeader1),
+                                Arrays.asList(new ReplicaPlacementInfo(initialLeader1),
+                                              initialLeader1 == 0 ? new ReplicaPlacementInfo(1) :
+                                                                    new ReplicaPlacementInfo(0)),
+                                Arrays.asList(initialLeader1 == 0 ? new ReplicaPlacementInfo(1) :
+                                                                    new ReplicaPlacementInfo(0),
+                                              new ReplicaPlacementInfo(initialLeader1)));
 
       Collection<ExecutionProposal> proposalsToExecute = Arrays.asList(proposal0, proposal1);
       executeAndVerifyProposals(kafkaZkClient, proposalsToExecute, Collections.emptyList());
@@ -168,7 +187,9 @@ public class ExecutorTest extends CCKafkaIntegrationTestHarness {
     // The proposal tries to move the leader. We fake the replica list to be unchanged so there is no replica
     // movement, but only leader movement.
     ExecutionProposal proposal =
-        new ExecutionProposal(TP1, 0, 1, Arrays.asList(0, 1), Arrays.asList(0, 1));
+        new ExecutionProposal(TP1, 0, new ReplicaPlacementInfo(1),
+                              Arrays.asList(new ReplicaPlacementInfo(0), new ReplicaPlacementInfo(1)),
+                              Arrays.asList(new ReplicaPlacementInfo(0), new ReplicaPlacementInfo(1)));
 
     KafkaCruiseControlConfig configs = new KafkaCruiseControlConfig(getExecutorProperties());
     Time time = new MockTime();
@@ -194,6 +215,7 @@ public class ExecutorTest extends CCKafkaIntegrationTestHarness {
                               Collections.emptySet(),
                               null,
                               EasyMock.mock(LoadMonitor.class),
+                              null,
                               null,
                               null,
                               null,
@@ -255,7 +277,7 @@ public class ExecutorTest extends CCKafkaIntegrationTestHarness {
     Executor executor = new Executor(configs, new SystemTime(), new MetricRegistry(), 86400000L, 43200000L);
     executor.setExecutionMode(false);
     executor.executeProposals(proposalsToExecute, Collections.emptySet(), null, EasyMock.mock(LoadMonitor.class), null,
-                              null, null, "random-uuid");
+                              null, null, null, "random-uuid");
 
     Map<TopicPartition, Integer> replicationFactors = new HashMap<>();
     for (ExecutionProposal proposal : proposalsToCheck) {
@@ -273,13 +295,13 @@ public class ExecutorTest extends CCKafkaIntegrationTestHarness {
                    expectedReplicationFactor, kafkaZkClient.getReplicasForPartition(tp).size());
 
       if (proposal.hasReplicaAction()) {
-        for (int brokerId : proposal.newReplicas()) {
+        for (ReplicaPlacementInfo r : proposal.newReplicas()) {
           assertTrue("The partition should have moved for " + tp,
-                     kafkaZkClient.getReplicasForPartition(tp).contains(brokerId));
+                     kafkaZkClient.getReplicasForPartition(tp).contains(r.brokerId()));
         }
       }
       assertEquals("The leader should have moved for " + tp,
-                   proposal.newLeader(), kafkaZkClient.getLeaderForPartition(tp).get());
+                   proposal.newLeader().brokerId(), kafkaZkClient.getLeaderForPartition(tp).get());
 
     }
   }

--- a/cruise-control/src/test/resources/testCapacityConfigJBOD.json
+++ b/cruise-control/src/test/resources/testCapacityConfigJBOD.json
@@ -33,7 +33,8 @@
     {
       "brokerId": "2",
       "capacity": {
-        "DISK": "2000000",
+        "DISK": {"/tmp/kafka-logs-1": "350000", "/tmp/kafka-logs-2": "550000", "/tmp/kafka-logs-3": "750000",
+                 "/tmp/kafka-logs-4": "950000"},
         "CPU": "300",
         "NW_IN": "300000",
         "NW_OUT": "200000"


### PR DESCRIPTION
* Add replica placement over disk information to cluster model. (address [issue 572](https://github.com/linkedin/cruise-control/issues/572))

* Add IntraBrokerDiskCapacityGoal and IntraBrokerDiskUsageDistributionGoal to support rebalance over disks within the broker. (address issue [573](https://github.com/linkedin/cruise-control/issues/573))
 
* Add Executor support to execute Execution task to move replica across disk within the same broker(address issue [577](https://github.com/linkedin/cruise-control/issues/577))

* Add a new parameter,`rebalance_disk` to `proposals` and `rebalance` servelet endpoint to access the new functionality(address issue [586](https://github.com/linkedin/cruise-control/issues/586))