### PR TITLE
Distinguish inter-broker and intra-broker replica movement.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -174,8 +174,8 @@ public class KafkaCruiseControl {
    * @param requirements The cluster model completeness requirements.
    * @param operationProgress The progress to report.
    * @param allowCapacityEstimation Allow capacity estimation in cluster model if the requested broker capacity is unavailable.
-   * @param concurrentPartitionMovements The maximum number of concurrent partition movements per broker
-   *                                     (if null, use num.concurrent.partition.movements.per.broker).
+   * @param concurrentInterBrokerPartitionMovements The maximum number of concurrent inter-broker partition movements per broker
+   *                                                (if null, use num.concurrent.partition.movements.per.broker).
    * @param concurrentLeaderMovements The maximum number of concurrent leader movements
    *                                  (if null, use num.concurrent.leader.movements).
    * @param skipHardGoalCheck True if the provided {@code goals} do not have to contain all hard goals, false otherwise.
@@ -196,7 +196,7 @@ public class KafkaCruiseControl {
                                                            ModelCompletenessRequirements requirements,
                                                            OperationProgress operationProgress,
                                                            boolean allowCapacityEstimation,
-                                                           Integer concurrentPartitionMovements,
+                                                           Integer concurrentInterBrokerPartitionMovements,
                                                            Integer concurrentLeaderMovements,
                                                            boolean skipHardGoalCheck,
                                                            Pattern excludedTopics,
@@ -223,7 +223,7 @@ public class KafkaCruiseControl {
                                                           excludeRecentlyRemovedBrokers);
       if (!dryRun) {
         executeRemoval(result.goalProposals(), throttleDecommissionedBroker, brokerIds, isKafkaAssignerMode(goals),
-                       concurrentPartitionMovements, concurrentLeaderMovements, replicaMovementStrategy, uuid);
+                       concurrentInterBrokerPartitionMovements, concurrentLeaderMovements, replicaMovementStrategy, uuid);
       }
       return result;
     } catch (KafkaCruiseControlException kcce) {
@@ -261,8 +261,8 @@ public class KafkaCruiseControl {
    * @param requirements The cluster model completeness requirements.
    * @param operationProgress The progress of the job to update.
    * @param allowCapacityEstimation Allow capacity estimation in cluster model if the requested broker capacity is unavailable.
-   * @param concurrentPartitionMovements The maximum number of concurrent partition movements per broker
-   *                                     (if null, use num.concurrent.partition.movements.per.broker).
+   * @param concurrentInterBrokerPartitionMovements The maximum number of concurrent inter-broker partition movements per broker
+   *                                                (if null, use num.concurrent.partition.movements.per.broker).
    * @param concurrentLeaderMovements The maximum number of concurrent leader movements
    *                                  (if null, use num.concurrent.leader.movements).
    * @param skipHardGoalCheck True if the provided {@code goals} do not have to contain all hard goals, false otherwise.
@@ -282,7 +282,7 @@ public class KafkaCruiseControl {
                                                   ModelCompletenessRequirements requirements,
                                                   OperationProgress operationProgress,
                                                   boolean allowCapacityEstimation,
-                                                  Integer concurrentPartitionMovements,
+                                                  Integer concurrentInterBrokerPartitionMovements,
                                                   Integer concurrentLeaderMovements,
                                                   boolean skipHardGoalCheck,
                                                   Pattern excludedTopics,
@@ -312,7 +312,7 @@ public class KafkaCruiseControl {
         executeProposals(result.goalProposals(),
                          throttleAddedBrokers ? Collections.emptyList() : brokerIds,
                          isKafkaAssignerMode(goals),
-                         concurrentPartitionMovements,
+                         concurrentInterBrokerPartitionMovements,
                          concurrentLeaderMovements,
                          replicaMovementStrategy,
                          uuid);
@@ -344,8 +344,8 @@ public class KafkaCruiseControl {
    * @param requirements The cluster model completeness requirements.
    * @param operationProgress The progress of the job to report.
    * @param allowCapacityEstimation Allow capacity estimation in cluster model if the requested broker capacity is unavailable.
-   * @param concurrentPartitionMovements The maximum number of concurrent partition movements per broker
-   *                                     (if null, use num.concurrent.partition.movements.per.broker).
+   * @param concurrentInterBrokerPartitionMovements The maximum number of concurrent inter-broker partition movements per broker
+   *                                                (if null, use num.concurrent.partition.movements.per.broker).
    * @param concurrentLeaderMovements The maximum number of concurrent leader movements
    *                                  (if null, use num.concurrent.leader.movements).
    * @param skipHardGoalCheck True if the provided {@code goals} do not have to contain all hard goals, false otherwise.
@@ -363,7 +363,7 @@ public class KafkaCruiseControl {
                                                  ModelCompletenessRequirements requirements,
                                                  OperationProgress operationProgress,
                                                  boolean allowCapacityEstimation,
-                                                 Integer concurrentPartitionMovements,
+                                                 Integer concurrentInterBrokerPartitionMovements,
                                                  Integer concurrentLeaderMovements,
                                                  boolean skipHardGoalCheck,
                                                  Pattern excludedTopics,
@@ -380,7 +380,7 @@ public class KafkaCruiseControl {
                                                         ignoreProposalCache);
     if (!dryRun) {
       executeProposals(result.goalProposals(), Collections.emptySet(), isKafkaAssignerMode(goals),
-                       concurrentPartitionMovements, concurrentLeaderMovements, replicaMovementStrategy, uuid);
+                       concurrentInterBrokerPartitionMovements, concurrentLeaderMovements, replicaMovementStrategy, uuid);
     }
     return result;
   }
@@ -576,12 +576,13 @@ public class KafkaCruiseControl {
    */
   public synchronized AdminResult handleAdminRequest(AdminParameters parameters) {
     String ongoingConcurrencyChangeRequest = "";
-    // 1.1. Change partition concurrency.
-    Integer concurrentPartitionMovements = parameters.concurrentPartitionMovements();
-    if (concurrentPartitionMovements != null) {
-      _executor.setRequestedPartitionMovementConcurrency(concurrentPartitionMovements);
-      ongoingConcurrencyChangeRequest += String.format("Partition movement concurrency is set to %d%n", concurrentPartitionMovements);
-      LOG.warn("Partition movement concurrency is set to: {} by user.", concurrentPartitionMovements);
+    // 1.1. Change inter-broker partition concurrency.
+    Integer concurrentInterBrokerPartitionMovements = parameters.concurrentInterBrokerPartitionMovements();
+    if (concurrentInterBrokerPartitionMovements != null) {
+      _executor.setRequestedInterBrokerPartitionMovementConcurrency(concurrentInterBrokerPartitionMovements);
+      ongoingConcurrencyChangeRequest += String.format("Inter-broker partition movement concurrency is set to %d%n",
+                                                       concurrentInterBrokerPartitionMovements);
+      LOG.warn("Inter-broker partition movement concurrency is set to: {} by user.", concurrentInterBrokerPartitionMovements);
     }
     // 1.2. Change leadership concurrency.
     Integer concurrentLeaderMovements = parameters.concurrentLeaderMovements();
@@ -765,8 +766,8 @@ public class KafkaCruiseControl {
    * @param proposals the given balancing proposals
    * @param unthrottledBrokers Brokers for which the rate of replica movements from/to will not be throttled.
    * @param isKafkaAssignerMode True if kafka assigner mode, false otherwise.
-   * @param concurrentPartitionMovements The maximum number of concurrent partition movements per broker
-   *                                     (if null, use num.concurrent.partition.movements.per.broker).
+   * @param concurrentInterBrokerPartitionMovements The maximum number of concurrent inter-broker partition movements per broker
+   *                                                (if null, use num.concurrent.partition.movements.per.broker).
    * @param concurrentLeaderMovements The maximum number of concurrent leader movements
    *                                  (if null, use num.concurrent.leader.movements).
    * @param replicaMovementStrategy The strategy used to determine the execution order of generated replica movement tasks
@@ -776,13 +777,13 @@ public class KafkaCruiseControl {
   private void executeProposals(Collection<ExecutionProposal> proposals,
                                 Collection<Integer> unthrottledBrokers,
                                 boolean isKafkaAssignerMode,
-                                Integer concurrentPartitionMovements,
+                                Integer concurrentInterBrokerPartitionMovements,
                                 Integer concurrentLeaderMovements,
                                 ReplicaMovementStrategy replicaMovementStrategy,
                                 String uuid) {
     // Set the execution mode, add execution proposals, and start execution.
     _executor.setExecutionMode(isKafkaAssignerMode);
-    _executor.executeProposals(proposals, unthrottledBrokers, null, _loadMonitor, concurrentPartitionMovements,
+    _executor.executeProposals(proposals, unthrottledBrokers, null, _loadMonitor, concurrentInterBrokerPartitionMovements,
                                concurrentLeaderMovements, replicaMovementStrategy, uuid);
   }
 
@@ -792,8 +793,8 @@ public class KafkaCruiseControl {
    * @param throttleDecommissionedBroker Whether throttle the brokers that are being decommissioned.
    * @param removedBrokers Brokers to be removed, null if no brokers has been removed.
    * @param isKafkaAssignerMode True if kafka assigner mode, false otherwise.
-   * @param concurrentPartitionMovements The maximum number of concurrent partition movements per broker
-   *                                     (if null, use num.concurrent.partition.movements.per.broker).
+   * @param concurrentInterBrokerPartitionMovements The maximum number of concurrent inter-broker partition movements per broker
+   *                                                (if null, use num.concurrent.partition.movements.per.broker).
    * @param concurrentLeaderMovements The maximum number of concurrent leader movements
    *                                  (if null, use num.concurrent.leader.movements).
    * @param replicaMovementStrategy The strategy used to determine the execution order of generated replica movement tasks
@@ -804,15 +805,15 @@ public class KafkaCruiseControl {
                               boolean throttleDecommissionedBroker,
                               Collection<Integer> removedBrokers,
                               boolean isKafkaAssignerMode,
-                              Integer concurrentPartitionMovements,
+                              Integer concurrentInterBrokerPartitionMovements,
                               Integer concurrentLeaderMovements,
                               ReplicaMovementStrategy replicaMovementStrategy,
                               String uuid) {
     // Set the execution mode, add execution proposals, and start execution.
     _executor.setExecutionMode(isKafkaAssignerMode);
     _executor.executeProposals(proposals, throttleDecommissionedBroker ? Collections.emptyList() : removedBrokers,
-                               removedBrokers, _loadMonitor, concurrentPartitionMovements, concurrentLeaderMovements,
-                               replicaMovementStrategy, uuid);
+                               removedBrokers, _loadMonitor, concurrentInterBrokerPartitionMovements,
+                               concurrentLeaderMovements, replicaMovementStrategy, uuid);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/ActionType.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/ActionType.java
@@ -13,20 +13,20 @@ import java.util.List;
  * Flags to indicate the type of an action.
  *
  * <ul>
- * <li>{@link #REPLICA_MOVEMENT}: Move a replica from a source broker to a destination broker.</li>
+ * <li>{@link #INTER_BROKER_REPLICA_MOVEMENT}: Move a replica from a source broker to a destination broker.</li>
  * <li>{@link #LEADERSHIP_MOVEMENT}: Move leadership of a leader from a source broker to a follower of the same
  * partition residing in a destination broker.</li>
  * <li>{@link #REPLICA_ADDITION}: Add a new replica to the cluster.</li>
  * <li>{@link #REPLICA_DELETION}: Remove an existing replica from the cluster.</li>
- * <li>{@link #REPLICA_SWAP}: Swap places of replicas residing in source and destination brokers.</li>
+ * <li>{@link #INTER_BROKER_REPLICA_SWAP}: Swap places of replicas residing in source and destination brokers.</li>
  * </ul>
  */
 public enum ActionType {
-  REPLICA_MOVEMENT("REPLICA"),
+  INTER_BROKER_REPLICA_MOVEMENT("REPLICA"),
   LEADERSHIP_MOVEMENT("LEADER"),
   REPLICA_ADDITION("ADDITION"),
   REPLICA_DELETION("DELETE"),
-  REPLICA_SWAP("SWAP");
+  INTER_BROKER_REPLICA_SWAP("SWAP");
 
   private static final List<ActionType> CACHED_VALUES = Collections.unmodifiableList(Arrays.asList(values()));
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUtils.java
@@ -84,8 +84,7 @@ public class AnalyzerUtils {
         finalReplicas.set(0, finalLeaderId);
       }
       Double partitionSize = optimizedClusterModel.partition(tp).leader().load().expectedUtilizationFor(Resource.DISK);
-      diff.add(new ExecutionProposal(tp, partitionSize.intValue(), initialLeaderDistribution.get(tp),
-                                     initialReplicas, finalReplicas));
+      diff.add(new ExecutionProposal(tp, partitionSize.intValue(), initialLeaderDistribution.get(tp), initialReplicas, finalReplicas));
     }
     return diff;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/BalancingAction.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/BalancingAction.java
@@ -81,9 +81,9 @@ public class BalancingAction {
           throw new IllegalArgumentException("The source broker cannot be null for balancing action " + this);
         }
         break;
-      case REPLICA_MOVEMENT:
+      case INTER_BROKER_REPLICA_MOVEMENT:
       case LEADERSHIP_MOVEMENT:
-      case REPLICA_SWAP:
+      case INTER_BROKER_REPLICA_SWAP:
         if (_destinationBrokerId == null) {
           throw new IllegalArgumentException("The destination broker cannot be null for balancing action " + this);
         } else if (_sourceBrokerId == null) {
@@ -170,7 +170,7 @@ public class BalancingAction {
    */
   @Override
   public String toString() {
-    String actSymbol = _actionType.equals(ActionType.REPLICA_SWAP) ? "<->" : "->";
+    String actSymbol = _actionType.equals(ActionType.INTER_BROKER_REPLICA_SWAP) ? "<->" : "->";
     return String.format("(%s%s%s, %d%s%d, %s)",
                          _tp, actSymbol, _destinationTp, _sourceBrokerId, actSymbol, _destinationBrokerId, _actionType);
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
@@ -56,8 +56,8 @@ import static com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunne
  * A class for optimizing goals in the given order of priority.
  */
 public class GoalOptimizer implements Runnable {
-  private static final String NUM_REPLICA_MOVEMENTS = "numReplicaMovements";
-  private static final String DATA_TO_MOVE_MB = "dataToMoveMB";
+  private static final String NUM_INTER_BROKER_REPLICA_MOVEMENTS = "numReplicaMovements";
+  private static final String INTER_BROKER_DATA_TO_MOVE_MB = "dataToMoveMB";
   private static final String NUM_LEADER_MOVEMENTS = "numLeaderMovements";
   private static final String RECENT_WINDOWS = "recentWindows";
   private static final String MONITORED_PARTITIONS_PERCENTAGE = "monitoredPartitionsPercentage";
@@ -601,23 +601,24 @@ public class GoalOptimizer implements Runnable {
     }
 
     private List<Number> getMovementStats() {
-      Integer numReplicaMovements = 0;
+      Integer numInterBrokerReplicaMovements = 0;
       Integer numLeaderMovements = 0;
-      long dataToMove = 0L;
+      long interBrokerDataToMove = 0L;
       for (ExecutionProposal p : _proposals) {
         if (!p.replicasToAdd().isEmpty() || !p.replicasToRemove().isEmpty()) {
-          numReplicaMovements++;
-          dataToMove += p.dataToMoveInMB();
+          numInterBrokerReplicaMovements++;
+          interBrokerDataToMove += p.dataToMoveInMB();
         } else {
           numLeaderMovements++;
         }
       }
-      return Arrays.asList(numReplicaMovements, dataToMove, numLeaderMovements);
+      return Arrays.asList(numInterBrokerReplicaMovements, interBrokerDataToMove,
+                           numLeaderMovements);
     }
 
     public String getProposalSummary() {
       List<Number> moveStats = getMovementStats();
-      return String.format("%n%nThe optimization proposal has %d replica(%d MB) movements and %d leadership movements "
+      return String.format("%n%nThe optimization proposal has %d inter-broker replica(%d MB) movements and %d leadership movements "
                            + "based on the cluster model with %d recent snapshot windows and %.3f%% of the partitions "
                            + "covered.%nExcluded Topics: %s.%nExcluded Brokers For Leadership: %s.%nExcluded Brokers "
                            + "For Replica Move: %s.",
@@ -629,8 +630,8 @@ public class GoalOptimizer implements Runnable {
     public Map<String, Object> getProposalSummaryForJson() {
       List<Number> moveStats = getMovementStats();
       Map<String, Object> ret = new HashMap<>();
-      ret.put(NUM_REPLICA_MOVEMENTS, moveStats.get(0).intValue());
-      ret.put(DATA_TO_MOVE_MB, moveStats.get(1).longValue());
+      ret.put(NUM_INTER_BROKER_REPLICA_MOVEMENTS, moveStats.get(0).intValue());
+      ret.put(INTER_BROKER_DATA_TO_MOVE_MB, moveStats.get(1).longValue());
       ret.put(NUM_LEADER_MOVEMENTS, moveStats.get(2).intValue());
       ret.put(RECENT_WINDOWS, _clusterModelStats.numSnapshotWindows());
       ret.put(MONITORED_PARTITIONS_PERCENTAGE, _clusterModelStats.monitoredPartitionsPercentage() * 100.0);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -226,7 +226,7 @@ public abstract class AbstractGoal implements Goal {
       if (acceptance == ACCEPT) {
         if (action == ActionType.LEADERSHIP_MOVEMENT) {
           clusterModel.relocateLeadership(replica.topicPartition(), replica.broker().id(), broker.id());
-        } else if (action == ActionType.REPLICA_MOVEMENT) {
+        } else if (action == ActionType.INTER_BROKER_REPLICA_MOVEMENT) {
           clusterModel.relocateReplica(replica.topicPartition(), replica.broker().id(), broker.id());
         }
         return broker;
@@ -260,18 +260,18 @@ public abstract class AbstractGoal implements Goal {
     for (Replica destinationReplica : eligibleReplicas) {
       BalancingAction swapProposal = new BalancingAction(sourceReplica.topicPartition(),
                                                          sourceReplica.broker().id(), destinationBroker.id(),
-                                                         ActionType.REPLICA_SWAP, destinationReplica.topicPartition());
+                                                         ActionType.INTER_BROKER_REPLICA_SWAP, destinationReplica.topicPartition());
       // A sourceReplica should be swapped with a replicaToSwapWith if:
       // 0. The swap from source to destination is legit.
       // 1. The swap from destination to source is legit.
       // 2. The goal requirements are not violated if this action is applied to the given cluster state.
       // 3. The movement is acceptable by the previously optimized goals.
-      if (!legitMove(sourceReplica, destinationBroker, ActionType.REPLICA_MOVEMENT)) {
+      if (!legitMove(sourceReplica, destinationBroker, ActionType.INTER_BROKER_REPLICA_MOVEMENT)) {
         LOG.trace("Swap from source to destination broker is not legit for {}.", swapProposal);
         return null;
       }
 
-      if (!legitMove(destinationReplica, sourceReplica.broker(), ActionType.REPLICA_MOVEMENT)) {
+      if (!legitMove(destinationReplica, sourceReplica.broker(), ActionType.INTER_BROKER_REPLICA_MOVEMENT)) {
         LOG.trace("Swap from destination to source broker is not legit for {}.", swapProposal);
         continue;
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CapacityGoal.java
@@ -88,10 +88,10 @@ public abstract class CapacityGoal extends AbstractGoal {
     Broker destinationBroker = clusterModel.broker(action.destinationBrokerId());
 
     switch (action.balancingAction()) {
-      case REPLICA_SWAP:
+      case INTER_BROKER_REPLICA_SWAP:
         Replica destinationReplica = destinationBroker.replica(action.destinationTopicPartition());
         return isSwapAcceptableForCapacity(sourceReplica, destinationReplica) ? ACCEPT : REPLICA_REJECT;
-      case REPLICA_MOVEMENT:
+      case INTER_BROKER_REPLICA_MOVEMENT:
       case LEADERSHIP_MOVEMENT:
         return isMovementAcceptableForCapacity(sourceReplica, destinationBroker) ? ACCEPT : REPLICA_REJECT;
       default:
@@ -319,7 +319,7 @@ public abstract class CapacityGoal extends AbstractGoal {
         // Unless the target broker would go over the host- and/or broker-level capacity,
         // the movement will be successful.
         Broker b = maybeApplyBalancingAction(clusterModel, replica, sortedAliveBrokersUnderCapacityLimit,
-                                             ActionType.REPLICA_MOVEMENT, optimizedGoals, optimizationOptions);
+                                             ActionType.INTER_BROKER_REPLICA_MOVEMENT, optimizedGoals, optimizationOptions);
         if (b == null) {
           LOG.debug("Failed to move replica {} to any broker in {}", replica, sortedAliveBrokersUnderCapacityLimit);
         }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/GoalUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/GoalUtils.java
@@ -35,7 +35,7 @@ public class GoalUtils {
   }
 
   /**
-   * Check whether the execution of a {@link com.linkedin.kafka.cruisecontrol.analyzer.ActionType#REPLICA_MOVEMENT}
+   * Check whether the execution of a {@link com.linkedin.kafka.cruisecontrol.analyzer.ActionType#INTER_BROKER_REPLICA_MOVEMENT}
    * action is eligible for the given replica in the given clusterModel to the given candidate broker.
    *
    * Invariant-1: If there are new brokers, an eligible candidate that triggers an action must be a new broker.
@@ -75,7 +75,7 @@ public class GoalUtils {
    * <ul>
    * <li>{@link com.linkedin.kafka.cruisecontrol.analyzer.ActionType#LEADERSHIP_MOVEMENT}, then brokers excluded for
    * leadership are not eligible.</li>
-   * <li>{@link com.linkedin.kafka.cruisecontrol.analyzer.ActionType#REPLICA_MOVEMENT} for a leader replica, then unless
+   * <li>{@link com.linkedin.kafka.cruisecontrol.analyzer.ActionType#INTER_BROKER_REPLICA_MOVEMENT} for a leader replica, then unless
    * the source leader replica is dead, brokers excluded for leadership are not eligible.</li>
    * </ul>
    *
@@ -99,7 +99,7 @@ public class GoalUtils {
   /**
    * Filter out the given excluded brokers from the original brokers (if needed). If the action is:
    * <ul>
-   * <li>{@link com.linkedin.kafka.cruisecontrol.analyzer.ActionType#REPLICA_MOVEMENT}, then unless the source replica
+   * <li>{@link com.linkedin.kafka.cruisecontrol.analyzer.ActionType#INTER_BROKER_REPLICA_MOVEMENT}, then unless the source replica
    * is dead, brokers excluded for replica move are not eligible.</li>
    * </ul>
    *
@@ -112,14 +112,14 @@ public class GoalUtils {
                                                              Set<Integer> excludedBrokers,
                                                              Replica replica,
                                                              ActionType action) {
-    if (!excludedBrokers.isEmpty() && action == ActionType.REPLICA_MOVEMENT && replica.originalBroker().isAlive()) {
+    if (!excludedBrokers.isEmpty() && action == ActionType.INTER_BROKER_REPLICA_MOVEMENT && replica.originalBroker().isAlive()) {
       originalBrokers.removeIf(broker -> excludedBrokers.contains(broker.id()));
     }
   }
 
   /**
    * Filter the given candidate brokers in the given clusterModel to retrieve the eligible ones for execution of a
-   * {@link com.linkedin.kafka.cruisecontrol.analyzer.ActionType#REPLICA_MOVEMENT} or
+   * {@link com.linkedin.kafka.cruisecontrol.analyzer.ActionType#INTER_BROKER_REPLICA_MOVEMENT} or
    * {@link com.linkedin.kafka.cruisecontrol.analyzer.ActionType#LEADERSHIP_MOVEMENT} action for the given replica.
    *
    * Invariant-1: If there are new brokers, an eligible candidate that triggers an action must be a new broker.
@@ -151,8 +151,9 @@ public class GoalUtils {
   }
 
   /**
-   * Check whether the proposed action is legit. An action is legit if it is:
-   * (1) a replica movement and the destination does not have a replica of the same partition, or
+   * Check whether the proposed inter-broker action is legit. An action is legit if it is:
+   * (1) a replica movement across brokers, the destination broker does not have a replica of the same partition and is
+   * allowed to have a replica from the partition
    * (2) a leadership movement, the replica is a leader and the destination broker has a follower of the same partition.
    *
    * @param replica Replica that is affected from the given action type.
@@ -162,7 +163,7 @@ public class GoalUtils {
    */
   static boolean legitMove(Replica replica, Broker destinationBroker, ActionType actionType) {
     switch (actionType) {
-      case REPLICA_MOVEMENT:
+      case INTER_BROKER_REPLICA_MOVEMENT:
         return destinationBroker.replica(replica.topicPartition()) == null;
       case LEADERSHIP_MOVEMENT:
         return replica.isLeader() && destinationBroker.replica(replica.topicPartition()) != null;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderBytesInDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderBytesInDistributionGoal.java
@@ -67,13 +67,13 @@ public class LeaderBytesInDistributionGoal extends AbstractGoal {
 
     if (!sourceReplica.isLeader()) {
       switch (action.balancingAction()) {
-        case REPLICA_SWAP:
+        case INTER_BROKER_REPLICA_SWAP:
           if (!destinationBroker.replica(action.destinationTopicPartition()).isLeader()) {
             // No leadership bytes are being swapped between source and destination.
             return ACCEPT;
           }
           break;
-        case REPLICA_MOVEMENT:
+        case INTER_BROKER_REPLICA_MOVEMENT:
           // No leadership bytes are being moved to destination.
           return ACCEPT;
         case LEADERSHIP_MOVEMENT:
@@ -87,7 +87,7 @@ public class LeaderBytesInDistributionGoal extends AbstractGoal {
     double newDestLeaderBytesIn;
 
     switch (action.balancingAction()) {
-      case REPLICA_SWAP:
+      case INTER_BROKER_REPLICA_SWAP:
         double destinationReplicaUtilization = destinationBroker.replica(action.destinationTopicPartition()).load()
             .expectedUtilizationFor(Resource.NW_IN);
         newDestLeaderBytesIn = destinationBroker.leadershipLoadForNwResources().expectedUtilizationFor(Resource.NW_IN)
@@ -101,7 +101,7 @@ public class LeaderBytesInDistributionGoal extends AbstractGoal {
           return REPLICA_REJECT;
         }
         break;
-      case REPLICA_MOVEMENT:
+      case INTER_BROKER_REPLICA_MOVEMENT:
       case LEADERSHIP_MOVEMENT:
         newDestLeaderBytesIn = destinationBroker.leadershipLoadForNwResources().expectedUtilizationFor(Resource.NW_IN)
                                + sourceReplicaUtilization;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/PotentialNwOutGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/PotentialNwOutGoal.java
@@ -74,8 +74,8 @@ public class PotentialNwOutGoal extends AbstractGoal {
       case LEADERSHIP_MOVEMENT:
         // it is a leadership movement,
         return ACCEPT;
-      case REPLICA_SWAP:
-      case REPLICA_MOVEMENT:
+      case INTER_BROKER_REPLICA_SWAP:
+      case INTER_BROKER_REPLICA_MOVEMENT:
         return isReplicaRelocationAcceptable(action, clusterModel);
       default:
         throw new IllegalArgumentException("Unsupported balancing action " + action.balancingAction() + " is provided.");
@@ -110,7 +110,7 @@ public class PotentialNwOutGoal extends AbstractGoal {
     double maxUtilization = Math.max(destinationBrokerUtilization, sourceBrokerUtilization);
 
     switch (action.balancingAction()) {
-      case REPLICA_SWAP:
+      case INTER_BROKER_REPLICA_SWAP:
         double destinationReplicaUtilization = clusterModel.partition(action.destinationTopicPartition())
             .leader().load().expectedUtilizationFor(Resource.NW_OUT);
         // Check source broker potential NW_OUT violation.
@@ -119,7 +119,7 @@ public class PotentialNwOutGoal extends AbstractGoal {
         }
         return destinationBrokerUtilization + sourceReplicaUtilization - destinationReplicaUtilization <= maxUtilization
                ? ACCEPT : REPLICA_REJECT;
-      case REPLICA_MOVEMENT:
+      case INTER_BROKER_REPLICA_MOVEMENT:
         return destinationBrokerUtilization + sourceReplicaUtilization <= maxUtilization ? ACCEPT : REPLICA_REJECT;
       default:
         throw new IllegalArgumentException("Unsupported balancing action " + action.balancingAction() + " is provided.");
@@ -179,7 +179,7 @@ public class PotentialNwOutGoal extends AbstractGoal {
     ActionType actionType = action.balancingAction();
     Broker sourceBroker = sourceReplica.broker();
     // If the source broker is dead and currently self healing dead brokers only, then the action must be executed.
-    if (!sourceBroker.isAlive() && _selfHealingDeadBrokersOnly && actionType != ActionType.REPLICA_SWAP) {
+    if (!sourceBroker.isAlive() && _selfHealingDeadBrokersOnly && actionType != ActionType.INTER_BROKER_REPLICA_SWAP) {
       return true;
     }
     Broker destinationBroker = clusterModel.broker(action.destinationBrokerId());
@@ -188,7 +188,7 @@ public class PotentialNwOutGoal extends AbstractGoal {
     double sourceReplicaUtilization = clusterModel.partition(sourceReplica.topicPartition()).leader().load()
                                                   .expectedUtilizationFor(Resource.NW_OUT);
 
-    if (actionType != ActionType.REPLICA_SWAP) {
+    if (actionType != ActionType.INTER_BROKER_REPLICA_SWAP) {
       // Check whether replica or leadership transfer leads to violation of capacity limit requirement.
       return destinationCapacity >= destinationBrokerUtilization + sourceReplicaUtilization;
     }
@@ -281,7 +281,7 @@ public class PotentialNwOutGoal extends AbstractGoal {
       eligibleBrokers.sort((b1, b2) -> Double.compare(b2.leadershipLoadForNwResources().expectedUtilizationFor(Resource.NW_OUT),
                                                       b1.leadershipLoadForNwResources().expectedUtilizationFor(Resource.NW_OUT)));
       Broker destinationBroker =
-          maybeApplyBalancingAction(clusterModel, replica, eligibleBrokers, ActionType.REPLICA_MOVEMENT,
+          maybeApplyBalancingAction(clusterModel, replica, eligibleBrokers, ActionType.INTER_BROKER_REPLICA_MOVEMENT,
                                     optimizedGoals, optimizationOptions);
       if (destinationBroker != null) {
         int destinationBrokerId = destinationBroker.id();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareGoal.java
@@ -69,15 +69,15 @@ public class RackAwareGoal extends AbstractGoal {
     switch (action.balancingAction()) {
       case LEADERSHIP_MOVEMENT:
         return ACCEPT;
-      case REPLICA_MOVEMENT:
-      case REPLICA_SWAP:
+      case INTER_BROKER_REPLICA_MOVEMENT:
+      case INTER_BROKER_REPLICA_SWAP:
         if (isReplicaMoveViolateRackAwareness(clusterModel,
                                               c -> c.broker(action.sourceBrokerId()).replica(action.topicPartition()),
                                               c -> c.broker(action.destinationBrokerId()))) {
           return BROKER_REJECT;
         }
 
-        if (action.balancingAction() == ActionType.REPLICA_SWAP
+        if (action.balancingAction() == ActionType.INTER_BROKER_REPLICA_SWAP
             && isReplicaMoveViolateRackAwareness(clusterModel,
                                                  c -> c.broker(action.destinationBrokerId()).replica(action.destinationTopicPartition()),
                                                  c -> c.broker(action.sourceBrokerId()))) {
@@ -237,7 +237,7 @@ public class RackAwareGoal extends AbstractGoal {
       }
       // Rack awareness is violated. Move replica to a broker in another rack.
       if (maybeApplyBalancingAction(clusterModel, replica, rackAwareEligibleBrokers(replica, clusterModel),
-                                    ActionType.REPLICA_MOVEMENT, optimizedGoals, optimizationOptions) == null) {
+                                    ActionType.INTER_BROKER_REPLICA_MOVEMENT, optimizedGoals, optimizationOptions) == null) {
         throw new OptimizationFailureException(
             String.format("[%s] Violated rack-awareness requirement for broker with id %d.", name(), broker.id()));
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
@@ -65,11 +65,11 @@ public class ReplicaCapacityGoal extends AbstractGoal {
   @Override
   public ActionAcceptance actionAcceptance(BalancingAction action, ClusterModel clusterModel) {
     switch (action.balancingAction()) {
-      case REPLICA_MOVEMENT:
+      case INTER_BROKER_REPLICA_MOVEMENT:
       case REPLICA_ADDITION:
         Broker destinationBroker = clusterModel.broker(action.destinationBrokerId());
         return destinationBroker.replicas().size() < _balancingConstraint.maxReplicasPerBroker() ? ACCEPT : REPLICA_REJECT;
-      case REPLICA_SWAP:
+      case INTER_BROKER_REPLICA_SWAP:
       case LEADERSHIP_MOVEMENT:
       case REPLICA_DELETION:
         return ACCEPT;
@@ -236,7 +236,7 @@ public class ReplicaCapacityGoal extends AbstractGoal {
       List<Broker> eligibleBrokers =
           eligibleBrokers(replica, clusterModel).stream().map(BrokerReplicaCount::broker).collect(Collectors.toList());
 
-      Broker b = maybeApplyBalancingAction(clusterModel, replica, eligibleBrokers, ActionType.REPLICA_MOVEMENT,
+      Broker b = maybeApplyBalancingAction(clusterModel, replica, eligibleBrokers, ActionType.INTER_BROKER_REPLICA_MOVEMENT,
                                            optimizedGoals, optimizationOptions);
       if (b == null) {
         if (!broker.isAlive()) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionGoal.java
@@ -113,10 +113,10 @@ public class ReplicaDistributionGoal extends AbstractGoal {
   @Override
   public ActionAcceptance actionAcceptance(BalancingAction action, ClusterModel clusterModel) {
     switch (action.balancingAction()) {
-      case REPLICA_SWAP:
+      case INTER_BROKER_REPLICA_SWAP:
       case LEADERSHIP_MOVEMENT:
         return ACCEPT;
-      case REPLICA_MOVEMENT:
+      case INTER_BROKER_REPLICA_MOVEMENT:
         Broker sourceBroker = clusterModel.broker(action.sourceBrokerId());
         Broker destinationBroker = clusterModel.broker(action.destinationBrokerId());
 
@@ -333,7 +333,7 @@ public class ReplicaDistributionGoal extends AbstractGoal {
         continue;
       }
 
-      Broker b = maybeApplyBalancingAction(clusterModel, replica, candidateBrokers, ActionType.REPLICA_MOVEMENT,
+      Broker b = maybeApplyBalancingAction(clusterModel, replica, candidateBrokers, ActionType.INTER_BROKER_REPLICA_MOVEMENT,
                                            optimizedGoals, optimizationOptions);
       // Only check if we successfully moved something.
       if (b != null) {
@@ -386,7 +386,7 @@ public class ReplicaDistributionGoal extends AbstractGoal {
         if (shouldExclude(replica, excludedTopics)) {
           continue;
         }
-        Broker b = maybeApplyBalancingAction(clusterModel, replica, candidateBrokers, ActionType.REPLICA_MOVEMENT,
+        Broker b = maybeApplyBalancingAction(clusterModel, replica, candidateBrokers, ActionType.INTER_BROKER_REPLICA_MOVEMENT,
                                              optimizedGoals, optimizationOptions);
         // Only need to check status if the action is taken. This will also handle the case that the source broker
         // has nothing to move in. In that case we will never reenqueue that source broker.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionTarget.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionTarget.java
@@ -234,8 +234,8 @@ class ReplicaDistributionTarget {
       // goals if for each optimized goal accepts the replica movement action.
       BalancingAction proposal =
           new BalancingAction(replicaToMove.topicPartition(), replicaToMove.broker().id(), candidateBrokerId,
-                              ActionType.REPLICA_MOVEMENT);
-      if (!legitMove(replicaToMove, clusterModel.broker(candidateBrokerId), ActionType.REPLICA_MOVEMENT)) {
+                              ActionType.INTER_BROKER_REPLICA_MOVEMENT);
+      if (!legitMove(replicaToMove, clusterModel.broker(candidateBrokerId), ActionType.INTER_BROKER_REPLICA_MOVEMENT)) {
         continue;
       }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicReplicaDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicReplicaDistributionGoal.java
@@ -69,7 +69,7 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
   @Override
   public ActionAcceptance actionAcceptance(BalancingAction action, ClusterModel clusterModel) {
     switch (action.balancingAction()) {
-      case REPLICA_SWAP:
+      case INTER_BROKER_REPLICA_SWAP:
         if (action.topic().equals(action.destinationTopic())) {
           return ACCEPT;
         }
@@ -77,7 +77,7 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
                >= varianceSum(clusterModel, action, false) ? ACCEPT : REPLICA_REJECT;
       case LEADERSHIP_MOVEMENT:
         return ACCEPT;
-      case REPLICA_MOVEMENT:
+      case INTER_BROKER_REPLICA_MOVEMENT:
         String sourceTopic = action.topic();
         Broker sourceBroker = clusterModel.broker(action.sourceBrokerId());
         Broker destinationBroker = clusterModel.broker(action.destinationBrokerId());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerEvenRackAwareGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerEvenRackAwareGoal.java
@@ -186,7 +186,7 @@ public class KafkaAssignerEvenRackAwareGoal implements Goal {
         // The destination broker has no replica from the source partition: move the source replica to the destination broker.
         LOG.trace("Destination broker {} has no other replica from the same partition, move the replica {} to there.",
                   destinationBroker, replicaAtPosition);
-        applyBalancingAction(clusterModel, replicaAtPosition, destinationBroker, ActionType.REPLICA_MOVEMENT);
+        applyBalancingAction(clusterModel, replicaAtPosition, destinationBroker, ActionType.INTER_BROKER_REPLICA_MOVEMENT);
       } else if (destinationBroker.id() != replicaAtPosition.broker().id() && replicaAtPosition.broker().isAlive()) {
         // The destination broker contains a replica from the source partition AND the destination broker is different
         // from the source replica broker AND the source broker is alive. Hence, we can safely swap replica positions.
@@ -258,7 +258,7 @@ public class KafkaAssignerEvenRackAwareGoal implements Goal {
 
     if (action == ActionType.LEADERSHIP_MOVEMENT) {
       clusterModel.relocateLeadership(sourceReplica.topicPartition(), sourceReplica.broker().id(), destinationBroker.id());
-    } else if (action == ActionType.REPLICA_MOVEMENT) {
+    } else if (action == ActionType.INTER_BROKER_REPLICA_MOVEMENT) {
       clusterModel.relocateReplica(sourceReplica.topicPartition(), sourceReplica.broker().id(), destinationBroker.id());
     }
   }
@@ -364,15 +364,15 @@ public class KafkaAssignerEvenRackAwareGoal implements Goal {
     switch (action.balancingAction()) {
       case LEADERSHIP_MOVEMENT:
         return ACCEPT;
-      case REPLICA_MOVEMENT:
-      case REPLICA_SWAP:
+      case INTER_BROKER_REPLICA_MOVEMENT:
+      case INTER_BROKER_REPLICA_SWAP:
         if (isReplicaMoveViolateRackAwareness(clusterModel,
                                               c -> c.broker(action.sourceBrokerId()).replica(action.topicPartition()),
                                               c -> c.broker(action.destinationBrokerId()))) {
           return BROKER_REJECT;
         }
 
-        if (action.balancingAction() == ActionType.REPLICA_SWAP
+        if (action.balancingAction() == ActionType.INTER_BROKER_REPLICA_SWAP
             && isReplicaMoveViolateRackAwareness(clusterModel,
                                                  c -> c.broker(action.destinationBrokerId()).replica(action.destinationTopicPartition()),
                                                  c -> c.broker(action.sourceBrokerId()))) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AddBrokerRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AddBrokerRunnable.java
@@ -26,7 +26,7 @@ class AddBrokerRunnable extends OperationRunnable {
   private final List<String> _goals;
   private final ModelCompletenessRequirements _modelCompletenessRequirements;
   private final boolean _allowCapacityEstimation;
-  private final Integer _concurrentPartitionMovements;
+  private final Integer _concurrentInterBrokerPartitionMovements;
   private final Integer _concurrentLeaderMovements;
   private final boolean _skipHardGoalCheck;
   private final Pattern _excludedTopics;
@@ -46,7 +46,7 @@ class AddBrokerRunnable extends OperationRunnable {
     _goals = parameters.goals();
     _modelCompletenessRequirements = parameters.modelCompletenessRequirements();
     _allowCapacityEstimation = parameters.allowCapacityEstimation();
-    _concurrentPartitionMovements = parameters.concurrentPartitionMovements();
+    _concurrentInterBrokerPartitionMovements = parameters.concurrentInterBrokerPartitionMovements();
     _concurrentLeaderMovements = parameters.concurrentLeaderMovements();
     _skipHardGoalCheck = parameters.skipHardGoalCheck();
     _excludedTopics = parameters.excludedTopics();
@@ -65,7 +65,7 @@ class AddBrokerRunnable extends OperationRunnable {
                                                                  _modelCompletenessRequirements,
                                                                  _future.operationProgress(),
                                                                  _allowCapacityEstimation,
-                                                                 _concurrentPartitionMovements,
+                                                                 _concurrentInterBrokerPartitionMovements,
                                                                  _concurrentLeaderMovements,
                                                                  _skipHardGoalCheck,
                                                                  _excludedTopics,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DecommissionBrokersRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/DecommissionBrokersRunnable.java
@@ -26,7 +26,7 @@ class DecommissionBrokersRunnable extends OperationRunnable {
   private final List<String> _goals;
   private final ModelCompletenessRequirements _modelCompletenessRequirements;
   private final boolean _allowCapacityEstimation;
-  private final Integer _concurrentPartitionMovements;
+  private final Integer _concurrentInterBrokerPartitionMovements;
   private final Integer _concurrentLeaderMovements;
   private final boolean _skipHardGoalCheck;
   private final Pattern _excludedTopics;
@@ -46,7 +46,7 @@ class DecommissionBrokersRunnable extends OperationRunnable {
     _goals = parameters.goals();
     _modelCompletenessRequirements = parameters.modelCompletenessRequirements();
     _allowCapacityEstimation = parameters.allowCapacityEstimation();
-    _concurrentPartitionMovements = parameters.concurrentPartitionMovements();
+    _concurrentInterBrokerPartitionMovements = parameters.concurrentInterBrokerPartitionMovements();
     _concurrentLeaderMovements = parameters.concurrentLeaderMovements();
     _skipHardGoalCheck = parameters.skipHardGoalCheck();
     _excludedTopics = parameters.excludedTopics();
@@ -65,7 +65,7 @@ class DecommissionBrokersRunnable extends OperationRunnable {
                                                                           _modelCompletenessRequirements,
                                                                           _future.operationProgress(),
                                                                           _allowCapacityEstimation,
-                                                                          _concurrentPartitionMovements,
+                                                                          _concurrentInterBrokerPartitionMovements,
                                                                           _concurrentLeaderMovements,
                                                                           _skipHardGoalCheck,
                                                                           _excludedTopics,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/RebalanceRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/RebalanceRunnable.java
@@ -23,7 +23,7 @@ class RebalanceRunnable extends OperationRunnable {
   private final boolean _dryRun;
   private final ModelCompletenessRequirements _modelCompletenessRequirements;
   private final boolean _allowCapacityEstimation;
-  private final Integer _concurrentPartitionMovements;
+  private final Integer _concurrentInterBrokerPartitionMovements;
   private final Integer _concurrentLeaderMovements;
   private final boolean _skipHardGoalCheck;
   private final Pattern _excludedTopics;
@@ -42,7 +42,7 @@ class RebalanceRunnable extends OperationRunnable {
     _dryRun = parameters.dryRun();
     _modelCompletenessRequirements = parameters.modelCompletenessRequirements();
     _allowCapacityEstimation = parameters.allowCapacityEstimation();
-    _concurrentPartitionMovements = parameters.concurrentPartitionMovements();
+    _concurrentInterBrokerPartitionMovements = parameters.concurrentInterBrokerPartitionMovements();
     _concurrentLeaderMovements = parameters.concurrentLeaderMovements();
     _skipHardGoalCheck = parameters.skipHardGoalCheck();
     _excludedTopics = parameters.excludedTopics();
@@ -60,7 +60,7 @@ class RebalanceRunnable extends OperationRunnable {
                                                                 _modelCompletenessRequirements,
                                                                 _future.operationProgress(),
                                                                 _allowCapacityEstimation,
-                                                                _concurrentPartitionMovements,
+                                                                _concurrentInterBrokerPartitionMovements,
                                                                 _concurrentLeaderMovements,
                                                                 _skipHardGoalCheck,
                                                                 _excludedTopics,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -429,12 +429,11 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
   /**
    * <code>num.concurrent.partition.movements.per.broker</code>
    */
-  public static final String NUM_CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER_CONFIG =
-      "num.concurrent.partition.movements.per.broker";
+  public static final String NUM_CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER_CONFIG = "num.concurrent.partition.movements.per.broker";
   private static final String NUM_CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER_DOC = "The maximum number of partitions " +
       "the executor will move to or out of a broker at the same time. e.g. setting the value to 10 means that the " +
       "executor will at most allow 10 partitions move out of a broker and 10 partitions move into a broker at any " +
-      "given point. This is to avoid overwhelming the cluster by partition movements.";
+      "given point. This is to avoid overwhelming the cluster by inter-broker partition movements.";
 
   /**
    * <code>num.concurrent.leader.movements</code>

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionProposal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionProposal.java
@@ -13,7 +13,6 @@ import java.util.Set;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 
-
 /**
  * The execution proposal corresponding to a particular partition.
  */
@@ -65,7 +64,7 @@ public class ExecutionProposal {
     _replicasToRemove.removeAll(newReplicas);
   }
 
-  private boolean orderMatched(Node[] currentOrderedReplicas, List<Integer> replicas) {
+  private boolean brokerOrderMatched(Node[] currentOrderedReplicas, List<Integer> replicas) {
     if (replicas.size() != currentOrderedReplicas.length) {
       return false;
     }
@@ -79,25 +78,27 @@ public class ExecutionProposal {
   }
 
   /**
-   * Check whether the successful proposal completion is reflected in the current ordered replicas in the given cluster.
+   * Check whether the successful completion of inter-broker replica movement from this proposal is reflected in the current
+   * ordered replicas in the given cluster.
    *
    * @param currentOrderedReplicas Current ordered replica list from the cluster.
    * @return True if successfully completed, false otherwise.
    */
-  public boolean isCompletedSuccessfully(Node[] currentOrderedReplicas) {
-    return orderMatched(currentOrderedReplicas, _newReplicas);
+  public boolean isInterBrokerMovementCompleted(Node[] currentOrderedReplicas) {
+    return brokerOrderMatched(currentOrderedReplicas, _newReplicas);
   }
 
   /**
-   * Check whether the proposal abortion is reflected in the current ordered replicas in the given cluster.
+   * Check whether the abortion of inter-broker replica movement from this proposal is reflected in the current ordered
+   * replicas in the given cluster.
    * There could be a race condition that when we abort a task, it is already completed.
    * In that case, we treat it as aborted as well.
    *
    * @param currentOrderedReplicas Current ordered replica list from the cluster.
    * @return True if aborted, false otherwise.
    */
-  public boolean isAborted(Node[] currentOrderedReplicas) {
-    return isCompletedSuccessfully(currentOrderedReplicas) || orderMatched(currentOrderedReplicas, _oldReplicas);
+  public boolean isInterBrokerMovementAborted(Node[] currentOrderedReplicas) {
+    return isInterBrokerMovementCompleted(currentOrderedReplicas) || brokerOrderMatched(currentOrderedReplicas, _oldReplicas);
   }
 
   /**
@@ -119,13 +120,6 @@ public class ExecutionProposal {
    */
   public TopicPartition topicPartition() {
     return _tp;
-  }
-
-  /**
-   * @return the partition size of the partition this proposal is about.
-   */
-  public long partitionSize() {
-    return _partitionSize;
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTask.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTask.java
@@ -210,7 +210,7 @@ public class ExecutionTask implements Comparable<ExecutionTask> {
   }
 
   public enum TaskType {
-    REPLICA_ACTION, LEADER_ACTION;
+    INTER_BROKER_REPLICA_ACTION, LEADER_ACTION;
 
     private static final List<TaskType> CACHED_VALUES = Collections.unmodifiableList(Arrays.asList(values()));
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorState.java
@@ -19,28 +19,38 @@ public class ExecutorState {
   private static final String STATE = "state";
   private static final String RECENTLY_DEMOTED_BROKERS = "recentlyDemotedBrokers";
   private static final String RECENTLY_REMOVED_BROKERS = "recentlyRemovedBrokers";
-  private static final String PENDING_LEADERSHIP_MOVEMENT = "pendingLeadershipMovement";
-  private static final String NUM_FINISHED_LEADERSHIP_MOVEMENTS = "numFinishedLeadershipMovements";
+
   private static final String NUM_TOTAL_LEADERSHIP_MOVEMENTS = "numTotalLeadershipMovements";
+  private static final String NUM_PENDING_LEADERSHIP_MOVEMENTS = "numPendingLeadershipMovements";
+  private static final String NUM_CANCELLED_LEADERSHIP_MOVEMENTS = "numCancelledLeadershipMovements";
+  private static final String NUM_FINISHED_LEADERSHIP_MOVEMENTS = "numFinishedLeadershipMovements";
+  private static final String PENDING_LEADERSHIP_MOVEMENT = "pendingLeadershipMovement";
+  private static final String CANCELLED_LEADERSHIP_MOVEMENT = "cancelledLeadershipMovement";
   private static final String MAXIMUM_CONCURRENT_LEADER_MOVEMENTS = "maximumConcurrentLeaderMovements";
-  private static final String NUM_TOTAL_PARTITION_MOVEMENTS = "numTotalPartitionMovements";
-  private static final String TOTAL_DATA_TO_MOVE = "totalDataToMove";
-  private static final String NUM_FINISHED_PARTITION_MOVEMENTS = "numFinishedPartitionMovements";
-  private static final String FINISHED_DATA_MOVEMENT = "finishedDataMovement";
-  private static final String ABORTING_PARTITIONS = "abortingPartitions";
-  private static final String ABORTED_PARTITIONS = "abortedPartitions";
-  private static final String DEAD_PARTITIONS = "deadPartitions";
-  private static final String MAXIMUM_CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER = "maximumConcurrentPartitionMovementsPerBroker";
-  private static final String IN_PROGRESS_PARTITION_MOVEMENT = "inProgressPartitionMovement";
-  private static final String ABORTING_PARTITION_MOVEMENT = "abortingPartitionMovement";
-  private static final String ABORTED_PARTITION_MOVEMENT = "abortedPartitionMovement";
-  private static final String DEAD_PARTITION_MOVEMENT = "deadPartitionMovement";
+
+  private static final String NUM_TOTAL_INTER_BROKER_PARTITION_MOVEMENTS = "numTotalPartitionMovements";
+  private static final String NUM_PENDING_INTER_BROKER_PARTITION_MOVEMENTS = "numPendingPartitionMovements";
+  private static final String NUM_CANCELLED_INTER_BROKER_PARTITION_MOVEMENTS = "numCancelledPartitionMovements";
+  private static final String NUM_IN_PROGRESS_INTER_BROKER_PARTITION_MOVEMENTS = "numInProgressPartitionMovements";
+  private static final String NUM_ABORTING_INTER_BROKER_PARTITION_MOVEMENTS = "abortingPartitions";
+  private static final String NUM_FINISHED_INTER_BROKER_PARTITION_MOVEMENTS = "numFinishedPartitionMovements";
+  private static final String IN_PROGRESS_INTER_BROKER_PARTITION_MOVEMENT = "inProgressPartitionMovement";
+  private static final String PENDING_INTER_BROKER_PARTITION_MOVEMENT = "pendingPartitionMovement";
+  private static final String CANCELLED_INTER_BROKER_PARTITION_MOVEMENT = "cancelledPartitionMovement";
+  private static final String DEAD_INTER_BROKER_PARTITION_MOVEMENT = "deadPartitionMovement";
+  private static final String COMPLETED_INTER_BROKER_PARTITION_MOVEMENT = "completedPartitionMovement";
+  private static final String ABORTING_INTER_BROKER_PARTITION_MOVEMENT = "abortingPartitionMovement";
+  private static final String ABORTED_INTER_BROKER_PARTITION_MOVEMENT = "abortedPartitionMovement";
+  private static final String FINISHED_INTER_BROKER_DATA_MOVEMENT = "finishedDataMovement";
+  private static final String TOTAL_INTER_BROKER_DATA_TO_MOVE = "totalDataToMove";
+  private static final String MAXIMUM_CONCURRENT_INTER_BROKER_PARTITION_MOVEMENTS_PER_BROKER = "maximumConcurrentPartitionMovementsPerBroker";
+
   private static final String ERROR = "error";
 
   public enum State {
     NO_TASK_IN_PROGRESS,
     STARTING_EXECUTION,
-    REPLICA_MOVEMENT_TASK_IN_PROGRESS,
+    INTER_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS,
     LEADER_MOVEMENT_TASK_IN_PROGRESS,
     STOPPING_EXECUTION
   }
@@ -49,7 +59,7 @@ public class ExecutorState {
   // Execution task statistics to report.
   private ExecutionTaskTracker.ExecutionTasksSummary _executionTasksSummary;
   // Configs to report.
-  private final int _maximumConcurrentPartitionMovementsPerBroker;
+  private final int _maximumConcurrentInterBrokerPartitionMovementsPerBroker;
   private final int _maximumConcurrentLeaderMovements;
   private final String _uuid;
   private final Set<Integer> _recentlyDemotedBrokers;
@@ -57,14 +67,14 @@ public class ExecutorState {
 
   private ExecutorState(State state,
                         ExecutionTasksSummary executionTasksSummary,
-                        int maximumConcurrentPartitionMovementsPerBroker,
+                        int maximumConcurrentInterBrokerPartitionMovementsPerBroker,
                         int maximumConcurrentLeaderMovements,
                         String uuid,
                         Set<Integer> recentlyDemotedBrokers,
                         Set<Integer> recentlyRemovedBrokers) {
     _state = state;
     _executionTasksSummary = executionTasksSummary;
-    _maximumConcurrentPartitionMovementsPerBroker = maximumConcurrentPartitionMovementsPerBroker;
+    _maximumConcurrentInterBrokerPartitionMovementsPerBroker = maximumConcurrentInterBrokerPartitionMovementsPerBroker;
     _maximumConcurrentLeaderMovements = maximumConcurrentLeaderMovements;
     _uuid = uuid;
     _recentlyDemotedBrokers = recentlyDemotedBrokers;
@@ -107,7 +117,8 @@ public class ExecutorState {
 
   /**
    * @param state State of executor.
-   * @param maximumConcurrentPartitionMovementsPerBroker Maximum concurrent partition movements per broker.
+   * @param executionTasksSummary Summary of the execution tasks.
+   * @param maximumConcurrentInterBrokerPartitionMovementsPerBroker Maximum concurrent inter-broker partition movement per broker.
    * @param maximumConcurrentLeaderMovements Maximum concurrent leader movements.
    * @param uuid UUID of the current execution.
    * @param recentlyDemotedBrokers Recently demoted broker IDs.
@@ -116,7 +127,7 @@ public class ExecutorState {
    */
   public static ExecutorState operationInProgress(State state,
                                                   ExecutionTasksSummary executionTasksSummary,
-                                                  int maximumConcurrentPartitionMovementsPerBroker,
+                                                  int maximumConcurrentInterBrokerPartitionMovementsPerBroker,
                                                   int maximumConcurrentLeaderMovements,
                                                   String uuid,
                                                   Set<Integer> recentlyDemotedBrokers,
@@ -126,7 +137,7 @@ public class ExecutorState {
     }
     return new ExecutorState(state,
                              executionTasksSummary,
-                             maximumConcurrentPartitionMovementsPerBroker,
+                             maximumConcurrentInterBrokerPartitionMovementsPerBroker,
                              maximumConcurrentLeaderMovements,
                              uuid,
                              recentlyDemotedBrokers,
@@ -142,14 +153,15 @@ public class ExecutorState {
   }
 
   public int numFinishedMovements(ExecutionTask.TaskType type) {
-    return _executionTasksSummary.taskStat().get(type).get(ExecutionTask.State.DEAD) +
-           _executionTasksSummary.taskStat().get(type).get(ExecutionTask.State.COMPLETED) +
-           _executionTasksSummary.taskStat().get(type).get(ExecutionTask.State.ABORTED);
+    return _executionTasksSummary.taskStat().get(type).get(DEAD) +
+           _executionTasksSummary.taskStat().get(type).get(COMPLETED) +
+           _executionTasksSummary.taskStat().get(type).get(ABORTED);
   }
-  public long totalDataToMoveInMB() {
-    return _executionTasksSummary.inExecutionDataMovementInMB() +
-           _executionTasksSummary.finishedDataMovementInMB() +
-           _executionTasksSummary.remainingDataToMoveInMB();
+
+  public long numTotalInterBrokerDataToMove() {
+    return _executionTasksSummary.inExecutionInterBrokerDataMovementInMB() +
+           _executionTasksSummary.finishedInterBrokerDataMovementInMB() +
+           _executionTasksSummary.remainingInterBrokerDataToMoveInMB();
   }
 
   public String uuid() {
@@ -168,6 +180,14 @@ public class ExecutorState {
     return _executionTasksSummary;
   }
 
+  private List<Object> getTaskDetails(ExecutionTask.TaskType type, ExecutionTask.State state) {
+    List<Object> taskList = new ArrayList<>();
+    for (ExecutionTask task : _executionTasksSummary.filteredTasksByState().get(type).get(state)) {
+      taskList.add(task.getJsonStructure());
+    }
+    return taskList;
+  }
+
   /*
    * Return an object that can be further used to encode into JSON
    */
@@ -180,6 +200,7 @@ public class ExecutorState {
     if (_recentlyRemovedBrokers != null && !_recentlyRemovedBrokers.isEmpty()) {
       execState.put(RECENTLY_REMOVED_BROKERS, _recentlyRemovedBrokers);
     }
+    Map<ExecutionTask.State, Integer> interBrokerPartitionMovementStats;
     switch (_state) {
       case NO_TASK_IN_PROGRESS:
         break;
@@ -187,66 +208,55 @@ public class ExecutorState {
         execState.put(TRIGGERED_USER_TASK_ID, _uuid);
         break;
       case LEADER_MOVEMENT_TASK_IN_PROGRESS:
+        execState.put(TRIGGERED_USER_TASK_ID, _uuid);
+        execState.put(MAXIMUM_CONCURRENT_LEADER_MOVEMENTS, _maximumConcurrentLeaderMovements);
+        execState.put(NUM_PENDING_LEADERSHIP_MOVEMENTS, _executionTasksSummary.taskStat().get(LEADER_ACTION).get(PENDING));
+        execState.put(NUM_FINISHED_LEADERSHIP_MOVEMENTS, numFinishedMovements(LEADER_ACTION));
+        execState.put(NUM_TOTAL_LEADERSHIP_MOVEMENTS, numTotalMovements(LEADER_ACTION));
         if (verbose) {
-          List<Object> pendingLeadershipMovementList = new ArrayList<>();
-          for (ExecutionTask task : _executionTasksSummary.filteredTasksByState().get(LEADER_ACTION).get(PENDING)) {
-            pendingLeadershipMovementList.add(task.getJsonStructure());
-          }
-          execState.put(PENDING_LEADERSHIP_MOVEMENT, pendingLeadershipMovementList);
+          execState.put(PENDING_LEADERSHIP_MOVEMENT, getTaskDetails(LEADER_ACTION, PENDING));
         }
-        execState.put(NUM_FINISHED_LEADERSHIP_MOVEMENTS, numFinishedMovements(LEADER_ACTION));
-        execState.put(NUM_TOTAL_LEADERSHIP_MOVEMENTS, numTotalMovements(LEADER_ACTION));
-        execState.put(MAXIMUM_CONCURRENT_LEADER_MOVEMENTS, _maximumConcurrentLeaderMovements);
-        execState.put(TRIGGERED_USER_TASK_ID, _uuid);
         break;
-      case REPLICA_MOVEMENT_TASK_IN_PROGRESS:
-      case STOPPING_EXECUTION:
-        execState.put(NUM_TOTAL_PARTITION_MOVEMENTS, numTotalMovements(REPLICA_ACTION));
-        execState.put(NUM_TOTAL_LEADERSHIP_MOVEMENTS, numTotalMovements(LEADER_ACTION));
-        execState.put(TOTAL_DATA_TO_MOVE, totalDataToMoveInMB());
-        execState.put(NUM_FINISHED_PARTITION_MOVEMENTS, numFinishedMovements(REPLICA_ACTION));
-        execState.put(NUM_FINISHED_LEADERSHIP_MOVEMENTS, numFinishedMovements(LEADER_ACTION));
-        execState.put(FINISHED_DATA_MOVEMENT, _executionTasksSummary.finishedDataMovementInMB());
-        execState.put(ABORTING_PARTITIONS, _executionTasksSummary.taskStat().get(REPLICA_ACTION).get(ABORTING));
-        execState.put(ABORTED_PARTITIONS, _executionTasksSummary.taskStat().get(REPLICA_ACTION).get(ABORTED));
-        execState.put(DEAD_PARTITIONS, _executionTasksSummary.taskStat().get(REPLICA_ACTION).get(DEAD));
-        execState.put(MAXIMUM_CONCURRENT_LEADER_MOVEMENTS, _maximumConcurrentLeaderMovements);
-        execState.put(MAXIMUM_CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER, _maximumConcurrentPartitionMovementsPerBroker);
+      case INTER_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS:
+        interBrokerPartitionMovementStats = _executionTasksSummary.taskStat().get(INTER_BROKER_REPLICA_ACTION);
         execState.put(TRIGGERED_USER_TASK_ID, _uuid);
+        execState.put(MAXIMUM_CONCURRENT_INTER_BROKER_PARTITION_MOVEMENTS_PER_BROKER, _maximumConcurrentInterBrokerPartitionMovementsPerBroker);
+        execState.put(NUM_IN_PROGRESS_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(IN_PROGRESS));
+        execState.put(NUM_ABORTING_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(ABORTING));
+        execState.put(NUM_PENDING_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(PENDING));
+        execState.put(NUM_FINISHED_INTER_BROKER_PARTITION_MOVEMENTS, numFinishedMovements(INTER_BROKER_REPLICA_ACTION));
+        execState.put(NUM_TOTAL_INTER_BROKER_PARTITION_MOVEMENTS, numTotalMovements(INTER_BROKER_REPLICA_ACTION));
+        execState.put(FINISHED_INTER_BROKER_DATA_MOVEMENT, _executionTasksSummary.finishedInterBrokerDataMovementInMB());
+        execState.put(TOTAL_INTER_BROKER_DATA_TO_MOVE, numTotalInterBrokerDataToMove());
         if (verbose) {
-          Map<ExecutionTask.State, Set<ExecutionTask>> partitionMovementsByState = _executionTasksSummary.filteredTasksByState().get(REPLICA_ACTION);
-          List<Object> inProgressPartitionMovementList = new ArrayList<>(partitionMovementsByState.get(IN_PROGRESS).size());
-          List<Object> abortingPartitionMovementList = new ArrayList<>(partitionMovementsByState.get(ABORTING).size());
-          List<Object> abortedPartitionMovementList = new ArrayList<>(partitionMovementsByState.get(ABORTED).size());
-          List<Object> deadPartitionMovementList = new ArrayList<>(partitionMovementsByState.get(DEAD).size());
-          List<Object> pendingPartitionMovementList = new ArrayList<>(partitionMovementsByState.get(PENDING).size());
-          for (ExecutionTask task : partitionMovementsByState.get(IN_PROGRESS)) {
-            inProgressPartitionMovementList.add(task.getJsonStructure());
-          }
-          for (ExecutionTask task : partitionMovementsByState.get(ABORTING)) {
-            abortingPartitionMovementList.add(task.getJsonStructure());
-          }
-          for (ExecutionTask task : partitionMovementsByState.get(ABORTED)) {
-            abortedPartitionMovementList.add(task.getJsonStructure());
-          }
-          for (ExecutionTask task : partitionMovementsByState.get(DEAD)) {
-            deadPartitionMovementList.add(task.getJsonStructure());
-          }
-          for (ExecutionTask task : partitionMovementsByState.get(PENDING)) {
-            pendingPartitionMovementList.add(task.getJsonStructure());
-          }
-          execState.put(IN_PROGRESS_PARTITION_MOVEMENT, inProgressPartitionMovementList);
-          execState.put(ABORTING_PARTITION_MOVEMENT, abortingPartitionMovementList);
-          execState.put(ABORTED_PARTITION_MOVEMENT, abortedPartitionMovementList);
-          execState.put(DEAD_PARTITION_MOVEMENT, deadPartitionMovementList);
-          execState.put(_state == State.STOPPING_EXECUTION ? "CancelledPartitionMovement" : "PendingPartitionMovement",
-                        pendingPartitionMovementList);
+          execState.put(IN_PROGRESS_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, IN_PROGRESS));
+          execState.put(PENDING_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, PENDING));
+          execState.put(ABORTING_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, ABORTING));
+          execState.put(ABORTED_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, ABORTED));
+          execState.put(DEAD_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, DEAD));
+          execState.put(COMPLETED_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, COMPLETED));
+        }
+        break;
+      case STOPPING_EXECUTION:
+        interBrokerPartitionMovementStats = _executionTasksSummary.taskStat().get(INTER_BROKER_REPLICA_ACTION);
+        execState.put(TRIGGERED_USER_TASK_ID, _uuid);
+        execState.put(MAXIMUM_CONCURRENT_INTER_BROKER_PARTITION_MOVEMENTS_PER_BROKER, _maximumConcurrentInterBrokerPartitionMovementsPerBroker);
+        execState.put(MAXIMUM_CONCURRENT_LEADER_MOVEMENTS, _maximumConcurrentLeaderMovements);
+        execState.put(NUM_CANCELLED_LEADERSHIP_MOVEMENTS,
+                      _executionTasksSummary.taskStat().get(LEADER_ACTION).get(PENDING));
+        execState.put(NUM_IN_PROGRESS_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(IN_PROGRESS));
+        execState.put(NUM_ABORTING_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(ABORTING));
+        execState.put(NUM_CANCELLED_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(PENDING));
+        if (verbose) {
+          execState.put(CANCELLED_LEADERSHIP_MOVEMENT, getTaskDetails(LEADER_ACTION, ExecutionTask.State.PENDING));
+          execState.put(CANCELLED_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, PENDING));
+          execState.put(IN_PROGRESS_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, IN_PROGRESS));
+          execState.put(ABORTING_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, ABORTING));
         }
         break;
       default:
+        execState.clear();
         execState.put(ERROR, "ILLEGAL_STATE_EXCEPTION");
-        execState.remove(RECENTLY_DEMOTED_BROKERS);
-        execState.remove(RECENTLY_REMOVED_BROKERS);
         break;
     }
 
@@ -259,6 +269,7 @@ public class ExecutorState {
     String recentlyRemovedBrokers = (_recentlyRemovedBrokers != null && !_recentlyRemovedBrokers.isEmpty())
                                     ? String.format(", %s: %s", RECENTLY_REMOVED_BROKERS, _recentlyRemovedBrokers) : "";
 
+    Map<ExecutionTask.State, Integer> interBrokerPartitionMovementStats;
     switch (_state) {
       case NO_TASK_IN_PROGRESS:
         return String.format("{%s: %s%s%s}", STATE, _state, recentlyDemotedBrokers, recentlyRemovedBrokers);
@@ -266,21 +277,36 @@ public class ExecutorState {
         return String.format("{%s: %s, %s: %s%s%s}", STATE, _state, TRIGGERED_USER_TASK_ID,
                              _uuid, recentlyDemotedBrokers, recentlyRemovedBrokers);
       case LEADER_MOVEMENT_TASK_IN_PROGRESS:
-        return String.format("{%s: %s, finished/total leadership movements: %d/%d, "
-                             + "maximum concurrent leadership movements: %d, %s: %s%s%s}", STATE, _state, numFinishedMovements(LEADER_ACTION),
-                             numTotalMovements(LEADER_ACTION), _maximumConcurrentLeaderMovements, TRIGGERED_USER_TASK_ID,
-                             _uuid, recentlyDemotedBrokers, recentlyRemovedBrokers);
-      case REPLICA_MOVEMENT_TASK_IN_PROGRESS:
+        return String.format("{%s: %s, finished/total leadership movements: %d/%d, maximum concurrent leadership movements: %d, %s: %s%s%s}",
+                             STATE, _state, numFinishedMovements(LEADER_ACTION), numTotalMovements(LEADER_ACTION),
+                             _maximumConcurrentLeaderMovements, TRIGGERED_USER_TASK_ID, _uuid, recentlyDemotedBrokers, recentlyRemovedBrokers);
+      case INTER_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS:
+        interBrokerPartitionMovementStats = _executionTasksSummary.taskStat().get(INTER_BROKER_REPLICA_ACTION);
+        return String.format("{%s: %s, pending/in-progress/aborting/finished/total inter-broker partition movement %d/%d/%d/%d/%d," +
+                             " completed/total bytes(MB): %d/%d, maximum concurrent inter-broker partition movements per-broker: %d, %s: %s%s%s}",
+                             STATE, _state,
+                             interBrokerPartitionMovementStats.get(PENDING),
+                             interBrokerPartitionMovementStats.get(IN_PROGRESS),
+                             interBrokerPartitionMovementStats.get(ABORTING),
+                             numFinishedMovements(INTER_BROKER_REPLICA_ACTION),
+                             numTotalMovements(INTER_BROKER_REPLICA_ACTION),
+                             _executionTasksSummary.finishedInterBrokerDataMovementInMB(),
+                             numTotalInterBrokerDataToMove(), _maximumConcurrentInterBrokerPartitionMovementsPerBroker,
+                             TRIGGERED_USER_TASK_ID, _uuid, recentlyDemotedBrokers, recentlyRemovedBrokers);
       case STOPPING_EXECUTION:
-        Map<ExecutionTask.State, Integer> partitionMovementStats = _executionTasksSummary.taskStat().get(REPLICA_ACTION);
-        return String.format("{%s: %s, in-progress/aborting partitions: %d/%d, completed/total bytes(MB): %d/%d, "
-                             + "finished/aborted/dead/total partitions: %d/%d/%d/%d, finished leadership movements: %d/%d, "
-                             + "maximum concurrent leadership/per-broker partition movements: %d/%d, %s: %s%s%s}",
-                             STATE, _state, partitionMovementStats.get(IN_PROGRESS), partitionMovementStats.get(ABORTING),
-                             _executionTasksSummary.finishedDataMovementInMB(), totalDataToMoveInMB(), numFinishedMovements(REPLICA_ACTION),
-                             partitionMovementStats.get(ABORTED), partitionMovementStats.get(DEAD),
-                             numTotalMovements(REPLICA_ACTION), numFinishedMovements(LEADER_ACTION), numTotalMovements(LEADER_ACTION),
-                             _maximumConcurrentLeaderMovements, _maximumConcurrentPartitionMovementsPerBroker,
+        interBrokerPartitionMovementStats = _executionTasksSummary.taskStat().get(INTER_BROKER_REPLICA_ACTION);
+        return String.format("{%s: %s, cancelled/in-progress/aborting/total inter-broker partition movements movements: %d/%d/%d/%d,"
+                             + "cancelled/total leadership movements: %d/%d, maximum concurrent inter-broker partition movements "
+                             + "per-broker: %d, maximum concurrent leadership movements: %d, %s: %s%s%s}",
+                             STATE, _state,
+                             interBrokerPartitionMovementStats.get(PENDING),
+                             interBrokerPartitionMovementStats.get(IN_PROGRESS),
+                             interBrokerPartitionMovementStats.get(ABORTING),
+                             numTotalMovements(INTER_BROKER_REPLICA_ACTION),
+                             _executionTasksSummary.taskStat().get(LEADER_ACTION).get(ExecutionTask.State.PENDING),
+                             numTotalMovements(LEADER_ACTION),
+                             _maximumConcurrentInterBrokerPartitionMovementsPerBroker,
+                             _maximumConcurrentLeaderMovements,
                              TRIGGERED_USER_TASK_ID, _uuid, recentlyDemotedBrokers, recentlyRemovedBrokers);
       default:
         throw new IllegalStateException("This should never happen");

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/strategy/AbstractReplicaMovementStrategy.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/strategy/AbstractReplicaMovementStrategy.java
@@ -14,7 +14,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import org.apache.kafka.common.Cluster;
 
-
 /**
  * An abstract class for replica movement strategy. This class will be extended to create custom strategy to determine the
  * execution order the replica movement tasks.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicas.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicas.java
@@ -43,7 +43,7 @@ import java.util.function.Function;
  *
  * <p>
  *   The SortedReplicas are initialized lazily, i.e. until one of {@link #sortedReplicas()},
- *   {@link #reverselySortedReplicas()} and {@link #sortedReplicas()} is invoked, the sorted replicas
+ *   {@link #reverselySortedReplicas()} and {@link #sortedReplicaWrappers()} is invoked, the sorted replicas
  *   will not be populated.
  * </p>
  */

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -389,6 +389,7 @@ public class LoadMonitor {
    * @param requirements the load requirements for getting the cluster model.
    * @param operationProgress the progress to report.
    * @return A cluster model with the configured number of windows whose timestamp is before given timestamp.
+   * @throws NotEnoughValidWindowsException If there is not enough sample to generate cluster model.
    */
   public ClusterModel clusterModel(long now,
                                    ModelCompletenessRequirements requirements,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AddedOrRemovedBrokerParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AddedOrRemovedBrokerParameters.java
@@ -22,7 +22,7 @@ import javax.servlet.http.HttpServletRequest;
  *    POST /kafkacruisecontrol/remove_broker?brokerid=[id1,id2...]&amp;dryRun=[true/false]
  *    &amp;throttle_removed_broker=[true/false]&amp;goals=[goal1,goal2...]&amp;allow_capacity_estimation=[true/false]
  *    &amp;concurrent_partition_movements_per_broker=[POSITIVE-INTEGER]&amp;concurrent_leader_movements=[POSITIVE-INTEGER]
- *    &amp;json=[true/false]&amp;skip_hard_goal_check=[true/false]&amp;excluded_topics=[pattern]
+ *    &amp;json=[true/false]&amp;skip_hard_goal_check=[true/false]&amp;excluded_topics=[pattern]&amp;kafka_assigner=[true/false]
  *    &amp;use_ready_default_goals=[true/false]&amp;verbose=[true/false]&amp;exclude_recently_demoted_brokers=[true/false]
  *    &amp;exclude_recently_removed_brokers=[true/false]&amp;replica_movement_strategies=[strategy1,strategy2...]
  *    &amp;review_id=[id]
@@ -31,7 +31,7 @@ import javax.servlet.http.HttpServletRequest;
  *    POST /kafkacruisecontrol/add_broker?brokerid=[id1,id2...]&amp;dryRun=[true/false]
  *    &amp;throttle_added_broker=[true/false]&amp;goals=[goal1,goal2...]&amp;allow_capacity_estimation=[true/false]
  *    &amp;concurrent_partition_movements_per_broker=[POSITIVE-INTEGER]&amp;concurrent_leader_movements=[POSITIVE-INTEGER]
- *    &amp;json=[true/false]&amp;skip_hard_goal_check=[true/false]&amp;excluded_topics=[pattern]
+ *    &amp;json=[true/false]&amp;skip_hard_goal_check=[true/false]&amp;excluded_topics=[pattern]&amp;kafka_assigner=[true/false]
  *    &amp;use_ready_default_goals=[true/false]&amp;verbose=[true/false]&amp;exclude_recently_demoted_brokers=[true/false]
  *    &amp;exclude_recently_removed_brokers=[true/false]&amp;replica_movement_strategies=[strategy1,strategy2...]
  *    &amp;review_id=[id]
@@ -39,7 +39,7 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class AddedOrRemovedBrokerParameters extends GoalBasedOptimizationParameters {
   private List<Integer> _brokerIds;
-  private Integer _concurrentPartitionMovements;
+  private Integer _concurrentInterBrokerPartitionMovements;
   private Integer _concurrentLeaderMovements;
   private boolean _dryRun;
   private boolean _throttleAddedOrRemovedBrokers;
@@ -59,7 +59,7 @@ public class AddedOrRemovedBrokerParameters extends GoalBasedOptimizationParamet
     _brokerIds = ParameterUtils.brokerIds(_request);
     _dryRun = ParameterUtils.getDryRun(_request);
     _throttleAddedOrRemovedBrokers = ParameterUtils.throttleAddedOrRemovedBrokers(_request, _endPoint);
-    _concurrentPartitionMovements = ParameterUtils.concurrentMovements(_request, true);
+    _concurrentInterBrokerPartitionMovements = ParameterUtils.concurrentMovements(_request, true);
     _concurrentLeaderMovements = ParameterUtils.concurrentMovements(_request, false);
     _skipHardGoalCheck = ParameterUtils.skipHardGoalCheck(_request);
     _replicaMovementStrategy = ParameterUtils.getReplicaMovementStrategy(_request, _config);
@@ -80,8 +80,8 @@ public class AddedOrRemovedBrokerParameters extends GoalBasedOptimizationParamet
     return _brokerIds;
   }
 
-  public Integer concurrentPartitionMovements() {
-    return _concurrentPartitionMovements;
+  public Integer concurrentInterBrokerPartitionMovements() {
+    return _concurrentInterBrokerPartitionMovements;
   }
 
   public Integer concurrentLeaderMovements() {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AdminParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AdminParameters.java
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServletRequest;
 public class AdminParameters extends AbstractParameters {
   private Set<AnomalyType> _disableSelfHealingFor;
   private Set<AnomalyType> _enableSelfHealingFor;
-  private Integer _concurrentPartitionMovements;
+  private Integer _concurrentInterBrokerPartitionMovements;
   private Integer _concurrentLeaderMovements;
   private Integer _reviewId;
   private boolean _twoStepVerificationEnabled;
@@ -41,7 +41,7 @@ public class AdminParameters extends AbstractParameters {
     Map<Boolean, Set<AnomalyType>> selfHealingFor = ParameterUtils.selfHealingFor(_request);
     _enableSelfHealingFor = selfHealingFor.get(true);
     _disableSelfHealingFor = selfHealingFor.get(false);
-    _concurrentPartitionMovements = ParameterUtils.concurrentMovements(_request, true);
+    _concurrentInterBrokerPartitionMovements = ParameterUtils.concurrentMovements(_request, true);
     _concurrentLeaderMovements = ParameterUtils.concurrentMovements(_request, false);
     _reviewId = ParameterUtils.reviewId(_request, _twoStepVerificationEnabled);
   }
@@ -63,8 +63,8 @@ public class AdminParameters extends AbstractParameters {
     return _enableSelfHealingFor;
   }
 
-  public Integer concurrentPartitionMovements() {
-    return _concurrentPartitionMovements;
+  public Integer concurrentInterBrokerPartitionMovements() {
+    return _concurrentInterBrokerPartitionMovements;
   }
 
   public Integer concurrentLeaderMovements() {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ProposalsParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ProposalsParameters.java
@@ -16,6 +16,7 @@ import javax.servlet.http.HttpServletRequest;
  *    &amp;goals=[goal1,goal2...]&amp;data_from=[valid_windows/valid_partitions]&amp;excluded_topics=[pattern]
  *    &amp;use_ready_default_goals=[true/false]&amp;allow_capacity_estimation=[true/false]&amp;json=[true/false]
  *    &amp;exclude_recently_demoted_brokers=[true/false]&amp;exclude_recently_removed_brokers=[true/false]
+ *    &amp;kafka_assigner=[true/false]
  * </pre>
  */
 public class ProposalsParameters extends GoalBasedOptimizationParameters {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RebalanceParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RebalanceParameters.java
@@ -22,13 +22,13 @@ import javax.servlet.http.HttpServletRequest;
  *    &amp;concurrent_leader_movements=[POSITIVE-INTEGER]&amp;json=[true/false]&amp;skip_hard_goal_check=[true/false]
  *    &amp;excluded_topics=[pattern]&amp;use_ready_default_goals=[true/false]&amp;verbose=[true/false]
  *    &amp;exclude_recently_demoted_brokers=[true/false]&amp;exclude_recently_removed_brokers=[true/false]
- *    &amp;replica_movement_strategies=[strategy1,strategy2...]
- *    &amp;ignore_proposal_cache=[true/false]&amp;review_id=[id]
+ *    &amp;replica_movement_strategies=[strategy1,strategy2...]&amp;ignore_proposal_cache=[true/false]
+ *    &amp;kafka_assigner=[true/false]&amp;review_id=[id]
  * </pre>
  */
 public class RebalanceParameters extends GoalBasedOptimizationParameters {
   private boolean _dryRun;
-  private Integer _concurrentPartitionMovements;
+  private Integer _concurrentInterBrokerPartitionMovements;
   private Integer _concurrentLeaderMovements;
   private boolean _skipHardGoalCheck;
   private ReplicaMovementStrategy _replicaMovementStrategy;
@@ -45,7 +45,7 @@ public class RebalanceParameters extends GoalBasedOptimizationParameters {
   protected void initParameters() throws UnsupportedEncodingException {
     super.initParameters();
     _dryRun = ParameterUtils.getDryRun(_request);
-    _concurrentPartitionMovements = ParameterUtils.concurrentMovements(_request, true);
+    _concurrentInterBrokerPartitionMovements = ParameterUtils.concurrentMovements(_request, true);
     _concurrentLeaderMovements = ParameterUtils.concurrentMovements(_request, false);
     _skipHardGoalCheck = ParameterUtils.skipHardGoalCheck(_request);
     _replicaMovementStrategy = ParameterUtils.getReplicaMovementStrategy(_request, _config);
@@ -67,8 +67,8 @@ public class RebalanceParameters extends GoalBasedOptimizationParameters {
     return _dryRun;
   }
 
-  public Integer concurrentPartitionMovements() {
-    return _concurrentPartitionMovements;
+  public Integer concurrentInterBrokerPartitionMovements() {
+    return _concurrentInterBrokerPartitionMovements;
   }
 
   public Integer concurrentLeaderMovements() {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlState.java
@@ -30,7 +30,7 @@ import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTask.State;
 
 
 public class CruiseControlState extends AbstractCruiseControlResponse {
-  private static final String PARTITION_MOVEMENTS = "partition movements";
+  private static final String INTER_BROKER_PARTITION_MOVEMENTS = "inter-broker partition movements";
   private static final String LEADERSHIP_MOVEMENTS = "leadership movements";
   private static final String MONITOR_STATE = "MonitorState";
   private static final String EXECUTOR_STATE = "ExecutorState";
@@ -123,8 +123,8 @@ public class CruiseControlState extends AbstractCruiseControlResponse {
     if (_executorState != null) {
       Map<TaskType, Map<State, Set<ExecutionTask>>> filteredTasksByState = _executorState.executionTasksSummary().filteredTasksByState();
       filteredTasksByState.forEach((type, taskMap) -> {
-        String taskTypeString = type == TaskType.REPLICA_ACTION ? PARTITION_MOVEMENTS :
-                                                                  LEADERSHIP_MOVEMENTS;
+        String taskTypeString = type == TaskType.INTER_BROKER_REPLICA_ACTION ? INTER_BROKER_PARTITION_MOVEMENTS :
+                                                                               LEADERSHIP_MOVEMENTS;
         sb.append(String.format("%n%n%s %s:%n",
                                 _executorState.state() == ExecutorState.State.STOPPING_EXECUTION ? "Cancelled" : "Pending",
                                 taskTypeString));

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -227,7 +227,7 @@ public class AnomalyDetectorTest {
     // The following state are used to test the delayed check when executor is busy.
     EasyMock.expect(mockKafkaCruiseControl.state(EasyMock.anyObject(), EasyMock.anyObject()))
             .andReturn(new CruiseControlState(
-                ExecutorState.operationInProgress(ExecutorState.State.REPLICA_MOVEMENT_TASK_IN_PROGRESS,
+                ExecutorState.operationInProgress(ExecutorState.State.INTER_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS,
                                                   null,
                                                   1,
                                                   1,

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskManagerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskManagerTest.java
@@ -66,9 +66,9 @@ public class ExecutionTaskManagerTest {
                                         Collections.emptySet(),
                                         generateExpectedCluster(proposal, tp),
                                         null);
-      taskManager.setRequestedPartitionMovementConcurrency(null);
+      taskManager.setRequestedInterBrokerPartitionMovementConcurrency(null);
       taskManager.setRequestedLeadershipMovementConcurrency(null);
-      List<ExecutionTask> tasks = taskManager.getReplicaMovementTasks();
+      List<ExecutionTask> tasks = taskManager.getInterBrokerReplicaMovementTasks();
       assertEquals(1, tasks.size());
       ExecutionTask task  = tasks.get(0);
       verifyStateChangeSequence(sequence, task, taskManager);
@@ -88,60 +88,60 @@ public class ExecutionTaskManagerTest {
       case IN_PROGRESS:
         taskManager.markTasksInProgress(Collections.singletonList(task));
         executionTasksSummary = taskManager.getExecutionTasksSummary(Collections.emptySet());
-        taskStat = executionTasksSummary.taskStat().get(ExecutionTask.TaskType.REPLICA_ACTION);
+        taskStat = executionTasksSummary.taskStat().get(ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION);
         assertEquals(0, (int) taskStat.get(PENDING));
         assertEquals(1, (int) taskStat.get(IN_PROGRESS));
         assertEquals(0, (int) taskStat.get(ABORTING));
         assertEquals(0, (int) taskStat.get(ABORTED));
         assertEquals(0, (int) taskStat.get(COMPLETED));
         assertEquals(0, (int) taskStat.get(DEAD));
-        assertEquals(0, executionTasksSummary.remainingDataToMoveInMB());
-        assertEquals(10, executionTasksSummary.inExecutionDataMovementInMB());
-        assertEquals(0, executionTasksSummary.finishedDataMovementInMB());
+        assertEquals(0, executionTasksSummary.remainingInterBrokerDataToMoveInMB());
+        assertEquals(10, executionTasksSummary.inExecutionInterBrokerDataMovementInMB());
+        assertEquals(0, executionTasksSummary.finishedInterBrokerDataMovementInMB());
         break;
       case ABORTING:
         taskManager.markTaskAborting(task);
         executionTasksSummary = taskManager.getExecutionTasksSummary(Collections.emptySet());
-        taskStat = executionTasksSummary.taskStat().get(ExecutionTask.TaskType.REPLICA_ACTION);
+        taskStat = executionTasksSummary.taskStat().get(ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION);
         assertEquals(0, (int) taskStat.get(PENDING));
         assertEquals(0, (int) taskStat.get(IN_PROGRESS));
         assertEquals(1, (int) taskStat.get(ABORTING));
         assertEquals(0, (int) taskStat.get(ABORTED));
         assertEquals(0, (int) taskStat.get(COMPLETED));
         assertEquals(0, (int) taskStat.get(DEAD));
-        assertEquals(0, executionTasksSummary.remainingDataToMoveInMB());
-        assertEquals(10, executionTasksSummary.inExecutionDataMovementInMB());
-        assertEquals(0, executionTasksSummary.finishedDataMovementInMB());
+        assertEquals(0, executionTasksSummary.remainingInterBrokerDataToMoveInMB());
+        assertEquals(10, executionTasksSummary.inExecutionInterBrokerDataMovementInMB());
+        assertEquals(0, executionTasksSummary.finishedInterBrokerDataMovementInMB());
         break;
       case DEAD:
         taskManager.markTaskDead(task);
         executionTasksSummary = taskManager.getExecutionTasksSummary(Collections.emptySet());
-        taskStat = executionTasksSummary.taskStat().get(ExecutionTask.TaskType.REPLICA_ACTION);
+        taskStat = executionTasksSummary.taskStat().get(ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION);
         assertEquals(0, (int) taskStat.get(PENDING));
         assertEquals(0, (int) taskStat.get(IN_PROGRESS));
         assertEquals(0, (int) taskStat.get(ABORTING));
         assertEquals(0, (int) taskStat.get(ABORTED));
         assertEquals(0, (int) taskStat.get(COMPLETED));
         assertEquals(1, (int) taskStat.get(DEAD));
-        assertEquals(0, executionTasksSummary.remainingDataToMoveInMB());
-        assertEquals(0, executionTasksSummary.inExecutionDataMovementInMB());
-        assertEquals(10, executionTasksSummary.finishedDataMovementInMB());
+        assertEquals(0, executionTasksSummary.remainingInterBrokerDataToMoveInMB());
+        assertEquals(0, executionTasksSummary.inExecutionInterBrokerDataMovementInMB());
+        assertEquals(10, executionTasksSummary.finishedInterBrokerDataMovementInMB());
         break;
       case ABORTED:
       case COMPLETED:
         ExecutionTask.State origState = task.state();
         taskManager.markTaskDone(task);
         executionTasksSummary = taskManager.getExecutionTasksSummary(Collections.emptySet());
-        taskStat = executionTasksSummary.taskStat().get(ExecutionTask.TaskType.REPLICA_ACTION);
+        taskStat = executionTasksSummary.taskStat().get(ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION);
         assertEquals(0, (int) taskStat.get(PENDING));
         assertEquals(0, (int) taskStat.get(IN_PROGRESS));
         assertEquals(0, (int) taskStat.get(ABORTING));
         assertEquals(origState == ExecutionTask.State.ABORTING ? 1 : 0, (int) taskStat.get(ABORTED));
         assertEquals(origState == ExecutionTask.State.ABORTING ? 0 : 1, (int) taskStat.get(COMPLETED));
         assertEquals(0, (int) taskStat.get(DEAD));
-        assertEquals(0, executionTasksSummary.remainingDataToMoveInMB());
-        assertEquals(0, executionTasksSummary.inExecutionDataMovementInMB());
-        assertEquals(10, executionTasksSummary.finishedDataMovementInMB());
+        assertEquals(0, executionTasksSummary.remainingInterBrokerDataToMoveInMB());
+        assertEquals(0, executionTasksSummary.inExecutionInterBrokerDataMovementInMB());
+        assertEquals(10, executionTasksSummary.finishedInterBrokerDataMovementInMB());
         break;
       default:
         throw new IllegalArgumentException("Invalid state " + state);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlannerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlannerTest.java
@@ -92,7 +92,7 @@ public class ExecutionTaskPlannerTest {
   }
 
   @Test
-  public void testGetPartitionMovementTasks() {
+  public void testGetInterBrokerPartitionMovementTasks() {
     List<ExecutionProposal> proposals = new ArrayList<>();
     proposals.add(_partitionMovement1);
     proposals.add(_partitionMovement2);
@@ -124,25 +124,25 @@ public class ExecutionTaskPlannerTest {
     readyBrokers.put(2, 8);
     readyBrokers.put(3, 8);
     basePlanner.addExecutionProposals(proposals, expectedCluster, null);
-    List<ExecutionTask> partitionMovementTasks = basePlanner.getReplicaMovementTasks(readyBrokers, Collections.emptySet());
+    List<ExecutionTask> partitionMovementTasks = basePlanner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet());
     assertEquals("First task should be partitionMovement1", _partitionMovement1, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task should be partitionMovement3", _partitionMovement3, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task should be partitionMovement4", _partitionMovement4, partitionMovementTasks.get(2).proposal());
 
     postponeUrpPlanner.addExecutionProposals(proposals, expectedCluster, null);
-    partitionMovementTasks = postponeUrpPlanner.getReplicaMovementTasks(readyBrokers, Collections.emptySet());
+    partitionMovementTasks = postponeUrpPlanner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet());
     assertEquals("First task should be partitionMovement4", _partitionMovement4, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task should be partitionMovement2", _partitionMovement2, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task should be partitionMovement1", _partitionMovement1, partitionMovementTasks.get(2).proposal());
 
     prioritizeLargeMovementPlanner.addExecutionProposals(proposals, expectedCluster, null);
-    partitionMovementTasks = prioritizeLargeMovementPlanner.getReplicaMovementTasks(readyBrokers, Collections.emptySet());
+    partitionMovementTasks = prioritizeLargeMovementPlanner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet());
     assertEquals("First task should be partitionMovement1", _partitionMovement1, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task should be partitionMovement3", _partitionMovement3, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task should be partitionMovement4", _partitionMovement4, partitionMovementTasks.get(2).proposal());
 
     prioritizeSmallMovementPlanner.addExecutionProposals(proposals, expectedCluster, null);
-    partitionMovementTasks = prioritizeSmallMovementPlanner.getReplicaMovementTasks(readyBrokers, Collections.emptySet());
+    partitionMovementTasks = prioritizeSmallMovementPlanner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet());
     assertEquals("First task should be partitionMovement4", _partitionMovement4, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task should be partitionMovement2", _partitionMovement2, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task should be partitionMovement1", _partitionMovement1, partitionMovementTasks.get(2).proposal());
@@ -175,25 +175,25 @@ public class ExecutionTaskPlannerTest {
     readyBrokers.put(2, 8);
     readyBrokers.put(3, 8);
     planner.addExecutionProposals(proposals, expectedCluster, null);
-    List<ExecutionTask> partitionMovementTasks = planner.getReplicaMovementTasks(readyBrokers, Collections.emptySet());
+    List<ExecutionTask> partitionMovementTasks = planner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet());
     assertEquals("First task should be partitionMovement1", _partitionMovement1, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task should be partitionMovement3", _partitionMovement3, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task should be partitionMovement4", _partitionMovement4, partitionMovementTasks.get(2).proposal());
 
     planner.addExecutionProposals(proposals, expectedCluster, new PostponeUrpReplicaMovementStrategy());
-    partitionMovementTasks = planner.getReplicaMovementTasks(readyBrokers, Collections.emptySet());
+    partitionMovementTasks = planner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet());
     assertEquals("First task should be partitionMovement4", _partitionMovement4, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task should be partitionMovement2", _partitionMovement2, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task should be partitionMovement1", _partitionMovement1, partitionMovementTasks.get(2).proposal());
 
     planner.addExecutionProposals(proposals, expectedCluster, new PrioritizeLargeReplicaMovementStrategy());
-    partitionMovementTasks = planner.getReplicaMovementTasks(readyBrokers, Collections.emptySet());
+    partitionMovementTasks = planner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet());
     assertEquals("First task should be partitionMovement1", _partitionMovement1, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task should be partitionMovement3", _partitionMovement3, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task should be partitionMovement4", _partitionMovement4, partitionMovementTasks.get(2).proposal());
 
     planner.addExecutionProposals(proposals, expectedCluster, new PrioritizeSmallReplicaMovementStrategy());
-    partitionMovementTasks = planner.getReplicaMovementTasks(readyBrokers, Collections.emptySet());
+    partitionMovementTasks = planner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet());
     assertEquals("First task should be partitionMovement4", _partitionMovement4, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task should be partitionMovement2", _partitionMovement2, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task should be partitionMovement1", _partitionMovement1, partitionMovementTasks.get(2).proposal());
@@ -219,10 +219,10 @@ public class ExecutionTaskPlannerTest {
 
     planner.addExecutionProposals(proposals, expectedCluster, null);
     assertEquals(2, planner.remainingLeadershipMovements().size());
-    assertEquals(2, planner.remainingReplicaMovements().size());
+    assertEquals(2, planner.remainingInterBrokerReplicaMovements().size());
     planner.clear();
     assertEquals(0, planner.remainingLeadershipMovements().size());
-    assertEquals(0, planner.remainingReplicaMovements().size());
+    assertEquals(0, planner.remainingInterBrokerReplicaMovements().size());
   }
 
   private Node[] generateExpectedReplicas(ExecutionProposal proposal) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -200,7 +200,7 @@ public class ExecutorTest extends AbstractKafkaIntegrationTestHarness {
       Thread.sleep(10);
     }
     // Sleep over 180000 (the hard coded timeout)
-    time.sleep(180001);
+    time.sleep(200000);
     // The execution should finish.
     waitUntilExecutionFinishes(executor);
   }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -199,7 +199,7 @@ public class ExecutorTest extends AbstractKafkaIntegrationTestHarness {
     while (executor.state().state() != ExecutorState.State.LEADER_MOVEMENT_TASK_IN_PROGRESS) {
       Thread.sleep(10);
     }
-    // Sleep over 180000 (the hard coded timeout)
+    // Sleep over 180000 (the hard coded timeout) with some margin for inter-thread synchronization.
     time.sleep(200000);
     // The execution should finish.
     waitUntilExecutionFinishes(executor);


### PR DESCRIPTION
This patch rename `replica movement` operation to `inter-broker replica movement` operation, it is a prerequisite to add a new type of operation, `intra-broker replica movement`, as part of JBOD support.