### PR TITLE
added config example for logdir response timeout

### DIFF
--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -31,6 +31,8 @@ bootstrap.servers=localhost:9092
 # The time to wait for a response from a host after sending a request.
 #request.timeout.ms=30000
 
+# The time to wait for broker logdir to respond after sending a request.
+#logdir.response.timeout.ms=10000
 
 # Configurations for the load monitor
 # =======================================


### PR DESCRIPTION
added config example for the newly added config in PR (https://github.com/linkedin/cruise-control/pull/883)

 Changes to be committed:
	modified:   config/cruisecontrol.properties