### PR TITLE
Ensure that partition_load endpoint returns the partitions ordered by peak load if requested so.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetClusterModelInRangeRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetClusterModelInRangeRunnable.java
@@ -31,7 +31,7 @@ class GetClusterModelInRangeRunnable extends OperationRunnable {
                                                                  _future.operationProgress(),
                                                                  _parameters.allowCapacityEstimation());
     int topicNameLength = clusterModel.topics().stream().mapToInt(String::length).max().orElse(20) + 5;
-    return new PartitionLoadState(clusterModel.replicasSortedByUtilization(_parameters.resource()),
+    return new PartitionLoadState(clusterModel.replicasSortedByUtilization(_parameters.resource(), _parameters.wantMaxLoad()),
                                   _parameters.wantMaxLoad(),
                                   _parameters.entries(),
                                   _parameters.partitionUpperBoundary(),

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -823,12 +823,13 @@ public class ClusterModel implements Serializable {
   /**
    * Sort the partitions in the cluster by the utilization of the given resource.
    * @param resource the resource type.
+   * @param wantMaxLoad True if the requested utilization represents the peak load, false otherwise.
    * @return a list of partitions sorted by utilization of the given resource.
    */
-  public List<Partition> replicasSortedByUtilization(Resource resource) {
+  public List<Partition> replicasSortedByUtilization(Resource resource, boolean wantMaxLoad) {
     List<Partition> partitionList = new ArrayList<>(_partitionsByTopicPartition.values());
-    partitionList.sort((o1, o2) -> Double.compare(o2.leader().load().expectedUtilizationFor(resource),
-                                                  o1.leader().load().expectedUtilizationFor(resource)));
+    partitionList.sort((o1, o2) -> Double.compare(o2.leader().load().expectedUtilizationFor(resource, wantMaxLoad),
+                                                  o1.leader().load().expectedUtilizationFor(resource, wantMaxLoad)));
     return partitionList;
   }
 


### PR DESCRIPTION
Fixes the issue https://github.com/linkedin/cruise-control/issues/540.