### PR TITLE
Fix wrong cpu metric value magnitude in cluster model.

### DIFF
--- a/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/CruiseControlUnitTestUtils.java
+++ b/cruise-control-core/src/test/java/com/linkedin/cruisecontrol/CruiseControlUnitTestUtils.java
@@ -16,6 +16,7 @@ public class CruiseControlUnitTestUtils {
   public static final String METRIC1 = "m1";
   public static final String METRIC2 = "m2";
   public static final String METRIC3 = "m3";
+  public static final String CPU_USAGE = "CPU_USAGE";
 
   private CruiseControlUnitTestUtils() {
 
@@ -32,7 +33,11 @@ public class CruiseControlUnitTestUtils {
       for (int j = 0; j < numSamplesPerWindow; j++) {
         MetricSample<G, E> sample = new MetricSample<>(entity);
         for (MetricInfo metricInfo : metricDef.all()) {
-          sample.record(metricInfo, i * 10 + j);
+          double sampleValue = i * 10 + j;
+          if (metricInfo.name().equals(CPU_USAGE)) {
+            sampleValue /= 100.0;
+          }
+          sample.record(metricInfo, sampleValue);
         }
         sample.close(i * windowMs + 1);
         metricSampleAggregator.addSample(sample);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -41,6 +41,7 @@ public class KafkaCruiseControlUtils {
       Collections.unmodifiableSet(new HashSet<>(Arrays.asList(KafkaAssignerEvenRackAwareGoal.class.getSimpleName(),
                                                               KafkaAssignerDiskUsageDistributionGoal.class.getSimpleName())));
   public static final String OPERATION_LOGGER = "operationLogger";
+  public static final double PERCENTILE_TO_ABSOLUTE_VALUE = 100.0;
 
   private KafkaCruiseControlUtils() {
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -60,6 +60,9 @@ import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.PERCENTILE_TO_ABSOLUTE_VALUE;
+
+
 /**
  * The LoadMonitor monitors the workload of a Kafka cluster. It periodically triggers the metric sampling and
  * maintains the collected {@link PartitionMetricSample}. It is also responsible for aggregate the metrics samples into
@@ -603,7 +606,7 @@ public class LoadMonitor {
    * @param valuesAndExtrapolations the values and extrapolations of the leader replica.
    * @param partitionInfo the partition info.
    * @param isLeader whether the value is created for leader replica or follower replica.
-   * @param needToAdjustCpuUsage whether need to adjust cpu usage metric for replica.
+   * @param needToAdjustCpuUsage whether need to cast cpu usage metric for replica from absolute value to percentile.
    * @return the {@link AggregatedMetricValues} to use for the given replica.
    */
   private AggregatedMetricValues getAggregatedMetricValues(ValuesAndExtrapolations valuesAndExtrapolations,
@@ -631,7 +634,7 @@ public class LoadMonitor {
     short cpuUsageId = KafkaMetricDef.commonMetricDefId(KafkaMetricDef.CPU_USAGE);
     MetricValues cpuUsage = aggregatedMetricValues.valuesFor(cpuUsageId);
     for (int i = 0; i < cpuUsage.length(); i++) {
-      cpuUsage.set(i, cpuUsage.get(i) * 100);
+      cpuUsage.set(i, cpuUsage.get(i) * PERCENTILE_TO_ABSOLUTE_VALUE);
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/stats/BasicStats.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/stats/BasicStats.java
@@ -32,8 +32,7 @@ class BasicStats {
              double followerBytesInRate, double bytesOutRate, double potentialBytesOutRate,
              int numReplicas, int numLeaders, double diskCapacity) {
     _diskUtil = diskUtil < 0.0 ? 0.0 : diskUtil;
-    // Convert cpu util b/c full utilization should look like 100% instead of 1
-    _cpuUtil = cpuUtil < 0.0 ? 0.0 : 100 * cpuUtil;
+    _cpuUtil = cpuUtil < 0.0 ? 0.0 : cpuUtil;
     _leaderBytesInRate = leaderBytesInRate < 0.0 ? 0.0 : leaderBytesInRate;
     _followerBytesInRate = followerBytesInRate < 0.0 ? 0.0 : followerBytesInRate;
     _bytesOutRate = bytesOutRate < 0.0 ? 0.0 : bytesOutRate;

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregatorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregatorTest.java
@@ -81,11 +81,12 @@ public class KafkaPartitionMetricSampleAggregatorTest {
         Collection<Short> metricIds = KafkaMetricDef.resourceToMetricIds(resource);
         double expectedValue = (resource == Resource.DISK ?
             (NUM_WINDOWS - 1 - i) * 10 + MIN_SAMPLES_PER_WINDOW - 1 :
-            (NUM_WINDOWS - 1 - i) * 10 + (MIN_SAMPLES_PER_WINDOW - 1) / 2.0) * metricIds.size();
+            (NUM_WINDOWS - 1 - i) * 10 + (MIN_SAMPLES_PER_WINDOW - 1) / 2.0)
+            * (resource == Resource.CPU ? 0.01 : 1.0) * metricIds.size();
         assertEquals("The utilization for " + resource + " should be " + expectedValue,
                      expectedValue, partitionValuesAndExtrapolations.metricValues().valuesForGroup(resource.name(),
                                                                             KafkaMetricDef.commonMetricDef(),
-                                                                            true).get(i), 0);
+                                                                            true).get(i), 0.01);
       }
     }
 
@@ -321,12 +322,12 @@ public class KafkaPartitionMetricSampleAggregatorTest {
     ValuesAndExtrapolations partitionValuesAndExtrapolations = valuesAndExtrapolations.get(PE);
     for (Resource resource : Resource.cachedValues()) {
       Collection<Short> metricIds = KafkaMetricDef.resourceToMetricIds(resource);
-      double expectedValue = (resource == Resource.DISK ?
-          MIN_SAMPLES_PER_WINDOW - 1 : (MIN_SAMPLES_PER_WINDOW - 1) / 2.0) * metricIds.size();
+      double expectedValue = (resource == Resource.DISK ? MIN_SAMPLES_PER_WINDOW - 1 : (MIN_SAMPLES_PER_WINDOW - 1) / 2.0)
+                             * (resource == Resource.CPU ? 0.01 : 1.0) * metricIds.size();
       assertEquals("The utilization for " + resource + " should be " + expectedValue,
                    expectedValue, partitionValuesAndExtrapolations.metricValues().valuesForGroup(resource.name(),
                                                                           KafkaMetricDef.commonMetricDef(),
-                                                                          true).get(NUM_WINDOWS - 1), 0);
+                                                                          true).get(NUM_WINDOWS - 1), 0.01);
     }
   }
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregatorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregatorTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.PERCENTILE_TO_ABSOLUTE_VALUE;
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC0;
 import static com.linkedin.kafka.cruisecontrol.model.LinearRegressionModelParameters.ModelCoefficient.LEADER_BYTES_OUT;
 import static com.linkedin.kafka.cruisecontrol.monitor.metricdefinition.KafkaMetricDef.CPU_USAGE;
@@ -82,7 +83,7 @@ public class KafkaPartitionMetricSampleAggregatorTest {
         double expectedValue = (resource == Resource.DISK ?
             (NUM_WINDOWS - 1 - i) * 10 + MIN_SAMPLES_PER_WINDOW - 1 :
             (NUM_WINDOWS - 1 - i) * 10 + (MIN_SAMPLES_PER_WINDOW - 1) / 2.0)
-            * (resource == Resource.CPU ? 0.01 : 1.0) * metricIds.size();
+            / (resource == Resource.CPU ? PERCENTILE_TO_ABSOLUTE_VALUE : 1.0) * metricIds.size();
         assertEquals("The utilization for " + resource + " should be " + expectedValue,
                      expectedValue, partitionValuesAndExtrapolations.metricValues().valuesForGroup(resource.name(),
                                                                             KafkaMetricDef.commonMetricDef(),
@@ -323,7 +324,7 @@ public class KafkaPartitionMetricSampleAggregatorTest {
     for (Resource resource : Resource.cachedValues()) {
       Collection<Short> metricIds = KafkaMetricDef.resourceToMetricIds(resource);
       double expectedValue = (resource == Resource.DISK ? MIN_SAMPLES_PER_WINDOW - 1 : (MIN_SAMPLES_PER_WINDOW - 1) / 2.0)
-                             * (resource == Resource.CPU ? 0.01 : 1.0) * metricIds.size();
+                             / (resource == Resource.CPU ? PERCENTILE_TO_ABSOLUTE_VALUE : 1.0) * metricIds.size();
       assertEquals("The utilization for " + resource + " should be " + expectedValue,
                    expectedValue, partitionValuesAndExtrapolations.metricValues().valuesForGroup(resource.name(),
                                                                           KafkaMetricDef.commonMetricDef(),


### PR DESCRIPTION
Fix for issue #849

Another way to fix this issue is to directly make adjustment to RawMetrics(metrics reported by reporter) `BROKER_CPU_UTIL`, so that the newly generate samples have correct cpu utilization value for each partition/broker entity. 
But this approach breaks back-compatibility and there will be a transition period(where there is both new samples and old samples sitting in memory and get aggregated together) that the CC is unable to generate accurate workload profile for the cluster.