### PR TITLE
Remove the redundant dropRecentBrokersRequest field in response of admin endpoint.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/sync/AdminRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/sync/AdminRequest.java
@@ -85,7 +85,7 @@ public class AdminRequest extends AbstractSyncRequest {
     return new AdminResult(selfHealingBefore,
                            selfHealingAfter,
                            ongoingConcurrencyChangeRequest.isEmpty() ? null : ongoingConcurrencyChangeRequest,
-                           dropRecentBrokersRequest,
+                           dropRecentBrokersRequest.isEmpty() ? null : dropRecentBrokersRequest,
                            _kafkaCruiseControl.config());
   }
 


### PR DESCRIPTION
Fix issue #835 