### PR TITLE
Add project description and command-line entrypoint

### DIFF
--- a/cruise-control-client/setup.py
+++ b/cruise-control-client/setup.py
@@ -17,7 +17,11 @@ setuptools.setup(
     description='A Python client for cruise-control',
     long_description=LONG_DESCRIPTION,
     url='https://github.com/linkedin/cruise-control',
-    scripts=['cruisecontrolclient/client/cccli.py'],
+    entry_points={
+        'console_scripts': [
+            'cccli = cruisecontrolclient.client.cccli:main'
+        ]
+    },
     packages=setuptools.find_packages(),
     install_requires=[
         'pandas',

--- a/cruise-control-client/setup.py
+++ b/cruise-control-client/setup.py
@@ -3,13 +3,21 @@
 
 import setuptools
 
+LONG_DESCRIPTION ='''`cruise-control-client` is an API-complete Python client for [`cruise-control`](https://github.com/linkedin/cruise-control).
+
+It comes with a command-line interface to the client (`cccli.py`) (see [README](https://github.com/linkedin/cruise-control/tree/master/docs/wiki/Python%20Client)).
+
+`cruise-control-client` can also be used in Python applications needing programmatic access to `cruise-control`.'''
+
 setuptools.setup(
     name='cruise-control-client',
-    version='0.1.0',
+    version='0.1.2',
     author='mgrubent',
     author_email='mgrubentrejo@linkedin.com',
     description='A Python client for cruise-control',
+    long_description=LONG_DESCRIPTION,
     url='https://github.com/linkedin/cruise-control',
+    scripts=['cruisecontrolclient/client/cccli.py'],
     packages=setuptools.find_packages(),
     install_requires=[
         'pandas',

--- a/docs/wiki/Python Client/README.md
+++ b/docs/wiki/Python Client/README.md
@@ -5,19 +5,20 @@ The `cruise-control-client` directory provides a `python` client for `cruise-con
 Within `cruise-control-client/cruisecontrolclient/client`, `cccli.py` is a command-line interface to this `python` client, but the `Endpoint`, `Query`, and `Responder` classes can be used outside of `cccli.py`, to supply a `cruise-control` client outside of a command-line interface.
 ## Getting Started
 `requirements.txt` has been supplied to assist in `python` dependency management.  
-### Virtual Environment
-In short, `setup.py` can be used with [Python's `venv`](https://docs.python.org/3/library/venv.html) to quickly and easily acquire this client's external dependencies.
+### `pip` Install
+`cruise-control-client` [exists on PyPI](https://pypi.org/project/cruise-control-client/).  
+To install it in a new [virtual environment](https://docs.python.org/3/library/venv.html), use the following:
 ```bash
-cd cruise-control-client
 python3.7 -m venv .
 . bin/activate
-python setup.py install
+pip install cruise-control-client
+cccli.py --help
 ```
 A `requirements.txt` has also been provided to more-precisely pin version requirements, if necessary.
 ### CLI Usage
 First, change into the `cruise-control-client/cruisecontrolclient/client` directory.
 
-Then, `./cccli.py --socket-address {hostname:port} {endpoint} {options}`
+Then, `cccli.py --socket-address {hostname:port} {endpoint} {options}`
 where  
 * `hostname:port` is the hostname and port of the `cruise-control` that you'd like to communicate with
 * `endpoint` is the `cruise-control` endpoint that you'd like to use
@@ -26,7 +27,7 @@ where
 ### Examples
 #### State
 ```
-./cccli.py -a someCruiseControlAddress:9090 state
+cccli.py -a someCruiseControlAddress:9090 state
 Starting long-running poll of http://someCruiseControlAddress:9090/kafkacruisecontrol/state?substates=executor&json=true
 'ExecutorState':
 {'state': 'NO_TASK_IN_PROGRESS'}
@@ -36,7 +37,7 @@ Starting long-running poll of http://someCruiseControlAddress:9090/kafkacruiseco
 ```
 #### Load
 ```bash
-./cccli.py -a someCruiseControlAddress:9090 load
+cccli.py -a someCruiseControlAddress:9090 load
 Starting long-running poll of http://someCruiseControlAddress:9090/kafkacruisecontrol/load?allow_capacity_estimation=False&json=true
 'version':
 1
@@ -65,7 +66,7 @@ Broker
 ```
 #### Rebalance
 ```
-./cccli.py -a someCruiseControlAddress:9090 rebalance --dry-run
+cccli.py -a someCruiseControlAddress:9090 rebalance --dry-run
 Starting long-running poll of http://someCruiseControlAddress:9090/kafkacruisecontrol/rebalance?allow_capacity_estimation=False&dryrun=True&json=true
 'version':
 1

--- a/docs/wiki/Python Client/README.md
+++ b/docs/wiki/Python Client/README.md
@@ -17,7 +17,7 @@ Then, to install `cruise-control-client`:
 ```bash
 pip install cruise-control-client
 ```
-The installation will bind `cccli` to invoke the `cruise-control-client` command-line interface script.
+The installation will bind `cccli` to invoke the `cruise-control-client` command-line interface script.  
 So, to view help for `cccli`, run the following:  
 ```bash
 cccli --help

--- a/docs/wiki/Python Client/README.md
+++ b/docs/wiki/Python Client/README.md
@@ -3,6 +3,8 @@
 The `cruise-control-client` directory provides a `python` client for `cruise-control`.  
 
 Within `cruise-control-client/cruisecontrolclient/client`, `cccli.py` is a command-line interface to this `python` client, but the `Endpoint`, `Query`, and `Responder` classes can be used outside of `cccli.py`, to supply a `cruise-control` client outside of a command-line interface.
+
+Upon installing `cruise-control-client`, `cccli` can be used as a command-line entry point to invoke the script.
 ## Getting Started
 `requirements.txt` has been supplied to assist in `python` dependency management.  
 ### `pip` Install
@@ -12,13 +14,13 @@ To install it in a new [virtual environment](https://docs.python.org/3/library/v
 python3.7 -m venv .
 . bin/activate
 pip install cruise-control-client
-cccli.py --help
+cccli --help
 ```
 A `requirements.txt` has also been provided to more-precisely pin version requirements, if necessary.
 ### CLI Usage
 First, change into the `cruise-control-client/cruisecontrolclient/client` directory.
 
-Then, `cccli.py --socket-address {hostname:port} {endpoint} {options}`
+Then, `cccli --socket-address {hostname:port} {endpoint} {options}`
 where  
 * `hostname:port` is the hostname and port of the `cruise-control` that you'd like to communicate with
 * `endpoint` is the `cruise-control` endpoint that you'd like to use
@@ -27,7 +29,7 @@ where
 ### Examples
 #### State
 ```
-cccli.py -a someCruiseControlAddress:9090 state
+cccli -a someCruiseControlAddress:9090 state
 Starting long-running poll of http://someCruiseControlAddress:9090/kafkacruisecontrol/state?substates=executor&json=true
 'ExecutorState':
 {'state': 'NO_TASK_IN_PROGRESS'}
@@ -37,7 +39,7 @@ Starting long-running poll of http://someCruiseControlAddress:9090/kafkacruiseco
 ```
 #### Load
 ```bash
-cccli.py -a someCruiseControlAddress:9090 load
+cccli -a someCruiseControlAddress:9090 load
 Starting long-running poll of http://someCruiseControlAddress:9090/kafkacruisecontrol/load?allow_capacity_estimation=False&json=true
 'version':
 1
@@ -66,7 +68,7 @@ Broker
 ```
 #### Rebalance
 ```
-cccli.py -a someCruiseControlAddress:9090 rebalance --dry-run
+cccli -a someCruiseControlAddress:9090 rebalance --dry-run
 Starting long-running poll of http://someCruiseControlAddress:9090/kafkacruisecontrol/rebalance?allow_capacity_estimation=False&dryrun=True&json=true
 'version':
 1

--- a/docs/wiki/Python Client/README.md
+++ b/docs/wiki/Python Client/README.md
@@ -2,25 +2,28 @@
 ## Introduction
 The `cruise-control-client` directory provides a `python` client for `cruise-control`.  
 
-Within `cruise-control-client/cruisecontrolclient/client`, `cccli.py` is a command-line interface to this `python` client, but the `Endpoint`, `Query`, and `Responder` classes can be used outside of `cccli.py`, to supply a `cruise-control` client outside of a command-line interface.
-
-Upon installing `cruise-control-client`, `cccli` can be used as a command-line entry point to invoke the script.
+`cruise-control-client` also provides `cccli`, which is a command-line interface to this `python` client.  
+Additionally, the `Endpoint`, `Query`, and `Responder` classes can be used outside of `cccli`, to supply a `cruise-control` client outside of a command-line interface.
 ## Getting Started
-`requirements.txt` has been supplied to assist in `python` dependency management.  
+The recommended method for installing `cruise-control-client` is to use the [Python Package Index](https://pypi.org/)  
 ### `pip` Install
 `cruise-control-client` [exists on PyPI](https://pypi.org/project/cruise-control-client/).  
-To install it in a new [virtual environment](https://docs.python.org/3/library/venv.html), use the following:
+To create and activate a new [virtual environment](https://docs.python.org/3/library/venv.html), use the following:
 ```bash
 python3.7 -m venv .
 . bin/activate
+```
+Then, to install `cruise-control-client`:  
+```bash
 pip install cruise-control-client
+```
+The installation will bind `cccli` to invoke the `cruise-control-client` command-line interface script.
+So, to view help for `cccli`, run the following:  
+```bash
 cccli --help
 ```
-A `requirements.txt` has also been provided to more-precisely pin version requirements, if necessary.
 ### CLI Usage
-First, change into the `cruise-control-client/cruisecontrolclient/client` directory.
-
-Then, `cccli --socket-address {hostname:port} {endpoint} {options}`
+In general, `cccli --socket-address {hostname:port} {endpoint} {options}`
 where  
 * `hostname:port` is the hostname and port of the `cruise-control` that you'd like to communicate with
 * `endpoint` is the `cruise-control` endpoint that you'd like to use


### PR DESCRIPTION
Functionally, this commit introduces the ability for direct command-line access to `cccli` through the use of the [`entry_points` keyword argument](https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation).

This commit also updates the Python Client README to direct users to `pip` for acquiring the `cruise-control-client` package, rather than cloning into this repo directly.

Finally, this commit adds a `long_description`, so that the [PyPI project page](https://pypi.org/project/cruise-control-client/) can have a description.