### PR TITLE
Un-shadow the stop endpoint

### DIFF
--- a/cruise-control-client/cruisecontrolclient/client/Endpoint.py
+++ b/cruise-control-client/cruisecontrolclient/client/Endpoint.py
@@ -541,7 +541,7 @@ class TopicConfigurationEndpoint(AbstractEndpoint):
     )
     argparse_properties = {
         'args': (name,),
-        'kwargs': dict(aliases=[name.replace('_', '-'), 'stop'], help=description)
+        'kwargs': dict(aliases=[name.replace('_', '-')], help=description)
     }
 
 

--- a/cruise-control-client/setup.py
+++ b/cruise-control-client/setup.py
@@ -11,7 +11,7 @@ It comes with a command-line interface to the client (`cccli`) (see [README](htt
 
 setuptools.setup(
     name='cruise-control-client',
-    version='0.1.3',
+    version='0.1.4',
     author='mgrubent',
     author_email='mgrubentrejo@linkedin.com',
     description='A Python client for cruise-control',


### PR DESCRIPTION
Previously, the `TopicConfigurationEndpoint` identified itself with an alias `stop`.

Unfortunately, there already exists an alias `stop`, belonging to the `StopProposalExecutionEndpoint`.

Accordingly, the `TopicConfigurationEndpoint`'s use of `stop` shadows the `StopProposalExecutionEndpoint`'s use of `stop`, such that  
```
cccli -a $somewhere stop
```
actually invokes the `TopicConfigurationEndpoint`.

This behavior is incorrect.

Accordingly, remove the `TopicConfigurationEndpoint`'s `stop` alias.