### PR TITLE
use config value for replicaThrottle in the fix method of Anomaly

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailures.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailures.java
@@ -6,6 +6,7 @@ package com.linkedin.kafka.cruisecontrol.detector;
 
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
 import com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.detector.notifier.AnomalyType;
 import com.linkedin.kafka.cruisecontrol.exception.KafkaCruiseControlException;
 import com.linkedin.kafka.cruisecontrol.servlet.response.OptimizationResult;
@@ -29,6 +30,7 @@ public class BrokerFailures extends KafkaAnomaly {
   private final boolean _excludeRecentlyRemovedBrokers;
   private final String _anomalyId;
   private final List<String> _selfHealingGoals;
+  private final Long _replicationThrottle;
 
   /**
    * An anomaly to indicate broker failure(s).
@@ -57,6 +59,11 @@ public class BrokerFailures extends KafkaAnomaly {
     _anomalyId = String.format("%s-%s", ID_PREFIX, UUID.randomUUID().toString().substring(ID_PREFIX.length() + 1));
     _optimizationResult = null;
     _selfHealingGoals = selfHealingGoals;
+    if (_kafkaCruiseControl != null && _kafkaCruiseControl.config() != null) {
+      _replicationThrottle = _kafkaCruiseControl.config().getLong(KafkaCruiseControlConfig.DEFAULT_REPLICATION_THROTTLE_CONFIG);
+    } else {
+      _replicationThrottle = null;
+    }
   }
 
   /**
@@ -87,7 +94,7 @@ public class BrokerFailures extends KafkaAnomaly {
                                                                                            false,
                                                                                            null,
                                                                                            null,
-                                                                                           null,
+                                                                                           _replicationThrottle,
                                                                                            _anomalyId,
                                                                                            _excludeRecentlyDemotedBrokers,
                                                                                            _excludeRecentlyRemovedBrokers,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DiskFailures.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DiskFailures.java
@@ -6,6 +6,7 @@ package com.linkedin.kafka.cruisecontrol.detector;
 
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
 import com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.detector.notifier.AnomalyType;
 import com.linkedin.kafka.cruisecontrol.exception.KafkaCruiseControlException;
 import com.linkedin.kafka.cruisecontrol.servlet.response.OptimizationResult;
@@ -27,6 +28,7 @@ public class DiskFailures extends KafkaAnomaly {
   private final boolean _allowCapacityEstimation;
   private final String _anomalyId;
   private final List<String> _selfHealingGoals;
+  private final Long _replicationThrottle;
 
   public DiskFailures(KafkaCruiseControl kafkaCruiseControl,
                       Map<Integer, Map<String, Long>> failedDisksByBroker,
@@ -45,6 +47,11 @@ public class DiskFailures extends KafkaAnomaly {
     _anomalyId = String.format("%s-%s", ID_PREFIX, UUID.randomUUID().toString().substring(ID_PREFIX.length() + 1));
     _optimizationResult = null;
     _selfHealingGoals = selfHealingGoals;
+    if (_kafkaCruiseControl != null && _kafkaCruiseControl.config() != null) {
+      _replicationThrottle = _kafkaCruiseControl.config().getLong(KafkaCruiseControlConfig.DEFAULT_REPLICATION_THROTTLE_CONFIG);
+    } else {
+      _replicationThrottle = null;
+    }
   }
 
   /**
@@ -72,7 +79,7 @@ public class DiskFailures extends KafkaAnomaly {
                                                                                         false,
                                                                                         null,
                                                                                         null,
-                                                                                        null,
+                                                                                        _replicationThrottle,
                                                                                         _anomalyId,
                                                                                         _excludeRecentlyDemotedBrokers,
                                                                                         _excludeRecentlyRemovedBrokers),

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolations.java
@@ -6,6 +6,7 @@ package com.linkedin.kafka.cruisecontrol.detector;
 
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
 import com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.detector.notifier.AnomalyType;
 import com.linkedin.kafka.cruisecontrol.exception.KafkaCruiseControlException;
 import com.linkedin.kafka.cruisecontrol.servlet.response.OptimizationResult;
@@ -34,6 +35,7 @@ public class GoalViolations extends KafkaAnomaly {
   private final boolean _excludeRecentlyRemovedBrokers;
   private final String _anomalyId;
   private final List<String> _selfHealingGoals;
+  private final Long _replicationThrottle;
 
   public GoalViolations(KafkaCruiseControl kafkaCruiseControl,
                         boolean allowCapacityEstimation,
@@ -48,6 +50,11 @@ public class GoalViolations extends KafkaAnomaly {
     _anomalyId = String.format("%s-%s", ID_PREFIX, UUID.randomUUID().toString().substring(ID_PREFIX.length() + 1));
     _optimizationResult = null;
     _selfHealingGoals = selfHealingGoals;
+    if (_kafkaCruiseControl != null && _kafkaCruiseControl.config() != null) {
+      _replicationThrottle = _kafkaCruiseControl.config().getLong(KafkaCruiseControlConfig.DEFAULT_REPLICATION_THROTTLE_CONFIG);
+    } else {
+      _replicationThrottle = null;
+    }
   }
 
   /**
@@ -88,7 +95,7 @@ public class GoalViolations extends KafkaAnomaly {
                                                                                    false,
                                                                                    null,
                                                                                    null,
-                                                                                   null,
+                                                                                   _replicationThrottle,
                                                                                    _anomalyId,
                                                                                    _excludeRecentlyDemotedBrokers,
                                                                                    _excludeRecentlyRemovedBrokers,

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -6,8 +6,10 @@ package com.linkedin.kafka.cruisecontrol.detector;
 
 import com.linkedin.cruisecontrol.detector.Anomaly;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
+import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUnitTestUtils;
 import com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress;
 import com.linkedin.kafka.cruisecontrol.common.KafkaCruiseControlThreadFactory;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.detector.notifier.AnomalyNotificationResult;
 import com.linkedin.kafka.cruisecontrol.detector.notifier.AnomalyNotifier;
 import com.linkedin.kafka.cruisecontrol.detector.notifier.AnomalyType;
@@ -17,6 +19,7 @@ import com.linkedin.kafka.cruisecontrol.monitor.LoadMonitor;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ScheduledExecutorService;
@@ -111,6 +114,8 @@ public class AnomalyDetectorTest {
     EasyMock.expect(mockAnomalyNotifier.onBrokerFailure(EasyMock.isA(BrokerFailures.class)))
             .andReturn(AnomalyNotificationResult.check(MOCK_DELAY_CHECK_MS));
     EasyMock.expect(mockAnomalyNotifier.selfHealingEnabledRatio()).andReturn(MOCK_SELF_HEALING_ENABLED_RATIO);
+    Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
+    EasyMock.expect(mockKafkaCruiseControl.config()).andReturn(new KafkaCruiseControlConfig(props)).times(1, 2);
 
     startPeriodicDetectors(mockDetectorScheduler, mockGoalViolationDetector, mockMetricAnomalyDetector, mockDiskFailureDetector, executorService);
     // Schedule a delayed check
@@ -174,6 +179,8 @@ public class AnomalyDetectorTest {
     ScheduledExecutorService mockDetectorScheduler = EasyMock.mock(ScheduledExecutorService.class);
     ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
     KafkaCruiseControl mockKafkaCruiseControl = EasyMock.mock(KafkaCruiseControl.class);
+    Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
+    EasyMock.expect(mockKafkaCruiseControl.config()).andReturn(new KafkaCruiseControlConfig(props)).times(1, 2);
 
     startPeriodicDetectors(mockDetectorScheduler, mockGoalViolationDetector, mockMetricAnomalyDetector, mockDiskFailureDetector, executorService);
     shutdownDetector(mockDetectorScheduler, executorService);
@@ -284,6 +291,8 @@ public class AnomalyDetectorTest {
     ScheduledExecutorService mockDetectorScheduler = EasyMock.mock(ScheduledExecutorService.class);
     ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
     KafkaCruiseControl mockKafkaCruiseControl = EasyMock.mock(KafkaCruiseControl.class);
+    Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
+    EasyMock.expect(mockKafkaCruiseControl.config()).andReturn(new KafkaCruiseControlConfig(props)).times(1, 2);
 
     startPeriodicDetectors(mockDetectorScheduler, mockGoalViolationDetector, mockMetricAnomalyDetector, mockDiskFailureDetector, executorService);
     shutdownDetector(mockDetectorScheduler, executorService);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailureDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/BrokerFailureDetectorTest.java
@@ -136,6 +136,8 @@ public class BrokerFailureDetectorTest extends CCKafkaIntegrationTestHarness {
     props.setProperty(KafkaCruiseControlConfig.ZOOKEEPER_CONNECT_CONFIG, zookeeper().connectionString());
     props.setProperty(KafkaCruiseControlConfig.ZOOKEEPER_SECURITY_ENABLED_CONFIG, "false");
     KafkaCruiseControlConfig kafkaCruiseControlConfig = new KafkaCruiseControlConfig(props);
+    EasyMock.expect(mockKafkaCruiseControl.config()).andReturn(kafkaCruiseControlConfig).atLeastOnce();
+    EasyMock.replay(mockKafkaCruiseControl);
     return new BrokerFailureDetector(kafkaCruiseControlConfig,
                                      mockLoadMonitor,
                                      anomalies,

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SelfHealingNotifierTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SelfHealingNotifierTest.java
@@ -5,12 +5,15 @@
 package com.linkedin.kafka.cruisecontrol.detector.notifier;
 
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
+import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUnitTestUtils;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.detector.BrokerFailures;
 import com.linkedin.kafka.cruisecontrol.detector.GoalViolations;
 import com.linkedin.kafka.cruisecontrol.detector.KafkaMetricAnomaly;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
@@ -35,6 +38,9 @@ public class SelfHealingNotifierTest {
     final long failureTime2 = 400L;
     final long startTime = 500L;
     KafkaCruiseControl mockKafkaCruiseControl = EasyMock.mock(KafkaCruiseControl.class);
+    Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
+    EasyMock.expect(mockKafkaCruiseControl.config()).andReturn(new KafkaCruiseControlConfig(props)).atLeastOnce();
+    EasyMock.replay(mockKafkaCruiseControl);
     Time mockTime = new MockTime(0, startTime, TimeUnit.NANOSECONDS.convert(startTime, TimeUnit.MILLISECONDS));
     TestingBrokerFailureAutoFixNotifier anomalyNotifier = new TestingBrokerFailureAutoFixNotifier(mockTime);
     anomalyNotifier.configure(Collections.singletonMap(SelfHealingNotifier.SELF_HEALING_BROKER_FAILURE_ENABLED_CONFIG, "true"));
@@ -116,6 +122,9 @@ public class SelfHealingNotifierTest {
     final long startTime = 500L;
     Time mockTime = new MockTime(startTime);
     KafkaCruiseControl mockKafkaCruiseControl = EasyMock.mock(KafkaCruiseControl.class);
+    Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
+    EasyMock.expect(mockKafkaCruiseControl.config()).andReturn(new KafkaCruiseControlConfig(props)).atLeastOnce();
+    EasyMock.replay(mockKafkaCruiseControl);
     TestingBrokerFailureAutoFixNotifier anomalyNotifier = new TestingBrokerFailureAutoFixNotifier(mockTime);
 
     Map<String, String> selfHealingExplicitlyDisabled = new HashMap<>(4);


### PR DESCRIPTION
for issue #842 

If default.replication.throttle is not set in config file, null is the default value as defined in KafkaCruiseControlConfig(pr #748 ).