### PR TITLE
Ensure that brokers for failed partition metric samples are identified when possible.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/holder/BrokerLoad.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/holder/BrokerLoad.java
@@ -131,15 +131,23 @@ public class BrokerLoad {
     return convertUnit ? convertUnit(rawMetricValue, rawMetricType) : rawMetricValue;
   }
 
-  public double partitionMetric(String dotHandledTopic, int partition, RawMetricType rawMetricType) {
+  /**
+   * Get partition metric with the given name for the partition from given topic and partition number. If the partition
+   * metric does not exist for given dot-handled topic name and partition, return {@code null}.
+   *
+   * @param dotHandledTopic Dot-handled topic name.
+   * @param partition Partition number.
+   * @param rawMetricType Raw metric type.
+   */
+  public Double partitionMetric(String dotHandledTopic, int partition, RawMetricType rawMetricType) {
     sanityCheckMetricScope(rawMetricType, PARTITION);
     RawMetricsHolder metricsHolder = _dotHandledPartitionMetrics.get(new TopicPartition(dotHandledTopic, partition));
     if (metricsHolder == null || metricsHolder.metricValue(rawMetricType) == null) {
-      throw new IllegalArgumentException(String.format("Partition metric %s does not exist for dot handled topic name %s"
-                                                       + " and partition %d.", rawMetricType, dotHandledTopic, partition));
-    } else {
-      return convertUnit(metricsHolder.metricValue(rawMetricType).value(), rawMetricType);
+      LOG.error("Partition metric {} does not exist for dot handled topic {} and partition {}.",
+                rawMetricType, dotHandledTopic, partition);
+      return null;
     }
+    return convertUnit(metricsHolder.metricValue(rawMetricType).value(), rawMetricType);
   }
 
   /**

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsProcessorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsProcessorTest.java
@@ -34,7 +34,7 @@ import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC1;
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC2;
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.metric.RawMetricType.*;
 import static com.linkedin.kafka.cruisecontrol.monitor.metricdefinition.KafkaMetricDef.*;
-import static com.linkedin.kafka.cruisecontrol.model.ModelUtils.estimateLeaderCpuUtil;
+import static com.linkedin.kafka.cruisecontrol.model.ModelUtils.estimateLeaderCpuUtilPerCore;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -83,31 +83,31 @@ public class CruiseControlMetricsProcessorTest {
   private static final Map<TopicPartition, Double> CPU_UTIL = new HashMap<>(4);
   static {
     CPU_UTIL.put(T1P0, MOCK_NUM_CPU_CORES *
-                       estimateLeaderCpuUtil(B0_CPU,
-                                             B0_ALL_TOPIC_BYTES_IN,
+                       estimateLeaderCpuUtilPerCore(B0_CPU,
+                                                    B0_ALL_TOPIC_BYTES_IN,
                                              B0_ALL_TOPIC_BYTES_OUT + B0_TOPIC1_REPLICATION_BYTES_OUT + B0_TOPIC2_REPLICATION_BYTES_OUT,
-                                             B0_TOPIC1_REPLICATION_BYTES_IN,
-                                             B0_TOPIC1_BYTES_IN,
+                                                    B0_TOPIC1_REPLICATION_BYTES_IN,
+                                                    B0_TOPIC1_BYTES_IN,
                                              B0_TOPIC1_BYTES_OUT + B0_TOPIC1_REPLICATION_BYTES_OUT));
     CPU_UTIL.put(T1P1, MOCK_NUM_CPU_CORES *
-                       estimateLeaderCpuUtil(B1_CPU,
-                                             B1_ALL_TOPIC_BYTES_IN,
+                       estimateLeaderCpuUtilPerCore(B1_CPU,
+                                                    B1_ALL_TOPIC_BYTES_IN,
                                              B1_ALL_TOPIC_BYTES_OUT + B1_TOPIC1_REPLICATION_BYTES_OUT,
                                              B1_TOPIC1_REPLICATION_BYTES_IN + B1_TOPIC2_REPLICATION_BYTES_IN,
-                                             B1_TOPIC1_BYTES_IN,
+                                                    B1_TOPIC1_BYTES_IN,
                                              B1_TOPIC1_BYTES_OUT + B1_TOPIC1_REPLICATION_BYTES_OUT));
     CPU_UTIL.put(T2P0, MOCK_NUM_CPU_CORES *
-                       estimateLeaderCpuUtil(B0_CPU,
-                                             B0_ALL_TOPIC_BYTES_IN,
+                       estimateLeaderCpuUtilPerCore(B0_CPU,
+                                                    B0_ALL_TOPIC_BYTES_IN,
                                              B0_ALL_TOPIC_BYTES_OUT + B0_TOPIC1_REPLICATION_BYTES_OUT + B0_TOPIC2_REPLICATION_BYTES_OUT,
-                                             B0_TOPIC1_REPLICATION_BYTES_IN,
+                                                    B0_TOPIC1_REPLICATION_BYTES_IN,
                                              B0_TOPIC2_BYTES_IN / 2,
                                              (B0_TOPIC2_BYTES_OUT + B0_TOPIC2_REPLICATION_BYTES_OUT) / 2));
     CPU_UTIL.put(T2P1, MOCK_NUM_CPU_CORES *
-                       estimateLeaderCpuUtil(B0_CPU,
-                                             B0_ALL_TOPIC_BYTES_IN,
+                       estimateLeaderCpuUtilPerCore(B0_CPU,
+                                                    B0_ALL_TOPIC_BYTES_IN,
                                              B0_ALL_TOPIC_BYTES_OUT + B0_TOPIC1_REPLICATION_BYTES_OUT + B0_TOPIC2_REPLICATION_BYTES_OUT,
-                                             B0_TOPIC1_REPLICATION_BYTES_IN,
+                                                    B0_TOPIC1_REPLICATION_BYTES_IN,
                                              B0_TOPIC2_BYTES_IN / 2,
                                              (B0_TOPIC2_BYTES_OUT + B0_TOPIC2_REPLICATION_BYTES_OUT) / 2));
   }


### PR DESCRIPTION
Addresses the issue https://github.com/linkedin/cruise-control/issues/951.