### PR TITLE
Make cruise control fail fast for real execution if there is any ongoing partition reassignments.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -325,14 +325,14 @@ public class KafkaCruiseControl {
   }
 
   /**
-   * Check if there is an ongoing execution and dryrun is false.
-   * This method helps to fail fast if a user attempts to start an execution during an ongoing execution.
+   * Check if there is an ongoing partition reassignment and dryrun is false.
+   * This method helps to fail fast if a user attempts to start an execution during an ongoing partition reassignment.
    *
    * @param dryRun True if the request is just a dryrun, false if the intention is to start an execution.
    */
   private void sanityCheckDryRun(boolean dryRun) {
-    if (!dryRun && _executor.hasOngoingExecution()) {
-      throw new IllegalStateException("Cannot execute new proposals while there is an ongoing execution.");
+    if (!dryRun && _executor.hasOngoingPartitionReassignments()) {
+      throw new IllegalStateException("Cannot execute new proposals while there is an ongoing partition reassignment.");
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -477,6 +477,10 @@ public class Executor {
     return _hasOngoingExecution;
   }
 
+  public boolean hasOngoingPartitionReassignments() {
+    return !ExecutorUtils.partitionsBeingReassigned(_zkUtils).isEmpty();
+  }
+
   /**
    * This class is thread safe.
    *

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -410,7 +410,7 @@ public class Executor {
   private void startExecution(LoadMonitor loadMonitor, Collection<Integer> demotedBrokers, Collection<Integer> removedBrokers) {
     // Note that in case there is an ongoing partition reassignment, we do not unpause metric sampling.
     _executionStoppedByUser.set(false);
-    if (!ExecutorUtils.partitionsBeingReassigned(_zkUtils).isEmpty()) {
+    if (hasOngoingPartitionReassignments()) {
       _executionTaskManager.clear();
       _uuid = null;
       // Note that in case there is an ongoing partition reassignment, we do not unpause metric sampling.
@@ -473,10 +473,24 @@ public class Executor {
     LOG.info("Executor shutdown completed.");
   }
 
+  /**
+   * Whether there is an ongoing operation triggered by current Cruise Control deployment.
+   *
+   * @return True if there is an ongoing execution.
+   */
   public boolean hasOngoingExecution() {
     return _hasOngoingExecution;
   }
 
+  /**
+   * Whether there is any ongoing partition reassignment.
+   * This method directly checks the existence of znode /admin/partition_reassignment.
+   * Note this method returning false does not guarantee that there is no ongoing execution because when there is an ongoing
+   * execution inside Cruise Control, partition reassignment task batches are writen to zookeeper periodically, there will be
+   * small intervals that /admin/partition_reassignment does not exist.
+   *
+   * @return True if there is any ongoing partition reassignment.
+   */
   public boolean hasOngoingPartitionReassignments() {
     return !ExecutorUtils.partitionsBeingReassigned(_zkUtils).isEmpty();
   }


### PR DESCRIPTION
Fix issue #823 