### PR TITLE
Add a pluggable NetworkClientProvider to create network clients supporting different Kafka client versions

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/KafkaNetworkClientProvider.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/KafkaNetworkClientProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.common;
+
+import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.NetworkClient;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.network.ChannelBuilder;
+import org.apache.kafka.common.network.Selector;
+import org.apache.kafka.common.utils.Time;
+
+
+public class KafkaNetworkClientProvider implements NetworkClientProvider {
+
+  public KafkaNetworkClientProvider() {
+
+  }
+
+  @Override
+  public NetworkClient createNetworkClient(long connectionMaxIdleMS,
+                                           Metrics metrics,
+                                           Time time,
+                                           String metricGrpPrefix,
+                                           ChannelBuilder channelBuilder,
+                                           Metadata metadata,
+                                           String clientId,
+                                           int maxInFlightRequestsPerConnection,
+                                           long reconnectBackoffMs,
+                                           long reconnectBackoffMax,
+                                           int socketSendBuffer,
+                                           int socketReceiveBuffer,
+                                           int defaultRequestTimeoutMs,
+                                           boolean discoverBrokerVersions,
+                                           ApiVersions apiVersions) {
+    return new NetworkClient(new Selector(connectionMaxIdleMS, metrics, time, metricGrpPrefix, channelBuilder),
+                             metadata, clientId, maxInFlightRequestsPerConnection, reconnectBackoffMs,
+                             reconnectBackoffMax, socketSendBuffer, socketReceiveBuffer, defaultRequestTimeoutMs, time,
+                             discoverBrokerVersions, apiVersions);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/NetworkClientProvider.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/NetworkClientProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.common;
+
+import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.NetworkClient;
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.network.ChannelBuilder;
+import org.apache.kafka.common.utils.Time;
+
+
+@InterfaceStability.Evolving
+public interface NetworkClientProvider {
+  /**
+   * Creates a new network client with the given properties.
+   *
+   * @return A new network client with the given properties.
+   */
+  NetworkClient createNetworkClient(long connectionMaxIdleMS,
+                                    Metrics metrics,
+                                    Time time,
+                                    String metricGrpPrefix,
+                                    ChannelBuilder channelBuilder,
+                                    Metadata metadata,
+                                    String clientId,
+                                    int maxInFlightRequestsPerConnection,
+                                    long reconnectBackoffMs,
+                                    long reconnectBackoffMax,
+                                    int socketSendBuffer,
+                                    int socketReceiveBuffer,
+                                    int defaultRequestTimeoutMs,
+                                    boolean discoverBrokerVersions,
+                                    ApiVersions apiVersions);
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -19,6 +19,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal;
+import com.linkedin.kafka.cruisecontrol.common.KafkaNetworkClientProvider;
 import com.linkedin.kafka.cruisecontrol.detector.NoopMetricAnomalyFinder;
 import com.linkedin.kafka.cruisecontrol.detector.notifier.NoopNotifier;
 import com.linkedin.kafka.cruisecontrol.executor.strategy.BaseReplicaMovementStrategy;
@@ -50,6 +51,8 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
   private static final String DEFAULT_FAILED_BROKERS_ZK_PATH = "/CruiseControlBrokerList";
   // We have to define this so we don't need to move every package to scala src folder.
   private static final String DEFAULT_ANOMALY_NOTIFIER_CLASS = NoopNotifier.class.getName();
+  // We have to define this to support the use of network clients with different Kafka client versions.
+  private static final String DEFAULT_NETWORK_CLIENT_PROVIDER_CLASS = KafkaNetworkClientProvider.class.getName();
   private static final String DEFAULT_METRIC_ANOMALY_FINDER_CLASS = NoopMetricAnomalyFinder.class.getName();
 
   private static final ConfigDef CONFIG;
@@ -491,6 +494,13 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
   public static final String ANOMALY_NOTIFIER_CLASS_CONFIG = "anomaly.notifier.class";
   private static final String ANOMALY_NOTIFIER_CLASS_DOC = "The notifier class to trigger an alert when an "
       + "anomaly is violated. The anomaly could be either a goal violation, broker failure, or metric anomaly.";
+
+  /**
+   * <code>network.client.provider.class</code>
+   */
+  public static final String NETWORK_CLIENT_PROVIDER_CLASS_CONFIG = "network.client.provider.class";
+  private static final String NETWORK_CLIENT_PROVIDER_CLASS_DOC = "The network client provider class to generate a "
+      + "network client with given properties.";
 
   /**
    * <code>anomaly.detection.interval.ms</code>
@@ -1123,6 +1133,10 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 ConfigDef.Type.CLASS,
                 DEFAULT_ANOMALY_NOTIFIER_CLASS,
                 ConfigDef.Importance.LOW, ANOMALY_NOTIFIER_CLASS_DOC)
+        .define(NETWORK_CLIENT_PROVIDER_CLASS_CONFIG,
+                ConfigDef.Type.CLASS, DEFAULT_NETWORK_CLIENT_PROVIDER_CLASS,
+                ConfigDef.Importance.LOW,
+                NETWORK_CLIENT_PROVIDER_CLASS_DOC)
         .define(ANOMALY_DETECTION_INTERVAL_MS_CONFIG,
                 ConfigDef.Type.LONG,
                 300000L,


### PR DESCRIPTION
Addresses the issue https://github.com/linkedin/cruise-control/issues/634.