### PR TITLE
Fix incorrect computation of enabledTimeMs causing inaccurate selfHealingEnabledRatio reporting

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SelfHealingNotifier.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SelfHealingNotifier.java
@@ -142,6 +142,16 @@ public class SelfHealingNotifier implements AnomalyNotifier {
     }
   }
 
+  private synchronized long enabledTimeMs(AnomalyType anomalyType, long nowMs) {
+    long enabledTimeMs = _selfHealingEnabledHistoricalDurationMs.get(anomalyType);
+    if (_selfHealingEnabled.get(anomalyType)) {
+      // Add current duration during which the self-healing is enabled.
+      Long currentEnabledSelfHealingStartTime = _selfHealingStateChangeTimeMs.get(true).get(anomalyType);
+      enabledTimeMs += nowMs - (currentEnabledSelfHealingStartTime == null ? _notifierStartTimeMs : currentEnabledSelfHealingStartTime);
+    }
+    return enabledTimeMs;
+  }
+
   @Override
   public synchronized Map<AnomalyType, Float> selfHealingEnabledRatio() {
     Map<AnomalyType, Float> selfHealingEnabledRatio = new HashMap<>(_selfHealingEnabled.size());
@@ -149,12 +159,7 @@ public class SelfHealingNotifier implements AnomalyNotifier {
     long uptimeMs = uptimeMs(nowMs);
 
     for (AnomalyType anomalyType : AnomalyType.cachedValues()) {
-      long enabledTimeMs = _selfHealingEnabledHistoricalDurationMs.get(anomalyType);
-      if (_selfHealingEnabled.get(anomalyType)) {
-        // Add current duration during which the self-healing is enabled.
-        Long currentEnabledSelfHealingStartTime = _selfHealingStateChangeTimeMs.get(false).get(anomalyType);
-        enabledTimeMs += nowMs - (currentEnabledSelfHealingStartTime == null ? _notifierStartTimeMs : currentEnabledSelfHealingStartTime);
-      }
+      long enabledTimeMs = enabledTimeMs(anomalyType, nowMs);
       selfHealingEnabledRatio.put(anomalyType, ((float) enabledTimeMs / uptimeMs));
     }
 


### PR DESCRIPTION
Addresses the issue https://github.com/linkedin/cruise-control/issues/827.