### PR TITLE
Prevent metrics reporter sampler from generating NPE when it fails to retrieve offsets for partitions to consume.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricFetcher.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricFetcher.java
@@ -23,7 +23,7 @@ abstract class MetricFetcher implements Callable<Boolean> {
     try {
       fetchMetricsForAssignedPartitions();
     } catch (MetricSamplingException mse) {
-      LOG.warn("Received sampling error.");
+      LOG.warn("Received sampling error.", mse);
       hasSamplingError = true;
     } catch (Throwable t) {
       LOG.error("Received exception.", t);


### PR DESCRIPTION
Addresses the issue https://github.com/linkedin/cruise-control/issues/708.