### PR TITLE
Fix the bug that user cannot retrieve the detailed response of in-execution task with UUID.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
@@ -446,7 +446,7 @@ public class UserTaskManager implements Closeable {
       }
     }
 
-    if (_inExecutionUserTaskInfo.userTaskId() == userTaskId
+    if (_inExecutionUserTaskInfo.userTaskId().equals(userTaskId)
         && _inExecutionUserTaskInfo.requestUrl().equals(requestUrl)
         && hasTheSameHttpParameter(_inExecutionUserTaskInfo.queryParams(), httpServletRequest.getParameterMap())) {
       return _inExecutionUserTaskInfo;


### PR DESCRIPTION
Fix issue #763 