### PR TITLE
Add public default constructor for LeaderReplicaDistributionGoal.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderReplicaDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderReplicaDistributionGoal.java
@@ -44,10 +44,17 @@ public class LeaderReplicaDistributionGoal extends ReplicaDistributionAbstractGo
   private static final Logger LOG = LoggerFactory.getLogger(LeaderReplicaDistributionGoal.class);
 
   /**
+   * Constructor for Leader Replica Distribution Goal.
+   */
+  public LeaderReplicaDistributionGoal() {
+
+  }
+
+  /**
    * Package private for unit test.
    */
-  LeaderReplicaDistributionGoal(BalancingConstraint balancingConstraint) {
-    super();
+  public LeaderReplicaDistributionGoal(BalancingConstraint balancingConstraint) {
+    this();
     _balancingConstraint = balancingConstraint;
   }
 


### PR DESCRIPTION
Fix for issue reported in [711](https://github.com/linkedin/cruise-control/issues/711).