### PR TITLE
Added log for old user tasks, executor action and self-healing action

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,7 +190,7 @@ project(':cruise-control') {
   dependencies {
     compile project(':cruise-control-metrics-reporter')
     compile project(':cruise-control-core')
-    compile "org.slf4j:slf4j-api:1.7.26"
+    compile "org.slf4j:slf4j-api:1.7.26" // TODO: Upgrade log4j to log4j2 to use async logger.
     compile "org.apache.zookeeper:zookeeper:3.4.14"
     compile "org.apache.kafka:kafka_2.11:0.11.0.2"
     compile 'org.apache.kafka:kafka-clients:0.11.0.2'

--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -14,11 +14,11 @@ log4j.appender.kafkaCruiseControlAppender.File=${kafka.logs.dir}/kafkacruisecont
 log4j.appender.kafkaCruiseControlAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.kafkaCruiseControlAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-log4j.appender.KafkaCruiseControlOperationAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.KafkaCruiseControlOperationAppender.DatePattern='.'yyyy-MM-dd
-log4j.appender.KafkaCruiseControlOperationAppender.File=${kafka.logs.dir}/kafkacruisecontrol-operation.log
-log4j.appender.KafkaCruiseControlOperationAppender.layout=org.apache.log4j.PatternLayout
-log4j.appender.KafkaCruiseControlOperationAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.operationAppender=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.operationAppender.DatePattern='.'yyyy-MM-dd
+log4j.appender.operationAppender.File=${kafka.logs.dir}/kafkacruisecontrol-operation.log
+log4j.appender.operationAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.operationAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
 log4j.appender.requestAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.requestAppender.DatePattern='.'yyyy-MM-dd-HH
@@ -29,7 +29,7 @@ log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 # Loggers
 log4j.logger.com.linkedin.kafka.cruisecontrol=INFO, kafkaCruiseControlAppender
 log4j.logger.com.linkedin.kafka.cruisecontrol.detector=INFO, kafkaCruiseControlAppender
-log4j.logger.com.linkedin.kafka.cruisecontrol.CruiseControlOperationLog=INFO, KafkaCruiseControlOperationAppender
+log4j.logger.com.linkedin.kafka.cruisecontrol.operationLog=INFO, operationAppender
 
 log4j.logger.LiKafkaCruiseControlPublicAccessLogger=DEBUG, requestAppender
 log4j.additivity.kafka.request.logger=false

--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -14,11 +14,11 @@ log4j.appender.kafkaCruiseControlAppender.File=${kafka.logs.dir}/kafkacruisecont
 log4j.appender.kafkaCruiseControlAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.kafkaCruiseControlAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-log4j.appender.KafkaCruiseControlResultAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.KafkaCruiseControlResultAppender.DatePattern='.'yyyy-MM-dd
-log4j.appender.KafkaCruiseControlResultAppender.File=${kafka.logs.dir}/kafkacruisecontrol-result.log
-log4j.appender.KafkaCruiseControlResultAppender.layout=org.apache.log4j.PatternLayout
-log4j.appender.KafkaCruiseControlResultAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.KafkaCruiseControlOperationAppender=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.KafkaCruiseControlOperationAppender.DatePattern='.'yyyy-MM-dd
+log4j.appender.KafkaCruiseControlOperationAppender.File=${kafka.logs.dir}/kafkacruisecontrol-operation.log
+log4j.appender.KafkaCruiseControlOperationAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.KafkaCruiseControlOperationAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
 log4j.appender.requestAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.requestAppender.DatePattern='.'yyyy-MM-dd-HH
@@ -29,7 +29,7 @@ log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 # Loggers
 log4j.logger.com.linkedin.kafka.cruisecontrol=INFO, kafkaCruiseControlAppender
 log4j.logger.com.linkedin.kafka.cruisecontrol.detector=INFO, kafkaCruiseControlAppender
-log4j.logger.com.linkedin.kafka.cruisecontrol.CruiseControlResultLog=INFO, KafkaCruiseControlResultAppender
+log4j.logger.com.linkedin.kafka.cruisecontrol.CruiseControlOperationLog=INFO, KafkaCruiseControlOperationAppender
 
 log4j.logger.LiKafkaCruiseControlPublicAccessLogger=DEBUG, requestAppender
 log4j.additivity.kafka.request.logger=false

--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -14,6 +14,12 @@ log4j.appender.kafkaCruiseControlAppender.File=${kafka.logs.dir}/kafkacruisecont
 log4j.appender.kafkaCruiseControlAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.kafkaCruiseControlAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
+log4j.appender.KafkaCruiseControlResultAppender=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.KafkaCruiseControlResultAppender.DatePattern='.'yyyy-MM-dd
+log4j.appender.KafkaCruiseControlResultAppender.File=${kafka.logs.dir}/kafkacruisecontrol-result.log
+log4j.appender.KafkaCruiseControlResultAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.KafkaCruiseControlResultAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
 log4j.appender.requestAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.requestAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.requestAppender.File=${kafka.logs.dir}/kafkacruisecontrol-request.log
@@ -23,6 +29,7 @@ log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 # Loggers
 log4j.logger.com.linkedin.kafka.cruisecontrol=INFO, kafkaCruiseControlAppender
 log4j.logger.com.linkedin.kafka.cruisecontrol.detector=INFO, kafkaCruiseControlAppender
+log4j.logger.com.linkedin.kafka.cruisecontrol.CruiseControlResultLog=INFO, KafkaCruiseControlResultAppender
 
 log4j.logger.LiKafkaCruiseControlPublicAccessLogger=DEBUG, requestAppender
 log4j.additivity.kafka.request.logger=false

--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -29,7 +29,7 @@ log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 # Loggers
 log4j.logger.com.linkedin.kafka.cruisecontrol=INFO, kafkaCruiseControlAppender
 log4j.logger.com.linkedin.kafka.cruisecontrol.detector=INFO, kafkaCruiseControlAppender
-log4j.logger.com.linkedin.kafka.cruisecontrol.operationLog=INFO, operationAppender
+log4j.logger.operationLog=INFO, operationAppender
 
 log4j.logger.LiKafkaCruiseControlPublicAccessLogger=DEBUG, requestAppender
 log4j.additivity.kafka.request.logger=false

--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -29,7 +29,7 @@ log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 # Loggers
 log4j.logger.com.linkedin.kafka.cruisecontrol=INFO, kafkaCruiseControlAppender
 log4j.logger.com.linkedin.kafka.cruisecontrol.detector=INFO, kafkaCruiseControlAppender
-log4j.logger.operationLog=INFO, operationAppender
+log4j.logger.operationLogger=INFO, operationAppender
 
 log4j.logger.LiKafkaCruiseControlPublicAccessLogger=DEBUG, requestAppender
 log4j.additivity.kafka.request.logger=false

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -41,7 +41,7 @@ public class KafkaCruiseControlUtils {
   private static final Set<String> KAFKA_ASSIGNER_GOALS =
       Collections.unmodifiableSet(new HashSet<>(Arrays.asList(KafkaAssignerEvenRackAwareGoal.class.getSimpleName(),
                                                               KafkaAssignerDiskUsageDistributionGoal.class.getSimpleName())));
-  public static final String OPERATION_LOGGER = "log4j.logger.com.linkedin.kafka.cruisecontrol.CruiseControlOperationLog";
+  public static final String OPERATION_LOGGER = "operationLogger";
 
   private KafkaCruiseControlUtils() {
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -41,6 +41,7 @@ public class KafkaCruiseControlUtils {
   private static final Set<String> KAFKA_ASSIGNER_GOALS =
       Collections.unmodifiableSet(new HashSet<>(Arrays.asList(KafkaAssignerEvenRackAwareGoal.class.getSimpleName(),
                                                               KafkaAssignerDiskUsageDistributionGoal.class.getSimpleName())));
+  public static final String OPERATION_LOGGER = "log4j.logger.com.linkedin.kafka.cruisecontrol.CruiseControlOperationLog";
 
   private KafkaCruiseControlUtils() {
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/KafkaAnomaly.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/KafkaAnomaly.java
@@ -7,6 +7,8 @@ package com.linkedin.kafka.cruisecontrol.detector;
 import com.linkedin.cruisecontrol.detector.Anomaly;
 import com.linkedin.kafka.cruisecontrol.servlet.response.OptimizationResult;
 
+import static com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorUtils.getAnomalyType;
+
 
 /**
  * The interface for a Kafka anomaly.
@@ -25,5 +27,10 @@ abstract class KafkaAnomaly implements Anomaly {
       return null;
     }
     return isJson ? _optimizationResult.cachedJSONResponse() : _optimizationResult.cachedPlaintextResponse();
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s anomaly with id: %s", getAnomalyType(this), anomalyId());
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/KafkaMetricAnomaly.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/KafkaMetricAnomaly.java
@@ -15,6 +15,8 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorUtils.getAnomalyType;
+
 
 /**
  * A class that holds Kafka metric anomalies.
@@ -103,7 +105,8 @@ public class KafkaMetricAnomaly implements MetricAnomaly<BrokerEntity> {
 
   @Override
   public String toString() {
-    return String.format("{%nMetric Anomaly windows: %s description: %s%n}", _windows, _description);
+    return String.format("%s anomaly with id: %s Metric Anomaly windows: %s description: %s",
+                         getAnomalyType(this), anomalyId(), _windows, _description);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -55,6 +55,7 @@ import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTaskTracker.Exe
  */
 public class Executor {
   private static final Logger LOG = LoggerFactory.getLogger(Executor.class);
+  private static final Logger RESULT_LOG = LoggerFactory.getLogger("com.linkedin.kafka.cruisecontrol.CruiseControlResultLog");
   private static final long EXECUTION_HISTORY_SCANNER_PERIOD_SECONDS = 5;
   private static final long EXECUTION_HISTORY_SCANNER_INITIAL_DELAY_SECONDS = 0;
   // The maximum time to wait for a leader movement to finish. A leader movement will be marked as failed if
@@ -521,6 +522,7 @@ public class Executor {
     private void execute() {
       _state = STARTING_EXECUTION;
       _executorState = ExecutorState.executionStarted(_uuid, _recentlyDemotedBrokers, _recentlyRemovedBrokers);
+      RESULT_LOG.info("Proposal execution:[{}] started.", _uuid);
       try {
         // Pause the metric sampling to avoid the loss of accuracy during execution.
         while (true) {
@@ -578,6 +580,7 @@ public class Executor {
                                                                      _executionStoppedByUser.get(),
                                                                      _executionException, executionSucceeded);
         _executorNotifier.sendNotification(notification);
+        RESULT_LOG.info("Proposal execution with UUID:[{}] ended.", _uuid);
         // Clear completed execution.
         clearCompletedExecution();
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -41,6 +41,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.currentUtcDate;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.OPERATION_LOGGER;
 import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTask.State.*;
 import static com.linkedin.kafka.cruisecontrol.executor.ExecutorState.State.*;
 import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTask.TaskType.*;
@@ -55,7 +56,7 @@ import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTaskTracker.Exe
  */
 public class Executor {
   private static final Logger LOG = LoggerFactory.getLogger(Executor.class);
-  private static final Logger RESULT_LOG = LoggerFactory.getLogger("com.linkedin.kafka.cruisecontrol.CruiseControlResultLog");
+  private static final Logger OPERATION_LOG = LoggerFactory.getLogger(OPERATION_LOGGER);
   private static final long EXECUTION_HISTORY_SCANNER_PERIOD_SECONDS = 5;
   private static final long EXECUTION_HISTORY_SCANNER_INITIAL_DELAY_SECONDS = 0;
   // The maximum time to wait for a leader movement to finish. A leader movement will be marked as failed if
@@ -522,7 +523,7 @@ public class Executor {
     private void execute() {
       _state = STARTING_EXECUTION;
       _executorState = ExecutorState.executionStarted(_uuid, _recentlyDemotedBrokers, _recentlyRemovedBrokers);
-      RESULT_LOG.info("Proposal execution:[{}] started.", _uuid);
+      OPERATION_LOG.info("Task [{}] execution starts.", _uuid);
       try {
         // Pause the metric sampling to avoid the loss of accuracy during execution.
         while (true) {
@@ -580,7 +581,7 @@ public class Executor {
                                                                      _executionStoppedByUser.get(),
                                                                      _executionException, executionSucceeded);
         _executorNotifier.sendNotification(notification);
-        RESULT_LOG.info("Proposal execution with UUID:[{}] ended.", _uuid);
+        OPERATION_LOG.info("Task [{}] execution finishes.", _uuid);
         // Clear completed execution.
         clearCompletedExecution();
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -508,8 +508,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
                                                           CruiseControlParameters parameters)
       throws ExecutionException, InterruptedException, IOException {
     int step = _asyncOperationStep.get();
-    List<OperationFuture> futures = _userTaskManager.getOrCreateUserTask(request, response, function, step,
-                                                                         true, parameters);
+    List<OperationFuture> futures = _userTaskManager.getOrCreateUserTask(request, response, function, step, true, parameters);
     _asyncOperationStep.set(step + 1);
     try {
       return futures.get(step).get(_maxBlockMs, TimeUnit.MILLISECONDS);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
@@ -165,7 +165,7 @@ public class UserTaskManager implements Closeable {
    *                 returns a completed Future.
    * @param step The index of the step that has to be added or fetched.
    * @param isAsyncRequest Indicate whether the task is async or sync.
-   * @param parameters Parsed parameters from http request.
+   * @param parameters Parsed parameters from http request, or null if the parsing result is unavailable.
    * @return The list of {@link OperationFuture} for the linked UserTask.
    */
   public List<OperationFuture> getOrCreateUserTask(HttpServletRequest httpServletRequest,
@@ -391,7 +391,7 @@ public class UserTaskManager implements Closeable {
    * @param userTaskId UUID to uniquely identify task.
    * @param operation lambda function to provide result to UserTaskInfo object
    * @param httpServletRequest http request associated with the task
-   * @param parameters Parsed parameters from http request.
+   * @param parameters Parsed parameters from http request, or null if parsing result is unavailable.
    * @return {@link UserTaskInfo} containing request detail and  {@link OperationFuture}
    */
   private synchronized UserTaskInfo insertFuturesByUserTaskId(UUID userTaskId,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/AbstractCruiseControlResponse.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/AbstractCruiseControlResponse.java
@@ -53,7 +53,7 @@ public abstract class AbstractCruiseControlResponse implements CruiseControlResp
     }
   }
 
-  String cachedResponse() {
+  public String cachedResponse() {
     return _cachedResponse;
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/AbstractCruiseControlResponse.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/AbstractCruiseControlResponse.java
@@ -53,6 +53,7 @@ public abstract class AbstractCruiseControlResponse implements CruiseControlResp
     }
   }
 
+  @Override
   public String cachedResponse() {
     return _cachedResponse;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlResponse.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlResponse.java
@@ -26,4 +26,11 @@ public interface CruiseControlResponse {
    * @param response HTTP response to return to user.
    */
   void writeSuccessResponse(CruiseControlParameters parameters, HttpServletResponse response) throws IOException;
+
+  /**
+   * Get response with the given parameters directly.
+   * @param parameters Parameters to determine the format of response to return.
+   * @return String containing response.
+   */
+  String cachedResponse(CruiseControlParameters parameters);
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlResponse.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlResponse.java
@@ -26,4 +26,11 @@ public interface CruiseControlResponse {
    * @param response HTTP response to return to user.
    */
   void writeSuccessResponse(CruiseControlParameters parameters, HttpServletResponse response) throws IOException;
+
+  /**
+   * Return the relevant response kept in-memory after {@link #discardIrrelevantResponse(CruiseControlParameters)} is called.
+   *
+   * @return The cached response, or {@code null} if the cached response is unavailable.
+   */
+  String cachedResponse();
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlResponse.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlResponse.java
@@ -26,11 +26,4 @@ public interface CruiseControlResponse {
    * @param response HTTP response to return to user.
    */
   void writeSuccessResponse(CruiseControlParameters parameters, HttpServletResponse response) throws IOException;
-
-  /**
-   * Get response with the given parameters directly.
-   * @param parameters Parameters to determine the format of response to return.
-   * @return String containing response.
-   */
-  String cachedResponse(CruiseControlParameters parameters);
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/UserTaskState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/UserTaskState.java
@@ -191,7 +191,7 @@ public class UserTaskState extends AbstractCruiseControlResponse {
   private String completedTaskResponse(UserTaskManager.UserTaskInfo userTaskInfo) {
     try {
       CruiseControlResponse response = userTaskInfo.futures().get(userTaskInfo.futures().size() - 1).get();
-      return ((AbstractCruiseControlResponse) response).cachedResponse();
+      return response.cachedResponse();
     } catch (InterruptedException | ExecutionException e) {
       throw new IllegalStateException("Error happened in fetching response for task " + userTaskInfo.userTaskId().toString(), e);
     }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletEndpointTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletEndpointTest.java
@@ -74,6 +74,9 @@ public class KafkaCruiseControlServletEndpointTest {
   private static class MockResult implements CruiseControlResponse {
     public void discardIrrelevantResponse(CruiseControlParameters parameters) { }
     public void writeSuccessResponse(CruiseControlParameters parameters, HttpServletResponse response) { }
+    public String cachedResponse(CruiseControlParameters parameters) {
+      return "";
+    }
   }
 
   private static Object[] inputRequestParams(UUID userTaskId,
@@ -131,7 +134,7 @@ public class KafkaCruiseControlServletEndpointTest {
 
     for (Object[] params : allParams) {
       OperationFuture future = userTaskManager.getOrCreateUserTask((HttpServletRequest) params[0], mockHttpServletResponse, FUTURE_CREATOR,
-                                                                   (int) params[1], true).get((int) params[2]);
+                                                                   (int) params[1], true, null).get((int) params[2]);
       _populateUserTaskManagerOutput.add(outputCreateTaskInfo(future));
     }
   }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletEndpointTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletEndpointTest.java
@@ -74,7 +74,7 @@ public class KafkaCruiseControlServletEndpointTest {
   private static class MockResult implements CruiseControlResponse {
     public void discardIrrelevantResponse(CruiseControlParameters parameters) { }
     public void writeSuccessResponse(CruiseControlParameters parameters, HttpServletResponse response) { }
-    public String cachedResponse(CruiseControlParameters parameters) {
+    public String cachedResponse() {
       return "";
     }
   }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManagerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManagerTest.java
@@ -46,7 +46,7 @@ public class UserTaskManagerTest {
                                                           100, new MockTime(), mockUUIDGenerator);
     // test-case: create user-task based on request and get future
     OperationFuture future1 =
-        userTaskManager.getOrCreateUserTask(mockHttpServletRequest1, mockHttpServletResponse, uuid -> future, 0, true).get(0);
+        userTaskManager.getOrCreateUserTask(mockHttpServletRequest1, mockHttpServletResponse, uuid -> future, 0, true, null).get(0);
 
     Assert.assertEquals(userTaskHeader.getValue(), UserTaskManager.USER_TASK_HEADER_NAME);
     Assert.assertEquals(userTaskHeaderValue.getValue(), testUserTaskId.toString());
@@ -55,7 +55,7 @@ public class UserTaskManagerTest {
     EasyMock.reset(mockHttpServletResponse);
     // test-case: get same future back using sessions
     OperationFuture future2 =
-        userTaskManager.getOrCreateUserTask(mockHttpServletRequest1, mockHttpServletResponse, uuid -> future, 0, true).get(0);
+        userTaskManager.getOrCreateUserTask(mockHttpServletRequest1, mockHttpServletResponse, uuid -> future, 0, true, null).get(0);
 
     Assert.assertEquals(userTaskHeader.getValue(), UserTaskManager.USER_TASK_HEADER_NAME);
     Assert.assertEquals(userTaskHeaderValue.getValue(), testUserTaskId.toString());
@@ -65,7 +65,7 @@ public class UserTaskManagerTest {
     EasyMock.reset(mockHttpServletResponse);
     // test-case: get future back using user-task-id
     OperationFuture future3 =
-        userTaskManager.getOrCreateUserTask(mockHttpServletRequest2, mockHttpServletResponse, uuid -> future, 0, true).get(0);
+        userTaskManager.getOrCreateUserTask(mockHttpServletRequest2, mockHttpServletResponse, uuid -> future, 0, true, null).get(0);
 
     Assert.assertEquals(userTaskHeader.getValue(), UserTaskManager.USER_TASK_HEADER_NAME);
     Assert.assertEquals(userTaskHeaderValue.getValue(), testUserTaskId.toString());
@@ -76,7 +76,7 @@ public class UserTaskManagerTest {
     // test-case: for sync task, UserTaskManager does not create mapping between request URL and UUID.
     HttpServletRequest mockHttpServletRequest3 = prepareRequest(null, null, "test_sync_request", Collections.emptyMap());
     OperationFuture future4 =
-        userTaskManager.getOrCreateUserTask(mockHttpServletRequest3, mockHttpServletResponse, uuid -> future, 0, false).get(0);
+        userTaskManager.getOrCreateUserTask(mockHttpServletRequest3, mockHttpServletResponse, uuid -> future, 0, false, null).get(0);
 
     // New async request have session mapping where a session key is mapped to the UUID associated with the request. Such a mapping is
     // not created for sync request. So in the 2 asserts below , we expect that given a http request, we are able to find request associated UUID
@@ -87,7 +87,7 @@ public class UserTaskManagerTest {
 
     EasyMock.reset(mockHttpServletResponse);
     OperationFuture future5 =
-        userTaskManager.getOrCreateUserTask(mockHttpServletRequest3, mockHttpServletResponse, uuid -> future, 0, true).get(0);
+        userTaskManager.getOrCreateUserTask(mockHttpServletRequest3, mockHttpServletResponse, uuid -> future, 0, true, null).get(0);
     savedUUID = userTaskManager.getUserTaskId(mockHttpServletRequest3);
     Assert.assertNotEquals(savedUUID, null);
     Assert.assertEquals(future5, future);
@@ -130,10 +130,10 @@ public class UserTaskManagerTest {
     OperationFuture future = new OperationFuture("future");
     UserTaskManager userTaskManager = new UserTaskManager(1000, 5, TimeUnit.HOURS.toMillis(6),
                                                           100, new MockTime(), mockUUIDGenerator);
-    userTaskManager.getOrCreateUserTask(mockHttpServletRequest1, mockHttpServletResponse1, uuid -> future, 0, true);
-    userTaskManager.getOrCreateUserTask(mockHttpServletRequest2, mockHttpServletResponse2, uuid -> future, 0, true);
+    userTaskManager.getOrCreateUserTask(mockHttpServletRequest1, mockHttpServletResponse1, uuid -> future, 0, true, null);
+    userTaskManager.getOrCreateUserTask(mockHttpServletRequest2, mockHttpServletResponse2, uuid -> future, 0, true, null);
     // Test UserTaskManger can recognize the previous created task by taskId.
-    userTaskManager.getOrCreateUserTask(mockHttpServletRequest3, mockHttpServletResponse3, uuid -> future, 0, true);
+    userTaskManager.getOrCreateUserTask(mockHttpServletRequest3, mockHttpServletResponse3, uuid -> future, 0, true, null);
 
     // The 2nd request should reuse the UserTask created for the 1st request since they use the same session and send the same request.
     Assert.assertEquals(1, userTaskManager.numActiveSessionKeys());
@@ -164,12 +164,12 @@ public class UserTaskManagerTest {
 
     OperationFuture insertedFuture1 =
         userTaskManager.getOrCreateUserTask(mockHttpServletRequest, mockHttpServletResponse, uuid -> testFuture1, 0,
-            true).get(0);
+            true, null).get(0);
     Assert.assertEquals(testFuture1, insertedFuture1);
     EasyMock.reset(mockHttpServletResponse);
     OperationFuture insertedFuture2 =
         userTaskManager.getOrCreateUserTask(mockHttpServletRequest, mockHttpServletResponse, uuid -> testFuture2, 1,
-            true).get(1);
+            true, null).get(1);
     Assert.assertEquals(testFuture2, insertedFuture2);
 
     Assert.assertEquals(userTaskManager.getUserTaskByUserTaskId(testUserTaskId, mockHttpServletRequest).futures().size(), 2);
@@ -198,7 +198,7 @@ public class UserTaskManagerTest {
     EasyMock.replay(mockUUIDGenerator, mockHttpSession, mockHttpServletResponse);
     // test-case: verify if the background cleaner task removes tasks that are completed
     OperationFuture future1 =
-        userTaskManager.getOrCreateUserTask(mockHttpServletRequest, mockHttpServletResponse, uuid -> future, 0, true).get(0);
+        userTaskManager.getOrCreateUserTask(mockHttpServletRequest, mockHttpServletResponse, uuid -> future, 0, true, null).get(0);
     Assert.assertEquals(future, future1);
 
     future1.cancel(true);
@@ -234,7 +234,7 @@ public class UserTaskManagerTest {
     EasyMock.replay(mockUUIDGenerator, mockHttpSession, mockHttpServletResponse);
     // test-case: test if the sessions are removed on expiration
     OperationFuture future1 =
-        userTaskManager.getOrCreateUserTask(mockHttpServletRequest, mockHttpServletResponse, uuid -> future, 0, true).get(0);
+        userTaskManager.getOrCreateUserTask(mockHttpServletRequest, mockHttpServletResponse, uuid -> future, 0, true, null).get(0);
     Assert.assertEquals(future, future1);
 
     mockTime.sleep(1001);
@@ -263,7 +263,7 @@ public class UserTaskManagerTest {
     EasyMock.replay(mockHttpSession1, mockHttpServletResponse);
     // test-case: test max limitation active tasks
     OperationFuture future1 =
-        userTaskManager.getOrCreateUserTask(mockHttpServletRequest1, mockHttpServletResponse, uuid -> future, 0, true).get(0);
+        userTaskManager.getOrCreateUserTask(mockHttpServletRequest1, mockHttpServletResponse, uuid -> future, 0, true, null).get(0);
     Assert.assertEquals(future, future1);
 
     HttpSession mockHttpSession2 = EasyMock.mock(HttpSession.class);
@@ -274,7 +274,7 @@ public class UserTaskManagerTest {
     HttpServletRequest mockHttpServletRequest2 = prepareRequest(mockHttpSession2, null, "/test2", Collections.emptyMap());
     try {
       OperationFuture future2 =
-          userTaskManager.getOrCreateUserTask(mockHttpServletRequest2, mockHttpServletResponse, uuid -> future, 0, true).get(0);
+          userTaskManager.getOrCreateUserTask(mockHttpServletRequest2, mockHttpServletResponse, uuid -> future, 0, true, null).get(0);
       Assert.assertEquals(future, future2);
     } catch (RuntimeException e) {
       userTaskManager.close();


### PR DESCRIPTION
Addresses issue #595.
The new log will be called kafkacruisecontrol-result.log. It's rolled daily.