### PR TITLE
Fail fast if there is an ongoing execution and the user attempts to start a new execution.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -198,6 +198,7 @@ public class KafkaCruiseControl {
                                                            boolean excludeRecentlyDemotedBrokers,
                                                            boolean excludeRecentlyRemovedBrokers)
       throws KafkaCruiseControlException {
+    sanityCheckDryRun(dryRun);
     sanityCheckHardGoalPresence(goals, skipHardGoalCheck);
     List<Goal> goalsByPriority = goalsByPriority(goals);
     ModelCompletenessRequirements modelCompletenessRequirements =
@@ -282,6 +283,7 @@ public class KafkaCruiseControl {
                                                   String uuid,
                                                   boolean excludeRecentlyDemotedBrokers,
                                                   boolean excludeRecentlyRemovedBrokers) throws KafkaCruiseControlException {
+    sanityCheckDryRun(dryRun);
     sanityCheckHardGoalPresence(goals, skipHardGoalCheck);
     List<Goal> goalsByPriority = goalsByPriority(goals);
     ModelCompletenessRequirements modelCompletenessRequirements =
@@ -313,6 +315,18 @@ public class KafkaCruiseControl {
       throw kcce;
     } catch (Exception e) {
       throw new KafkaCruiseControlException(e);
+    }
+  }
+
+  /**
+   * Check if there is an ongoing execution and dryrun is false.
+   * This method helps to fail fast if a user attempts to start an execution during an ongoing execution.
+   *
+   * @param dryRun True if the request is just a dryrun, false if the intention is to start an execution.
+   */
+  private void sanityCheckDryRun(boolean dryRun) {
+    if (!dryRun && _executor.hasOngoingExecution()) {
+      throw new IllegalStateException("Cannot execute new proposals while there is an ongoing execution.");
     }
   }
 
@@ -351,6 +365,7 @@ public class KafkaCruiseControl {
                                                  boolean excludeRecentlyDemotedBrokers,
                                                  boolean excludeRecentlyRemovedBrokers,
                                                  boolean ignoreProposalCache) throws KafkaCruiseControlException {
+    sanityCheckDryRun(dryRun);
     GoalOptimizer.OptimizerResult result = getProposals(goals, requirements, operationProgress,
                                                         allowCapacityEstimation, skipHardGoalCheck,
                                                         excludedTopics, excludeRecentlyDemotedBrokers,
@@ -401,6 +416,7 @@ public class KafkaCruiseControl {
                                                      String uuid,
                                                      boolean excludeRecentlyDemotedBrokers)
       throws KafkaCruiseControlException {
+    sanityCheckDryRun(dryRun);
     PreferredLeaderElectionGoal goal = new PreferredLeaderElectionGoal(skipUrpDemotion,
                                                                        excludeFollowerDemotion,
                                                                        skipUrpDemotion ? _loadMonitor.kafkaCluster() : null);


### PR DESCRIPTION
Fixes the issue https://github.com/linkedin/cruise-control/issues/555.