### PR TITLE
Fix broken PyPI markdown

### DIFF
--- a/cruise-control-client/cruisecontrolclient/__init__.py
+++ b/cruise-control-client/cruisecontrolclient/__init__.py
@@ -1,7 +1,2 @@
 # Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").
 # See License in the project root for license information.
-
-# This is a package.
-#
-# Please do not add the code to this file unless absolutely
-# necessary because __init__.py files are not needed with Python 3

--- a/cruise-control-client/setup.py
+++ b/cruise-control-client/setup.py
@@ -5,17 +5,18 @@ import setuptools
 
 LONG_DESCRIPTION ='''`cruise-control-client` is an API-complete Python client for [`cruise-control`](https://github.com/linkedin/cruise-control).
 
-It comes with a command-line interface to the client (`cccli.py`) (see [README](https://github.com/linkedin/cruise-control/tree/master/docs/wiki/Python%20Client)).
+It comes with a command-line interface to the client (`cccli`) (see [README](https://github.com/linkedin/cruise-control/tree/master/docs/wiki/Python%20Client)).
 
 `cruise-control-client` can also be used in Python applications needing programmatic access to `cruise-control`.'''
 
 setuptools.setup(
     name='cruise-control-client',
-    version='0.1.2',
+    version='0.1.3',
     author='mgrubent',
     author_email='mgrubentrejo@linkedin.com',
     description='A Python client for cruise-control',
     long_description=LONG_DESCRIPTION,
+    long_description_content_type='text/markdown',
     url='https://github.com/linkedin/cruise-control',
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Currently, the markdown on the [PyPI site for `cruise-control-client`](https://pypi.org/project/cruise-control-client/) renders in an unintended manner.
![Screen Shot 2019-07-10 at 5 48 59 PM](https://user-images.githubusercontent.com/38822530/61014188-0d1e5380-a33b-11e9-9a84-9dbcb4da6761.png)

Accordingly, fix this rendering by specifying the description type.

Additionally remove needless comments from `__init__.py`.

Finally, remove reference to `cccli.py` in favor of consistent use of `cccli` command-line entry point, and patch version bump.