### PR TITLE
Fix the format conversion issue in ReviewResult response.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ReviewResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ReviewResult.java
@@ -72,7 +72,7 @@ public class ReviewResult extends AbstractCruiseControlResponse {
     // Populate header.
     StringBuilder formattingStringBuilder = new StringBuilder("%n%-");
     formattingStringBuilder.append(idLabelSize + padding)
-                           .append("d%-")
+                           .append("s%-")
                            .append(submitterAddressLabelSize + padding)
                            .append("s%-")
                            .append(submissionTimeLabelSize + padding)


### PR DESCRIPTION
When two step verification is enabled,  request to all POST endpoint and review_board GET point will get error response.
`Error processing POST/GET request 'endpoint' due to: 'd != java.lang.String'`
The root cause is a formatting conversion bug in `ReviewResult`.