### PR TITLE
Add explicit parameter to force retrieval of avg utilization of partitions

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetClusterModelInRangeRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/GetClusterModelInRangeRunnable.java
@@ -35,8 +35,11 @@ class GetClusterModelInRangeRunnable extends OperationRunnable {
                                                                  _future.operationProgress(),
                                                                  _parameters.allowCapacityEstimation());
     int topicNameLength = clusterModel.topics().stream().mapToInt(String::length).max().orElse(20) + 5;
-    return new PartitionLoadState(clusterModel.replicasSortedByUtilization(_parameters.resource(), _parameters.wantMaxLoad()),
+    return new PartitionLoadState(clusterModel.replicasSortedByUtilization(_parameters.resource(),
+                                                                           _parameters.wantMaxLoad(),
+                                                                           _parameters.wantAvgLoad()),
                                   _parameters.wantMaxLoad(),
+                                  _parameters.wantAvgLoad(),
                                   _parameters.entries(),
                                   _parameters.partitionUpperBoundary(),
                                   _parameters.partitionLowerBoundary(),

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -843,12 +843,13 @@ public class ClusterModel implements Serializable {
    * Sort the partitions in the cluster by the utilization of the given resource.
    * @param resource the resource type.
    * @param wantMaxLoad True if the requested utilization represents the peak load, false otherwise.
+   * @param wantAvgLoad True if the requested utilization represents the avg load, false otherwise.
    * @return a list of partitions sorted by utilization of the given resource.
    */
-  public List<Partition> replicasSortedByUtilization(Resource resource, boolean wantMaxLoad) {
+  public List<Partition> replicasSortedByUtilization(Resource resource, boolean wantMaxLoad, boolean wantAvgLoad) {
     List<Partition> partitionList = new ArrayList<>(_partitionsByTopicPartition.values());
-    partitionList.sort((o1, o2) -> Double.compare(o2.leader().load().expectedUtilizationFor(resource, wantMaxLoad),
-                                                  o1.leader().load().expectedUtilizationFor(resource, wantMaxLoad)));
+    partitionList.sort((o1, o2) -> Double.compare(o2.leader().load().expectedUtilizationFor(resource, wantMaxLoad, wantAvgLoad),
+                                                  o1.leader().load().expectedUtilizationFor(resource, wantMaxLoad, wantAvgLoad)));
     return partitionList;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Load.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Load.java
@@ -66,27 +66,33 @@ public class Load implements Serializable {
   /**
    * Get a single snapshot value that is representative for the given resource. The current algorithm uses
    * <ol>
-   *   <li>If the max load is not requested, then:
+   *   <li>If the max or avg load is not requested, then:
    *   <ol>
    *   <li>It is the mean of the recent resource load for inbound network load, outbound network load, and cpu load.</li>
    *   <li>It is the latest utilization for disk space usage.</li>
    *   </ol>
    *   </li>
    *   <li>If the max load is requested: the peak load.</li>
+   *   <li>If the avg load is requested: the avg load.</li>
    * </ol>
    *
    * @param resource Resource for which the expected utilization will be provided.
    * @param wantMaxLoad True if the requested utilization represents the peak load, false otherwise.
+   * @param wantAvgLoad True if the requested utilization represents the avg load, false otherwise.
    * @return A single representative utilization value on a resource.
    */
-  public double expectedUtilizationFor(Resource resource, boolean wantMaxLoad) {
+  public double expectedUtilizationFor(Resource resource, boolean wantMaxLoad, boolean wantAvgLoad) {
+    if (wantMaxLoad && wantAvgLoad) {
+      throw new IllegalArgumentException("Attempt to request expected utilization with both max and avg load.");
+    }
     if (_metricValues.isEmpty()) {
       return 0.0;
     }
     double result = 0;
     for (MetricInfo info : KafkaMetricDef.resourceToMetricInfo(resource)) {
       MetricValues valuesForId = _metricValues.valuesFor(info.id());
-      result += wantMaxLoad ? valuesForId.max() : (resource == Resource.DISK ? valuesForId.latest() : valuesForId.avg());
+      result += wantMaxLoad ? valuesForId.max()
+                            : (resource == Resource.DISK && !wantAvgLoad ? valuesForId.latest() : valuesForId.avg());
     }
     return max(result, 0.0);
   }
@@ -98,16 +104,21 @@ public class Load implements Serializable {
   /**
    * Get a single snapshot value that is representative for the given KafkaMetric type. The current algorithm uses
    * <ol>
-   *   <li>If the max load is not requested, it is max/latest/mean load depending on the ValueComputingStrategy
+   *   <li>If the max or avg load is not requested, it is max/latest/mean load depending on the ValueComputingStrategy
    *   which the KafkaMetric type uses.</li>
    *   <li>If the max load is requested, it is the max load.</li>
+   *   <li>If the avg load is requested, it is the avg load.</li>
    * </ol>
    *
    * @param metric KafkaMetric type for which the expected utilization will be provided.
    * @param wantMaxLoad True if the requested utilization represents the peak load, false otherwise.
+   * @param wantAvgLoad True if the requested utilization represents the avg load, false otherwise.
    * @return A single representative utilization value on a metric type.
    */
-  public double expectedUtilizationFor(KafkaMetricDef metric, boolean wantMaxLoad) {
+  public double expectedUtilizationFor(KafkaMetricDef metric, boolean wantMaxLoad, boolean wantAvgLoad) {
+    if (wantMaxLoad && wantAvgLoad) {
+      throw new IllegalArgumentException("Attempt to request expected utilization with both max and avg load.");
+    }
     MetricInfo info;
     switch (metric.defScope()) {
       case COMMON:
@@ -125,6 +136,8 @@ public class Load implements Serializable {
     MetricValues valuesForId = _metricValues.valuesFor(info.id());
     if (wantMaxLoad) {
       return max(valuesForId.max(), 0.0);
+    } else if (wantAvgLoad) {
+      return max(valuesForId.avg(), 0.0);
     }
     switch (metric.valueComputingStrategy()) {
       case MAX: return max(valuesForId.max(), 0.0);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
@@ -65,6 +65,7 @@ public class ParameterUtils {
   public static final String DATA_FROM_PARAM = "data_from";
   public static final String KAFKA_ASSIGNER_MODE_PARAM = "kafka_assigner";
   public static final String MAX_LOAD_PARAM = "max_load";
+  public static final String AVG_LOAD_PARAM = "avg_load";
   public static final String GOALS_PARAM = "goals";
   public static final String BROKER_ID_PARAM = "brokerid";
   public static final String DROP_RECENTLY_REMOVED_BROKERS_PARAM = "drop_recently_removed_brokers";
@@ -133,6 +134,7 @@ public class ParameterUtils {
     partitionLoad.add(JSON_PARAM);
     partitionLoad.add(ALLOW_CAPACITY_ESTIMATION_PARAM);
     partitionLoad.add(MAX_LOAD_PARAM);
+    partitionLoad.add(AVG_LOAD_PARAM);
     partitionLoad.add(TOPIC_PARAM);
     partitionLoad.add(PARTITION_PARAM);
     partitionLoad.add(MIN_VALID_PARTITION_RATIO_PARAM);
@@ -418,6 +420,10 @@ public class ParameterUtils {
 
   static boolean wantMaxLoad(HttpServletRequest request) {
     return getBooleanParam(request, MAX_LOAD_PARAM, false);
+  }
+
+  static boolean wantAvgLoad(HttpServletRequest request) {
+    return getBooleanParam(request, AVG_LOAD_PARAM, false);
   }
 
   static boolean isVerbose(HttpServletRequest request) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/PartitionLoadParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/PartitionLoadParameters.java
@@ -56,7 +56,7 @@ public class PartitionLoadParameters extends AbstractParameters {
     _wantMaxLoad = ParameterUtils.wantMaxLoad(_request);
     _wantAvgLoad = ParameterUtils.wantAvgLoad(_request);
     if (_wantMaxLoad && _wantAvgLoad) {
-      throw new UserRequestException("Configurations to ask for max and avg load are mutually exclusive to each other.");
+      throw new UserRequestException("Parameters to ask for max and avg load are mutually exclusive to each other.");
     }
     _topic = ParameterUtils.topic(_request);
     Long startMsValue = ParameterUtils.startMs(_request);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/PartitionLoadParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/PartitionLoadParameters.java
@@ -21,7 +21,7 @@ import javax.servlet.http.HttpServletRequest;
  *    GET /kafkacruisecontrol/partition_load?resource=[RESOURCE]&amp;start=[START_TIMESTAMP]&amp;end=[END_TIMESTAMP]
  *    &amp;entries=[number-of-entries-to-show]&amp;topic=[topic]&amp;partition=[partition/start_partition-end_partition]
  *    &amp;min_valid_partition_ratio=[min_valid_partition_ratio]&amp;allow_capacity_estimation=[true/false]
- *    &amp;max_load=[true/false]&amp;json=[true/false]
+ *    &amp;max_load=[true/false]&amp;avg_load=[true/false]&amp;json=[true/false]
  * </pre>
  */
 public class PartitionLoadParameters extends AbstractParameters {
@@ -35,6 +35,7 @@ public class PartitionLoadParameters extends AbstractParameters {
   private Double _minValidPartitionRatio;
   private boolean _allowCapacityEstimation;
   private boolean _wantMaxLoad;
+  private boolean _wantAvgLoad;
 
 
   public PartitionLoadParameters(HttpServletRequest request, KafkaCruiseControlConfig config) {
@@ -53,6 +54,10 @@ public class PartitionLoadParameters extends AbstractParameters {
     }
 
     _wantMaxLoad = ParameterUtils.wantMaxLoad(_request);
+    _wantAvgLoad = ParameterUtils.wantAvgLoad(_request);
+    if (_wantMaxLoad && _wantAvgLoad) {
+      throw new UserRequestException("Configurations to ask for max and avg load are mutually exclusive to each other.");
+    }
     _topic = ParameterUtils.topic(_request);
     Long startMsValue = ParameterUtils.startMs(_request);
     _startMs = startMsValue == null ? -1L : startMsValue;
@@ -103,5 +108,9 @@ public class PartitionLoadParameters extends AbstractParameters {
 
   public boolean wantMaxLoad() {
     return _wantMaxLoad;
+  }
+
+  public boolean wantAvgLoad() {
+    return _wantAvgLoad;
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/PartitionLoadState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/PartitionLoadState.java
@@ -30,6 +30,7 @@ public class PartitionLoadState extends AbstractCruiseControlResponse {
   private static final String RECORDS = "records";
   private final List<Partition> _sortedPartitions;
   private final boolean _wantMaxLoad;
+  private final boolean _wantAvgLoad;
   private final int _entries;
   private final int _partitionUpperBoundary;
   private final int _partitionLowerBoundary;
@@ -38,6 +39,7 @@ public class PartitionLoadState extends AbstractCruiseControlResponse {
 
   public PartitionLoadState(List<Partition> sortedPartitions,
                             boolean wantMaxLoad,
+                            boolean wantAvgLoad,
                             int entries,
                             int partitionUpperBoundary,
                             int partitionLowerBoundary,
@@ -47,6 +49,7 @@ public class PartitionLoadState extends AbstractCruiseControlResponse {
     super(config);
     _sortedPartitions = sortedPartitions;
     _wantMaxLoad = wantMaxLoad;
+    _wantAvgLoad = wantAvgLoad;
     _entries = entries;
     _partitionUpperBoundary = partitionUpperBoundary;
     _partitionLowerBoundary = partitionLowerBoundary;
@@ -73,11 +76,11 @@ public class PartitionLoadState extends AbstractCruiseControlResponse {
                               p.leader().topicPartition(),
                               p.leader().broker().id(),
                               followers,
-                              p.leader().load().expectedUtilizationFor(Resource.CPU, _wantMaxLoad),
-                              p.leader().load().expectedUtilizationFor(Resource.DISK, _wantMaxLoad),
-                              p.leader().load().expectedUtilizationFor(Resource.NW_IN, _wantMaxLoad),
-                              p.leader().load().expectedUtilizationFor(Resource.NW_OUT, _wantMaxLoad),
-                              p.leader().load().expectedUtilizationFor(KafkaMetricDef.MESSAGE_IN_RATE, _wantMaxLoad)));
+                              p.leader().load().expectedUtilizationFor(Resource.CPU, _wantMaxLoad, _wantAvgLoad),
+                              p.leader().load().expectedUtilizationFor(Resource.DISK, _wantMaxLoad, _wantAvgLoad),
+                              p.leader().load().expectedUtilizationFor(Resource.NW_IN, _wantMaxLoad, _wantAvgLoad),
+                              p.leader().load().expectedUtilizationFor(Resource.NW_OUT, _wantMaxLoad, _wantAvgLoad),
+                              p.leader().load().expectedUtilizationFor(KafkaMetricDef.MESSAGE_IN_RATE, _wantMaxLoad, _wantAvgLoad)));
     }
     return sb.toString();
   }
@@ -112,11 +115,11 @@ public class PartitionLoadState extends AbstractCruiseControlResponse {
       record.put(PARTITION, p.leader().topicPartition().partition());
       record.put(LEADER, p.leader().broker().id());
       record.put(FOLLOWERS, followers);
-      record.put(Resource.CPU.resource(), p.leader().load().expectedUtilizationFor(Resource.CPU, _wantMaxLoad));
-      record.put(Resource.DISK.resource(), p.leader().load().expectedUtilizationFor(Resource.DISK, _wantMaxLoad));
-      record.put(Resource.NW_IN.resource(), p.leader().load().expectedUtilizationFor(Resource.NW_IN, _wantMaxLoad));
-      record.put(Resource.NW_OUT.resource(), p.leader().load().expectedUtilizationFor(Resource.NW_OUT, _wantMaxLoad));
-      record.put(MSG_IN, p.leader().load().expectedUtilizationFor(KafkaMetricDef.MESSAGE_IN_RATE, _wantMaxLoad));
+      record.put(Resource.CPU.resource(), p.leader().load().expectedUtilizationFor(Resource.CPU, _wantMaxLoad, _wantAvgLoad));
+      record.put(Resource.DISK.resource(), p.leader().load().expectedUtilizationFor(Resource.DISK, _wantMaxLoad, _wantAvgLoad));
+      record.put(Resource.NW_IN.resource(), p.leader().load().expectedUtilizationFor(Resource.NW_IN, _wantMaxLoad, _wantAvgLoad));
+      record.put(Resource.NW_OUT.resource(), p.leader().load().expectedUtilizationFor(Resource.NW_OUT, _wantMaxLoad, _wantAvgLoad));
+      record.put(MSG_IN, p.leader().load().expectedUtilizationFor(KafkaMetricDef.MESSAGE_IN_RATE, _wantMaxLoad, _wantAvgLoad));
       partitionList.add(record);
     }
     partitionMap.put(RECORDS, partitionList);


### PR DESCRIPTION
Addresses the issue https://github.com/linkedin/cruise-control/issues/759 by adding `avg_load` parameter to `partition_load` endpoint.

-- Note that to get the average over a given time frame (e.g. the past 7 days), users can set `start` and `end` parameters with the relevant timestamps, accordingly.