### PR TITLE
Add a configurable multiplier to adjust the balance threshold of distribution goals during detection and fixing of goal violations

### DIFF
--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -236,6 +236,8 @@ self.healing.enabled=false
 # Enable self healing for metric anomaly detector
 #self.healing.metric.anomaly.enabled=true
 
+# The multiplier applied to the threshold of distribution goals used by goal.violation.detector.
+#goal.violation.distribution.threshold.multiplier=2.50
 
 # configurations for the webserver
 # ================================

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -220,7 +220,8 @@ public class KafkaCruiseControl {
                                                           allowCapacityEstimation,
                                                           excludedTopics,
                                                           excludeRecentlyDemotedBrokers,
-                                                          excludeRecentlyRemovedBrokers);
+                                                          excludeRecentlyRemovedBrokers,
+                                                          false);
       if (!dryRun) {
         executeRemoval(result.goalProposals(), throttleDecommissionedBroker, brokerIds, isKafkaAssignerMode(goals),
                        concurrentInterBrokerPartitionMovements, concurrentLeaderMovements, replicaMovementStrategy, uuid);
@@ -307,7 +308,8 @@ public class KafkaCruiseControl {
                                                           allowCapacityEstimation,
                                                           excludedTopics,
                                                           excludeRecentlyDemotedBrokers,
-                                                          excludeRecentlyRemovedBrokers);
+                                                          excludeRecentlyRemovedBrokers,
+                                                          false);
       if (!dryRun) {
         executeProposals(result.goalProposals(),
                          throttleAddedBrokers ? Collections.emptyList() : brokerIds,
@@ -355,6 +357,7 @@ public class KafkaCruiseControl {
    * @param excludeRecentlyDemotedBrokers Exclude recently demoted brokers from proposal generation for leadership transfer.
    * @param excludeRecentlyRemovedBrokers Exclude recently removed brokers from proposal generation for replica transfer.
    * @param ignoreProposalCache True to explicitly ignore the proposal cache, false otherwise.
+   * @param isTriggeredByGoalViolation True if rebalance is triggered by goal violation, false otherwise.
    * @return The optimization result.
    * @throws KafkaCruiseControlException When the rebalance encounter errors.
    */
@@ -371,13 +374,15 @@ public class KafkaCruiseControl {
                                                  String uuid,
                                                  boolean excludeRecentlyDemotedBrokers,
                                                  boolean excludeRecentlyRemovedBrokers,
-                                                 boolean ignoreProposalCache) throws KafkaCruiseControlException {
+                                                 boolean ignoreProposalCache,
+                                                 boolean isTriggeredByGoalViolation) throws KafkaCruiseControlException {
     sanityCheckDryRun(dryRun);
     GoalOptimizer.OptimizerResult result = getProposals(goals, requirements, operationProgress,
                                                         allowCapacityEstimation, skipHardGoalCheck,
                                                         excludedTopics, excludeRecentlyDemotedBrokers,
                                                         excludeRecentlyRemovedBrokers,
-                                                        ignoreProposalCache);
+                                                        ignoreProposalCache,
+                                                        isTriggeredByGoalViolation);
     if (!dryRun) {
       executeProposals(result.goalProposals(), Collections.emptySet(), isKafkaAssignerMode(goals),
                        concurrentInterBrokerPartitionMovements, concurrentLeaderMovements, replicaMovementStrategy, uuid);
@@ -440,6 +445,7 @@ public class KafkaCruiseControl {
                                                           allowCapacityEstimation,
                                                           null,
                                                           excludeRecentlyDemotedBrokers,
+                                                          false,
                                                           false);
       if (!dryRun) {
         executeDemotion(result.goalProposals(), brokerIds, concurrentLeaderMovements, replicaMovementStrategy, uuid);
@@ -686,6 +692,7 @@ public class KafkaCruiseControl {
    * @param excludeRecentlyDemotedBrokers Exclude recently demoted brokers from proposal generation for leadership transfer.
    * @param excludeRecentlyRemovedBrokers Exclude recently removed brokers from proposal generation for replica transfer.
    * @param ignoreProposalCache True to explicitly ignore the proposal cache, false otherwise.
+   * @param isTriggeredByGoalViolation True if proposals is triggered by goal violation, false otherwise.
    * @return The optimization result.
    * @throws KafkaCruiseControlException
    */
@@ -697,7 +704,8 @@ public class KafkaCruiseControl {
                                                     Pattern excludedTopics,
                                                     boolean excludeRecentlyDemotedBrokers,
                                                     boolean excludeRecentlyRemovedBrokers,
-                                                    boolean ignoreProposalCache)
+                                                    boolean ignoreProposalCache,
+                                                    boolean isTriggeredByGoalViolation)
       throws KafkaCruiseControlException {
     GoalOptimizer.OptimizerResult result;
     sanityCheckHardGoalPresence(goals, skipHardGoalCheck);
@@ -716,7 +724,8 @@ public class KafkaCruiseControl {
                               allowCapacityEstimation,
                               excludedTopics,
                               excludeRecentlyDemotedBrokers,
-                              excludeRecentlyRemovedBrokers);
+                              excludeRecentlyRemovedBrokers,
+                              isTriggeredByGoalViolation);
       } catch (KafkaCruiseControlException kcce) {
         throw kcce;
       } catch (Exception e) {
@@ -734,7 +743,8 @@ public class KafkaCruiseControl {
                                                      boolean allowCapacityEstimation,
                                                      Pattern requestedExcludedTopics,
                                                      boolean excludeRecentlyDemotedBrokers,
-                                                     boolean excludeRecentlyRemovedBrokers)
+                                                     boolean excludeRecentlyRemovedBrokers,
+                                                     boolean isTriggeredByGoalViolation)
       throws KafkaCruiseControlException {
     sanityCheckCapacityEstimation(allowCapacityEstimation, clusterModel.capacityEstimationInfoByBrokerId());
     synchronized (this) {
@@ -754,7 +764,8 @@ public class KafkaCruiseControl {
                                           operationProgress,
                                           requestedExcludedTopics,
                                           excludedBrokersForLeadership,
-                                          excludedBrokersForReplicaMove);
+                                          excludedBrokersForReplicaMove,
+                                          isTriggeredByGoalViolation);
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/BalancingConstraint.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/BalancingConstraint.java
@@ -83,8 +83,8 @@ public class BalancingConstraint {
     props.put(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, _maxReplicasPerBroker.toString());
     props.put(KafkaCruiseControlConfig.REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG, _replicaBalancePercentage.toString());
     props.put(KafkaCruiseControlConfig.TOPIC_REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG, _topicReplicaBalancePercentage.toString());
-    props.put(KafkaCruiseControlConfig.GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_CONFIG, _goalViolationDistributionThresholdMultiplier
-        .toString());
+    props.put(KafkaCruiseControlConfig.GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_CONFIG,
+              _goalViolationDistributionThresholdMultiplier.toString());
     return props;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/BalancingConstraint.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/BalancingConstraint.java
@@ -16,14 +16,15 @@ import java.util.Properties;
 
 
 /**
- * A class that holds the information of balancing constraint of resources in descending order of balancing priority,
- * balance percentage and capacity threshold for each resource.
+ * A class that holds the information of balancing constraint of resources, balance and capacity thresholds, and self
+ * healing distribution threshold multiplier.
  */
 public class BalancingConstraint {
   private final List<Resource> _resources;
   private final Map<Resource, Double> _resourceBalancePercentage;
   private final Double _replicaBalancePercentage;
   private final Double _topicReplicaBalancePercentage;
+  private final Double _goalViolationDistributionThresholdMultiplier;
   private final Map<Resource, Double> _capacityThreshold;
   private final Map<Resource, Double> _lowUtilizationThreshold;
   private final Long _maxReplicasPerBroker;
@@ -60,6 +61,7 @@ public class BalancingConstraint {
     // Set default value for the balance percentage of (1) replica and (2) topic replica distribution.
     _replicaBalancePercentage = config.getDouble(KafkaCruiseControlConfig.REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG);
     _topicReplicaBalancePercentage = config.getDouble(KafkaCruiseControlConfig.TOPIC_REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG);
+    _goalViolationDistributionThresholdMultiplier = config.getDouble(KafkaCruiseControlConfig.GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_CONFIG);
   }
 
   Properties setProps(Properties props) {
@@ -81,6 +83,8 @@ public class BalancingConstraint {
     props.put(KafkaCruiseControlConfig.MAX_REPLICAS_PER_BROKER_CONFIG, _maxReplicasPerBroker.toString());
     props.put(KafkaCruiseControlConfig.REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG, _replicaBalancePercentage.toString());
     props.put(KafkaCruiseControlConfig.TOPIC_REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG, _topicReplicaBalancePercentage.toString());
+    props.put(KafkaCruiseControlConfig.GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_CONFIG, _goalViolationDistributionThresholdMultiplier
+        .toString());
     return props;
   }
 
@@ -111,6 +115,13 @@ public class BalancingConstraint {
    */
   public Double topicReplicaBalancePercentage() {
     return _topicReplicaBalancePercentage;
+  }
+
+  /**
+   * Get goal violation distribution threshold multiplier to be used in detection and fixing goal violations.
+   */
+  public Double goalViolationDistributionThresholdMultiplier() {
+    return _goalViolationDistributionThresholdMultiplier;
   }
 
   /**
@@ -199,11 +210,13 @@ public class BalancingConstraint {
     return String.format("BalancingConstraint[cpuBalancePercentage=%.4f,diskBalancePercentage=%.4f,"
                          + "inboundNwBalancePercentage=%.4f,outboundNwBalancePercentage=%.4f,cpuCapacityThreshold=%.4f,"
                          + "diskCapacityThreshold=%.4f,inboundNwCapacityThreshold=%.4f,outboundNwCapacityThreshold=%.4f,"
-                         + "maxReplicasPerBroker=%d,replicaBalancePercentage=%.4f,topicReplicaBalancePercentage=%.4f]",
+                         + "maxReplicasPerBroker=%d,replicaBalancePercentage=%.4f,topicReplicaBalancePercentage=%.4f,"
+                         + "goalViolationDistributionThresholdMultiplier=%.4f]",
                          _resourceBalancePercentage.get(Resource.CPU), _resourceBalancePercentage.get(Resource.DISK),
                          _resourceBalancePercentage.get(Resource.NW_IN), _resourceBalancePercentage.get(Resource.NW_OUT),
                          _capacityThreshold.get(Resource.CPU), _capacityThreshold.get(Resource.DISK),
                          _capacityThreshold.get(Resource.NW_IN), _capacityThreshold.get(Resource.NW_OUT),
-                         _maxReplicasPerBroker, _replicaBalancePercentage, _topicReplicaBalancePercentage);
+                         _maxReplicasPerBroker, _replicaBalancePercentage, _topicReplicaBalancePercentage,
+                         _goalViolationDistributionThresholdMultiplier);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/OptimizationOptions.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/OptimizationOptions.java
@@ -15,6 +15,7 @@ public class OptimizationOptions {
   private final Set<String> _excludedTopics;
   private final Set<Integer> _excludedBrokersForLeadership;
   private final Set<Integer> _excludedBrokersForReplicaMove;
+  private final boolean _isTriggeredByGoalViolation;
 
   /**
    * Default value for {@link #_excludedBrokersForLeadership} is an empty set.
@@ -30,9 +31,17 @@ public class OptimizationOptions {
   public OptimizationOptions(Set<String> excludedTopics,
                              Set<Integer> excludedBrokersForLeadership,
                              Set<Integer> excludedBrokersForReplicaMove) {
+    this(excludedTopics, excludedBrokersForLeadership, excludedBrokersForReplicaMove, false);
+  }
+
+  public OptimizationOptions(Set<String> excludedTopics,
+                             Set<Integer> excludedBrokersForLeadership,
+                             Set<Integer> excludedBrokersForReplicaMove,
+                             boolean isTriggeredByGoalViolation) {
     _excludedTopics = excludedTopics;
     _excludedBrokersForLeadership = excludedBrokersForLeadership;
     _excludedBrokersForReplicaMove = excludedBrokersForReplicaMove;
+    _isTriggeredByGoalViolation = isTriggeredByGoalViolation;
   }
 
   public Set<String> excludedTopics() {
@@ -47,9 +56,14 @@ public class OptimizationOptions {
     return Collections.unmodifiableSet(_excludedBrokersForReplicaMove);
   }
 
+  public boolean isTriggeredByGoalViolation() {
+    return _isTriggeredByGoalViolation;
+  }
+
   @Override
   public String toString() {
-    return String.format("{excludedTopics: %s, excludedBrokersForLeadership: %s, excludedBrokersForReplicaMove: %s}",
-                         _excludedTopics, _excludedBrokersForLeadership, _excludedBrokersForReplicaMove);
+    return String.format("[excludedTopics=%s,excludedBrokersForLeadership=%s,excludedBrokersForReplicaMove=%s,"
+                         + "isTriggeredByGoalViolation=%s}", _excludedTopics, _excludedBrokersForLeadership,
+                         _excludedBrokersForReplicaMove, _isTriggeredByGoalViolation);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -66,7 +66,6 @@ public abstract class AbstractGoal implements Goal {
   @Override
   public boolean optimize(ClusterModel clusterModel, Set<Goal> optimizedGoals, OptimizationOptions optimizationOptions)
       throws OptimizationFailureException {
-    Set<String> excludedTopics = optimizationOptions.excludedTopics();
     _succeeded = true;
     LOG.debug("Starting optimization for {}.", name());
     // Initialize pre-optimized stats.
@@ -74,9 +73,10 @@ public abstract class AbstractGoal implements Goal {
     LOG.trace("[PRE - {}] {}", name(), statsBeforeOptimization);
     _finished = false;
     long goalStartTime = System.currentTimeMillis();
-    initGoalState(clusterModel, excludedTopics);
+    initGoalState(clusterModel, optimizationOptions);
     Collection<Broker> deadBrokers = clusterModel.deadBrokers();
 
+    Set<String> excludedTopics = optimizationOptions.excludedTopics();
     while (!_finished) {
       for (Broker broker : brokersToBalance(clusterModel)) {
         rebalanceForBroker(broker, clusterModel, optimizedGoals, optimizationOptions);
@@ -147,9 +147,9 @@ public abstract class AbstractGoal implements Goal {
    * Initialize states that this goal requires -- e.g. run sanity checks regarding hard goals requirements.
    *
    * @param clusterModel The state of the cluster.
-   * @param excludedTopics The topics that should be excluded from the optimization proposals.
+   * @param optimizationOptions Options to take into account during optimization -- e.g. excluded topics.
    */
-  protected abstract void initGoalState(ClusterModel clusterModel, Set<String> excludedTopics)
+  protected abstract void initGoalState(ClusterModel clusterModel, OptimizationOptions optimizationOptions)
       throws OptimizationFailureException;
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CapacityGoal.java
@@ -154,10 +154,11 @@ public abstract class CapacityGoal extends AbstractGoal {
    * determined by the total capacity of alive cluster multiplied by the capacity threshold.
    *
    * @param clusterModel The state of the cluster.
-   * @param excludedTopics The topics that should be excluded from the optimization proposals.
+   * @param optimizationOptions Options to take into account during optimization.
    */
   @Override
-  protected void initGoalState(ClusterModel clusterModel, Set<String> excludedTopics) throws OptimizationFailureException {
+  protected void initGoalState(ClusterModel clusterModel, OptimizationOptions optimizationOptions)
+      throws OptimizationFailureException {
     // Sanity Check -- i.e. not enough resources.
     Load recentClusterLoad = clusterModel.load();
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderBytesInDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderBytesInDistributionGoal.java
@@ -47,7 +47,7 @@ public class LeaderBytesInDistributionGoal extends AbstractGoal {
 
   /** Testing constructor */
   LeaderBytesInDistributionGoal(BalancingConstraint balancingConstraint) {
-    this._balancingConstraint = balancingConstraint;
+    _balancingConstraint = balancingConstraint;
   }
 
   /**
@@ -158,7 +158,7 @@ public class LeaderBytesInDistributionGoal extends AbstractGoal {
   }
 
   @Override
-  protected void initGoalState(ClusterModel clusterModel, Set<String> excludedTopics) {
+  protected void initGoalState(ClusterModel clusterModel, OptimizationOptions optimizationOptions) {
     // While proposals exclude the excludedTopics, the leader bytes in still considers replicas of the excludedTopics.
     _meanLeaderBytesIn = 0.0;
     _overLimitBrokerIds = new HashSet<>();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/PotentialNwOutGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/PotentialNwOutGoal.java
@@ -212,10 +212,10 @@ public class PotentialNwOutGoal extends AbstractGoal {
    * its initial attempt. Since self healing has not been executed yet, this flag is false.
    *
    * @param clusterModel The state of the cluster.
-   * @param excludedTopics The topics that should be excluded from the optimization proposals.
+   * @param optimizationOptions Options to take into account during optimization.
    */
   @Override
-  protected void initGoalState(ClusterModel clusterModel, Set<String> excludedTopics) {
+  protected void initGoalState(ClusterModel clusterModel, OptimizationOptions optimizationOptions) {
     // While proposals exclude the excludedTopics, the potential nw_out still considers replicas of the excludedTopics.
     _selfHealingDeadBrokersOnly = false;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/PreferredLeaderElectionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/PreferredLeaderElectionGoal.java
@@ -51,8 +51,15 @@ public class PreferredLeaderElectionGoal implements Goal {
     _kafkaCluster = kafkaCluster;
   }
 
+  private void sanityCheckOptimizationOptions(OptimizationOptions optimizationOptions) {
+    if (optimizationOptions.isTriggeredByGoalViolation()) {
+      throw new IllegalArgumentException(String.format("%s goal does not support use by goal violation detector.", name()));
+    }
+  }
+
   @Override
   public boolean optimize(ClusterModel clusterModel, Set<Goal> optimizedGoals, OptimizationOptions optimizationOptions) {
+    sanityCheckOptimizationOptions(optimizationOptions);
     // First move the replica on the demoted brokers to the end of the replica list.
     // If all the replicas are demoted, no change is made to the leader.
     Set<TopicPartition> partitionsToMove = new HashSet<>();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareGoal.java
@@ -164,12 +164,14 @@ public class RackAwareGoal extends AbstractGoal {
    * Sanity Check: There exists sufficient number of racks for achieving rack-awareness.
    *
    * @param clusterModel The state of the cluster.
-   * @param excludedTopics The topics that should be excluded from the optimization proposals.
+   * @param optimizationOptions Options to take into account during optimization.
    */
   @Override
-  protected void initGoalState(ClusterModel clusterModel, Set<String> excludedTopics) throws OptimizationFailureException {
+  protected void initGoalState(ClusterModel clusterModel, OptimizationOptions optimizationOptions)
+      throws OptimizationFailureException {
     // Sanity Check: not enough racks to satisfy rack awareness.
     int numAliveRacks = clusterModel.numAliveRacks();
+    Set<String> excludedTopics = optimizationOptions.excludedTopics();
     if (!excludedTopics.isEmpty()) {
       int maxReplicationFactorOfIncludedTopics = 1;
       Map<String, Integer> replicationFactorByTopic = clusterModel.replicationFactorByTopic();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
@@ -115,12 +115,14 @@ public class ReplicaCapacityGoal extends AbstractGoal {
    * This is a hard goal; hence, the proposals are not limited to dead broker replicas in case of self-healing.
    * Sanity Check: Each node has sufficient number of replicas that can be moved to satisfy the replica capacity goal.
    *
-   *  @param clusterModel The state of the cluster.
-   * @param excludedTopics The topics that should be excluded from the optimization proposals.
+   * @param clusterModel The state of the cluster.
+   * @param optimizationOptions Options to take into account during optimization.
    */
   @Override
-  protected void initGoalState(ClusterModel clusterModel, Set<String> excludedTopics) throws OptimizationFailureException {
+  protected void initGoalState(ClusterModel clusterModel, OptimizationOptions optimizationOptions)
+      throws OptimizationFailureException {
     List<String> topicsToRebalance = new ArrayList<>(clusterModel.topics());
+    Set<String> excludedTopics = optimizationOptions.excludedTopics();
     topicsToRebalance.removeAll(excludedTopics);
     if (topicsToRebalance.isEmpty()) {
       LOG.warn("All topics are excluded from {}.", name());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionGoal.java
@@ -47,8 +47,9 @@ import static com.linkedin.kafka.cruisecontrol.analyzer.goals.GoalUtils.MIN_NUM_
  * <li>Under: (the average number of replicas per broker) * (1 + replica count balance percentage)</li>
  * <li>Above: (the average number of replicas per broker) * Math.max(0, 1 - replica count balance percentage)</li>
  * </ul>
- * Also see: {@link com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig#REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG}
- * and {@link #balancePercentageWithMargin()}.
+ * Also see: {@link com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig#REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG},
+ * {@link com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig#GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_CONFIG},
+ * and {@link #balancePercentageWithMargin(OptimizationOptions)}.
  */
 public class ReplicaDistributionGoal extends AbstractGoal {
   private static final Logger LOG = LoggerFactory.getLogger(ReplicaDistributionGoal.class);
@@ -81,24 +82,36 @@ public class ReplicaDistributionGoal extends AbstractGoal {
    * To avoid churns, we add a balance margin to the user specified rebalance threshold. e.g. when user sets the
    * threshold to be {@link BalancingConstraint#replicaBalancePercentage()}, we use
    * ({@link BalancingConstraint#replicaBalancePercentage()}-1)*{@link #BALANCE_MARGIN} instead.
+   *
+   * @param optimizationOptions Options to adjust balance percentage with margin in case goal optimization is triggered
+   * by goal violation detector.
    * @return the rebalance threshold with a margin.
    */
-  private double balancePercentageWithMargin() {
-    return (_balancingConstraint.replicaBalancePercentage() - 1) * BALANCE_MARGIN;
+  private double balancePercentageWithMargin(OptimizationOptions optimizationOptions) {
+    double balancePercentage = optimizationOptions.isTriggeredByGoalViolation()
+                               ? _balancingConstraint.replicaBalancePercentage()
+                                 * _balancingConstraint.goalViolationDistributionThresholdMultiplier()
+                               : _balancingConstraint.replicaBalancePercentage();
+
+    return (balancePercentage - 1) * BALANCE_MARGIN;
   }
 
   /**
+   * @param optimizationOptions Options to adjust balance upper limit in case goal optimization is triggered by goal
+   * violation detector.
    * @return The replica balance upper threshold in number of replicas.
    */
-  private int balanceUpperLimit() {
-    return (int) Math.ceil(_avgReplicasOnAliveBroker * (1 + balancePercentageWithMargin()));
+  private int balanceUpperLimit(OptimizationOptions optimizationOptions) {
+    return (int) Math.ceil(_avgReplicasOnAliveBroker * (1 + balancePercentageWithMargin(optimizationOptions)));
   }
 
   /**
+   * @param optimizationOptions Options to adjust balance lower limit in case goal optimization is triggered by goal
+   * violation detector.
    * @return The replica balance lower threshold in number of replicas.
    */
-  private int balanceLowerLimit() {
-    return (int) Math.floor(_avgReplicasOnAliveBroker * Math.max(0, (1 - balancePercentageWithMargin())));
+  private int balanceLowerLimit(OptimizationOptions optimizationOptions) {
+    return (int) Math.floor(_avgReplicasOnAliveBroker * Math.max(0, (1 - balancePercentageWithMargin(optimizationOptions))));
   }
 
   /**
@@ -179,16 +192,16 @@ public class ReplicaDistributionGoal extends AbstractGoal {
    * Initiates replica distribution goal.
    *
    * @param clusterModel The state of the cluster.
-   * @param excludedTopics The topics that should be excluded from the optimization proposals.
+   * @param optimizationOptions Options to take into account during optimization.
    */
   @Override
-  protected void initGoalState(ClusterModel clusterModel, Set<String> excludedTopics) {
+  protected void initGoalState(ClusterModel clusterModel, OptimizationOptions optimizationOptions) {
     // Initialize the average replicas on an alive broker.
     int numReplicasInCluster = clusterModel.getReplicaDistribution().values().stream().mapToInt(List::size).sum();
     _avgReplicasOnAliveBroker = (numReplicasInCluster / (double) clusterModel.aliveBrokers().size());
 
     // Log a warning if all replicas are excluded.
-    if (clusterModel.topics().equals(excludedTopics)) {
+    if (clusterModel.topics().equals(optimizationOptions.excludedTopics())) {
       LOG.warn("All replicas are excluded from {}.", name());
     }
 
@@ -198,8 +211,8 @@ public class ReplicaDistributionGoal extends AbstractGoal {
     }
 
     _selfHealingDeadBrokersOnly = false;
-    _balanceUpperLimit = balanceUpperLimit();
-    _balanceLowerLimit = balanceLowerLimit();
+    _balanceUpperLimit = balanceUpperLimit(optimizationOptions);
+    _balanceLowerLimit = balanceLowerLimit(optimizationOptions);
   }
 
   /**
@@ -208,7 +221,7 @@ public class ReplicaDistributionGoal extends AbstractGoal {
    *
    * @param clusterModel The state of the cluster.
    * @param action Action containing information about potential modification to the given cluster model. Assumed to be
-   * of type {@link ActionType#REPLICA_MOVEMENT}.
+   * of type {@link ActionType#INTER_BROKER_REPLICA_MOVEMENT}.
    * @return True if requirements of this goal are not violated if this proposal is applied to the given cluster state,
    * false otherwise.
    */

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicReplicaDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicReplicaDistributionGoal.java
@@ -47,7 +47,7 @@ import static com.linkedin.kafka.cruisecontrol.analyzer.goals.GoalUtils.MIN_NUM_
  * <li>Above: (the average number of topic replicas per broker) * Math.max(0, 1 - topic replica count balance percentage)</li>
  * </ul>
  * Also see: {@link com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig#TOPIC_REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG},
- *  * {@link com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig#GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_CONFIG},
+ * {@link com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig#GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_CONFIG},
  * and {@link #balancePercentageWithMargin(OptimizationOptions)}.
  */
 public class TopicReplicaDistributionGoal extends AbstractGoal {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicReplicaDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicReplicaDistributionGoal.java
@@ -46,8 +46,9 @@ import static com.linkedin.kafka.cruisecontrol.analyzer.goals.GoalUtils.MIN_NUM_
  * <li>Under: (the average number of topic replicas per broker) * (1 + topic replica count balance percentage)</li>
  * <li>Above: (the average number of topic replicas per broker) * Math.max(0, 1 - topic replica count balance percentage)</li>
  * </ul>
- * Also see: {@link com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig#TOPIC_REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG}
- * and {@link #balancePercentageWithMargin()}.
+ * Also see: {@link com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig#TOPIC_REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG},
+ *  * {@link com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig#GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_CONFIG},
+ * and {@link #balancePercentageWithMargin(OptimizationOptions)}.
  */
 public class TopicReplicaDistributionGoal extends AbstractGoal {
   private static final Logger LOG = LoggerFactory.getLogger(TopicReplicaDistributionGoal.class);
@@ -82,26 +83,40 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
    * To avoid churns, we add a balance margin to the user specified rebalance threshold. e.g. when user sets the
    * threshold to be {@link BalancingConstraint#topicReplicaBalancePercentage()}, we use
    * ({@link BalancingConstraint#topicReplicaBalancePercentage()}-1)*{@link #BALANCE_MARGIN} instead.
+   *
+   * @param optimizationOptions Options to adjust balance percentage with margin in case goal optimization is triggered
+   * by goal violation detector.
    * @return the rebalance threshold with a margin.
    */
-  private double balancePercentageWithMargin() {
-    return (_balancingConstraint.topicReplicaBalancePercentage() - 1) * BALANCE_MARGIN;
+  private double balancePercentageWithMargin(OptimizationOptions optimizationOptions) {
+    double balancePercentage = optimizationOptions.isTriggeredByGoalViolation()
+                               ? _balancingConstraint.topicReplicaBalancePercentage()
+                                 * _balancingConstraint.goalViolationDistributionThresholdMultiplier()
+                               : _balancingConstraint.topicReplicaBalancePercentage();
+
+    return (balancePercentage - 1) * BALANCE_MARGIN;
   }
 
   /**
    * @param topic Topic for which the upper limit is requested.
+   * @param optimizationOptions Options to adjust balance upper limit in case goal optimization is triggered by goal
+   * violation detector.
    * @return The topic replica balance upper threshold in number of topic replicas.
    */
-  private int balanceUpperLimit(String topic) {
-    return (int) Math.ceil(_avgTopicReplicasOnAliveBroker.get(topic) * (1 + balancePercentageWithMargin()));
+  private int balanceUpperLimit(String topic, OptimizationOptions optimizationOptions) {
+    return (int) Math.ceil(_avgTopicReplicasOnAliveBroker.get(topic)
+                           * (1 + balancePercentageWithMargin(optimizationOptions)));
   }
 
   /**
    * @param topic Topic for which the lower limit is requested.
+   * @param optimizationOptions Options to adjust balance lower limit in case goal optimization is triggered by goal
+   * violation detector.
    * @return The replica balance lower threshold in number of topic replicas.
    */
-  private int balanceLowerLimit(String topic) {
-    return (int) Math.floor(_avgTopicReplicasOnAliveBroker.get(topic) * Math.max(0, (1 - balancePercentageWithMargin())));
+  private int balanceLowerLimit(String topic, OptimizationOptions optimizationOptions) {
+    return (int) Math.floor(_avgTopicReplicasOnAliveBroker.get(topic)
+                            * Math.max(0, (1 - balancePercentageWithMargin(optimizationOptions))));
   }
 
   /**
@@ -225,18 +240,18 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
    * Initiates this goal.
    *
    * @param clusterModel The state of the cluster.
-   * @param excludedTopics The topics that should be excluded from the optimization proposals.
+   * @param optimizationOptions Options to take into account during optimization.
    */
   @Override
-  protected void initGoalState(ClusterModel clusterModel, Set<String> excludedTopics) {
-    Set<String> topicsToRebalance = topicsToRebalance(clusterModel, excludedTopics);
+  protected void initGoalState(ClusterModel clusterModel, OptimizationOptions optimizationOptions) {
+    Set<String> topicsToRebalance = topicsToRebalance(clusterModel, optimizationOptions.excludedTopics());
 
     // Initialize the average replicas on an alive broker.
     for (String topic : topicsToRebalance) {
       int numTopicReplicas = clusterModel.numTopicReplicas(topic);
       _avgTopicReplicasOnAliveBroker.put(topic, (numTopicReplicas / (double) clusterModel.aliveBrokers().size()));
-      _balanceUpperLimitByTopic.put(topic, balanceUpperLimit(topic));
-      _balanceLowerLimitByTopic.put(topic, balanceLowerLimit(topic));
+      _balanceUpperLimitByTopic.put(topic, balanceUpperLimit(topic, optimizationOptions));
+      _balanceLowerLimitByTopic.put(topic, balanceLowerLimit(topic, optimizationOptions));
     }
 
     _selfHealingDeadBrokersOnly = false;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoal.java
@@ -87,6 +87,7 @@ public class KafkaAssignerDiskUsageDistributionGoal implements Goal {
 
   @Override
   public boolean optimize(ClusterModel clusterModel, Set<Goal> optimizedGoals, OptimizationOptions optimizationOptions) {
+    KafkaAssignerUtils.sanityCheckOptimizationOptions(optimizationOptions);
     Set<String> excludedTopics = optimizationOptions.excludedTopics();
     double meanDiskUsage = clusterModel.load().expectedUtilizationFor(DISK) / clusterModel.capacityFor(DISK);
     double upperThreshold = meanDiskUsage * (1 + balancePercentageWithMargin());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerEvenRackAwareGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerEvenRackAwareGoal.java
@@ -99,6 +99,7 @@ public class KafkaAssignerEvenRackAwareGoal implements Goal {
   @Override
   public boolean optimize(ClusterModel clusterModel, Set<Goal> optimizedGoals, OptimizationOptions optimizationOptions)
       throws KafkaCruiseControlException {
+    KafkaAssignerUtils.sanityCheckOptimizationOptions(optimizationOptions);
     Set<String> excludedTopics = optimizationOptions.excludedTopics();
     LOG.debug("Starting {} with excluded topics = {}", name(), excludedTopics);
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerUtils.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ *
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner;
+
+import com.linkedin.kafka.cruisecontrol.analyzer.OptimizationOptions;
+
+
+/**
+ * A util class for Kafka Assigner Goals.
+ */
+public class KafkaAssignerUtils {
+
+  private KafkaAssignerUtils() {
+
+  }
+
+  static void sanityCheckOptimizationOptions(OptimizationOptions optimizationOptions) {
+    if (optimizationOptions.isTriggeredByGoalViolation()) {
+      throw new IllegalArgumentException("Kafka Assigner goals do not support usage by goal violation detector.");
+    }
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AsyncKafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/AsyncKafkaCruiseControl.java
@@ -42,10 +42,11 @@ import java.util.concurrent.Executors;
  * <li>{@link KafkaCruiseControl#getProposals(OperationProgress, boolean)}</li>
  * <li>{@link KafkaCruiseControl#state(OperationProgress, Set)}</li>
  * <li>{@link KafkaCruiseControl#getProposals(java.util.List, ModelCompletenessRequirements, OperationProgress,
- * boolean, boolean, java.util.regex.Pattern, boolean, boolean, boolean)}</li>
+ * boolean, boolean, java.util.regex.Pattern, boolean, boolean, boolean, boolean)}</li>
  * <li>{@link KafkaCruiseControl#rebalance(java.util.List, boolean, ModelCompletenessRequirements, OperationProgress,
  * boolean, Integer, Integer, boolean, java.util.regex.Pattern,
- * com.linkedin.kafka.cruisecontrol.executor.strategy.ReplicaMovementStrategy, String, boolean, boolean, boolean)}</li>
+ * com.linkedin.kafka.cruisecontrol.executor.strategy.ReplicaMovementStrategy, String, boolean, boolean, boolean,
+ * boolean)}</li>
  * </ul>
  *
  * The other operations are non-blocking by default.
@@ -123,7 +124,7 @@ public class AsyncKafkaCruiseControl extends KafkaCruiseControl {
 
   /**
    * @see KafkaCruiseControl#getProposals(java.util.List, ModelCompletenessRequirements, OperationProgress,
-   * boolean, boolean, java.util.regex.Pattern, boolean, boolean, boolean)
+   * boolean, boolean, java.util.regex.Pattern, boolean, boolean, boolean, boolean)
    */
   public OperationFuture getProposals(ProposalsParameters parameters) {
     OperationFuture future = new OperationFuture("Get customized proposals");
@@ -135,7 +136,8 @@ public class AsyncKafkaCruiseControl extends KafkaCruiseControl {
   /**
    * @see KafkaCruiseControl#rebalance(java.util.List, boolean, ModelCompletenessRequirements, OperationProgress,
    * boolean, Integer, Integer, boolean, java.util.regex.Pattern,
-   * com.linkedin.kafka.cruisecontrol.executor.strategy.ReplicaMovementStrategy, String, boolean, boolean, boolean)
+   * com.linkedin.kafka.cruisecontrol.executor.strategy.ReplicaMovementStrategy, String, boolean, boolean, boolean,
+   * boolean)
    */
   public OperationFuture rebalance(RebalanceParameters parameters, String uuid) {
     OperationFuture future = new OperationFuture("Rebalance");

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetProposalsRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetProposalsRunnable.java
@@ -17,7 +17,8 @@ import java.util.regex.Pattern;
  * The async runnable for {@link KafkaCruiseControl#getProposals(
  * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean)} and
  * {@link KafkaCruiseControl#getProposals(List, ModelCompletenessRequirements,
- * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean, boolean, Pattern, boolean, boolean, boolean)}
+ * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean, boolean, Pattern, boolean, boolean,
+ * boolean, boolean)}
  */
 class GetProposalsRunnable extends OperationRunnable {
   private final List<String> _goals;
@@ -54,7 +55,8 @@ class GetProposalsRunnable extends OperationRunnable {
                                                                    _excludedTopics,
                                                                    _excludeRecentlyDemotedBrokers,
                                                                    _excludeRecentlyRemovedBrokers,
-                                                                   _ignoreProposalCache),
+                                                                   _ignoreProposalCache,
+                                                                   false),
                                   _config);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/RebalanceRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/RebalanceRunnable.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 /**
  * The async runnable for {@link KafkaCruiseControl#rebalance(List, boolean, ModelCompletenessRequirements,
  * com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress, boolean, Integer, Integer, boolean, Pattern,
- * ReplicaMovementStrategy, String, boolean, boolean, boolean)}
+ * ReplicaMovementStrategy, String, boolean, boolean, boolean, boolean)}
  */
 class RebalanceRunnable extends OperationRunnable {
   private final List<String> _goals;
@@ -72,7 +72,8 @@ class RebalanceRunnable extends OperationRunnable {
                                                                 _uuid,
                                                                 _excludeRecentlyDemotedBrokers,
                                                                 _excludeRecentlyRemovedBrokers,
-                                                                _ignoreProposalCache),
+                                                                _ignoreProposalCache,
+                                                                false),
                                   _config);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -330,6 +330,14 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
       + "should not be above 1.80x of average replica count of all brokers for the same topic.";
 
   /**
+   * <code>goal.violation.distribution.threshold.multiplier</code>
+   */
+  public static final String GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_CONFIG = "goal.violation.distribution.threshold.multiplier";
+  private static final String GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_DOC = "The multiplier applied to the threshold"
+      + " of distribution goals used for detecting and fixing anomalies. For example, 2.50 means the threshold for each "
+      + "distribution goal will be 2.50x of the value used in manual goal optimization requests (e.g. rebalance).";
+
+  /**
    * <code>cpu.capacity.threshold</code>
    */
   public static final String CPU_CAPACITY_THRESHOLD_CONFIG = "cpu.capacity.threshold";
@@ -1004,6 +1012,11 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
                 atLeast(1),
                 ConfigDef.Importance.HIGH,
                 TOPIC_REPLICA_COUNT_BALANCE_THRESHOLD_DOC)
+        .define(GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_CONFIG,
+                ConfigDef.Type.DOUBLE,
+                1.00,
+                atLeast(1),
+                ConfigDef.Importance.MEDIUM, GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_DOC)
         .define(CPU_CAPACITY_THRESHOLD_CONFIG,
                 ConfigDef.Type.DOUBLE,
                 0.8,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -335,7 +335,8 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
   public static final String GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_CONFIG = "goal.violation.distribution.threshold.multiplier";
   private static final String GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_DOC = "The multiplier applied to the threshold"
       + " of distribution goals used for detecting and fixing anomalies. For example, 2.50 means the threshold for each "
-      + "distribution goal will be 2.50x of the value used in manual goal optimization requests (e.g. rebalance).";
+      + "distribution goal (i.e. Replica Distribution, Resource Distribution, and Topic Replica Distribution Goals) will "
+      + "be 2.50x of the value used in manual goal optimization requests (e.g. rebalance).";
 
   /**
    * <code>cpu.capacity.threshold</code>

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
@@ -229,7 +229,8 @@ public class GoalViolationDetector implements Runnable {
     try {
       goal.optimize(clusterModel, new HashSet<>(), new OptimizationOptions(excludedTopics(clusterModel),
                                                                            excludedBrokersForLeadership,
-                                                                           excludedBrokersForReplicaMove));
+                                                                           excludedBrokersForReplicaMove,
+                                                                           true));
     } catch (OptimizationFailureException ofe) {
       // An OptimizationFailureException indicates (1) a hard goal violation that cannot be fixed typically due to
       // lack of physical hardware (e.g. insufficient number of racks to satisfy rack awareness, insufficient number

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
@@ -87,7 +87,8 @@ public class GoalViolations extends KafkaAnomaly {
                                                                                    _anomalyId,
                                                                                    _excludeRecentlyDemotedBrokers,
                                                                                    _excludeRecentlyRemovedBrokers,
-                                                                                   false),
+                                                                                   false,
+                                                                                   true),
                                                      null);
         // Ensure that only the relevant response is cached to avoid memory pressure.
         _optimizationResult.discardIrrelevantAndCacheJsonAndPlaintext();

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUnitTestUtils.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUnitTestUtils.java
@@ -38,6 +38,7 @@ public class KafkaCruiseControlUnitTestUtils {
     props.setProperty(KafkaCruiseControlConfig.COMPLETED_USER_TASK_RETENTION_TIME_MS_CONFIG, Long.toString(TimeUnit.HOURS.toMillis(6)));
     props.setProperty(KafkaCruiseControlConfig.DEMOTION_HISTORY_RETENTION_TIME_MS_CONFIG, Long.toString(TimeUnit.HOURS.toMillis(24)));
     props.setProperty(KafkaCruiseControlConfig.REMOVAL_HISTORY_RETENTION_TIME_MS_CONFIG, Long.toString(TimeUnit.HOURS.toMillis(12)));
+    props.setProperty(KafkaCruiseControlConfig.GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_CONFIG, "2.0");
     props.setProperty(
         KafkaCruiseControlConfig.DEFAULT_GOALS_CONFIG,
         "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,"

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -157,7 +157,8 @@ public class AnomalyDetectorTest {
                                                      EasyMock.anyString(),
                                                      EasyMock.eq(true),
                                                      EasyMock.eq(true),
-                                                     EasyMock.eq(false)))
+                                                     EasyMock.eq(false),
+                                                     EasyMock.eq(true)))
             .andReturn(null);
     EasyMock.expect(mockKafkaCruiseControl.meetCompletenessRequirements(EasyMock.anyObject())).andReturn(true);
 


### PR DESCRIPTION
Addresses the issue https://github.com/linkedin/cruise-control/issues/654.