### PR TITLE
Avoid IllegalStateException upon invalidating a session in a SessionKey that has already been invalidated for another SessionKey.

### DIFF
--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManagerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManagerTest.java
@@ -114,9 +114,8 @@ public class UserTaskManagerTest {
     // Test UserTaskManger can recognize the previous created task by taskId.
     userTaskManager.getOrCreateUserTask(mockHttpServletRequest3, mockHttpServletResponse3, uuid -> future, 0);
 
-
     // The 2nd request should reuse the UserTask created for the 1st request since they use the same session and send the same request.
-    Assert.assertEquals(1, userTaskManager.numActiveSessions());
+    Assert.assertEquals(1, userTaskManager.numActiveSessionKeys());
   }
 
   @Test


### PR DESCRIPTION
Fixes the issue https://github.com/linkedin/cruise-control/issues/538.