### PR TITLE
Increase the default value of TOPIC_REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG to 3.00 to prevent excessive violations of Topic Replica Distribution Goal.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -1000,7 +1000,7 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 REPLICA_COUNT_BALANCE_THRESHOLD_DOC)
         .define(TOPIC_REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG,
                 ConfigDef.Type.DOUBLE,
-                1.80,
+                3.00,
                 atLeast(1),
                 ConfigDef.Importance.HIGH,
                 TOPIC_REPLICA_COUNT_BALANCE_THRESHOLD_DOC)


### PR DESCRIPTION
Addresses the issue https://github.com/linkedin/cruise-control/issues/645.