### PR TITLE
Bump up versions of checkstyle, slf4j-api, zookeeper, commons-math3, httpclient, gson, jetty-server, jetty-servlet, metrics-core, easymock, and commons-io.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ subprojects {
 
   //code quality and inspections
   checkstyle {
-    toolVersion = '7.5.1'
+    toolVersion = '8.0'
     ignoreFailures = false
     configFile = rootProject.file('checkstyle/checkstyle.xml')
   }
@@ -117,7 +117,7 @@ project(':cruise-control-core') {
   }
 
   dependencies {
-    compile "org.slf4j:slf4j-api:1.7.25"
+    compile "org.slf4j:slf4j-api:1.7.26"
     compile 'junit:junit:4.12'
     compile 'org.apache.commons:commons-math3:3.6.1'
 
@@ -190,28 +190,28 @@ project(':cruise-control') {
   dependencies {
     compile project(':cruise-control-metrics-reporter')
     compile project(':cruise-control-core')
-    compile "org.slf4j:slf4j-api:1.7.25"
-    compile "org.apache.zookeeper:zookeeper:3.4.6"
+    compile "org.slf4j:slf4j-api:1.7.26"
+    compile "org.apache.zookeeper:zookeeper:3.4.14"
     compile "org.apache.kafka:kafka_2.11:0.11.0.2"
     compile 'org.apache.kafka:kafka-clients:0.11.0.2'
     compile "org.scala-lang:scala-library:2.11.11"
     compile 'junit:junit:4.12'
     compile 'org.apache.commons:commons-math3:3.6.1'
-    compile 'org.apache.httpcomponents:httpclient:4.5.6'
-    compile 'com.google.code.gson:gson:2.7'
-    compile 'org.eclipse.jetty:jetty-server:9.4.6.v20170531'
-    compile 'org.eclipse.jetty:jetty-servlet:9.4.6.v20170531'
-    compile 'io.dropwizard.metrics:metrics-core:3.2.2'
+    compile 'org.apache.httpcomponents:httpclient:4.5.8'
+    compile 'com.google.code.gson:gson:2.8.5'
+    compile 'org.eclipse.jetty:jetty-server:9.4.15.v20190215'
+    compile 'org.eclipse.jetty:jetty-servlet:9.4.15.v20190215'
+    compile 'io.dropwizard.metrics:metrics-core:3.2.6'
 
     testCompile project(path: ':cruise-control-metrics-reporter', configuration: 'testOutput')
     testCompile project(path: ':cruise-control-core', configuration: 'testOutput')
     testCompile "org.scala-lang:scala-library:2.11.11"
-    testCompile 'org.easymock:easymock:3.4'
+    testCompile 'org.easymock:easymock:4.0.2'
     testCompile 'com.linkedin.kafka.clients:li-apache-kafka-clients:0.0.12'
     testCompile 'com.linkedin.kafka.clients:li-apache-kafka-clients:0.0.12:tests'
     testCompile 'org.apache.kafka:kafka_2.11:0.11.0.2:test'
     testCompile 'org.apache.kafka:kafka-clients:0.11.0.2:test'
-    testCompile 'commons-io:commons-io:2.5'
+    testCompile 'commons-io:commons-io:2.6'
   }
 
   publishing {
@@ -307,7 +307,7 @@ project(':cruise-control-metrics-reporter') {
   }
 
   dependencies {
-    compile "org.slf4j:slf4j-api:1.7.25"
+    compile "org.slf4j:slf4j-api:1.7.26"
     compile "org.apache.kafka:kafka_2.11:0.11.0.2"
     compile 'org.apache.kafka:kafka-clients:0.11.0.2'
     compile 'junit:junit:4.12'
@@ -318,7 +318,7 @@ project(':cruise-control-metrics-reporter') {
     testCompile 'com.linkedin.kafka.clients:li-apache-kafka-clients:0.0.12:tests'
     testCompile 'org.apache.kafka:kafka-clients:0.11.0.2:test'
     testCompile 'org.apache.kafka:kafka-clients:0.11.0.2'
-    testCompile 'commons-io:commons-io:2.5'
+    testCompile 'commons-io:commons-io:2.6'
     testOutput sourceSets.test.output
   }
 

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -3,8 +3,7 @@
   ~ Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
   -->
 
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
-
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <!--
     Checkstyle-Configuration: LinkedIn Style
     Description:


### PR DESCRIPTION
Addresses the issue https://github.com/linkedin/cruise-control/issues/662.