### PR TITLE
Add self healing enabled ratio metric under anomaly_detector substate of state response.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetector.java
@@ -184,6 +184,7 @@ public class AnomalyDetector {
   }
 
   public AnomalyDetectorState anomalyDetectorState() {
+    _anomalyDetectorState.setSelfHealingEnabledRatio(_anomalyNotifier.selfHealingEnabledRatio());
     return _anomalyDetectorState;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorState.java
@@ -67,7 +67,7 @@ public class AnomalyDetectorState {
     _selfHealingEnabledRatio = null;
   }
 
-  void setSelfHealingEnabledRatio(Map<AnomalyType, Float> selfHealingEnabledRatio) {
+  public void setSelfHealingEnabledRatio(Map<AnomalyType, Float> selfHealingEnabledRatio) {
     if (selfHealingEnabledRatio == null) {
       throw new IllegalArgumentException("Attempt to set selfHealingEnabledRatio with null.");
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorState.java
@@ -39,6 +39,7 @@ public class AnomalyDetectorState {
   private static final String DESCRIPTION = "description";
   private static final String SELF_HEALING_ENABLED = "selfHealingEnabled";
   private static final String SELF_HEALING_DISABLED = "selfHealingDisabled";
+  private static final String SELF_HEALING_ENABLED_RATIO = "selfHealingEnabledRatio";
   private static final String RECENT_GOAL_VIOLATIONS = "recentGoalViolations";
   private static final String RECENT_BROKER_FAILURES = "recentBrokerFailures";
   private static final String RECENT_METRIC_ANOMALIES = "recentMetricAnomalies";
@@ -47,6 +48,7 @@ public class AnomalyDetectorState {
   // Recent anomalies with anomaly state by the anomaly type.
   private final Map<AnomalyType, Map<String, AnomalyState>> _recentAnomaliesByType;
   private final Map<AnomalyType, Boolean> _selfHealingEnabled;
+  private Map<String, Float> _selfHealingEnabledRatio;
   // Maximum number of anomalies to keep in the anomaly detector state.
   private final int _numCachedRecentAnomalyStates;
 
@@ -62,6 +64,19 @@ public class AnomalyDetectorState {
       });
     }
     _selfHealingEnabled = selfHealingEnabled;
+    _selfHealingEnabledRatio = null;
+  }
+
+  void setSelfHealingEnabledRatio(Map<AnomalyType, Float> selfHealingEnabledRatio) {
+    if (selfHealingEnabledRatio == null) {
+      throw new IllegalArgumentException("Attempt to set selfHealingEnabledRatio with null.");
+    }
+    _selfHealingEnabledRatio = new HashMap<>(selfHealingEnabledRatio.size());
+    selfHealingEnabledRatio.forEach((key, value) -> _selfHealingEnabledRatio.put(key.name(), value));
+  }
+
+  private Map<String, Float> selfHealingEnabledRatio() {
+    return _selfHealingEnabledRatio == null ? Collections.emptyMap() : _selfHealingEnabledRatio;
   }
 
   /**
@@ -184,10 +199,11 @@ public class AnomalyDetectorState {
   }
 
   public Map<String, Object> getJsonStructure() {
-    Map<String, Object> anomalyDetectorState = new HashMap<>(_recentAnomaliesByType.size() + 2);
+    Map<String, Object> anomalyDetectorState = new HashMap<>(_recentAnomaliesByType.size() + 3);
     Map<Boolean, Set<String>> selfHealingByEnableStatus = getSelfHealingByEnableStatus();
     anomalyDetectorState.put(SELF_HEALING_ENABLED, selfHealingByEnableStatus.get(true));
     anomalyDetectorState.put(SELF_HEALING_DISABLED, selfHealingByEnableStatus.get(false));
+    anomalyDetectorState.put(SELF_HEALING_ENABLED_RATIO, selfHealingEnabledRatio());
     anomalyDetectorState.put(RECENT_GOAL_VIOLATIONS, recentGoalViolations(true));
     anomalyDetectorState.put(RECENT_BROKER_FAILURES, recentBrokerFailures(true));
     anomalyDetectorState.put(RECENT_METRIC_ANOMALIES, recentMetricAnomalies(true));
@@ -198,9 +214,10 @@ public class AnomalyDetectorState {
   @Override
   public String toString() {
     Map<Boolean, Set<String>> selfHealingByEnableStatus = getSelfHealingByEnableStatus();
-    return String.format("{%s:%s, %s:%s, %s:%s, %s:%s, %s:%s}%n",
+    return String.format("{%s:%s, %s:%s, %s:%s, %s:%s, %s:%s, %s:%s}%n",
                          SELF_HEALING_ENABLED, selfHealingByEnableStatus.get(true),
                          SELF_HEALING_DISABLED, selfHealingByEnableStatus.get(false),
+                         SELF_HEALING_ENABLED_RATIO, selfHealingEnabledRatio(),
                          RECENT_GOAL_VIOLATIONS, recentGoalViolations(false),
                          RECENT_BROKER_FAILURES, recentBrokerFailures(false),
                          RECENT_METRIC_ANOMALIES, recentMetricAnomalies(false));

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/AnomalyNotifier.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/AnomalyNotifier.java
@@ -57,4 +57,17 @@ public interface AnomalyNotifier extends CruiseControlConfigurable {
    * @return The old value of self healing for the given anomaly type.
    */
   boolean setSelfHealingFor(AnomalyType anomalyType, boolean isSelfHealingEnabled);
+
+  /**
+   * Get the ratio during which the self-healing is enabled over the total operating time.
+   *
+   * @return The ratio during which the self-healing is enabled over the total operating time for each anomaly type.
+   */
+  Map<AnomalyType, Float> selfHealingEnabledRatio();
+
+  /**
+   * @param nowMs Current time in ms.
+   * @return Uptime until now in ms.
+   */
+  long uptimeMs(long nowMs);
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/NoopNotifier.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/NoopNotifier.java
@@ -50,4 +50,14 @@ public class NoopNotifier implements AnomalyNotifier {
   public boolean setSelfHealingFor(AnomalyType anomalyType, boolean isSelfHealingEnabled) {
     return false;
   }
+
+  @Override
+  public Map<AnomalyType, Float> selfHealingEnabledRatio() {
+    return null;
+  }
+
+  @Override
+  public long uptimeMs(long nowMs) {
+    return 0;
+  }
 }


### PR DESCRIPTION
Adds `self healing enabled ratio metric` specified at issue https://github.com/linkedin/cruise-control/issues/723.