### PR TITLE
Add header required by CORS to Cruise Control response.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
@@ -389,7 +389,7 @@ public class GoalOptimizer implements Runnable {
     }
 
     LOG.trace("Cluster before optimization is {}", clusterModel);
-    BrokerStats brokerStatsBeforeOptimization = clusterModel.brokerStats();
+    BrokerStats brokerStatsBeforeOptimization = clusterModel.brokerStats(null);
     Map<TopicPartition, List<Integer>> initReplicaDistribution = clusterModel.getReplicaDistribution();
     Map<TopicPartition, Integer> initLeaderDistribution = clusterModel.getLeaderDistribution();
     boolean isSelfHealing = !clusterModel.selfHealingEligibleReplicas().isEmpty();
@@ -427,14 +427,14 @@ public class GoalOptimizer implements Runnable {
       logProgress(isSelfHealing, goal.name(), optimizedGoals.size(), goalProposals);
       step.done();
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Broker level stats after optimization: {}", clusterModel.brokerStats());
+        LOG.debug("Broker level stats after optimization: {}", clusterModel.brokerStats(null));
       }
     }
 
     clusterModel.sanityCheck();
     // Broker level stats in the final cluster state.
     if (LOG.isTraceEnabled()) {
-      LOG.trace("Broker level stats after optimization: {}%n", clusterModel.brokerStats());
+      LOG.trace("Broker level stats after optimization: {}%n", clusterModel.brokerStats(null));
     }
 
     Set<ExecutionProposal> proposals = AnalyzerUtils.getDiff(initReplicaDistribution, initLeaderDistribution, clusterModel);
@@ -443,7 +443,7 @@ public class GoalOptimizer implements Runnable {
                                violatedGoalNamesAfterOptimization,
                                proposals,
                                brokerStatsBeforeOptimization,
-                               clusterModel.brokerStats(),
+                               clusterModel.brokerStats(null),
                                clusterModel.generation(),
                                clusterModel.getClusterStats(_balancingConstraint),
                                clusterModel.capacityEstimationInfoByBrokerId(),

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AddBrokerRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AddBrokerRunnable.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.async;
 
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.executor.strategy.ReplicaMovementStrategy;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.AddedOrRemovedBrokerParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.response.OptimizationResult;
@@ -34,11 +35,13 @@ class AddBrokerRunnable extends OperationRunnable {
   private final boolean _excludeRecentlyDemotedBrokers;
   private final boolean _excludeRecentlyRemovedBrokers;
   private final ReplicaMovementStrategy _replicaMovementStrategy;
+  private final KafkaCruiseControlConfig _config;
 
   AddBrokerRunnable(KafkaCruiseControl kafkaCruiseControl,
                     OperationFuture future,
                     AddedOrRemovedBrokerParameters parameters,
-                    String uuid) {
+                    String uuid,
+                    KafkaCruiseControlConfig config) {
     super(kafkaCruiseControl, future);
     _brokerIds = parameters.brokerIds();
     _dryRun = parameters.dryRun();
@@ -54,6 +57,7 @@ class AddBrokerRunnable extends OperationRunnable {
     _uuid = uuid;
     _excludeRecentlyDemotedBrokers = parameters.excludeRecentlyDemotedBrokers();
     _excludeRecentlyRemovedBrokers = parameters.excludeRecentlyRemovedBrokers();
+    _config = config;
   }
 
   @Override
@@ -72,6 +76,7 @@ class AddBrokerRunnable extends OperationRunnable {
                                                                  _replicaMovementStrategy,
                                                                  _uuid,
                                                                  _excludeRecentlyDemotedBrokers,
-                                                                 _excludeRecentlyRemovedBrokers));
+                                                                 _excludeRecentlyRemovedBrokers),
+                                  _config);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AsyncKafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AsyncKafkaCruiseControl.java
@@ -117,7 +117,7 @@ public class AsyncKafkaCruiseControl extends KafkaCruiseControl {
   public OperationFuture getBrokerStats(ClusterLoadParameters parameters) {
     OperationFuture future = new OperationFuture("Get broker stats");
     pending(future.operationProgress());
-    _sessionExecutor.submit(new GetBrokerStatsRunnable(this, future, parameters));
+    _sessionExecutor.submit(new GetBrokerStatsRunnable(this, future, parameters, _config));
     return future;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AsyncKafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AsyncKafkaCruiseControl.java
@@ -84,7 +84,7 @@ public class AsyncKafkaCruiseControl extends KafkaCruiseControl {
   public OperationFuture decommissionBrokers(AddedOrRemovedBrokerParameters parameters, String uuid) {
     OperationFuture future = new OperationFuture("Decommission brokers");
     pending(future.operationProgress());
-    _sessionExecutor.submit(new DecommissionBrokersRunnable(this, future, parameters, uuid));
+    _sessionExecutor.submit(new DecommissionBrokersRunnable(this, future, parameters, uuid, _config));
     return future;
   }
 
@@ -96,7 +96,7 @@ public class AsyncKafkaCruiseControl extends KafkaCruiseControl {
   public OperationFuture addBrokers(AddedOrRemovedBrokerParameters parameters, String uuid) {
     OperationFuture future = new OperationFuture("Add brokers");
     pending(future.operationProgress());
-    _sessionExecutor.submit(new AddBrokerRunnable(this, future, parameters, uuid));
+    _sessionExecutor.submit(new AddBrokerRunnable(this, future, parameters, uuid, _config));
     return future;
   }
 
@@ -107,7 +107,7 @@ public class AsyncKafkaCruiseControl extends KafkaCruiseControl {
     OperationFuture future =
         new OperationFuture(String.format("Get partition load from %d to %d", parameters.startMs(), parameters.endMs()));
     pending(future.operationProgress());
-    _sessionExecutor.submit(new GetClusterModelInRangeRunnable(this, future, parameters));
+    _sessionExecutor.submit(new GetClusterModelInRangeRunnable(this, future, parameters, _config));
     return future;
   }
 
@@ -128,7 +128,7 @@ public class AsyncKafkaCruiseControl extends KafkaCruiseControl {
   public OperationFuture getProposals(ProposalsParameters parameters) {
     OperationFuture future = new OperationFuture("Get customized proposals");
     pending(future.operationProgress());
-    _sessionExecutor.submit(new GetProposalsRunnable(this, future, parameters));
+    _sessionExecutor.submit(new GetProposalsRunnable(this, future, parameters, _config));
     return future;
   }
 
@@ -140,7 +140,7 @@ public class AsyncKafkaCruiseControl extends KafkaCruiseControl {
   public OperationFuture rebalance(RebalanceParameters parameters, String uuid) {
     OperationFuture future = new OperationFuture("Rebalance");
     pending(future.operationProgress());
-    _sessionExecutor.submit(new RebalanceRunnable(this, future, parameters, uuid));
+    _sessionExecutor.submit(new RebalanceRunnable(this, future, parameters, uuid, _config));
     return future;
   }
 
@@ -151,7 +151,7 @@ public class AsyncKafkaCruiseControl extends KafkaCruiseControl {
   public OperationFuture demoteBrokers(String uuid, DemoteBrokerParameters parameters) {
     OperationFuture future = new OperationFuture("Demote");
     pending(future.operationProgress());
-    _sessionExecutor.submit(new DemoteBrokerRunnable(this, future, uuid, parameters));
+    _sessionExecutor.submit(new DemoteBrokerRunnable(this, future, uuid, parameters, _config));
     return future;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DecommissionBrokersRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DecommissionBrokersRunnable.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.async;
 
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.executor.strategy.ReplicaMovementStrategy;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.AddedOrRemovedBrokerParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.response.OptimizationResult;
@@ -34,11 +35,13 @@ class DecommissionBrokersRunnable extends OperationRunnable {
   private final boolean _excludeRecentlyDemotedBrokers;
   private final boolean _excludeRecentlyRemovedBrokers;
   private final ReplicaMovementStrategy _replicaMovementStrategy;
+  private final KafkaCruiseControlConfig _config;
 
   DecommissionBrokersRunnable(KafkaCruiseControl kafkaCruiseControl,
                               OperationFuture future,
                               AddedOrRemovedBrokerParameters parameters,
-                              String uuid) {
+                              String uuid,
+                              KafkaCruiseControlConfig config) {
     super(kafkaCruiseControl, future);
     _brokerIds = parameters.brokerIds();
     _dryRun = parameters.dryRun();
@@ -54,6 +57,7 @@ class DecommissionBrokersRunnable extends OperationRunnable {
     _uuid = uuid;
     _excludeRecentlyDemotedBrokers = parameters.excludeRecentlyDemotedBrokers();
     _excludeRecentlyRemovedBrokers = parameters.excludeRecentlyRemovedBrokers();
+    _config = config;
   }
 
   @Override
@@ -72,6 +76,7 @@ class DecommissionBrokersRunnable extends OperationRunnable {
                                                                           _replicaMovementStrategy,
                                                                           _uuid,
                                                                           _excludeRecentlyDemotedBrokers,
-                                                                          _excludeRecentlyRemovedBrokers));
+                                                                          _excludeRecentlyRemovedBrokers),
+                                  _config);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DemoteBrokerRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DemoteBrokerRunnable.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.async;
 
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.executor.strategy.ReplicaMovementStrategy;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.DemoteBrokerParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.response.OptimizationResult;
@@ -26,11 +27,13 @@ public class DemoteBrokerRunnable extends OperationRunnable {
   private final String _uuid;
   private final boolean _excludeRecentlyDemotedBrokers;
   private final ReplicaMovementStrategy _replicaMovementStrategy;
+  private final KafkaCruiseControlConfig _config;
 
   DemoteBrokerRunnable(KafkaCruiseControl kafkaCruiseControl,
                        OperationFuture future,
                        String uuid,
-                       DemoteBrokerParameters parameters) {
+                       DemoteBrokerParameters parameters,
+                       KafkaCruiseControlConfig config) {
     super(kafkaCruiseControl, future);
     _brokerIds = parameters.brokerIds();
     _dryRun = parameters.dryRun();
@@ -41,6 +44,7 @@ public class DemoteBrokerRunnable extends OperationRunnable {
     _replicaMovementStrategy = parameters.replicaMovementStrategy();
     _uuid = uuid;
     _excludeRecentlyDemotedBrokers = parameters.excludeRecentlyDemotedBrokers();
+    _config = config;
   }
 
   @Override
@@ -54,6 +58,7 @@ public class DemoteBrokerRunnable extends OperationRunnable {
                                                                     _excludeFollowerDemotion,
                                                                     _replicaMovementStrategy,
                                                                     _uuid,
-                                                                    _excludeRecentlyDemotedBrokers));
+                                                                    _excludeRecentlyDemotedBrokers),
+                                  _config);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetBrokerStatsRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetBrokerStatsRunnable.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.async;
 
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.ClusterLoadParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.response.stats.BrokerStats;
@@ -20,14 +21,17 @@ class GetBrokerStatsRunnable extends OperationRunnable {
   private final long _time;
   private final ModelCompletenessRequirements _modelCompletenessRequirements;
   private final boolean _allowCapacityEstimation;
+  private final KafkaCruiseControlConfig _config;
 
   GetBrokerStatsRunnable(KafkaCruiseControl kafkaCruiseControl,
                          OperationFuture future,
-                         ClusterLoadParameters parameters) {
+                         ClusterLoadParameters parameters,
+                         KafkaCruiseControlConfig config) {
     super(kafkaCruiseControl, future);
     _time = parameters.time();
     _modelCompletenessRequirements = parameters.requirements();
     _allowCapacityEstimation = parameters.allowCapacityEstimation();
+    _config = config;
   }
 
   @Override
@@ -40,6 +44,6 @@ class GetBrokerStatsRunnable extends OperationRunnable {
     return _kafkaCruiseControl.clusterModel(_time,
                                             _modelCompletenessRequirements,
                                             _future.operationProgress(),
-                                            _allowCapacityEstimation).brokerStats();
+                                            _allowCapacityEstimation).brokerStats(_config);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetClusterModelInRangeRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetClusterModelInRangeRunnable.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.async;
 
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.PartitionLoadParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.response.PartitionLoadState;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
@@ -15,12 +16,15 @@ import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
  */
 class GetClusterModelInRangeRunnable extends OperationRunnable {
   private final PartitionLoadParameters _parameters;
+  private final KafkaCruiseControlConfig _config;
 
   GetClusterModelInRangeRunnable(KafkaCruiseControl kafkaCruiseControl,
                                  OperationFuture future,
-                                 PartitionLoadParameters parameters) {
+                                 PartitionLoadParameters parameters,
+                                 KafkaCruiseControlConfig config) {
     super(kafkaCruiseControl, future);
     _parameters = parameters;
+    _config = config;
   }
 
   @Override
@@ -37,6 +41,7 @@ class GetClusterModelInRangeRunnable extends OperationRunnable {
                                   _parameters.partitionUpperBoundary(),
                                   _parameters.partitionLowerBoundary(),
                                   _parameters.topic(),
-                                  topicNameLength);
+                                  topicNameLength,
+                                  _config);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetProposalsRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetProposalsRunnable.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.async;
 
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.ProposalsParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.response.OptimizationResult;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
@@ -26,10 +27,12 @@ class GetProposalsRunnable extends OperationRunnable {
   private final boolean _excludeRecentlyDemotedBrokers;
   private final boolean _excludeRecentlyRemovedBrokers;
   private final boolean _ignoreProposalCache;
+  private final KafkaCruiseControlConfig _config;
 
   GetProposalsRunnable(KafkaCruiseControl kafkaCruiseControl,
                        OperationFuture future,
-                       ProposalsParameters parameters) {
+                       ProposalsParameters parameters,
+                       KafkaCruiseControlConfig config) {
     super(kafkaCruiseControl, future);
     _goals = parameters.goals();
     _modelCompletenessRequirements = parameters.modelCompletenessRequirements();
@@ -38,6 +41,7 @@ class GetProposalsRunnable extends OperationRunnable {
     _excludeRecentlyDemotedBrokers = parameters.excludeRecentlyDemotedBrokers();
     _excludeRecentlyRemovedBrokers = parameters.excludeRecentlyRemovedBrokers();
     _ignoreProposalCache = parameters.ignoreProposalCache();
+    _config = config;
   }
 
   @Override
@@ -50,6 +54,7 @@ class GetProposalsRunnable extends OperationRunnable {
                                                                    _excludedTopics,
                                                                    _excludeRecentlyDemotedBrokers,
                                                                    _excludeRecentlyRemovedBrokers,
-                                                                   _ignoreProposalCache));
+                                                                   _ignoreProposalCache),
+                                  _config);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/RebalanceRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/RebalanceRunnable.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.async;
 
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.executor.strategy.ReplicaMovementStrategy;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.RebalanceParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.response.OptimizationResult;
@@ -32,11 +33,13 @@ class RebalanceRunnable extends OperationRunnable {
   private final boolean _excludeRecentlyRemovedBrokers;
   private final ReplicaMovementStrategy _replicaMovementStrategy;
   private final boolean _ignoreProposalCache;
+  private final KafkaCruiseControlConfig _config;
 
   RebalanceRunnable(KafkaCruiseControl kafkaCruiseControl,
                     OperationFuture future,
                     RebalanceParameters parameters,
-                    String uuid) {
+                    String uuid,
+                    KafkaCruiseControlConfig config) {
     super(kafkaCruiseControl, future);
     _goals = parameters.goals();
     _dryRun = parameters.dryRun();
@@ -51,6 +54,7 @@ class RebalanceRunnable extends OperationRunnable {
     _excludeRecentlyDemotedBrokers = parameters.excludeRecentlyDemotedBrokers();
     _excludeRecentlyRemovedBrokers = parameters.excludeRecentlyRemovedBrokers();
     _ignoreProposalCache = parameters.ignoreProposalCache();
+    _config = config;
   }
 
   @Override
@@ -68,6 +72,7 @@ class RebalanceRunnable extends OperationRunnable {
                                                                 _uuid,
                                                                 _excludeRecentlyDemotedBrokers,
                                                                 _excludeRecentlyRemovedBrokers,
-                                                                _ignoreProposalCache));
+                                                                _ignoreProposalCache),
+                                  _config);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailures.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailures.java
@@ -73,7 +73,8 @@ public class BrokerFailures extends KafkaAnomaly {
                                                                                            null,
                                                                                            _anomalyId,
                                                                                            _excludeRecentlyDemotedBrokers,
-                                                                                           _excludeRecentlyRemovedBrokers));
+                                                                                           _excludeRecentlyRemovedBrokers),
+                                                   null);
       // Ensure that only the relevant response is cached to avoid memory pressure.
       _optimizationResult.discardIrrelevantAndCacheJsonAndPlaintext();
       return true;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
@@ -87,7 +87,8 @@ public class GoalViolations extends KafkaAnomaly {
                                                                                    _anomalyId,
                                                                                    _excludeRecentlyDemotedBrokers,
                                                                                    _excludeRecentlyRemovedBrokers,
-                                                                                   false));
+                                                                                   false),
+                                                     null);
         // Ensure that only the relevant response is cached to avoid memory pressure.
         _optimizationResult.discardIrrelevantAndCacheJsonAndPlaintext();
         return true;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -10,6 +10,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.BalancingConstraint;
 import com.linkedin.kafka.cruisecontrol.analyzer.AnalyzerUtils;
 
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelGeneration;
 import com.linkedin.kafka.cruisecontrol.servlet.response.stats.BrokerStats;
 import java.io.IOException;
@@ -991,8 +992,8 @@ public class ClusterModel implements Serializable {
   /**
    * Get broker return the broker stats.
    */
-  public BrokerStats brokerStats() {
-    BrokerStats brokerStats = new BrokerStats();
+  public BrokerStats brokerStats(KafkaCruiseControlConfig config) {
+    BrokerStats brokerStats = new BrokerStats(config);
     brokers().forEach(broker -> {
       double leaderBytesInRate = broker.leadershipLoadForNwResources().expectedUtilizationFor(Resource.NW_IN);
       brokerStats.addSingleBrokerStats(broker.host().name(),

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -77,6 +77,7 @@ public class LoadMonitor {
   private final KafkaBrokerMetricSampleAggregator _brokerMetricSampleAggregator;
   // A semaphore to help throttle the simultaneous cluster model creation
   private final Semaphore _clusterModelSemaphore;
+  private final KafkaCruiseControlConfig _config;
   private final MetadataClient _metadataClient;
   private final BrokerCapacityConfigResolver _brokerCapacityConfigResolver;
   private final ScheduledExecutorService _loadMonitorExecutor;
@@ -128,6 +129,8 @@ public class LoadMonitor {
               Time time,
               MetricRegistry dropwizardMetricRegistry,
               MetricDef metricDef) {
+    _config = config;
+
     _metadataClient = metadataClient;
 
     _brokerCapacityConfigResolver = config.getConfiguredInstance(KafkaCruiseControlConfig.BROKER_CAPACITY_CONFIG_RESOLVER_CLASS_CONFIG,
@@ -397,7 +400,7 @@ public class LoadMonitor {
       throws NotEnoughValidWindowsException {
     ClusterModel clusterModel = clusterModel(-1L, now, requirements, operationProgress);
     // Micro optimization: put the broker stats construction out of the lock.
-    BrokerStats brokerStats = clusterModel.brokerStats();
+    BrokerStats brokerStats = clusterModel.brokerStats(_config);
     // update the cached brokerLoadStats
     synchronized (this) {
       _cachedBrokerLoadStats = brokerStats;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -110,8 +110,11 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       response.setHeader("Access-Control-Allow-Origin",
                          _config.getString(KafkaCruiseControlConfig.WEBSERVER_HTTP_CORS_ORIGIN_CONFIG));
       // This is required only as part of pre-flight response
-      response.setHeader("Access-Control-Request-Method",
+      response.setHeader("Access-Control-Allow-Method",
                          _config.getString(KafkaCruiseControlConfig.WEBSERVER_HTTP_CORS_ALLOWMETHODS_CONFIG));
+      response.setHeader("Access-Control-Allow-Headers",
+                         _config.getString(KafkaCruiseControlConfig.WEBSERVER_HTTP_CORS_EXPOSEHEADERS_CONFIG));
+      response.setHeader("Access-Control-Max-Age", String.valueOf(1728000));
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -110,7 +110,7 @@ public class KafkaCruiseControlServlet extends HttpServlet {
       response.setHeader("Access-Control-Allow-Origin",
                          _config.getString(KafkaCruiseControlConfig.WEBSERVER_HTTP_CORS_ORIGIN_CONFIG));
       // This is required only as part of pre-flight response
-      response.setHeader("Access-Control-Allow-Method",
+      response.setHeader("Access-Control-Allow-Methods",
                          _config.getString(KafkaCruiseControlConfig.WEBSERVER_HTTP_CORS_ALLOWMETHODS_CONFIG));
       response.setHeader("Access-Control-Allow-Headers",
                          _config.getString(KafkaCruiseControlConfig.WEBSERVER_HTTP_CORS_EXPOSEHEADERS_CONFIG));

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.servlet;
 
 import com.linkedin.cruisecontrol.common.config.ConfigException;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -68,17 +69,19 @@ public class KafkaCruiseControlServletUtils {
    *
    * @param request HTTP request received by Cruise Control.
    * @param response HTTP response of Cruise Control.
+   * @param config The config of Cruise Control.
    * @return The endpoint if the request contains a valid one, otherwise (1) writes the error response to the given HTTP
    * response and (2) returns null.
    */
-  static EndPoint getValidEndpoint(HttpServletRequest request, HttpServletResponse response) throws IOException {
+  static EndPoint getValidEndpoint(HttpServletRequest request, HttpServletResponse response, KafkaCruiseControlConfig config)
+      throws IOException {
     EndPoint endPoint = endPoint(request);
     if (endPoint == null) {
       String method = request.getMethod();
       String errorMessage = String.format("Unrecognized endpoint in request '%s'%nSupported %s endpoints: %s",
                                           request.getPathInfo(), method, method.equals("GET") ? EndPoint.getEndpoint()
                                                                                               : EndPoint.postEndpoint());
-      writeErrorResponse(response, "", errorMessage, SC_NOT_FOUND, wantJSON(request));
+      writeErrorResponse(response, "", errorMessage, SC_NOT_FOUND, wantJSON(request), config);
       return null;
     }
     return endPoint;
@@ -87,37 +90,41 @@ public class KafkaCruiseControlServletUtils {
   /**
    * Creates a {@link HttpServletResponse#SC_BAD_REQUEST} Http servlet response.
    */
-  static String handleUserRequestException(UserRequestException ure, HttpServletRequest request, HttpServletResponse response)
+  static String handleUserRequestException(UserRequestException ure, HttpServletRequest request,
+                                           HttpServletResponse response, KafkaCruiseControlConfig config)
       throws IOException {
     String errorMessage = String.format("Bad %s request '%s' due to '%s'.", request.getMethod(), request.getPathInfo(), ure.getMessage());
     StringWriter sw = new StringWriter();
     ure.printStackTrace(new PrintWriter(sw));
-    writeErrorResponse(response, sw.toString(), errorMessage, SC_BAD_REQUEST, wantJSON(request));
+    writeErrorResponse(response, sw.toString(), errorMessage, SC_BAD_REQUEST, wantJSON(request), config);
     return errorMessage;
   }
 
   /**
    * Creates a {@link HttpServletResponse#SC_FORBIDDEN} Http servlet response.
    */
-  static String handleConfigException(ConfigException ce, HttpServletRequest request, HttpServletResponse response)
+  static String handleConfigException(ConfigException ce, HttpServletRequest request,
+                                      HttpServletResponse response, KafkaCruiseControlConfig config)
       throws IOException {
     StringWriter sw = new StringWriter();
     ce.printStackTrace(new PrintWriter(sw));
     String errorMessage = String.format("Cannot process %s request '%s' due to: '%s'.",
                                         request.getMethod(), request.getPathInfo(), ce.getMessage());
-    writeErrorResponse(response, sw.toString(), errorMessage, SC_FORBIDDEN, wantJSON(request));
+    writeErrorResponse(response, sw.toString(), errorMessage, SC_FORBIDDEN, wantJSON(request), config);
     return errorMessage;
   }
 
   /**
    * Creates a {@link HttpServletResponse#SC_INTERNAL_SERVER_ERROR} Http servlet response.
    */
-  static String handleException(Exception e, HttpServletRequest request, HttpServletResponse response) throws IOException {
+  static String handleException(Exception e, HttpServletRequest request,
+                                HttpServletResponse response, KafkaCruiseControlConfig config)
+      throws IOException {
     StringWriter sw = new StringWriter();
     e.printStackTrace(new PrintWriter(sw));
     String errorMessage = String.format("Error processing %s request '%s' due to: '%s'.",
                                         request.getMethod(), request.getPathInfo(), e.getMessage());
-    writeErrorResponse(response, sw.toString(), errorMessage, SC_INTERNAL_SERVER_ERROR, wantJSON(request));
+    writeErrorResponse(response, sw.toString(), errorMessage, SC_INTERNAL_SERVER_ERROR, wantJSON(request), config);
     return errorMessage;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
@@ -90,8 +90,10 @@ public class KafkaCruiseControlServletUtils {
   /**
    * Creates a {@link HttpServletResponse#SC_BAD_REQUEST} Http servlet response.
    */
-  static String handleUserRequestException(UserRequestException ure, HttpServletRequest request,
-                                           HttpServletResponse response, KafkaCruiseControlConfig config)
+  static String handleUserRequestException(UserRequestException ure,
+                                           HttpServletRequest request,
+                                           HttpServletResponse response,
+                                           KafkaCruiseControlConfig config)
       throws IOException {
     String errorMessage = String.format("Bad %s request '%s' due to '%s'.", request.getMethod(), request.getPathInfo(), ure.getMessage());
     StringWriter sw = new StringWriter();
@@ -103,8 +105,10 @@ public class KafkaCruiseControlServletUtils {
   /**
    * Creates a {@link HttpServletResponse#SC_FORBIDDEN} Http servlet response.
    */
-  static String handleConfigException(ConfigException ce, HttpServletRequest request,
-                                      HttpServletResponse response, KafkaCruiseControlConfig config)
+  static String handleConfigException(ConfigException ce,
+                                      HttpServletRequest request,
+                                      HttpServletResponse response,
+                                      KafkaCruiseControlConfig config)
       throws IOException {
     StringWriter sw = new StringWriter();
     ce.printStackTrace(new PrintWriter(sw));
@@ -117,8 +121,10 @@ public class KafkaCruiseControlServletUtils {
   /**
    * Creates a {@link HttpServletResponse#SC_INTERNAL_SERVER_ERROR} Http servlet response.
    */
-  static String handleException(Exception e, HttpServletRequest request,
-                                HttpServletResponse response, KafkaCruiseControlConfig config)
+  static String handleException(Exception e,
+                                HttpServletRequest request,
+                                HttpServletResponse response,
+                                KafkaCruiseControlConfig config)
       throws IOException {
     StringWriter sw = new StringWriter();
     e.printStackTrace(new PrintWriter(sw));

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AbstractParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AbstractParameters.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.EndPoint;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -23,12 +24,14 @@ public abstract class AbstractParameters implements CruiseControlParameters {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractParameters.class);
   protected final HttpServletRequest _request;
   private boolean _initialized = false;
+  protected final KafkaCruiseControlConfig _config;
   // Common to all parameters, expected to be populated via initParameters.
   protected boolean _json = false;
   protected EndPoint _endPoint = null;
 
-  public AbstractParameters(HttpServletRequest request) {
+  public AbstractParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
     _request = request;
+    _config = config;
   }
 
   protected void initParameters() throws UnsupportedEncodingException {
@@ -48,7 +51,7 @@ public abstract class AbstractParameters implements CruiseControlParameters {
       return false;
     } catch (Exception e) {
       try {
-        handleParameterParseException(e, response, e.getMessage(), _json);
+        handleParameterParseException(e, response, e.getMessage(), _json, _config);
       } catch (IOException ioe) {
         LOG.error(String.format("Failed to write parse parameter exception to output stream. Endpoint: %s.", _endPoint), ioe);
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AddedOrRemovedBrokerParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AddedOrRemovedBrokerParameters.java
@@ -46,11 +46,9 @@ public class AddedOrRemovedBrokerParameters extends GoalBasedOptimizationParamet
   private boolean _skipHardGoalCheck;
   private ReplicaMovementStrategy _replicaMovementStrategy;
   private Integer _reviewId;
-  private final KafkaCruiseControlConfig _config;
 
   public AddedOrRemovedBrokerParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
-    super(request);
-    _config = config;
+    super(request, config);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AdminParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AdminParameters.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.detector.notifier.AnomalyType;
 import java.io.UnsupportedEncodingException;
 import java.util.Map;
@@ -30,9 +31,9 @@ public class AdminParameters extends AbstractParameters {
   private Integer _reviewId;
   private boolean _twoStepVerificationEnabled;
 
-  public AdminParameters(HttpServletRequest request, boolean twoStepVerificationEnabled) {
-    super(request);
-    _twoStepVerificationEnabled = twoStepVerificationEnabled;
+  public AdminParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
+    super(request, config);
+    _twoStepVerificationEnabled = _config.getBoolean(KafkaCruiseControlConfig.TWO_STEP_VERIFICATION_ENABLED_CONFIG);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AdminParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AdminParameters.java
@@ -29,7 +29,7 @@ public class AdminParameters extends AbstractParameters {
   private Integer _concurrentInterBrokerPartitionMovements;
   private Integer _concurrentLeaderMovements;
   private Integer _reviewId;
-  private boolean _twoStepVerificationEnabled;
+  private final boolean _twoStepVerificationEnabled;
 
   public AdminParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
     super(request, config);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/BootstrapParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/BootstrapParameters.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.UserRequestException;
 import java.io.UnsupportedEncodingException;
 import javax.servlet.http.HttpServletRequest;
@@ -27,8 +28,8 @@ public class BootstrapParameters extends AbstractParameters {
   private Long _endMs;
   private boolean _clearMetrics;
 
-  public BootstrapParameters(HttpServletRequest request) {
-    super(request);
+  public BootstrapParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
+    super(request, config);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ClusterLoadParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ClusterLoadParameters.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 import java.io.UnsupportedEncodingException;
 import javax.servlet.http.HttpServletRequest;
@@ -22,8 +23,8 @@ public class ClusterLoadParameters extends AbstractParameters {
   private ModelCompletenessRequirements _requirements;
   private boolean _allowCapacityEstimation;
 
-  public ClusterLoadParameters(HttpServletRequest request) {
-    super(request);
+  public ClusterLoadParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
+    super(request, config);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/CruiseControlStateParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/CruiseControlStateParameters.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.response.CruiseControlState;
 import java.io.UnsupportedEncodingException;
 import java.util.Set;
@@ -23,8 +24,8 @@ public class CruiseControlStateParameters extends AbstractParameters {
   private boolean _isVerbose;
   private boolean _isSuperVerbose;
 
-  public CruiseControlStateParameters(HttpServletRequest request) {
-    super(request);
+  public CruiseControlStateParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
+    super(request, config);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/DemoteBrokerParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/DemoteBrokerParameters.java
@@ -32,12 +32,10 @@ public class DemoteBrokerParameters extends KafkaOptimizationParameters {
   private boolean _skipUrpDemotion;
   private boolean _excludeFollowerDemotion;
   private ReplicaMovementStrategy _replicaMovementStrategy;
-  private KafkaCruiseControlConfig _config;
   private Integer _reviewId;
 
   public DemoteBrokerParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
-    super(request);
-    _config = config;
+    super(request, config);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/GoalBasedOptimizationParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/GoalBasedOptimizationParameters.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
@@ -31,8 +32,8 @@ public abstract class GoalBasedOptimizationParameters extends KafkaOptimizationP
   protected boolean _excludeRecentlyRemovedBrokers;
   protected GoalsAndRequirements _goalsAndRequirements;
 
-  GoalBasedOptimizationParameters(HttpServletRequest request) {
-    super(request);
+  GoalBasedOptimizationParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
+    super(request, config);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/KafkaClusterStateParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/KafkaClusterStateParameters.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import java.io.UnsupportedEncodingException;
 import javax.servlet.http.HttpServletRequest;
 
@@ -19,8 +20,8 @@ import javax.servlet.http.HttpServletRequest;
 public class KafkaClusterStateParameters extends AbstractParameters {
   private boolean _isVerbose;
 
-  public KafkaClusterStateParameters(HttpServletRequest request) {
-    super(request);
+  public KafkaClusterStateParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
+    super(request, config);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/KafkaOptimizationParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/KafkaOptimizationParameters.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import java.io.UnsupportedEncodingException;
 import javax.servlet.http.HttpServletRequest;
 
@@ -13,8 +14,8 @@ public abstract class KafkaOptimizationParameters extends AbstractParameters {
   protected boolean _isVerbose;
   protected boolean _excludeRecentlyDemotedBrokers;
 
-  KafkaOptimizationParameters(HttpServletRequest request) {
-    super(request);
+  KafkaOptimizationParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
+    super(request, config);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
@@ -300,14 +300,16 @@ public class ParameterUtils {
     return null;
   }
 
-  static void handleParameterParseException(Exception e, HttpServletResponse response, String errorMsg, boolean json)
+  static void handleParameterParseException(Exception e, HttpServletResponse response, String errorMsg,
+                                            boolean json, KafkaCruiseControlConfig config)
       throws IOException {
     StringWriter sw = new StringWriter();
     e.printStackTrace(new PrintWriter(sw));
-    writeErrorResponse(response, sw.toString(), errorMsg, SC_BAD_REQUEST, json);
+    writeErrorResponse(response, sw.toString(), errorMsg, SC_BAD_REQUEST, json, config);
   }
 
-  public static boolean hasValidParameters(HttpServletRequest request, HttpServletResponse response) throws IOException {
+  public static boolean hasValidParameters(HttpServletRequest request, HttpServletResponse response, KafkaCruiseControlConfig config)
+      throws IOException {
     EndPoint endPoint = endPoint(request);
     Set<String> validParamNames = VALID_ENDPOINT_PARAM_NAMES.get(endPoint);
     Set<String> userParams = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
@@ -320,7 +322,7 @@ public class ParameterUtils {
       // User request specifies parameters that are not a subset of the valid parameters.
       String errorResp = String.format("Unrecognized endpoint parameters in %s %s request: %s.",
                                        endPoint, request.getMethod(), userParams.toString());
-      writeErrorResponse(response, "", errorResp, SC_BAD_REQUEST, wantJSON(request));
+      writeErrorResponse(response, "", errorResp, SC_BAD_REQUEST, wantJSON(request), config);
       return false;
     }
     return true;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
@@ -300,9 +300,11 @@ public class ParameterUtils {
     return null;
   }
 
-  static void handleParameterParseException(Exception e, HttpServletResponse response, String errorMsg,
-                                            boolean json, KafkaCruiseControlConfig config)
-      throws IOException {
+  static void handleParameterParseException(Exception e,
+                                            HttpServletResponse response,
+                                            String errorMsg,
+                                            boolean json,
+                                            KafkaCruiseControlConfig config) throws IOException {
     StringWriter sw = new StringWriter();
     e.printStackTrace(new PrintWriter(sw));
     writeErrorResponse(response, sw.toString(), errorMsg, SC_BAD_REQUEST, json, config);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/PartitionLoadParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/PartitionLoadParameters.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
 import com.linkedin.kafka.cruisecontrol.common.Resource;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.UserRequestException;
 import java.io.UnsupportedEncodingException;
 import java.util.regex.Pattern;
@@ -36,8 +37,8 @@ public class PartitionLoadParameters extends AbstractParameters {
   private boolean _wantMaxLoad;
 
 
-  public PartitionLoadParameters(HttpServletRequest request) {
-    super(request);
+  public PartitionLoadParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
+    super(request, config);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/PauseResumeParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/PauseResumeParameters.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import java.io.UnsupportedEncodingException;
 import javax.servlet.http.HttpServletRequest;
 
@@ -27,9 +28,9 @@ public class PauseResumeParameters extends AbstractParameters {
   private Integer _reviewId;
   private boolean _twoStepVerificationEnabled;
 
-  public PauseResumeParameters(HttpServletRequest request, boolean twoStepVerificationEnabled) {
-    super(request);
-    _twoStepVerificationEnabled = twoStepVerificationEnabled;
+  public PauseResumeParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
+    super(request, config);
+    _twoStepVerificationEnabled = _config.getBoolean(KafkaCruiseControlConfig.TWO_STEP_VERIFICATION_ENABLED_CONFIG);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/PauseResumeParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/PauseResumeParameters.java
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletRequest;
 public class PauseResumeParameters extends AbstractParameters {
   private String _reason;
   private Integer _reviewId;
-  private boolean _twoStepVerificationEnabled;
+  private final boolean _twoStepVerificationEnabled;
 
   public PauseResumeParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
     super(request, config);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ProposalsParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ProposalsParameters.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import java.io.UnsupportedEncodingException;
 import javax.servlet.http.HttpServletRequest;
 
@@ -22,8 +23,8 @@ import javax.servlet.http.HttpServletRequest;
 public class ProposalsParameters extends GoalBasedOptimizationParameters {
   private boolean _ignoreProposalCache;
 
-  public ProposalsParameters(HttpServletRequest request) {
-    super(request);
+  public ProposalsParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
+    super(request, config);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RebalanceParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RebalanceParameters.java
@@ -32,13 +32,11 @@ public class RebalanceParameters extends GoalBasedOptimizationParameters {
   private Integer _concurrentLeaderMovements;
   private boolean _skipHardGoalCheck;
   private ReplicaMovementStrategy _replicaMovementStrategy;
-  private final KafkaCruiseControlConfig _config;
   private boolean _ignoreProposalCache;
   private Integer _reviewId;
 
   public RebalanceParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
-    super(request);
-    _config = config;
+    super(request, config);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ReviewBoardParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ReviewBoardParameters.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import java.io.UnsupportedEncodingException;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
@@ -19,8 +20,8 @@ import javax.servlet.http.HttpServletRequest;
 public class ReviewBoardParameters extends AbstractParameters {
   private Set<Integer> _reviewIds;
 
-  public ReviewBoardParameters(HttpServletRequest request) {
-    super(request);
+  public ReviewBoardParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
+    super(request, config);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ReviewParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ReviewParameters.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.purgatory.ReviewStatus;
 import java.io.UnsupportedEncodingException;
 import java.util.Map;
@@ -23,8 +24,8 @@ public class ReviewParameters extends AbstractParameters {
   private String _reason;
   private Map<ReviewStatus, Set<Integer>> _reviewRequests;
 
-  public ReviewParameters(HttpServletRequest request) {
-    super(request);
+  public ReviewParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
+    super(request, config);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/StopProposalParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/StopProposalParameters.java
@@ -21,7 +21,7 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class StopProposalParameters extends AbstractParameters {
   private Integer _reviewId;
-  private boolean _twoStepVerificationEnabled;
+  private final boolean _twoStepVerificationEnabled;
 
   public StopProposalParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
     super(request, config);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/StopProposalParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/StopProposalParameters.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import java.io.UnsupportedEncodingException;
 import javax.servlet.http.HttpServletRequest;
 
@@ -22,9 +23,9 @@ public class StopProposalParameters extends AbstractParameters {
   private Integer _reviewId;
   private boolean _twoStepVerificationEnabled;
 
-  public StopProposalParameters(HttpServletRequest request, boolean twoStepVerificationEnabled) {
-    super(request);
-    _twoStepVerificationEnabled = twoStepVerificationEnabled;
+  public StopProposalParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
+    super(request, config);
+    _twoStepVerificationEnabled = _config.getBoolean(KafkaCruiseControlConfig.TWO_STEP_VERIFICATION_ENABLED_CONFIG);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/TrainParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/TrainParameters.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.UserRequestException;
 import java.io.UnsupportedEncodingException;
 import javax.servlet.http.HttpServletRequest;
@@ -23,8 +24,8 @@ public class TrainParameters extends AbstractParameters {
   private Long _startMs;
   private Long _endMs;
 
-  public TrainParameters(HttpServletRequest request) {
-    super(request);
+  public TrainParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
+    super(request, config);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/UserTasksParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/UserTasksParameters.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.EndPoint;
 import com.linkedin.kafka.cruisecontrol.servlet.UserTaskManager;
 import java.io.UnsupportedEncodingException;
@@ -28,8 +29,8 @@ public class UserTasksParameters extends AbstractParameters {
   private Set<UserTaskManager.TaskState> _types;
   private int _entries;
 
-  public UserTasksParameters(HttpServletRequest request) {
-    super(request);
+  public UserTasksParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
+    super(request, config);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/AbstractCruiseControlResponse.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/AbstractCruiseControlResponse.java
@@ -20,11 +20,9 @@ public abstract class AbstractCruiseControlResponse implements CruiseControlResp
   protected String _cachedResponse;
   protected KafkaCruiseControlConfig _config;
 
-  public AbstractCruiseControlResponse() {
-    _cachedResponse = null;
-    _config = null;
-  }
-
+  /**
+   * Note if the response corresponds to a request which is initiated by Cruise Control, the config passed in will be null.
+   */
   public AbstractCruiseControlResponse(KafkaCruiseControlConfig config) {
     _cachedResponse = null;
     _config = config;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/AbstractCruiseControlResponse.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/AbstractCruiseControlResponse.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.servlet.response;
 
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.CruiseControlParameters;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -17,9 +18,16 @@ import static javax.servlet.http.HttpServletResponse.SC_OK;
 
 public abstract class AbstractCruiseControlResponse implements CruiseControlResponse {
   protected String _cachedResponse;
+  protected KafkaCruiseControlConfig _config;
 
   public AbstractCruiseControlResponse() {
     _cachedResponse = null;
+    _config = null;
+  }
+
+  public AbstractCruiseControlResponse(KafkaCruiseControlConfig config) {
+    _cachedResponse = null;
+    _config = config;
   }
 
   protected abstract void discardIrrelevantAndCacheRelevant(CruiseControlParameters parameters);
@@ -28,7 +36,7 @@ public abstract class AbstractCruiseControlResponse implements CruiseControlResp
   public void writeSuccessResponse(CruiseControlParameters parameters, HttpServletResponse response) throws IOException {
     OutputStream out = response.getOutputStream();
     boolean json = parameters.json();
-    setResponseCode(response, SC_OK, json, null);
+    setResponseCode(response, SC_OK, json, _config);
     response.addHeader("Cruise-Control-Version", KafkaCruiseControl.cruiseControlVersion());
     response.addHeader("Cruise-Control-Commit_Id", KafkaCruiseControl.cruiseControlCommitId());
     discardIrrelevantResponse(parameters);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/AdminResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/AdminResult.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.servlet.response;
 
 import com.google.gson.Gson;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.detector.notifier.AnomalyType;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.CruiseControlParameters;
 import java.util.HashMap;
@@ -24,7 +25,9 @@ public class AdminResult extends AbstractCruiseControlResponse {
 
   public AdminResult(Map<AnomalyType, Boolean> selfHealingEnabledBefore,
                      Map<AnomalyType, Boolean> selfHealingEnabledAfter,
-                     String ongoingConcurrencyChangeRequest) {
+                     String ongoingConcurrencyChangeRequest,
+                     KafkaCruiseControlConfig config) {
+    super(config);
     _selfHealingEnabledBefore = selfHealingEnabledBefore;
     _selfHealingEnabledAfter = selfHealingEnabledAfter;
     _ongoingConcurrencyChangeRequest = ongoingConcurrencyChangeRequest;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/BootstrapResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/BootstrapResult.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.response;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.EndPoint;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.CruiseControlParameters;
 
@@ -11,6 +12,10 @@ import static com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils.ge
 
 
 public class BootstrapResult extends AbstractCruiseControlResponse {
+
+  public BootstrapResult(KafkaCruiseControlConfig config) {
+    super(config);
+  }
 
   @Override
   protected void discardIrrelevantAndCacheRelevant(CruiseControlParameters parameters) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlState.java
@@ -6,6 +6,7 @@ package com.linkedin.kafka.cruisecontrol.servlet.response;
 
 import com.linkedin.kafka.cruisecontrol.analyzer.AnalyzerState;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorState;
 import com.linkedin.kafka.cruisecontrol.executor.ExecutionTask;
 import com.linkedin.kafka.cruisecontrol.executor.ExecutorState;
@@ -44,7 +45,9 @@ public class CruiseControlState extends AbstractCruiseControlResponse {
   public CruiseControlState(ExecutorState executionState,
                             LoadMonitorState monitorState,
                             AnalyzerState analyzerState,
-                            AnomalyDetectorState anomalyDetectorState) {
+                            AnomalyDetectorState anomalyDetectorState,
+                            KafkaCruiseControlConfig config) {
+    super(config);
     _executorState = executionState;
     _monitorState = monitorState;
     _analyzerState = analyzerState;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/KafkaClusterState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/KafkaClusterState.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.servlet.response;
 
 import com.google.gson.Gson;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.CruiseControlParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.KafkaClusterStateParameters;
 import java.util.ArrayList;
@@ -27,7 +28,6 @@ import org.apache.kafka.common.PartitionInfo;
 import static com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils.JSON_VERSION;
 import static com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils.VERSION;
 
-
 public class KafkaClusterState extends AbstractCruiseControlResponse {
   private static final String TOPIC = "topic";
   private static final String PARTITION = "partition";
@@ -45,7 +45,8 @@ public class KafkaClusterState extends AbstractCruiseControlResponse {
   private static final String REPLICA_COUNT = "ReplicaCountByBrokerId";
   private Cluster _kafkaCluster;
 
-  public KafkaClusterState(Cluster kafkaCluster) {
+  public KafkaClusterState(Cluster kafkaCluster, KafkaCruiseControlConfig config) {
+    super(config);
     _kafkaCluster = kafkaCluster;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/OptimizationResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/OptimizationResult.java
@@ -7,6 +7,7 @@ package com.linkedin.kafka.cruisecontrol.servlet.response;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.linkedin.kafka.cruisecontrol.analyzer.GoalOptimizer;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.executor.ExecutionProposal;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.AddedOrRemovedBrokerParameters;
@@ -42,7 +43,9 @@ public class OptimizationResult extends AbstractCruiseControlResponse {
   private String _cachedJSONResponse;
   private String _cachedPlaintextResponse;
 
-  public OptimizationResult(GoalOptimizer.OptimizerResult optimizerResult) {
+  public OptimizationResult(GoalOptimizer.OptimizerResult optimizerResult,
+                            KafkaCruiseControlConfig config) {
+    super(config);
     _optimizerResult = optimizerResult;
     _cachedJSONResponse = null;
     _cachedPlaintextResponse = null;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/PartitionLoadState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/PartitionLoadState.java
@@ -6,6 +6,7 @@ package com.linkedin.kafka.cruisecontrol.servlet.response;
 
 import com.google.gson.Gson;
 import com.linkedin.kafka.cruisecontrol.common.Resource;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.model.Partition;
 import com.linkedin.kafka.cruisecontrol.monitor.metricdefinition.KafkaMetricDef;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.CruiseControlParameters;
@@ -41,7 +42,9 @@ public class PartitionLoadState extends AbstractCruiseControlResponse {
                             int partitionUpperBoundary,
                             int partitionLowerBoundary,
                             Pattern topic,
-                            int topicNameLength) {
+                            int topicNameLength,
+                            KafkaCruiseControlConfig config) {
+    super(config);
     _sortedPartitions = sortedPartitions;
     _wantMaxLoad = wantMaxLoad;
     _entries = entries;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/PauseSamplingResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/PauseSamplingResult.java
@@ -4,12 +4,17 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.response;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.CruiseControlParameters;
 
 import static com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils.getBaseJSONString;
 
 
 public class PauseSamplingResult extends AbstractCruiseControlResponse {
+
+  public PauseSamplingResult(KafkaCruiseControlConfig config) {
+    super(config);
+  }
 
   @Override
   protected void discardIrrelevantAndCacheRelevant(CruiseControlParameters parameters) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ResponseUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ResponseUtils.java
@@ -110,8 +110,7 @@ public class ResponseUtils {
                                         String errorMessage,
                                         int responseCode,
                                         boolean json,
-                                        KafkaCruiseControlConfig config
-                                        )
+                                        KafkaCruiseControlConfig config)
       throws IOException {
     String responseMsg;
     if (json) {
@@ -124,8 +123,7 @@ public class ResponseUtils {
     } else {
       responseMsg = errorMessage == null ? "" : errorMessage;
     }
-    // We don't need to send the CORS Task ID header as part of this
-    // error response
+    // Send the CORS Task ID header as part of this error response if 2-step verification is enabled.
     writeResponseToOutputStream(response, responseCode, json, responseMsg, config);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ResponseUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ResponseUtils.java
@@ -44,6 +44,8 @@ public class ResponseUtils {
     boolean corsEnabled = config == null ? false : config.getBoolean(KafkaCruiseControlConfig.WEBSERVER_HTTP_CORS_ENABLED_CONFIG);
     if (corsEnabled) {
       // These headers are exposed to the browser
+      response.setHeader("Access-Control-Allow-Origin",
+                         config.getString(KafkaCruiseControlConfig.WEBSERVER_HTTP_CORS_ORIGIN_CONFIG));
       response.setHeader("Access-Control-Expose-Headers",
                          config.getString(KafkaCruiseControlConfig.WEBSERVER_HTTP_CORS_EXPOSEHEADERS_CONFIG));
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ResponseUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ResponseUtils.java
@@ -45,7 +45,7 @@ public class ResponseUtils {
     if (corsEnabled) {
       // These headers are exposed to the browser
       response.setHeader("Access-Control-Expose-Headers",
-            config.getString(KafkaCruiseControlConfig.WEBSERVER_HTTP_CORS_EXPOSEHEADERS_CONFIG));
+                         config.getString(KafkaCruiseControlConfig.WEBSERVER_HTTP_CORS_EXPOSEHEADERS_CONFIG));
 
     }
   }
@@ -109,7 +109,8 @@ public class ResponseUtils {
                                         String stackTrace,
                                         String errorMessage,
                                         int responseCode,
-                                        boolean json
+                                        boolean json,
+                                        KafkaCruiseControlConfig config
                                         )
       throws IOException {
     String responseMsg;
@@ -125,6 +126,6 @@ public class ResponseUtils {
     }
     // We don't need to send the CORS Task ID header as part of this
     // error response
-    writeResponseToOutputStream(response, responseCode, json, responseMsg, null);
+    writeResponseToOutputStream(response, responseCode, json, responseMsg, config);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ResumeSamplingResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ResumeSamplingResult.java
@@ -4,12 +4,17 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.response;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.CruiseControlParameters;
 
 import static com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils.getBaseJSONString;
 
 
 public class ResumeSamplingResult extends AbstractCruiseControlResponse {
+
+  public ResumeSamplingResult(KafkaCruiseControlConfig config) {
+    super(config);
+  }
 
   @Override
   protected void discardIrrelevantAndCacheRelevant(CruiseControlParameters parameters) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ReviewResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ReviewResult.java
@@ -6,6 +6,7 @@ package com.linkedin.kafka.cruisecontrol.servlet.response;
 
 import com.google.gson.Gson;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.CruiseControlParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.purgatory.RequestInfo;
 import java.util.ArrayList;
@@ -35,7 +36,10 @@ public class ReviewResult extends AbstractCruiseControlResponse {
    * @param requestInfoById Request info by Id.
    * @param filteredRequestIds Requests for which the result is requested, empty set implies all requests in review board
    */
-  public ReviewResult(Map<Integer, RequestInfo> requestInfoById, Set<Integer> filteredRequestIds) {
+  public ReviewResult(Map<Integer, RequestInfo> requestInfoById,
+                      Set<Integer> filteredRequestIds,
+                      KafkaCruiseControlConfig config) {
+    super(config);
     _requestInfoById = requestInfoById;
     _filteredRequestIds = filteredRequestIds.isEmpty() ? _requestInfoById.keySet() : filteredRequestIds;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/StopProposalResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/StopProposalResult.java
@@ -4,12 +4,17 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.response;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.CruiseControlParameters;
 
 import static com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils.getBaseJSONString;
 
 
 public class StopProposalResult extends AbstractCruiseControlResponse {
+
+  public StopProposalResult(KafkaCruiseControlConfig config) {
+    super(config);
+  }
 
   @Override
   protected void discardIrrelevantAndCacheRelevant(CruiseControlParameters parameters) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/TrainResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/TrainResult.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.response;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.EndPoint;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.CruiseControlParameters;
 
@@ -11,6 +12,10 @@ import static com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils.ge
 
 
 public class TrainResult extends AbstractCruiseControlResponse {
+
+  public TrainResult(KafkaCruiseControlConfig config) {
+    super(config);
+  }
 
   @Override
   protected void discardIrrelevantAndCacheRelevant(CruiseControlParameters parameters) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/UserTaskState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/UserTaskState.java
@@ -6,6 +6,7 @@ package com.linkedin.kafka.cruisecontrol.servlet.response;
 
 import com.google.gson.Gson;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.EndPoint;
 import com.linkedin.kafka.cruisecontrol.servlet.UserTaskManager;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.CruiseControlParameters;
@@ -36,7 +37,8 @@ public class UserTaskState extends AbstractCruiseControlResponse {
   private static final String USER_TASKS = "userTasks";
   private final Map<UserTaskManager.TaskState, List<UserTaskManager.UserTaskInfo>> _userTasksByTaskState;
 
-  public UserTaskState(UserTaskManager userTaskManager) {
+  public UserTaskState(UserTaskManager userTaskManager, KafkaCruiseControlConfig config) {
+    super(config);
     _userTasksByTaskState = new HashMap<>(2);
     _userTasksByTaskState.put(UserTaskManager.TaskState.ACTIVE, userTaskManager.getActiveUserTasks());
     _userTasksByTaskState.put(UserTaskManager.TaskState.COMPLETED, userTaskManager.getCompletedUserTasks());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/stats/BrokerStats.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/stats/BrokerStats.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.servlet.response.stats;
 
 import com.google.gson.Gson;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.CruiseControlParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.response.AbstractCruiseControlResponse;
@@ -33,7 +34,8 @@ public class BrokerStats extends AbstractCruiseControlResponse {
   private String _cachedJSONResponse;
   private boolean _isBrokerStatsEstimated;
 
-  public BrokerStats() {
+  public BrokerStats(KafkaCruiseControlConfig config) {
+    super(config);
     _brokerStats = new ArrayList<>();
     _hostStats = new ConcurrentSkipListMap<>();
     _hostFieldLength = 0;

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/OfflineProposalGenerator.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/OfflineProposalGenerator.java
@@ -47,7 +47,7 @@ public class OfflineProposalGenerator {
 
     ClusterModelStats origStats = clusterModel.getClusterStats(balancingConstraint);
 
-    String loadBeforeOptimization = clusterModel.brokerStats().toString();
+    String loadBeforeOptimization = clusterModel.brokerStats(null).toString();
     // Instantiate the components.
     GoalOptimizer goalOptimizer = new GoalOptimizer(config,
                                                     null,
@@ -58,7 +58,7 @@ public class OfflineProposalGenerator {
     GoalOptimizer.OptimizerResult optimizerResult = goalOptimizer.optimizations(clusterModel, new OperationProgress());
     end = System.currentTimeMillis();
     duration = (end - start) / 1000.0;
-    String loadAfterOptimization = clusterModel.brokerStats().toString();
+    String loadAfterOptimization = clusterModel.brokerStats(null).toString();
     System.out.println("Optimize goals in " + duration + "s.");
     System.out.println(optimizerResult.goalProposals().size());
     System.out.println(loadBeforeOptimization);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/async/OperationFutureTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/async/OperationFutureTest.java
@@ -21,14 +21,14 @@ import static org.junit.Assert.assertFalse;
 
 
 public class OperationFutureTest {
-  private static CruiseControlResponse DEFAULT_RESULT = new PauseSamplingResult();
+  private static CruiseControlResponse DEFAULT_RESULT = new PauseSamplingResult(null);
 
   @Test
   public void testGetCompleted() throws InterruptedException {
     OperationFuture future = new OperationFuture("testGetCompleted");
     TestThread t = new TestThread(future);
     t.start();
-    CruiseControlResponse expectedResponse = new ResumeSamplingResult();
+    CruiseControlResponse expectedResponse = new ResumeSamplingResult(null);
     future.complete(expectedResponse);
     t.join();
     assertTrue(future.isDone());
@@ -78,7 +78,7 @@ public class OperationFutureTest {
               this.wait();
             }
           }
-          return new ResumeSamplingResult();
+          return new ResumeSamplingResult(null);
         } catch (InterruptedException ie) {
           interrupted.set(true);
           throw ie;

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -74,7 +74,7 @@ public class AnomalyDetectorTest {
     // The following state are used to test the delayed check when executor is busy.
     EasyMock.expect(mockKafkaCruiseControl.state(EasyMock.anyObject(), EasyMock.anyObject()))
             .andReturn(new CruiseControlState(ExecutorState.noTaskInProgress(null, null), null, null,
-                                              null));
+                                              null, null));
 
     EasyMock.replay(mockAnomalyNotifier);
     EasyMock.replay(mockBrokerFailureDetector);
@@ -143,7 +143,7 @@ public class AnomalyDetectorTest {
     // The following state are used to test the delayed check when executor is busy.
     EasyMock.expect(mockKafkaCruiseControl.state(EasyMock.anyObject(), EasyMock.anyObject()))
             .andReturn(new CruiseControlState(ExecutorState.noTaskInProgress(null, null), null, null,
-                                              null));
+                                              null, null));
     EasyMock.expect(mockKafkaCruiseControl.rebalance(EasyMock.eq(Collections.emptyList()),
                                                      EasyMock.eq(false),
                                                      EasyMock.eq(null),
@@ -234,7 +234,7 @@ public class AnomalyDetectorTest {
                                                   null,
                                                   null,
                                                   null),
-                null, null, null));
+                null, null, null, null));
 
     EasyMock.replay(mockAnomalyNotifier);
     EasyMock.replay(mockBrokerFailureDetector);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletEndpointTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletEndpointTest.java
@@ -144,7 +144,7 @@ public class KafkaCruiseControlServletEndpointTest {
     EasyMock.replay(_mockUUIDGenerator, _mockHttpSession, _mockHttpServletResponse);
     populateUserTaskManager(_mockHttpServletResponse, _userTaskManager);
 
-    UserTaskState userTaskState = new UserTaskState(_userTaskManager);
+    UserTaskState userTaskState = new UserTaskState(_userTaskManager, null);
 
     // Test Case 1: Get all PROPOSAL or REBALANCE tasks
     Map<String,  String []> answerQueryParam1 = new HashMap<>();
@@ -202,7 +202,7 @@ public class KafkaCruiseControlServletEndpointTest {
     // Update task manager active vs completed state
     _userTaskManager.checkActiveUserTasks();
     // Now the UserTaskManager state has changed, so we reload the states
-    UserTaskState userTaskState2 = new UserTaskState(_userTaskManager);
+    UserTaskState userTaskState2 = new UserTaskState(_userTaskManager, null);
 
     // Test Case 5: Get all LOAD or REMOVE_BROKER tasks that's completed and with user task id repeatUUID
     Map<String,  String []> answerQueryParam5 = new HashMap<>();

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/SessionManagerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/SessionManagerTest.java
@@ -111,11 +111,11 @@ public class SessionManagerTest {
       // Create the first future.
       OperationFuture firstFuture = sessionManager.getAndCreateSessionIfNotExist(request, () -> future1, 0);
       assertSame(firstFuture, future1);
-      future1.complete(new PauseSamplingResult());
+      future1.complete(new PauseSamplingResult(null));
       // create the second future.
       OperationFuture secondFuture = sessionManager.getAndCreateSessionIfNotExist(request, () -> future2, 1);
       assertSame(secondFuture, future2);
-      future2.complete(new ResumeSamplingResult());
+      future2.complete(new ResumeSamplingResult(null));
     }
   }
 


### PR DESCRIPTION
Add `Access-Control-Expose-Headers` field in HTTP response header for all Cruise control response(normal/error/in-progress) if config `webserver.http.cors.enabled` is set to true. 
Fix for [585](https://github.com/linkedin/cruise-control/issues/585)