### PR TITLE
Prevent redundant updates to the window generation during the sampling and loading processes

### DIFF
--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregatorState.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregatorState.java
@@ -46,7 +46,6 @@ class MetricSampleAggregatorState<G, E extends Entity<G>> extends WindowIndexedA
    */
   MetricSampleAggregatorState(int numWindows, long windowMs, int completenessCacheSize) {
     super();
-    // Only keep as many as _windowStates.size() completeness caches.
     _completenessCache = new LinkedHashMap<AggregationOptions<G, E>, MetricSampleCompleteness<G, E>>() {
       @Override
       protected boolean removeEldestEntry(Map.Entry<AggregationOptions<G, E>, MetricSampleCompleteness<G, E>> eldest) {
@@ -55,8 +54,8 @@ class MetricSampleAggregatorState<G, E extends Entity<G>> extends WindowIndexedA
     };
     _windowStates = new ConcurrentSkipListMap<>(Comparator.reverseOrder());
     _windowGenerations = new MyAtomicLong[numWindows];
-    for (int i = 0; i < numWindows; i++) {
-      _windowGenerations[i] = new MyAtomicLong(0);
+    for (int arrayIndex = 0; arrayIndex < numWindows; arrayIndex++) {
+      _windowGenerations[arrayIndex] = new MyAtomicLong(0);
     }
     _windowMs = windowMs;
   }
@@ -106,7 +105,7 @@ class MetricSampleAggregatorState<G, E extends Entity<G>> extends WindowIndexedA
       throw new IllegalStateException("Should never reset a window index that is in the valid range");
     }
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Resetting window index [{}, {}]", startingWindowIndex,
+      LOG.debug("Resetting window indices [{}, {}]", startingWindowIndex,
                 startingWindowIndex + numWindowIndicesToReset - 1);
     }
     // We are resetting all the data here.

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/RawMetricValues.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/RawMetricValues.java
@@ -215,17 +215,28 @@ public class RawMetricValues extends WindowIndexedArrays {
   }
 
   /**
+   * Check whether the given window range can be reset.
+   *
+   * @param startingWindowIndex the starting index of the windows to reset.
+   * @param numWindowIndicesToReset the number of windows to reset.
+   */
+  public synchronized void sanityCheckWindowRangeReset(long startingWindowIndex, int numWindowIndicesToReset) {
+    if (inValidWindowRange(startingWindowIndex)
+        || inValidWindowRange(startingWindowIndex + numWindowIndicesToReset - 1)) {
+      throw new IllegalStateException("Should never reset a window index that is in the valid range");
+    }
+  }
+
+  /**
    * Clear the state of a given number of windows starting at the given window index.
+   * Assumes that {@link #sanityCheckWindowRangeReset(long, int)} is satisfied -- this prevents repetitive sanity checks
+   * within this function.
    *
    * @param startingWindowIndex the starting index of the windows to reset.
    * @param numWindowIndicesToReset the number of windows to reset.
    * @return number of samples abandoned in window clearing process. The abandoned samples are samples in the windows which get reset.
    */
   public synchronized int resetWindowIndices(long startingWindowIndex, int numWindowIndicesToReset) {
-    if (inValidWindowRange(startingWindowIndex)
-        || inValidWindowRange(startingWindowIndex + numWindowIndicesToReset - 1)) {
-      throw new IllegalStateException("Should never reset a window index that is in the valid range");
-    }
     // We are not resetting all the data here. The data will be interpreted to 0 if count is 0.
     int numAbandonedSamples = 0;
     for (long i = startingWindowIndex; i < startingWindowIndex + numWindowIndicesToReset; i++) {

--- a/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/RawMetricValuesTest.java
+++ b/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/RawMetricValuesTest.java
@@ -315,6 +315,7 @@ public class RawMetricValuesTest {
     populate(rawValues, oldestWindowIndex);
     // reset index, we need to play the trick to change the oldest window index temporarily to make it work.
     rawValues.updateOldestWindowIndex(oldestWindowIndex + 100);
+    windowIndices.forEach(startingWindowIndex -> rawValues.sanityCheckWindowRangeReset(startingWindowIndex, 1));
     windowIndices.forEach(startingWindowIndex -> rawValues.resetWindowIndices(startingWindowIndex, 1));
     rawValues.updateOldestWindowIndex(oldestWindowIndex);
   }


### PR DESCRIPTION
Addresses the issue https://github.com/linkedin/cruise-control/issues/716.
* Also eliminates the repetitive sanity check for window range reset validity.