### PR TITLE
Add support for BrokerCapacityInfo to keep number of CPU cores.

### DIFF
--- a/config/capacityCores.json
+++ b/config/capacityCores.json
@@ -1,0 +1,24 @@
+{
+  "brokerCapacities":[
+    {
+      "brokerId": "-1",
+      "capacity": {
+        "DISK": "100000",
+        "CPU": {"num.cores": "16"},
+        "NW_IN": "10000",
+        "NW_OUT": "10000"
+      },
+      "doc": "This is the default capacity. Capacity unit used for disk is in MB, cpu is in number of cores, network throughput is in KB."
+    },
+    {
+      "brokerId": "0",
+      "capacity": {
+        "DISK": "500000",
+        "CPU": {"num.cores": "32"},
+        "NW_IN": "50000",
+        "NW_OUT": "50000"
+      },
+      "doc": "This overrides the capacity for broker 0."
+    }
+  ]
+}

--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -83,7 +83,7 @@ num.broker.metrics.windows=20
 # The minimum broker metric samples required for a partition in each window
 min.samples.per.broker.metrics.window=1
 
-# The configuration for the BrokerCapacityConfigFileResolver (supports JBOD and non-JBOD broker capacities)
+# The configuration for the BrokerCapacityConfigFileResolver (supports JBOD, non-JBOD, and heterogeneous CPU core capacities)
 #capacity.config.file=config/capacity.json
 capacity.config.file=config/capacityJBOD.json
 

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/metric/MetricsUtils.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/metric/MetricsUtils.java
@@ -141,8 +141,14 @@ public class MetricsUtils {
     return ccm;
   }
 
+  /**
+   * Returns the "recent CPU usage" for the JVM process as a double in [0.0,1.0].
+   */
   public static BrokerMetric getCpuMetric(long now, int brokerId) {
     double cpuUtil = ((com.sun.management.OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getProcessCpuLoad();
+    if (cpuUtil < 0) {
+      throw new IllegalStateException("Java Virtual Machine recent CPU usage is not available.");
+    }
     return new BrokerMetric(RawMetricType.BROKER_CPU_UTIL, now, brokerId, cpuUtil);
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigResolver.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigResolver.java
@@ -16,12 +16,13 @@ import com.linkedin.kafka.cruisecontrol.common.Resource;
 public interface BrokerCapacityConfigResolver extends CruiseControlConfigurable, AutoCloseable {
   /**
    * Get the capacity of a broker based on rack, host and broker id.
-   * The map returned must contain all the resources defined in {@link Resource}. The units for each resource are:
+   * The response must contain all the resources defined in {@link Resource}. The units for each resource are:
    * DISK - MegaBytes
    * CPU - Percentage (0 - 100)
    * Network Inbound - KB/s
    * Network Outbounds - KB/s
    *
+   * The response also contains the number of CPU cores and may contain disk capacities by logDirs (i.e. for JBOD).
    * May estimate the capacity of a broker, if it is not directly available.
    *
    * @param rack The rack of the broker

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityInfo.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityInfo.java
@@ -9,32 +9,71 @@ import java.util.Map;
 
 
 public class BrokerCapacityInfo {
+  public final static short DEFAULT_NUM_CPU_CORES = 1;
+  private final static String DEFAULT_ESTIMATION_INFO = "";
   private final Map<Resource, Double> _capacity;
   private final String _estimationInfo;
   private final Map<String, Double> _diskCapacityByLogDir;
+  private final short _numCpuCores;
 
   /**
-   * BrokerCapacityInfo with the given capacity, estimation, and per absolute logDir disk capacity information.
+   * BrokerCapacityInfo with the given capacity, estimation, per absolute logDir disk capacity, and number of CPU cores.
    *
    * @param capacity Capacity information for each resource.
-   * @param estimationInfo Description if there is any capacity estimation, null or empty string otherwise.
+   * @param estimationInfo Description if there is any capacity estimation, null or {@link #DEFAULT_ESTIMATION_INFO} otherwise.
    * @param diskCapacityByLogDir Disk capacity by absolute logDir.
+   * @param numCpuCores Number of CPU cores.
    */
-  public BrokerCapacityInfo(Map<Resource, Double> capacity, String estimationInfo,
-                            Map<String, Double> diskCapacityByLogDir) {
+  public BrokerCapacityInfo(Map<Resource, Double> capacity,
+                            String estimationInfo,
+                            Map<String, Double> diskCapacityByLogDir,
+                            short numCpuCores) {
     _capacity = capacity;
     _estimationInfo = estimationInfo == null ? "" : estimationInfo;
     _diskCapacityByLogDir = diskCapacityByLogDir;
+    _numCpuCores = numCpuCores;
+  }
+
+  /**
+   * BrokerCapacityInfo with the given capacity, estimation, and number of CPU cores.
+   *
+   * @param capacity Capacity information for each resource.
+   * @param diskCapacityByLogDir Disk capacity by absolute logDir.
+   * @param numCpuCores Number of CPU cores.
+   */
+  public BrokerCapacityInfo(Map<Resource, Double> capacity, Map<String, Double> diskCapacityByLogDir, short numCpuCores) {
+    this(capacity, DEFAULT_ESTIMATION_INFO, diskCapacityByLogDir, numCpuCores);
+  }
+
+  /**
+   * BrokerCapacityInfo with the given capacity and number of CPU cores.
+   *
+   * @param capacity Capacity information for each resource.
+   * @param numCpuCores Number of CPU cores.
+   */
+  public BrokerCapacityInfo(Map<Resource, Double> capacity, short numCpuCores) {
+    this(capacity, DEFAULT_ESTIMATION_INFO, null, numCpuCores);
+  }
+
+  /**
+   * BrokerCapacityInfo with the given capacity, estimation, and per absolute logDir disk capacity.
+   *
+   * @param capacity Capacity information for each resource.
+   * @param estimationInfo Description if there is any capacity estimation, null or {@link #DEFAULT_ESTIMATION_INFO} otherwise.
+   * @param diskCapacityByLogDir Disk capacity by absolute logDir.
+   */
+  public BrokerCapacityInfo(Map<Resource, Double> capacity, String estimationInfo, Map<String, Double> diskCapacityByLogDir) {
+    this(capacity, estimationInfo, diskCapacityByLogDir, DEFAULT_NUM_CPU_CORES);
   }
 
   /**
    * BrokerCapacityInfo with no capacity information specified per absolute logDir.
    *
    * @param capacity Capacity information for each resource.
-   * @param estimationInfo Description if there is any capacity estimation, null or empty string otherwise.
+   * @param estimationInfo Description if there is any capacity estimation, null or {@link #DEFAULT_ESTIMATION_INFO} otherwise.
    */
   public BrokerCapacityInfo(Map<Resource, Double> capacity, String estimationInfo) {
-    this(capacity, estimationInfo, null);
+    this(capacity, estimationInfo, null, DEFAULT_NUM_CPU_CORES);
   }
 
   /**
@@ -44,7 +83,7 @@ public class BrokerCapacityInfo {
    * @param diskCapacityByLogDir Disk capacity by absolute logDir.
    */
   public BrokerCapacityInfo(Map<Resource, Double> capacity, Map<String, Double> diskCapacityByLogDir) {
-    this(capacity, null, diskCapacityByLogDir);
+    this(capacity, DEFAULT_ESTIMATION_INFO, diskCapacityByLogDir, DEFAULT_NUM_CPU_CORES);
   }
 
   /**
@@ -53,7 +92,7 @@ public class BrokerCapacityInfo {
    * @param capacity Capacity information for each resource.
    */
   public BrokerCapacityInfo(Map<Resource, Double> capacity) {
-    this(capacity, null, null);
+    this(capacity, DEFAULT_ESTIMATION_INFO, null, DEFAULT_NUM_CPU_CORES);
   }
 
   /**
@@ -71,7 +110,7 @@ public class BrokerCapacityInfo {
   }
 
   /**
-   * @return Empty string if no estimation, related estimation info otherwise.
+   * @return {@link #DEFAULT_ESTIMATION_INFO} if no estimation, related estimation info otherwise.
    */
   public String estimationInfo() {
     return _estimationInfo;
@@ -82,5 +121,12 @@ public class BrokerCapacityInfo {
    */
   public Map<String, Double> diskCapacityByLogDir() {
     return _diskCapacityByLogDir;
+  }
+
+  /**
+   * @return Number of CPU cores (if provided), {@link #DEFAULT_NUM_CPU_CORES} otherwise.
+   */
+  public short numCpuCores() {
+    return _numCpuCores;
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityInfo.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityInfo.java
@@ -29,13 +29,13 @@ public class BrokerCapacityInfo {
                             Map<String, Double> diskCapacityByLogDir,
                             short numCpuCores) {
     _capacity = capacity;
-    _estimationInfo = estimationInfo == null ? "" : estimationInfo;
+    _estimationInfo = estimationInfo == null ? DEFAULT_ESTIMATION_INFO : estimationInfo;
     _diskCapacityByLogDir = diskCapacityByLogDir;
     _numCpuCores = numCpuCores;
   }
 
   /**
-   * BrokerCapacityInfo with the given capacity, estimation, and number of CPU cores.
+   * BrokerCapacityInfo with the given capacity, per absolute logDir disk capacity, and number of CPU cores.
    *
    * @param capacity Capacity information for each resource.
    * @param diskCapacityByLogDir Disk capacity by absolute logDir.

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolverTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolverTest.java
@@ -5,12 +5,14 @@
 package com.linkedin.kafka.cruisecontrol.config;
 
 import com.linkedin.kafka.cruisecontrol.common.Resource;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 
@@ -18,14 +20,18 @@ import static org.junit.Assert.fail;
  * Unit test for {@link BrokerCapacityConfigFileResolver}
  */
 public class BrokerCapacityConfigFileResolverTest {
+  private static BrokerCapacityConfigResolver getBrokerCapacityConfigResolver(String configFileName, Class<?> klass) {
+    BrokerCapacityConfigResolver configResolver = new BrokerCapacityConfigFileResolver();
+    String fileName = Objects.requireNonNull(klass.getClassLoader().getResource(configFileName)).getFile();
+    Map<String, String> configs = Collections.singletonMap(BrokerCapacityConfigFileResolver.CAPACITY_CONFIG_FILE, fileName);
+    configResolver.configure(configs);
+
+    return configResolver;
+  }
 
   @Test
   public void testParseConfigFile() {
-    BrokerCapacityConfigResolver configResolver = new BrokerCapacityConfigFileResolver();
-    Map<String, String> configs = new HashMap<>();
-    String fileName = this.getClass().getClassLoader().getResource("testCapacityConfig.json").getFile();
-    configs.put(BrokerCapacityConfigFileResolver.CAPACITY_CONFIG_FILE, fileName);
-    configResolver.configure(configs);
+    BrokerCapacityConfigResolver configResolver = getBrokerCapacityConfigResolver("testCapacityConfig.json", this.getClass());
 
     assertEquals(200000.0, configResolver.capacityForBroker("", "", 0)
                                          .capacity().get(Resource.NW_IN), 0.01);
@@ -44,11 +50,7 @@ public class BrokerCapacityConfigFileResolverTest {
 
   @Test
   public void testParseConfigJBODFile() {
-    BrokerCapacityConfigResolver configResolver = new BrokerCapacityConfigFileResolver();
-    Map<String, String> configs = new HashMap<>();
-    String fileName = this.getClass().getClassLoader().getResource("testCapacityConfigJBOD.json").getFile();
-    configs.put(BrokerCapacityConfigFileResolver.CAPACITY_CONFIG_FILE, fileName);
-    configResolver.configure(configs);
+    BrokerCapacityConfigResolver configResolver = getBrokerCapacityConfigResolver("testCapacityConfigJBOD.json", this.getClass());
 
     assertEquals(2000000.0, configResolver.capacityForBroker("", "", 0)
                                          .capacity().get(Resource.DISK), 0.01);
@@ -57,7 +59,25 @@ public class BrokerCapacityConfigFileResolverTest {
     assertEquals(200000.0, configResolver.capacityForBroker("", "", 3)
                                          .diskCapacityByLogDir().get("/tmp/kafka-logs-4"), 0.01);
 
-    assertTrue(!configResolver.capacityForBroker("", "", 2).isEstimated());
+    assertFalse(configResolver.capacityForBroker("", "", 2).isEstimated());
+    assertTrue(configResolver.capacityForBroker("", "", 3).isEstimated());
+    assertTrue(configResolver.capacityForBroker("", "", 3).estimationInfo().length() > 0);
+  }
+
+  @Test
+  public void testParseConfigCoresFile() {
+    BrokerCapacityConfigResolver configResolver = getBrokerCapacityConfigResolver("testCapacityConfigCores.json", this.getClass());
+
+    assertEquals(BrokerCapacityConfigFileResolver.DEFAULT_CPU_CAPACITY_WITH_CORES, configResolver
+        .capacityForBroker("", "", 0).capacity().get(Resource.CPU), 0.01);
+    assertEquals(BrokerCapacityConfigFileResolver.DEFAULT_CPU_CAPACITY_WITH_CORES, configResolver
+        .capacityForBroker("", "", 3).capacity().get(Resource.CPU), 0.01);
+
+    assertEquals(8, configResolver.capacityForBroker("", "", 0).numCpuCores());
+    assertEquals(64, configResolver.capacityForBroker("", "", 1).numCpuCores());
+    assertEquals(16, configResolver.capacityForBroker("", "", 3).numCpuCores());
+
+    assertFalse(configResolver.capacityForBroker("", "", 1).isEstimated());
     assertTrue(configResolver.capacityForBroker("", "", 3).isEstimated());
     assertTrue(configResolver.capacityForBroker("", "", 3).estimationInfo().length() > 0);
   }

--- a/cruise-control/src/test/resources/testCapacityConfigCores.json
+++ b/cruise-control/src/test/resources/testCapacityConfigCores.json
@@ -1,0 +1,31 @@
+{
+  "brokerCapacities": [
+    {
+      "brokerId": "-1",
+      "capacity": {
+        "DISK": "1000000",
+        "CPU": {"num.cores": "16"},
+        "NW_IN": "100000",
+        "NW_OUT": "100000"
+      }
+    },
+    {
+      "brokerId": "0",
+      "capacity": {
+        "DISK": "2000000",
+        "CPU": {"num.cores": "8"},
+        "NW_IN": "200000",
+        "NW_OUT": "200000"
+      }
+    },
+    {
+      "brokerId": "1",
+      "capacity": {
+        "DISK": "3000000",
+        "CPU": {"num.cores": "64"},
+        "NW_IN": "300000",
+        "NW_OUT": "200000"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Addresses the issue https://github.com/linkedin/cruise-control/issues/860.