### PR TITLE
Remove extra test.dependsOn from subprojects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,6 @@ subprojects {
   apply plugin: 'checkstyle'
   apply plugin: 'findbugs'
 
-  test.dependsOn('checkstyleMain', 'checkstyleTest')
-
   task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
     from sourceSets.main.allSource


### PR DESCRIPTION
This commit fixes #947