### PR TITLE
(1) Make goal violation exclude recently removed/demoted brokers configurable, and (2) fix incorrect check in determining excludedBrokersForReplicaMove.

### DIFF
--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -197,6 +197,12 @@ broker.failure.exclude.recently.demoted.brokers=true
 # True if recently removed brokers are excluded from optimizations during broker failure self healing, false otherwise
 broker.failure.exclude.recently.removed.brokers=true
 
+# True if recently demoted brokers are excluded from optimizations during goal violation self healing, false otherwise
+goal.violation.exclude.recently.demoted.brokers=true
+
+# True if recently removed brokers are excluded from optimizations during goal violation self healing, false otherwise
+goal.violation.exclude.recently.removed.brokers=true
+
 # The zk path to store failed broker information.
 failed.brokers.zk.path=/CruiseControlBrokerList
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -528,6 +528,20 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
       + "are excluded from optimizations during broker failure self healing, false otherwise.";
 
   /**
+   * <code>goal.violation.exclude.recently.demoted.brokers</code>
+   */
+  public static final String GOAL_VIOLATION_EXCLUDE_RECENTLY_DEMOTED_BROKERS_CONFIG = "goal.violation.exclude.recently.demoted.brokers";
+  private static final String GOAL_VIOLATION_EXCLUDE_RECENTLY_DEMOTED_BROKERS_DOC = "True if recently demoted brokers "
+      + "are excluded from optimizations during goal violation self healing, false otherwise.";
+
+  /**
+   * <code>goal.violation.exclude.recently.removed.brokers</code>
+   */
+  public static final String GOAL_VIOLATION_EXCLUDE_RECENTLY_REMOVED_BROKERS_CONFIG = "goal.violation.exclude.recently.removed.brokers";
+  private static final String GOAL_VIOLATION_EXCLUDE_RECENTLY_REMOVED_BROKERS_DOC = "True if recently removed brokers "
+      + "are excluded from optimizations during goal violation self healing, false otherwise.";
+
+  /**
    * <code>failed.brokers.zk.path</code>
    */
   public static final String FAILED_BROKERS_ZK_PATH_CONFIG = "failed.brokers.zk.path";
@@ -1106,6 +1120,16 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 true,
                 ConfigDef.Importance.MEDIUM,
                 BROKER_FAILURE_EXCLUDE_RECENTLY_REMOVED_BROKERS_DOC)
+        .define(GOAL_VIOLATION_EXCLUDE_RECENTLY_DEMOTED_BROKERS_CONFIG,
+                ConfigDef.Type.BOOLEAN,
+                true,
+                ConfigDef.Importance.MEDIUM,
+                GOAL_VIOLATION_EXCLUDE_RECENTLY_DEMOTED_BROKERS_DOC)
+        .define(GOAL_VIOLATION_EXCLUDE_RECENTLY_REMOVED_BROKERS_CONFIG,
+                ConfigDef.Type.BOOLEAN,
+                true,
+                ConfigDef.Importance.MEDIUM,
+                GOAL_VIOLATION_EXCLUDE_RECENTLY_REMOVED_BROKERS_DOC)
         .define(FAILED_BROKERS_ZK_PATH_CONFIG,
                 ConfigDef.Type.STRING,
                 DEFAULT_FAILED_BROKERS_ZK_PATH,


### PR DESCRIPTION
Addresses the issues https://github.com/linkedin/cruise-control/issues/522 and https://github.com/linkedin/cruise-control/issues/523.