### PR TITLE
Make exclusion of recently removed/demoted brokers configurable for broker failure self-healing.

### DIFF
--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -191,6 +191,12 @@ metric.anomaly.analyzer.metrics=BROKER_PRODUCE_LOCAL_TIME_MS_MAX,BROKER_PRODUCE_
 ## Adjust accordingly if your metrics reporter is an older version and does not produce these metrics.
 #metric.anomaly.analyzer.metrics=BROKER_PRODUCE_LOCAL_TIME_MS_50TH,BROKER_PRODUCE_LOCAL_TIME_MS_999TH,BROKER_CONSUMER_FETCH_LOCAL_TIME_MS_50TH,BROKER_CONSUMER_FETCH_LOCAL_TIME_MS_999TH,BROKER_FOLLOWER_FETCH_LOCAL_TIME_MS_50TH,BROKER_FOLLOWER_FETCH_LOCAL_TIME_MS_999TH,BROKER_LOG_FLUSH_TIME_MS_50TH,BROKER_LOG_FLUSH_TIME_MS_999TH
 
+# True if recently demoted brokers are excluded from optimizations during broker failure self healing, false otherwise
+broker.failure.exclude.recently.demoted.brokers=true
+
+# True if recently removed brokers are excluded from optimizations during broker failure self healing, false otherwise
+broker.failure.exclude.recently.removed.brokers=true
+
 # The zk path to store failed broker information.
 failed.brokers.zk.path=/CruiseControlBrokerList
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -514,6 +514,20 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
       + "violated.";
 
   /**
+   * <code>broker.failure.exclude.recently.demoted.brokers</code>
+   */
+  public static final String BROKER_FAILURE_EXCLUDE_RECENTLY_DEMOTED_BROKERS_CONFIG = "broker.failure.exclude.recently.demoted.brokers";
+  private static final String BROKER_FAILURE_EXCLUDE_RECENTLY_DEMOTED_BROKERS_DOC = "True if recently demoted brokers "
+      + "are excluded from optimizations during broker failure self healing, false otherwise.";
+
+  /**
+   * <code>broker.failure.exclude.recently.removed.brokers</code>
+   */
+  public static final String BROKER_FAILURE_EXCLUDE_RECENTLY_REMOVED_BROKERS_CONFIG = "broker.failure.exclude.recently.removed.brokers";
+  private static final String BROKER_FAILURE_EXCLUDE_RECENTLY_REMOVED_BROKERS_DOC = "True if recently removed brokers "
+      + "are excluded from optimizations during broker failure self healing, false otherwise.";
+
+  /**
    * <code>failed.brokers.zk.path</code>
    */
   public static final String FAILED_BROKERS_ZK_PATH_CONFIG = "failed.brokers.zk.path";
@@ -1082,6 +1096,16 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                     .add(DiskCapacityGoal.class.getName()).toString(),
                 ConfigDef.Importance.MEDIUM,
                 ANOMALY_DETECTION_GOALS_DOC)
+        .define(BROKER_FAILURE_EXCLUDE_RECENTLY_DEMOTED_BROKERS_CONFIG,
+                ConfigDef.Type.BOOLEAN,
+                true,
+                ConfigDef.Importance.MEDIUM,
+                BROKER_FAILURE_EXCLUDE_RECENTLY_DEMOTED_BROKERS_DOC)
+        .define(BROKER_FAILURE_EXCLUDE_RECENTLY_REMOVED_BROKERS_CONFIG,
+                ConfigDef.Type.BOOLEAN,
+                true,
+                ConfigDef.Importance.MEDIUM,
+                BROKER_FAILURE_EXCLUDE_RECENTLY_REMOVED_BROKERS_DOC)
         .define(FAILED_BROKERS_ZK_PATH_CONFIG,
                 ConfigDef.Type.STRING,
                 DEFAULT_FAILED_BROKERS_ZK_PATH,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailureDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailureDetector.java
@@ -36,10 +36,6 @@ import static java.util.stream.Collectors.toSet;
  */
 public class BrokerFailureDetector {
   private static final Logger LOG = LoggerFactory.getLogger(BrokerFailureDetector.class);
-  // TODO: Make this configurable.
-  private static final boolean EXCLUDE_RECENTLY_DEMOTED_BROKERS = true;
-  // TODO: Make this configurable.
-  private static final boolean EXCLUDE_RECENTLY_REMOVED_BROKERS = true;
   private static final long MAX_METADATA_WAIT_MS = 60000L;
   private final KafkaCruiseControl _kafkaCruiseControl;
   private final String _failedBrokersZkPath;
@@ -50,6 +46,8 @@ public class BrokerFailureDetector {
   private final Queue<Anomaly> _anomalies;
   private final Time _time;
   private final boolean _allowCapacityEstimation;
+  private final boolean _excludeRecentlyDemotedBrokers;
+  private final boolean _excludeRecentlyRemovedBrokers;
 
   public BrokerFailureDetector(KafkaCruiseControlConfig config,
                                LoadMonitor loadMonitor,
@@ -68,6 +66,8 @@ public class BrokerFailureDetector {
     _time = time;
     _kafkaCruiseControl = kafkaCruiseControl;
     _allowCapacityEstimation = config.getBoolean(KafkaCruiseControlConfig.ANOMALY_DETECTION_ALLOW_CAPACITY_ESTIMATION_CONFIG);
+    _excludeRecentlyDemotedBrokers = config.getBoolean(KafkaCruiseControlConfig.BROKER_FAILURE_EXCLUDE_RECENTLY_DEMOTED_BROKERS_CONFIG);
+    _excludeRecentlyRemovedBrokers = config.getBoolean(KafkaCruiseControlConfig.BROKER_FAILURE_EXCLUDE_RECENTLY_REMOVED_BROKERS_CONFIG);
   }
 
   void startDetection() {
@@ -161,8 +161,8 @@ public class BrokerFailureDetector {
       _anomalies.add(new BrokerFailures(_kafkaCruiseControl,
                                         failedBrokers,
                                         _allowCapacityEstimation,
-                                        EXCLUDE_RECENTLY_DEMOTED_BROKERS,
-                                        EXCLUDE_RECENTLY_REMOVED_BROKERS));
+                                        _excludeRecentlyDemotedBrokers,
+                                        _excludeRecentlyRemovedBrokers));
     }
   }
 


### PR DESCRIPTION
Fixes the issue https://github.com/linkedin/cruise-control/issues/525.