### PR TITLE
Add kafka-cruise-control-stop.sh.

### DIFF
--- a/kafka-cruise-control-stop.sh
+++ b/kafka-cruise-control-stop.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").
+# See License in the project root for license information.
+
+SIGNAL=${SIGNAL:-TERM}
+PIDS=$(ps ax | grep -i 'cruise-control' | grep java | grep -v grep | awk '{print $1}')
+
+if [ -z "$PIDS" ]; then
+  echo "No cruise-control to stop"
+  exit 1
+else
+  kill -s $SIGNAL $PIDS
+fi


### PR DESCRIPTION
This pull request addresses the issue #579.

Note: this script assumes that the only running java process is the cruise-control.

This is an example log output that I got from testing the command:
https://gist.github.com/emilyki/1dbbf380646c2079400faeb2c084f2fb