### PR TITLE
Add slack notification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,6 +197,7 @@ project(':cruise-control') {
     compile "org.scala-lang:scala-library:2.11.11"
     compile 'junit:junit:4.12'
     compile 'org.apache.commons:commons-math3:3.6.1'
+    compile 'org.apache.httpcomponents:httpclient:4.5.6'
     compile 'com.google.code.gson:gson:2.7'
     compile 'org.eclipse.jetty:jetty-server:9.4.6.v20170531'
     compile 'org.eclipse.jetty:jetty-servlet:9.4.6.v20170531'

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SlackMessage.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SlackMessage.java
@@ -1,0 +1,42 @@
+package com.linkedin.kafka.cruisecontrol.detector.notifier;
+
+import java.io.Serializable;
+
+public final class SlackMessage implements Serializable {
+
+    private String username;
+    private String text;
+    private String icon_emoji;
+    private String channel;
+
+    public SlackMessage(String username, String text, String icon_emoji, String channel) {
+        this.username = username;
+        this.text = text;
+        this.icon_emoji = icon_emoji;
+        this.channel = channel;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public String getIcon_emoji() {
+        return icon_emoji;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    @Override
+    public String toString() {
+        return "{\"username\" : " + (username == null ? null : "\"" + username + "\"")
+                + ",\"text\" : " + (text == null ? null : "\"" + text + "\"")
+                + ",\"icon_emoji\" : " + (icon_emoji == null ? null : "\"" + icon_emoji + "\"")
+                + ",\"channel\" : " + (channel == null ? null : "\"" + channel + "\"") + "}";
+    }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SlackMessage.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SlackMessage.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
 package com.linkedin.kafka.cruisecontrol.detector.notifier;
 
 import java.io.Serializable;
@@ -6,13 +10,13 @@ public final class SlackMessage implements Serializable {
 
     private String username;
     private String text;
-    private String icon_emoji;
+    private String iconEmoji;
     private String channel;
 
-    public SlackMessage(String username, String text, String icon_emoji, String channel) {
+    public SlackMessage(String username, String text, String iconEmoji, String channel) {
         this.username = username;
         this.text = text;
-        this.icon_emoji = icon_emoji;
+        this.iconEmoji = iconEmoji;
         this.channel = channel;
     }
 
@@ -24,8 +28,8 @@ public final class SlackMessage implements Serializable {
         return text;
     }
 
-    public String getIcon_emoji() {
-        return icon_emoji;
+    public String getIconEmoji() {
+        return iconEmoji;
     }
 
     public String getChannel() {
@@ -36,7 +40,7 @@ public final class SlackMessage implements Serializable {
     public String toString() {
         return "{\"username\" : " + (username == null ? null : "\"" + username + "\"")
                 + ",\"text\" : " + (text == null ? null : "\"" + text + "\"")
-                + ",\"icon_emoji\" : " + (icon_emoji == null ? null : "\"" + icon_emoji + "\"")
+                + ",\"icon_emoji\" : " + (iconEmoji == null ? null : "\"" + iconEmoji + "\"")
                 + ",\"channel\" : " + (channel == null ? null : "\"" + channel + "\"") + "}";
     }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SlackSelfHealingNotifier.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SlackSelfHealingNotifier.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
 package com.linkedin.kafka.cruisecontrol.detector.notifier;
 
 import org.apache.http.client.methods.HttpPost;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SlackSelfHealingNotifier.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SlackSelfHealingNotifier.java
@@ -1,0 +1,91 @@
+package com.linkedin.kafka.cruisecontrol.detector.notifier;
+
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.toDateString;
+
+public class SlackSelfHealingNotifier extends SelfHealingNotifier {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SlackSelfHealingNotifier.class);
+    public static final String SLACK_SELF_HEALING_NOTIFIER_WEBHOOK = "slack.self.healing.notifier.webhook";
+    public static final String SLACK_SELF_HEALING_NOTIFIER_ICON = "slack.self.healing.notifier.icon";
+    public static final String SLACK_SELF_HEALING_NOTIFIER_USER = "slack.self.healing.notifier.user";
+    public static final String SLACK_SELF_HEALING_NOTIFIER_CHANNEL = "slack.self.healing.notifier.channel";
+
+    public static final String DEFAULT_SLACK_SELF_HEALING_NOTIFIER_ICON = ":information_source:";
+    public static final String DEFAULT_SLACK_SELF_HEALING_NOTIFIER_USER = "Cruise Control";
+
+    protected String _slackWebhook;
+    protected String _slackIcon;
+    protected String _slackChannel;
+    protected String _slackUser;
+
+    public SlackSelfHealingNotifier() {
+    }
+
+    public SlackSelfHealingNotifier(Time time) {
+        super(time);
+    }
+
+    @Override
+    public void configure(Map<String, ?> config) {
+        super.configure(config);
+        _slackWebhook = (String) config.get(SLACK_SELF_HEALING_NOTIFIER_WEBHOOK);
+        _slackIcon = (String) config.get(SLACK_SELF_HEALING_NOTIFIER_ICON);
+        _slackChannel = (String) config.get(SLACK_SELF_HEALING_NOTIFIER_CHANNEL);
+        _slackUser = (String) config.get(SLACK_SELF_HEALING_NOTIFIER_USER);
+        _slackIcon = _slackIcon == null ? DEFAULT_SLACK_SELF_HEALING_NOTIFIER_ICON : _slackIcon;
+        _slackUser = _slackUser == null ? DEFAULT_SLACK_SELF_HEALING_NOTIFIER_USER : _slackUser;
+    }
+
+    @Override
+    public void alert(Object anomaly, boolean autoFixTriggered, long selfHealingStartTime, AnomalyType anomalyType) {
+        super.alert(anomaly, autoFixTriggered, selfHealingStartTime, anomalyType);
+
+        if (_slackWebhook == null) {
+            LOG.warn("Slack webhook is null, can't send Slack self healing notification");
+            return;
+        }
+
+        if (_slackChannel == null) {
+            LOG.warn("Slack channel name is null, can't send Slack self healing notification");
+            return;
+        }
+
+        String text;
+        if (autoFixTriggered) {
+            text = "Self-healing has been triggered.";
+        } else {
+            text = String.format("%s detected %s. Self healing %s.", anomalyType, anomaly,
+                    _selfHealingEnabled.get(anomalyType) ? String.format("start time %s", toDateString(selfHealingStartTime)) : "is disabled");
+        }
+        try {
+            sendSlackMessage(new SlackMessage(_slackUser, text, _slackIcon, _slackChannel), _slackWebhook);
+        } catch (IOException e) {
+            LOG.warn("ERROR sending alert to Slack", e);
+        }
+    }
+
+    protected void sendSlackMessage(SlackMessage slackMessage, String slackWebhookUrl) throws IOException {
+        CloseableHttpClient client = HttpClients.createDefault();
+        HttpPost httpPost = new HttpPost(slackWebhookUrl);
+        StringEntity entity = new StringEntity(slackMessage.toString());
+        httpPost.setEntity(entity);
+        httpPost.setHeader("Accept", "application/json");
+        httpPost.setHeader("Content-type", "application/json");
+        try {
+            client.execute(httpPost);
+        } finally {
+            client.close();
+        }
+    }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SlackMessageTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SlackMessageTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
 package com.linkedin.kafka.cruisecontrol.detector.notifier;
 
 import org.junit.Test;

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SlackMessageTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SlackMessageTest.java
@@ -1,0 +1,14 @@
+package com.linkedin.kafka.cruisecontrol.detector.notifier;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SlackMessageTest {
+
+    @Test
+    public void testSlackMessageJsonFormat() {
+        String expectedJson = "{\"username\" : \"userA\",\"text\" : \"cc alert\",\"icon_emoji\" : \":information_source:\",\"channel\" : \"#cc-alerts\"}";
+        assertEquals(expectedJson, new SlackMessage("userA", "cc alert", ":information_source:", "#cc-alerts").toString());
+    }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SlackSelfHealingNotifierTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SlackSelfHealingNotifierTest.java
@@ -1,0 +1,89 @@
+package com.linkedin.kafka.cruisecontrol.detector.notifier;
+
+import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
+import com.linkedin.kafka.cruisecontrol.detector.BrokerFailures;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.easymock.EasyMock;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class SlackSelfHealingNotifierTest {
+
+    private static BrokerFailures failures;
+    private static KafkaCruiseControl mockKafkaCruiseControl;
+    private static MockSlackSelfHealingNotifier notifier;
+
+    @BeforeClass
+    public static void setup() {
+        final long startTime = 500L;
+        Time mockTime = new MockTime(0, startTime, TimeUnit.NANOSECONDS.convert(startTime, TimeUnit.MILLISECONDS));
+        notifier = new MockSlackSelfHealingNotifier(mockTime);
+        mockKafkaCruiseControl = EasyMock.mock(KafkaCruiseControl.class);
+        Map<Integer, Long> failedBrokers = new HashMap<>();
+        failedBrokers.put(1, 200L);
+        failedBrokers.put(2, 400L);
+        failures = new BrokerFailures(mockKafkaCruiseControl, failedBrokers, true, true, true);
+    }
+
+    @Test
+    public void testSlackAlertWithNoWebhook() {
+        notifier.alert(failures, false, 1L, AnomalyType.BROKER_FAILURE);
+        assertEquals(0, notifier.getSlackMessageList().size());
+    }
+
+    @Test
+    public void testSlackAlertWithNoChannel() {
+        notifier._slackWebhook = "http://dummy.slack.webhook";
+        notifier.alert(failures, false, 1L, AnomalyType.BROKER_FAILURE);
+        assertEquals(0, notifier.getSlackMessageList().size());
+    }
+
+    @Test
+    public void testSlackAlertWithDefaultOptions() {
+        notifier._slackWebhook = "http://dummy.slack.webhook";
+        notifier._slackChannel = "#dummy-channel";
+        notifier.alert(failures, false, 1L, AnomalyType.BROKER_FAILURE);
+        assertEquals(1, notifier.getSlackMessageList().size());
+        SlackMessage message = notifier.getSlackMessageList().get(0);
+        assertEquals("#dummy-channel", message.getChannel());
+    }
+
+    private static class MockSlackSelfHealingNotifier extends SlackSelfHealingNotifier {
+        private static List<SlackMessage> slackMessageList = new ArrayList<>();
+
+        final Map<AnomalyType, Boolean> _alertCalled;
+        final Map<AnomalyType, Boolean> _autoFixTriggered;
+
+        MockSlackSelfHealingNotifier(Time time) {
+            super(time);
+            _alertCalled = new HashMap<>(AnomalyType.cachedValues().size());
+            _autoFixTriggered = new HashMap<>(AnomalyType.cachedValues().size());
+            for (AnomalyType alertType : AnomalyType.cachedValues()) {
+                _alertCalled.put(alertType, false);
+                _autoFixTriggered.put(alertType, false);
+            }
+            _selfHealingEnabled.put(AnomalyType.BROKER_FAILURE, true);
+        }
+
+
+        @Override
+        protected void sendSlackMessage(SlackMessage slackMessage, String slackWebhookUrl) throws IOException {
+            slackMessageList.add(slackMessage);
+        }
+
+        List<SlackMessage> getSlackMessageList() {
+            return slackMessageList;
+        }
+    }
+
+}


### PR DESCRIPTION
Desc:
The self-healing and anomaly detected is the crown feature of Cruise Control, but often the actions taken by Cruise Control provide less visibility to its operation. Adding a slack notification for all the anomaly detection and self-healing will increase Cruise control visibility.

Changelog:
The SlackSelfHealingNotifier extends SelfHealingNotifier and merely override the alerts method to send the notification to Slack.

Configuration:
The following property requires to be configured on cruisecontrol.properties 

1. slack.self.healing.notifier.webhook (Required)
(Slack webhook URL) Ref:https://api.slack.com/incoming-webhooks
2. slack.self.healing.notifier.channel (Required)
(Slack channel name to send the alert, (e.g) #alerts-cruise-control
3. slack.self.healing.notifier.user (Optional)
User name to display in the slack notification message. (default: Cruise Control)
4. slack.self.healing.notifier.icon (Optional)
Icon to display in the slack notification message. (default: ℹ️ )


To enable Slack notification, set
anomaly.notifier.class=com.linkedin.kafka.cruisecontrol.detector.notifier.SlackSelfHealingNotifier
