### PR TITLE
Make Cruise Control ignore all metric anomaly if metric.anomaly.analyzer.metrics is set to empty string.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/KafkaMetricAnomalyFinder.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/KafkaMetricAnomalyFinder.java
@@ -69,7 +69,7 @@ public class KafkaMetricAnomalyFinder extends PercentileMetricAnomalyFinder<Brok
   @SuppressWarnings("unchecked")
   public void configure(Map<String, ?> configs) {
     String interestedMetrics = (String) configs.get(CruiseControlConfig.METRIC_ANOMALY_FINDER_METRICS_CONFIG);
-    if (interestedMetrics == null || interestedMetrics.isEmpty()) {
+    if (interestedMetrics == null) {
       ((Map<String, Object>) configs).put(CruiseControlConfig.METRIC_ANOMALY_FINDER_METRICS_CONFIG, DEFAULT_METRICS);
     }
     super.configure(configs);


### PR DESCRIPTION
Currently if the config `metric.anomaly.analyzer.metrics` is set to empty string, the default list of metric anomaly will be picked up, which may not be what we want in some case. 
This patch changes `KafkaMetricAnomalyFinder`'s behavior to:
if (`metric.anomaly.analyzer.metrics` is null)
        pick up default list
else if(`metric.anomaly.analyzer.metrics` is an empty string)
       just ignore all metric anomaly
else
        pick up what is specified in this config

