### PR TITLE
Remove redundant verbose parameter

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/CruiseControlStateParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/CruiseControlStateParameters.java
@@ -15,7 +15,7 @@ import javax.servlet.http.HttpServletRequest;
  *
  * <pre>
  *    GET /kafkacruisecontrol/state?verbose=[true/false]&amp;substates=[SUBSTATES]&amp;super_verbose=[true/false]
- *    &amp;verbose=[true/false]&amp;json=[true/false]
+ *    &amp;json=[true/false]
  * </pre>
  */
 public class CruiseControlStateParameters extends AbstractParameters {


### PR DESCRIPTION
`verbose` is present twice in the docstring for this class.

Accordingly, remove the last occurrence of this parameter from the docstring.