### PR TITLE
Allow easier passing of data payload

### DIFF
--- a/cruise-control-client/cruisecontrolclient/client/CCParameter/BooleanParameter.py
+++ b/cruise-control-client/cruisecontrolclient/client/CCParameter/BooleanParameter.py
@@ -2,6 +2,7 @@ from typing import Union
 
 from cruisecontrolclient.client.CCParameter.Parameter import AbstractParameter
 
+set_of_choices = {'true', 'false'}
 
 class AbstractBooleanParameter(AbstractParameter):
     def __init__(self, value: Union[bool, str]):
@@ -30,7 +31,7 @@ class ClearMetricsParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--clearmetrics', '--clear-metrics'),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, type=bool, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
     }
 
 
@@ -53,7 +54,7 @@ class ExcludeFollowerDemotionParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--exclude-follower-demotion',),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, type=bool, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
     }
 
 
@@ -64,7 +65,7 @@ class ExcludeRecentlyDemotedBrokersParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--exclude-recently-demoted-brokers', '--exclude-recently-demoted', '--exclude-demoted'),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, type=bool, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
     }
 
 
@@ -75,7 +76,7 @@ class ExcludeRecentlyRemovedBrokersParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--exclude-recently-removed-brokers', '--exclude-recently-removed', '--exclude-removed'),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, type=bool, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
     }
 
 
@@ -86,7 +87,7 @@ class IgnoreProposalCacheParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--ignore-proposal-cache',),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, type=bool, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
     }
 
 
@@ -97,7 +98,7 @@ class JSONParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--json', '--json-response'),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, type=bool, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
     }
 
 
@@ -108,7 +109,7 @@ class MaxLoadParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--max-load',),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, type=bool, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
     }
 
 
@@ -119,7 +120,7 @@ class SkipHardGoalCheckParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--skip-hard-goal-check', '--skip-hard-goal-checks'),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, type=bool, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
     }
 
 
@@ -141,7 +142,7 @@ class SkipURPDemotionParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--skip-urp-demotion',),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, type=bool, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
     }
 
 
@@ -152,7 +153,7 @@ class SuperVerboseParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--super-verbose',),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, type=bool, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
     }
 
 
@@ -163,7 +164,7 @@ class ThrottleRemovedBrokerParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--throttle-removed-broker',),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, type=bool, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
     }
 
 
@@ -174,7 +175,7 @@ class UseReadyDefaultGoalsParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--use-ready-default-goals',),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, type=bool, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
     }
 
 
@@ -185,5 +186,5 @@ class VerboseParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--verbose',),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, type=bool, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
     }

--- a/cruise-control-client/cruisecontrolclient/client/CCParameter/BooleanParameter.py
+++ b/cruise-control-client/cruisecontrolclient/client/CCParameter/BooleanParameter.py
@@ -31,7 +31,7 @@ class ClearMetricsParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--clearmetrics', '--clear-metrics'),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL', type=str.lower)
     }
 
 
@@ -54,7 +54,7 @@ class ExcludeFollowerDemotionParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--exclude-follower-demotion',),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL', type=str.lower)
     }
 
 
@@ -65,7 +65,7 @@ class ExcludeRecentlyDemotedBrokersParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--exclude-recently-demoted-brokers', '--exclude-recently-demoted', '--exclude-demoted'),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL', type=str.lower)
     }
 
 
@@ -76,7 +76,7 @@ class ExcludeRecentlyRemovedBrokersParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--exclude-recently-removed-brokers', '--exclude-recently-removed', '--exclude-removed'),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL', type=str.lower)
     }
 
 
@@ -87,7 +87,7 @@ class IgnoreProposalCacheParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--ignore-proposal-cache',),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL', type=str.lower)
     }
 
 
@@ -98,7 +98,7 @@ class JSONParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--json', '--json-response'),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL', type=str.lower)
     }
 
 
@@ -109,7 +109,7 @@ class MaxLoadParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--max-load',),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL', type=str.lower)
     }
 
 
@@ -120,7 +120,7 @@ class SkipHardGoalCheckParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--skip-hard-goal-check', '--skip-hard-goal-checks'),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL', type=str.lower)
     }
 
 
@@ -142,7 +142,7 @@ class SkipURPDemotionParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--skip-urp-demotion',),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL', type=str.lower)
     }
 
 
@@ -153,7 +153,7 @@ class SuperVerboseParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--super-verbose',),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL', type=str.lower)
     }
 
 
@@ -164,7 +164,7 @@ class ThrottleRemovedBrokerParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--throttle-removed-broker',),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL', type=str.lower)
     }
 
 
@@ -175,7 +175,7 @@ class UseReadyDefaultGoalsParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--use-ready-default-goals',),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL', type=str.lower)
     }
 
 
@@ -186,5 +186,5 @@ class VerboseParameter(AbstractBooleanParameter):
     argparse_properties = {
         'args': ('--verbose',),
         # There is no sensible default here; allow for ternary state
-        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL')
+        'kwargs': dict(help=description, choices=set_of_choices, metavar='BOOL', type=str.lower)
     }

--- a/cruise-control-client/cruisecontrolclient/client/CCParameter/SetOfChoicesParameter.py
+++ b/cruise-control-client/cruisecontrolclient/client/CCParameter/SetOfChoicesParameter.py
@@ -1,14 +1,5 @@
 from typing import Set, Union, Collection  # noqa
 
-# To allow for warnings that don't break the program.
-#
-# Specifically, we don't want this client to break forward compatibility with
-# new cruise-control features and parameter choices.
-#
-# Accordingly, for enums, we want to warn, but not raise an Exception, when
-# a provided value is outside of that enum
-from warnings import warn
-
 from cruisecontrolclient.client.CCParameter.Parameter import AbstractParameter
 
 
@@ -21,12 +12,7 @@ class AbstractSetOfChoicesParameter(AbstractParameter):
         AbstractParameter.__init__(self, value)
 
     def validate_value(self):
-        if type(self.value) == str:
-            for i in self.value.split(','):
-                # Assume that cruise-control uses case-insensitive enums
-                if i.lower() not in self.lowercase_set_of_choices:
-                    warn(f"{i} is not in the valid set of choices")
-        else:
+        if type(self.value) != str and type(self.value) != Collection:
             raise ValueError(f"{self.value} must be either a string or a Collection")
 
 
@@ -38,7 +24,7 @@ class DisableSelfHealingForParameter(AbstractSetOfChoicesParameter):
     argparse_properties = {
         'args': ('--disable-self-healing-for', '--disable-self-healing'),
         # nargs='+' allows for multiple of the set to be specified
-        'kwargs': dict(help=description, metavar='ANOMALY_DETECTOR', choices=lowercase_set_of_choices, nargs='+')
+        'kwargs': dict(help=description, metavar='ANOMALY_DETECTOR', choices=lowercase_set_of_choices, nargs='+', type=str.lower)
 
     }
 
@@ -51,7 +37,7 @@ class EnableSelfHealingForParameter(AbstractSetOfChoicesParameter):
     argparse_properties = {
         'args': ('--enable-self-healing-for', '--enable-self-healing'),
         # nargs='+' allows for multiple of the set to be specified
-        'kwargs': dict(help=description, metavar='ANOMALY_DETECTOR', choices=lowercase_set_of_choices, nargs='+')
+        'kwargs': dict(help=description, metavar='ANOMALY_DETECTOR', choices=lowercase_set_of_choices, nargs='+', type=str.lower)
     }
 
 
@@ -62,7 +48,7 @@ class ResourceParameter(AbstractSetOfChoicesParameter):
     description = "The host and broker-level resource by which to sort the cruise-control response"
     argparse_properties = {
         'args': ('--resource',),
-        'kwargs': dict(help=description, metavar='RESOURCE', choices=lowercase_set_of_choices)
+        'kwargs': dict(help=description, metavar='RESOURCE', choices=lowercase_set_of_choices, type=str.lower)
     }
 
 
@@ -74,5 +60,5 @@ class SubstatesParameter(AbstractSetOfChoicesParameter):
     argparse_properties = {
         'args': ('--substate', '--substates'),
         # nargs='+' allows for multiple of the set to be specified
-        'kwargs': dict(help=description, metavar='SUBSTATE', choices=lowercase_set_of_choices, nargs='+')
+        'kwargs': dict(help=description, metavar='SUBSTATE', choices=lowercase_set_of_choices, nargs='+', type=str.lower)
     }

--- a/cruise-control-client/cruisecontrolclient/client/Endpoint.py
+++ b/cruise-control-client/cruisecontrolclient/client/Endpoint.py
@@ -13,6 +13,9 @@ from typing import Callable, ClassVar, Dict, List, Tuple, Union  # noqa
 # To help us generate the right parameter string from a dict of parameters
 from urllib.parse import urlencode
 
+# To be able to deprecate methods
+import warnings
+
 
 class AbstractEndpoint(metaclass=ABCMeta):
     """
@@ -133,17 +136,13 @@ class AbstractEndpoint(metaclass=ABCMeta):
         elif parameter_name in self.parameter_name_to_value:
             self.parameter_name_to_value.pop(parameter_name)
 
-    def compose_endpoint(self) -> str:
+    def get_composed_params(self) -> Dict[str, Union[bool, int, str]]:
         """
-        Returns a valid URL suffix of this endpoint and any parameters
-        that have been defined for it.
+        Returns a requests-compatible dictionary of this Endpoint's current parameters.
 
-        Note that the ordering of the parameters is not guaranteed.
-
-        :return: A string like:
-            'rebalance?dryrun=false&allow_capacity_estimation=false&concurrent_partition_movements_per_broker=5'
-            'state'
-            'stop_proposal_execution'
+        :return: A dict like:
+            {'json': True,
+             'allow_capacity_estimation': False}
         """
         # All parameter:value mappings that have been specified for this endpoint.
         #
@@ -158,6 +157,27 @@ class AbstractEndpoint(metaclass=ABCMeta):
         # Update our mapping with parameter: value pairs that lack Parameter objects
         if self.parameter_name_to_value:
             combined_parameter_to_value.update(self.parameter_name_to_value)
+
+        return combined_parameter_to_value
+
+    def compose_endpoint(self) -> str:
+        warnings.warn("This method is deprecated as of 1.0.0, as it needlessly recreates requests functionality. "
+                      "It may be removed entirely in future versions. "
+                      "Please use get_composed_params instead.",
+                      DeprecationWarning,
+                      stacklevel=2)
+        """
+        Returns a valid URL suffix of this endpoint and any parameters
+        that have been defined for it.
+
+        Note that the ordering of the parameters is not guaranteed.
+
+        :return: A string like:
+            'rebalance?dryrun=false&allow_capacity_estimation=false&concurrent_partition_movements_per_broker=5'
+            'state'
+            'stop_proposal_execution'
+        """
+        combined_parameter_to_value = self.get_composed_params()
 
         # If we have any mappings, urlencode them and return the full string
         if combined_parameter_to_value:

--- a/cruise-control-client/cruisecontrolclient/client/Endpoint.py
+++ b/cruise-control-client/cruisecontrolclient/client/Endpoint.py
@@ -161,11 +161,6 @@ class AbstractEndpoint(metaclass=ABCMeta):
         return combined_parameter_to_value
 
     def compose_endpoint(self) -> str:
-        warnings.warn("This method is deprecated as of 1.0.0, as it needlessly recreates requests functionality. "
-                      "It may be removed entirely in future versions. "
-                      "Please use get_composed_params instead.",
-                      DeprecationWarning,
-                      stacklevel=2)
         """
         Returns a valid URL suffix of this endpoint and any parameters
         that have been defined for it.
@@ -177,6 +172,11 @@ class AbstractEndpoint(metaclass=ABCMeta):
             'state'
             'stop_proposal_execution'
         """
+        warnings.warn("This method is deprecated as of 1.0.0, as it needlessly recreates requests functionality. "
+                      "It may be removed entirely in future versions. "
+                      "Please use get_composed_params instead.",
+                      DeprecationWarning,
+                      stacklevel=2)
         combined_parameter_to_value = self.get_composed_params()
 
         # If we have any mappings, urlencode them and return the full string

--- a/cruise-control-client/cruisecontrolclient/client/Endpoint.py
+++ b/cruise-control-client/cruisecontrolclient/client/Endpoint.py
@@ -172,7 +172,7 @@ class AbstractEndpoint(metaclass=ABCMeta):
             'state'
             'stop_proposal_execution'
         """
-        warnings.warn("This method is deprecated as of 1.0.0, as it needlessly recreates requests functionality. "
+        warnings.warn("This method is deprecated as of 0.2.0, as it needlessly recreates requests functionality. "
                       "It may be removed entirely in future versions. "
                       "Please use get_composed_params instead.",
                       DeprecationWarning,

--- a/cruise-control-client/cruisecontrolclient/client/Query.py
+++ b/cruise-control-client/cruisecontrolclient/client/Query.py
@@ -7,6 +7,7 @@ from cruisecontrolclient.client.Endpoint import AbstractEndpoint
 # To be able to signify deprecation
 import warnings
 
+
 def generate_url_from_cc_socket_address(cc_socket_address: str, endpoint: AbstractEndpoint) -> str:
     warnings.warn("This function is deprecated as of 1.0.0. "
                   "It may be removed entirely in future versions.",
@@ -25,7 +26,6 @@ def generate_url_from_cc_socket_address(cc_socket_address: str, endpoint: Abstra
     """
     url = f"http://{cc_socket_address}/kafkacruisecontrol/{endpoint.compose_endpoint()}"
     return url
-
 
 
 def generate_base_url_from_cc_socket_address(cc_socket_address: str, endpoint: AbstractEndpoint) -> str:

--- a/cruise-control-client/cruisecontrolclient/client/Query.py
+++ b/cruise-control-client/cruisecontrolclient/client/Query.py
@@ -20,7 +20,7 @@ def generate_url_from_cc_socket_address(cc_socket_address: str, endpoint: Abstra
     :return: URL, the correct URL to perform the Endpoint's operation
              on the given cruise-control host, _including parameters_.
     """
-    warnings.warn("This function is deprecated as of 1.0.0. "
+    warnings.warn("This function is deprecated as of 0.2.0. "
                   "It may be removed entirely in future versions.",
                   DeprecationWarning,
                   stacklevel=2)

--- a/cruise-control-client/cruisecontrolclient/client/Query.py
+++ b/cruise-control-client/cruisecontrolclient/client/Query.py
@@ -9,10 +9,6 @@ import warnings
 
 
 def generate_url_from_cc_socket_address(cc_socket_address: str, endpoint: AbstractEndpoint) -> str:
-    warnings.warn("This function is deprecated as of 1.0.0. "
-                  "It may be removed entirely in future versions.",
-                  DeprecationWarning,
-                  stacklevel=2)
     """
     Given a cruise-control hostname[:port] and an Endpoint, return the correct URL
     for this cruise-control operation.
@@ -24,6 +20,10 @@ def generate_url_from_cc_socket_address(cc_socket_address: str, endpoint: Abstra
     :return: URL, the correct URL to perform the Endpoint's operation
              on the given cruise-control host, _including parameters_.
     """
+    warnings.warn("This function is deprecated as of 1.0.0. "
+                  "It may be removed entirely in future versions.",
+                  DeprecationWarning,
+                  stacklevel=2)
     url = f"http://{cc_socket_address}/kafkacruisecontrol/{endpoint.compose_endpoint()}"
     return url
 

--- a/cruise-control-client/cruisecontrolclient/client/Query.py
+++ b/cruise-control-client/cruisecontrolclient/client/Query.py
@@ -4,16 +4,41 @@
 # To be able to make more-precise type hints
 from cruisecontrolclient.client.Endpoint import AbstractEndpoint
 
+# To be able to signify deprecation
+import warnings
 
 def generate_url_from_cc_socket_address(cc_socket_address: str, endpoint: AbstractEndpoint) -> str:
+    warnings.warn("This function is deprecated as of 1.0.0. "
+                  "It may be removed entirely in future versions.",
+                  DeprecationWarning,
+                  stacklevel=2)
     """
     Given a cruise-control hostname[:port] and an Endpoint, return the correct URL
     for this cruise-control operation.
 
+    Note that this URL _includes_ parameters.
+
     :param cc_socket_address: like hostname[:port], ip-address[:port]
     :param endpoint:
     :return: URL, the correct URL to perform the Endpoint's operation
-             on the given cruise-control host.
+             on the given cruise-control host, _including parameters_.
     """
     url = f"http://{cc_socket_address}/kafkacruisecontrol/{endpoint.compose_endpoint()}"
+    return url
+
+
+
+def generate_base_url_from_cc_socket_address(cc_socket_address: str, endpoint: AbstractEndpoint) -> str:
+    """
+    Given a cruise-control hostname[:port] and an Endpoint, return the correct URL
+    for this cruise-control operation.
+
+    Note that this URL _excludes_ parameters.
+
+    :param cc_socket_address: like hostname[:port], ip-address[:port]
+    :param endpoint:
+    :return: URL, the correct URL to perform the Endpoint's operation
+             on the given cruise-control host, _excluding parameters_.
+    """
+    url = f"http://{cc_socket_address}/kafkacruisecontrol/{endpoint.name}"
     return url

--- a/cruise-control-client/cruisecontrolclient/client/Responder.py
+++ b/cruise-control-client/cruisecontrolclient/client/Responder.py
@@ -74,22 +74,11 @@ class CruiseControlResponder(requests.Session):
         if 'params' in kwargs:
             if 'json' in kwargs['params']:
                 json_val = kwargs['params']['json']
-                if (type(json_val) is bool and not json_val) or\
+                if (type(json_val) is bool and not json_val) or \
                         (type(json_val) is str and json_val.lower() != 'true'):
                     raise ValueError(f"Parameter 'json':{kwargs['params']['json']} is not supported")
 
-        # Convenience closure to not have to copy-paste the parameters from
-        # this current environment.
-        def inner_request_helper():
-            return self.request(method, url, **kwargs)
-
-        response = inner_request_helper()
-        while 'progress' in response.json().keys():
-            display_response(response)
-            response = inner_request_helper()
-
-        # return the requests.response object
-        return response
+        return self.request(method, url, **kwargs)
 
     def retrieve_response_from_Endpoint(self,
                                         cc_socket_address: str,

--- a/cruise-control-client/cruisecontrolclient/client/Responder.py
+++ b/cruise-control-client/cruisecontrolclient/client/Responder.py
@@ -28,7 +28,7 @@ import warnings
 
 class CruiseControlResponder(requests.Session):
     """
-    This class is intented to lightly wrap requests' Session class,
+    This class is intended to lightly wrap requests' Session class,
     in order to provide the cruise-control-client with some basic
     sanity checking and session-management functionality.
     """

--- a/cruise-control-client/cruisecontrolclient/client/Responder.py
+++ b/cruise-control-client/cruisecontrolclient/client/Responder.py
@@ -115,7 +115,7 @@ class AbstractResponder(object):
     """
 
     def __init__(self, url: str, headers: Dict[str, str] = None):
-        warnings.warn("This class is deprecated as of 1.0.0. "
+        warnings.warn("This class is deprecated as of 0.2.0. "
                       "It may be removed entirely in future versions.",
                       DeprecationWarning,
                       stacklevel=2)
@@ -145,7 +145,7 @@ class AbstractTextResponder(AbstractResponder):
     """
 
     def __init__(self, url: str, headers: Dict[str, str] = None):
-        warnings.warn("This class is deprecated as of 1.0.0. "
+        warnings.warn("This class is deprecated as of 0.2.0. "
                       "It may be removed entirely in future versions.",
                       DeprecationWarning,
                       stacklevel=2)
@@ -180,7 +180,7 @@ class AbstractJSONResponder(AbstractResponder):
     """
 
     def __init__(self, url: str, headers: Dict[str, str] = None):
-        warnings.warn("This class is deprecated as of 1.0.0. "
+        warnings.warn("This class is deprecated as of 0.2.0. "
                       "It may be removed entirely in future versions.",
                       DeprecationWarning,
                       stacklevel=2)
@@ -237,7 +237,7 @@ class JSONDisplayingResponderGet(AbstractJSONDisplayingResponder):
     """
 
     def __init__(self, url: str, headers: Dict[str, str] = None):
-        warnings.warn("This class is deprecated as of 1.0.0. "
+        warnings.warn("This class is deprecated as of 0.2.0. "
                       "It may be removed entirely in future versions.",
                       DeprecationWarning,
                       stacklevel=2)
@@ -253,7 +253,7 @@ class JSONDisplayingResponderPost(AbstractJSONDisplayingResponder):
     """
 
     def __init__(self, url: str, headers: Dict[str, str] = None):
-        warnings.warn("This class is deprecated as of 1.0.0. "
+        warnings.warn("This class is deprecated as of 0.2.0. "
                       "It may be removed entirely in future versions.",
                       DeprecationWarning,
                       stacklevel=2)
@@ -273,7 +273,7 @@ class AbstractJSONResponderThread(Thread):
     """
 
     def __init__(self):
-        warnings.warn("This class is deprecated as of 1.0.0. "
+        warnings.warn("This class is deprecated as of 0.2.0. "
                       "It may be removed entirely in future versions.",
                       DeprecationWarning,
                       stacklevel=2)
@@ -300,7 +300,7 @@ class JSONResponderGetThread(AbstractJSONResponderThread):
     """
 
     def __init__(self, url: str, headers: Dict[str, str] = None):
-        warnings.warn("This class is deprecated as of 1.0.0. "
+        warnings.warn("This class is deprecated as of 0.2.0. "
                       "It may be removed entirely in future versions.",
                       DeprecationWarning,
                       stacklevel=2)
@@ -316,7 +316,7 @@ class JSONResponderPostThread(AbstractJSONResponderThread):
     """
 
     def __init__(self, url: str, headers: Dict[str, str] = None):
-        warnings.warn("This class is deprecated as of 1.0.0. "
+        warnings.warn("This class is deprecated as of 0.2.0. "
                       "It may be removed entirely in future versions.",
                       DeprecationWarning,
                       stacklevel=2)

--- a/cruise-control-client/cruisecontrolclient/client/cccli.py
+++ b/cruise-control-client/cruisecontrolclient/client/cccli.py
@@ -15,12 +15,8 @@ from cruisecontrolclient.client.Display import display_response
 # To be able to instantiate Endpoint objects
 import cruisecontrolclient.client.Endpoint as Endpoint
 
-# To be able to make requests and get a response given a URL to cruise-control
-from cruisecontrolclient.client.Responder import AbstractResponder, JSONDisplayingResponderGet, \
-    JSONDisplayingResponderPost
-
-# To be able to compose a URL to hand to requests
-from cruisecontrolclient.client.Query import generate_url_from_cc_socket_address
+# To be able to make long-running requests to cruise-control
+from cruisecontrolclient.client.Responder import CruiseControlResponder
 
 
 def get_endpoint(args: argparse.Namespace,
@@ -144,19 +140,6 @@ def get_endpoint(args: argparse.Namespace,
     return endpoint
 
 
-def get_responder(endpoint: Endpoint.AbstractEndpoint,
-                  url: str) -> AbstractResponder:
-    # Handle instantiating the correct Responder
-    if endpoint.http_method == "GET":
-        json_responder = JSONDisplayingResponderGet(url)
-    elif endpoint.http_method == "POST":
-        json_responder = JSONDisplayingResponderPost(url)
-    else:
-        raise ValueError(f"Unexpected http_method {endpoint.http_method} in endpoint")
-
-    return json_responder
-
-
 def build_argument_parser(execution_context: ExecutionContext) -> argparse.ArgumentParser:
     """
     Builds and returns an argument parser for interacting with cruise-control via CLI.
@@ -245,15 +228,9 @@ def main():
     # Get the socket address for the cruise-control we're communicating with
     cc_socket_address = args.socket_address
 
-    # Generate the correct URL from the endpoint and the socket address
-    url = generate_url_from_cc_socket_address(cc_socket_address=cc_socket_address,
-                                              endpoint=endpoint)
-
-    # Get a responder from the given URL and endpoint
-    json_responder = get_responder(endpoint=endpoint, url=url)
-
     # Retrieve the response and display it
-    response = json_responder.retrieve_response()
+    json_responder = CruiseControlResponder()
+    response = json_responder.retrieve_response_from_Endpoint(cc_socket_address, endpoint)
     display_response(response)
 
 

--- a/cruise-control-client/cruisecontrolclient/client/cccli.py
+++ b/cruise-control-client/cruisecontrolclient/client/cccli.py
@@ -157,7 +157,7 @@ def get_responder(endpoint: Endpoint.AbstractEndpoint,
     :param fully_composed_url: The full cruise-control URL, including paths and parameters
     :return: An instantiation of the correct JSONDisplayingResponder.
     """
-    warnings.warn("This function is deprecated as of 1.0.0, as "
+    warnings.warn("This function is deprecated as of 0.2.0, as "
                   "it only exists to facilitate the use of deprecated classes. "
                   "It may be removed entirely in future versions.",
                   DeprecationWarning,

--- a/cruise-control-client/cruisecontrolclient/client/cccli.py
+++ b/cruise-control-client/cruisecontrolclient/client/cccli.py
@@ -6,6 +6,9 @@
 # To be able to easily parse command-line arguments
 import argparse
 
+# To be able to signify deprecation
+import warnings
+
 # To be able to easily pass around the available endpoints and parameters
 from cruisecontrolclient.client.ExecutionContext import ExecutionContext
 
@@ -16,7 +19,8 @@ from cruisecontrolclient.client.Display import display_response
 import cruisecontrolclient.client.Endpoint as Endpoint
 
 # To be able to make long-running requests to cruise-control
-from cruisecontrolclient.client.Responder import CruiseControlResponder
+from cruisecontrolclient.client.Responder import AbstractResponder, \
+    CruiseControlResponder, JSONDisplayingResponderGet, JSONDisplayingResponderPost
 
 
 def get_endpoint(args: argparse.Namespace,
@@ -138,6 +142,35 @@ def get_endpoint(args: argparse.Namespace,
             endpoint.remove_param(parameter)
 
     return endpoint
+
+
+def get_responder(endpoint: Endpoint.AbstractEndpoint,
+                  fully_composed_url: str) -> AbstractResponder:
+    """
+    Given an Endpoint and fully-composed URL, return an instantiation of
+    the correct JSONDisplayingResponder.
+
+    This is needed because the JSONDisplayingResponder classes do not dynamically
+    determine from the given Endpoint which type of HTTP request they must make.
+
+    :param endpoint: A built Endpoint object
+    :param fully_composed_url: The full cruise-control URL, including paths and parameters
+    :return: An instantiation of the correct JSONDisplayingResponder.
+    """
+    warnings.warn("This function is deprecated as of 1.0.0, as "
+                  "it only exists to facilitate the use of deprecated classes. "
+                  "It may be removed entirely in future versions.",
+                  DeprecationWarning,
+                  stacklevel=2)
+    # Handle instantiating the correct Responder
+    if endpoint.http_method == "GET":
+        json_responder = JSONDisplayingResponderGet(fully_composed_url)
+    elif endpoint.http_method == "POST":
+        json_responder = JSONDisplayingResponderPost(fully_composed_url)
+    else:
+        raise ValueError(f"Unexpected http_method {endpoint.http_method} in endpoint")
+
+    return json_responder
 
 
 def build_argument_parser(execution_context: ExecutionContext) -> argparse.ArgumentParser:

--- a/cruise-control-client/setup.py
+++ b/cruise-control-client/setup.py
@@ -11,7 +11,7 @@ It comes with a command-line interface to the client (`cccli`) (see [README](htt
 
 setuptools.setup(
     name='cruise-control-client',
-    version='1.0.0',
+    version='0.2.0',
     author='mgrubent',
     author_email='mgrubentrejo@linkedin.com',
     description='A Python client for cruise-control',

--- a/cruise-control-client/setup.py
+++ b/cruise-control-client/setup.py
@@ -11,7 +11,7 @@ It comes with a command-line interface to the client (`cccli`) (see [README](htt
 
 setuptools.setup(
     name='cruise-control-client',
-    version='0.1.5',
+    version='1.0.0',
     author='mgrubent',
     author_email='mgrubentrejo@linkedin.com',
     description='A Python client for cruise-control',

--- a/docs/wiki/Python Client/cruise-control-client-Usage-in-Python-Applications.md
+++ b/docs/wiki/Python Client/cruise-control-client-Usage-in-Python-Applications.md
@@ -16,8 +16,7 @@ cccli -a someCruiseControlAddress:9090 rebalance
 This will generate a `POST` request to `http://someCruiseControlAddress:9090/kafkacruisecontrol/rebalance?allow_capacity_estimation=False&dryrun=False&json=true`.
 ```python
 from cruisecontrolclient.client.Endpoint import RebalanceEndpoint
-from cruisecontrolclient.client.Query import generate_url_from_cc_socket_address
-from cruisecontrolclient.client.cccli import get_responder
+from cruisecontrolclient.client.Responder import CruiseControlResponder
 
 # 1) Generate or define the socket address for the desired cruise-control instance
 cc_socket_address = 'someCruiseControlAddress:9090'
@@ -27,18 +26,13 @@ endpoint = RebalanceEndpoint()
 endpoint.add_param(parameter_name="allow_capacity_estimation", value=False)
 endpoint.add_param(parameter_name="json", value=True)
 
-# 3) URLify the above information
-url = generate_url_from_cc_socket_address(cc_socket_address=cc_socket_address,
-          endpoint=endpoint)
+# 3) Instantiate a Responder
+json_responder = CruiseControlResponder()
 
-# 4) Instantiate a Responder for the given Endpoint and URL
-#    (which Responder is returned depends on the HTTP method of the Endpoint)
-json_responder = get_responder(endpoint=endpoint, url=url)
+# 4) Start a long-running poll to retrieve a Requests.Response object
+response = json_responder.retrieve_response_from_Endpoint(cc_socket_address, endpoint)
 
-# 5) Start a long-running poll to retrieve a Requests.Response object
-response = json_responder.retrieve_response()
-
-# 6) Process the response, likely by JSONifying it
+# 5) Process the response, likely by JSONifying it
 json_response = response.json()
 ```
 
@@ -57,8 +51,7 @@ This will generate a `POST` request to `http://someCruiseControlAddress:9090/kaf
 `.
 ```python
 from cruisecontrolclient.client.Endpoint import RemoveBrokerEndpoint
-from cruisecontrolclient.client.Query import generate_url_from_cc_socket_address
-from cruisecontrolclient.client.cccli import get_responder
+from cruisecontrolclient.client.Responder import CruiseControlResponder
 
 # 1) Generate or define the socket address for the desired cruise-control instance
 cc_socket_address = 'someCruiseControlAddress:9090'
@@ -68,18 +61,13 @@ endpoint = RemoveBrokerEndpoint(['broker', 'ids', 'to', 'remove'])
 endpoint.add_param(parameter_name="allow_capacity_estimation", value=False)
 endpoint.add_param(parameter_name="json", value=True)
 
-# 3) URLify the above information
-url = generate_url_from_cc_socket_address(cc_socket_address=cc_socket_address,
-          endpoint=endpoint)
+# 3) Instantiate a Responder
+json_responder = CruiseControlResponder()
 
-# 4) Instantiate a Responder for the given Endpoint and URL
-#    (which Responder is returned depends on the HTTP method of the Endpoint)
-json_responder = get_responder(endpoint=endpoint, url=url)
+# 4) Start a long-running poll to retrieve a Requests.Response object
+response = json_responder.retrieve_response_from_Endpoint(cc_socket_address, endpoint)
 
-# 5) Start a long-running poll to retrieve a Requests.Response object
-response = json_responder.retrieve_response()
-
-# 6) Process the response, likely by JSONifying it
+# 5) Process the response, likely by JSONifying it
 json_response = response.json()
 ```
 ## Add-Broker Example
@@ -96,8 +84,7 @@ cccli -a someCruiseControlAddress:9090 add-broker broker,ids,to,add
 This will generate a `POST` request to `http://someCruiseControlAddress:9090/kafkacruisecontrol/add_broker?brokerid=broker%2Cids%2Cto%2Cadd&allow_capacity_estimation=False&dryrun=False&json=true`.
 ```python
 from cruisecontrolclient.client.Endpoint import AddBrokerEndpoint
-from cruisecontrolclient.client.Query import generate_url_from_cc_socket_address
-from cruisecontrolclient.client.cccli import get_responder
+from cruisecontrolclient.client.Responder import CruiseControlResponder
 
 # 1) Generate or define the socket address for the desired cruise-control instance
 cc_socket_address = 'someCruiseControlAddress:9090'
@@ -107,17 +94,12 @@ endpoint = AddBrokerEndpoint(['broker', 'ids', 'to', 'add'])
 endpoint.add_param(parameter_name="allow_capacity_estimation", value=False)
 endpoint.add_param(parameter_name="json", value=True)
 
-# 3) URLify the above information
-url = generate_url_from_cc_socket_address(cc_socket_address=cc_socket_address,
-          endpoint=endpoint)
+# 3) Instantiate a Responder
+json_responder = CruiseControlResponder()
 
-# 4) Instantiate a Responder for the given Endpoint and URL
-#    (which Responder is returned depends on the HTTP method of the Endpoint)
-json_responder = get_responder(endpoint=endpoint, url=url)
+# 4) Start a long-running poll to retrieve a Requests.Response object
+response = json_responder.retrieve_response_from_Endpoint(cc_socket_address, endpoint)
 
-# 5) Start a long-running poll to retrieve a Requests.Response object
-response = json_responder.retrieve_response()
-
-# 6) Process the response, likely by JSONifying it
+# 5) Process the response, likely by JSONifying it
 json_response = response.json()
 ```


### PR DESCRIPTION
# Background
Currently, there is no support for `cruise-control-client` passing a data payload to `cruise-control`.  
Accomplishing this at present would require some deep subclassing of the existing `Responder` classes.

Conceivably (e.g. as an outcome of #875), `cruise-control` will accept data payloads in the future.

# Proposal
This PR seeks to allow for `cruise-control-client` to easily pass arbitrary data payloads to `cruise-control`, by adhering more-closely to how `requests` creates and sends HTTP requests.

In short:  
```python
# Get the endpoint that the parsed args specify
endpoint = get_endpoint(args=args, execution_context=e)

# Get the socket address for the cruise-control we're communicating with
cc_socket_address = args.socket_address

# Define some JSON payload to send to cruise-control
data = {'a': 1}

# Retrieve the response and display it
json_responder = CruiseControlResponder()
response = json_responder.retrieve_response_from_Endpoint(cc_socket_address, endpoint, json=data)
```

# Changes
This PR:  
1. Introduces a new `CruiseControlResponder` class, which is a thin subclass of `requests.Session`, with some convenience methods.
2. Refactors `cccli` to make use of the new `CruiseControlResponder` class and paradigm.
3. Deprecates all previous classes in `Responder.py`, as these are needlessly deep and overcomplicated ways to construct and create responses.
4. Deprecates the `Endpoint.compose_endpoint` method and the `generate_url_from_cc_socket_address` function for similar reasons.
5. Fixes a long-existing bug with the `BooleanParameters` where most of them were just always True 🤦‍♂️
6. Introduces a minor version bump, as this PR introduces new classes and deprecates old ones.