### PR TITLE
Fix failure-to-copy-Object bug

### DIFF
--- a/cruise-control-client/cruisecontrolclient/client/cccli.py
+++ b/cruise-control-client/cruisecontrolclient/client/cccli.py
@@ -25,10 +25,15 @@ from cruisecontrolclient.client.Responder import AbstractResponder, \
 
 def get_endpoint(args: argparse.Namespace,
                  execution_context: ExecutionContext) -> Endpoint.AbstractEndpoint:
-    # Deepcopy the args so that we can delete keys from it as we handle them.
+    # Use a __dict__ view of args for a more pythonic processing idiom.
     #
-    # Otherwise successive iterations will step on each other's toes.
-    arg_dict = vars(args)
+    # Also, shallow copy this dict, since otherwise deletions of keys from
+    # this dict would have the unintended consequence of mutating `args` outside
+    # of the scope of this function.
+    #
+    # A deep copy is not needed here since in this method we're only ever
+    # removing properties, not mutating the objects which those properties reference.
+    arg_dict = vars(args).copy()
 
     # If we have a broker list, we need to make it into a comma-separated list
     # and pass it to the Endpoint at instantiation.

--- a/cruise-control-client/setup.py
+++ b/cruise-control-client/setup.py
@@ -11,7 +11,7 @@ It comes with a command-line interface to the client (`cccli`) (see [README](htt
 
 setuptools.setup(
     name='cruise-control-client',
-    version='0.2.1',
+    version='0.2.2',
     author='mgrubent',
     author_email='mgrubentrejo@linkedin.com',
     description='A Python client for cruise-control',


### PR DESCRIPTION
# Issue
Currently, `get_endpoint` unintentionally mutates one of its passed arguments, `args`, by deleting some properties of this Object.

In `cccli.py` currently, this has no effect, as no method subsequent to `get_endpoint` relies on an un-mutated copy of `args`.

That said, it's bad style, and creates a pitfall in case `cccli.py` (or other user code) uses the buggy `get_endpoint` implementation.

# Fix
`get_endpoint` now shallow copies the argument it expects to mutate, then mutates the shallow copy.