### PR TITLE
Ensure that json module is used

### DIFF
--- a/cruise-control-client/cruisecontrolclient/client/Display.py
+++ b/cruise-control-client/cruisecontrolclient/client/Display.py
@@ -366,7 +366,7 @@ def display_response(response: Response) -> None:
 
     # Handle non-JSON (presumably plain-text) responses
     try:
-        j: dict = response.json()
+        j: dict = json.loads(response.text)
     except json.decoder.JSONDecodeError:
         print_error(response.text)
         return

--- a/cruise-control-client/cruisecontrolclient/client/Responder.py
+++ b/cruise-control-client/cruisecontrolclient/client/Responder.py
@@ -118,7 +118,7 @@ class CruiseControlResponder(requests.Session):
         response = inner_request_helper()
         final_response = is_response_final(response)
         while not final_response:
-            print(response.text)
+            print_error(response.text)
             response = inner_request_helper()
             final_response = is_response_final(response)
 

--- a/cruise-control-client/cruisecontrolclient/client/Responder.py
+++ b/cruise-control-client/cruisecontrolclient/client/Responder.py
@@ -118,7 +118,7 @@ class CruiseControlResponder(requests.Session):
         response = inner_request_helper()
         final_response = is_response_final(response)
         while not final_response:
-            display_response(response)
+            print(response.text)
             response = inner_request_helper()
             final_response = is_response_final(response)
 

--- a/cruise-control-client/cruisecontrolclient/client/cccli.py
+++ b/cruise-control-client/cruisecontrolclient/client/cccli.py
@@ -12,9 +12,6 @@ import warnings
 # To be able to easily pass around the available endpoints and parameters
 from cruisecontrolclient.client.ExecutionContext import ExecutionContext
 
-# Convenience functions for displaying the retrieved Response
-from cruisecontrolclient.client.Display import display_response
-
 # To be able to instantiate Endpoint objects
 import cruisecontrolclient.client.Endpoint as Endpoint
 
@@ -259,7 +256,7 @@ def main():
     # Retrieve the response and display it
     json_responder = CruiseControlResponder()
     response = json_responder.retrieve_response_from_Endpoint(cc_socket_address, endpoint)
-    display_response(response)
+    print(response.text)
 
 
 if __name__ == "__main__":

--- a/cruise-control-client/setup.py
+++ b/cruise-control-client/setup.py
@@ -11,7 +11,7 @@ It comes with a command-line interface to the client (`cccli`) (see [README](htt
 
 setuptools.setup(
     name='cruise-control-client',
-    version='0.3.0',
+    version='0.3.1',
     author='mgrubent',
     author_email='mgrubentrejo@linkedin.com',
     description='A Python client for cruise-control',


### PR DESCRIPTION
Fixes #927.

This proposed change also removes default use of the deprecated function `display_response`, in favor of a straight `print` statement.  

Non-final responses will be printed to `stderr`, while final responses are returned to the caller.