### PR TITLE
Add header field Access-Control-Allow-Credentials in GET/POST response e if CORS is enabled.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ResponseUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ResponseUtils.java
@@ -48,7 +48,7 @@ public class ResponseUtils {
                          config.getString(KafkaCruiseControlConfig.WEBSERVER_HTTP_CORS_ORIGIN_CONFIG));
       response.setHeader("Access-Control-Expose-Headers",
                          config.getString(KafkaCruiseControlConfig.WEBSERVER_HTTP_CORS_EXPOSEHEADERS_CONFIG));
-
+      response.setHeader("Access-Control-Allow-Credentials", "true");
     }
   }
 


### PR DESCRIPTION
Per conversation in Slack channel, extra header field is needed for CORS to work.