### PR TITLE
Handle NPE in refreshPartitionAssignment

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsReporterSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsReporterSampler.java
@@ -184,7 +184,7 @@ public class CruiseControlMetricsReporterSampler implements MetricSampler {
   private boolean refreshPartitionAssignment() {
     List<PartitionInfo> remotePartitionInfo = _metricConsumer.partitionsFor(_metricReporterTopic);
     if (remotePartitionInfo == null) {
-      LOG.error(String.format("_metricConsumer returned null for _metricReporterTopic %s", _metricReporterTopic));
+      LOG.error("_metricConsumer returned null for _metricReporterTopic {}", _metricReporterTopic);
       return true;
     }
     if (remotePartitionInfo.isEmpty()) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsReporterSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsReporterSampler.java
@@ -183,6 +183,10 @@ public class CruiseControlMetricsReporterSampler implements MetricSampler {
    */
   private boolean refreshPartitionAssignment() {
     List<PartitionInfo> remotePartitionInfo = _metricConsumer.partitionsFor(_metricReporterTopic);
+    if (remotePartitionInfo == null) {
+      LOG.error(String.format("_metricConsumer returned null for _metricReporterTopic %s", _metricReporterTopic));
+      return true;
+    }
     if (remotePartitionInfo.isEmpty()) {
       _currentPartitionAssignment = Collections.emptySet();
       LOG.error("The set of partitions currently assigned to the metric consumer is empty.");


### PR DESCRIPTION
Currently, it is possible for the `_metricConsumer.partitionsFor` method to return `null`, which then is assigned to `remotePartitionInfo`.

With the current logic, it is possible to attempt to invoke the `isEmpty` method on `remotePartitionInfo` while it is `null`, generating a `java.lang.NullPointerException`.  
```
2019/06/28 17:07:30.611 ERROR [OffspringServletRuntime] [main] [kafka-cruise-control] [] BOOT_1000 Boot listener com.linkedin.kafka.licruisecontrol.LiKafkaCruiseControlBootListener failed
java.lang.NullPointerException: null
        at com.linkedin.kafka.cruisecontrol.monitor.sampling.CruiseControlMetricsReporterSampler.refreshPartitionAssignment(CruiseControlMetricsReporterSampler.java:186) ~[cruise-control-2.0.50.jar:?]
        at com.linkedin.kafka.cruisecontrol.monitor.sampling.CruiseControlMetricsReporterSampler.configure(CruiseControlMetricsReporterSampler.java:253) ~[cruise-control-2.0.50.jar:?]
```
Accordingly, the suggestion for handling `null` is to return from `refreshPartitionAssignment` with `true`, which should cause a new `IllegalStateException` to be thrown in the calling `configure` method. (L258 in diff).

There are probably many possible (and even some preferable) alternatives for handling `null`, but `null` should be handled.