### PR TITLE
Add acceptable staleness lags for model generation to avoid aggressive invalidation of cached rebalance cache

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
@@ -267,8 +267,7 @@ public class GoalOptimizer implements Runnable {
 
   private boolean validCachedProposal() {
     synchronized (_cacheLock) {
-      return _bestProposal != null
-             && _bestProposal.modelGeneration().equals(_loadMonitor.clusterModelGeneration());
+      return _bestProposal != null && !_bestProposal.modelGeneration().isStale(_loadMonitor.clusterModelGeneration());
     }
   }
 
@@ -368,7 +367,10 @@ public class GoalOptimizer implements Runnable {
           }
         }
       }
-      LOG.debug("Returning optimization result from cache. Cached generation: {}", _bestProposal.modelGeneration());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Returning optimization result from cache. Model generation (cached: {}, current: {}).",
+                  _bestProposal.modelGeneration(), _loadMonitor.clusterModelGeneration());
+      }
       // If the cached proposals are estimated, and the user requested for no estimation, we invalidate the cache and
       // calculate best proposals just once. If the returned result still involves an estimation, throw an exception.
       KafkaCruiseControl.sanityCheckCapacityEstimation(allowCapacityEstimation, _bestProposal.capacityEstimationInfoByBrokerId());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/ModelGeneration.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/ModelGeneration.java
@@ -12,6 +12,9 @@ import java.io.Serializable;
  */
 public class ModelGeneration implements Serializable {
   private static final long serialVersionUID = 1494955635123L;
+  // TODO: Make acceptable staleness lags configurable.
+  public static final int CLUSTER_GENERATION_ACCEPTABLE_STALENESS_LAG = 1;
+  public static final int LOAD_GENERATION_ACCEPTABLE_STALENESS_LAG = 4;
 
   private final int _clusterGeneration;
   private final long _loadGeneration;
@@ -38,6 +41,18 @@ public class ModelGeneration implements Serializable {
 
     ModelGeneration other = (ModelGeneration) o;
     return _clusterGeneration == other.clusterGeneration() && _loadGeneration == other.loadGeneration();
+  }
+
+  /**
+   * Check whether this model generation is stale. A model generation is stale if it is behind the latest model
+   * generation more than the acceptable staleness limit.
+   *
+   * @param latestModelGeneration The model generation to compare against this model generation for staleness check.
+   * @return True if this model generation is within the acceptable staleness limits, false otherwise.
+   */
+  public boolean isStale(ModelGeneration latestModelGeneration) {
+    return latestModelGeneration.clusterGeneration() - _clusterGeneration > CLUSTER_GENERATION_ACCEPTABLE_STALENESS_LAG
+        || latestModelGeneration.loadGeneration() - _loadGeneration > LOAD_GENERATION_ACCEPTABLE_STALENESS_LAG;
   }
 
   @Override


### PR DESCRIPTION
Fixes the issue https://github.com/linkedin/cruise-control/issues/488.