### PR TITLE
Drop brokers from list

### DIFF
--- a/cruise-control-client/cruisecontrolclient/client/CCParameter/CommaSeparatedParameter.py
+++ b/cruise-control-client/cruisecontrolclient/client/CCParameter/CommaSeparatedParameter.py
@@ -71,6 +71,34 @@ class DiscardParameter(AbstractCommaSeparatedParameter):
     }
 
 
+class DropRecentlyDemotedBrokersParameter(AbstractCommaSeparatedParameter):
+    """drop_recently_demoted_brokers=[id1,id2...]"""
+    name = 'drop_recently_demoted_brokers'
+    description = 'Comma-separated and/or space-separated list of broker IDs'
+    argparse_properties = {
+        'args': ('--drop-recently-demoted-broker',
+                 '--drop-recently-demoted-brokers',
+                 '--drop-recently-demoted-broker-id',
+                 '--drop-recently-demoted-brokers-ids'),
+        'kwargs': dict(help=description,
+                       nargs='+')
+    }
+
+
+class DropRecentlyRemovedBrokersParameter(AbstractCommaSeparatedParameter):
+    """drop_recently_removed_brokers=[id1,id2...]"""
+    name = 'drop_recently_removed_brokers'
+    description = 'Comma-separated and/or space-separated list of broker IDs'
+    argparse_properties = {
+        'args': ('--drop-recently-removed-broker',
+                 '--drop-recently-removed-brokers',
+                 '--drop-recently-removed-broker-id',
+                 '--drop-recently-removed-brokers-ids'),
+        'kwargs': dict(help=description,
+                       nargs='+')
+    }
+
+
 class EndpointsParameter(AbstractCommaSeparatedParameter):
     """endpoints=[Set-of-{@link EndPoint}]"""
     name = 'endpoints'

--- a/cruise-control-client/cruisecontrolclient/client/Endpoint.py
+++ b/cruise-control-client/cruisecontrolclient/client/Endpoint.py
@@ -197,6 +197,8 @@ class AdminEndpoint(AbstractEndpoint):
         CCParameter.ConcurrentLeaderMovementsParameter,
         CCParameter.ConcurrentPartitionMovementsPerBrokerParameter,
         CCParameter.DisableSelfHealingForParameter,
+        CCParameter.DropRecentlyDemotedBrokersParameter,
+        CCParameter.DropRecentlyRemovedBrokersParameter,
         CCParameter.EnableSelfHealingForParameter,
         CCParameter.JSONParameter,
         CCParameter.ReviewIDParameter,

--- a/cruise-control-client/setup.py
+++ b/cruise-control-client/setup.py
@@ -11,7 +11,7 @@ It comes with a command-line interface to the client (`cccli`) (see [README](htt
 
 setuptools.setup(
     name='cruise-control-client',
-    version='1.0.1',
+    version='1.0.2',
     author='mgrubent',
     author_email='mgrubentrejo@linkedin.com',
     description='A Python client for cruise-control',

--- a/cruise-control-client/setup.py
+++ b/cruise-control-client/setup.py
@@ -11,7 +11,7 @@ It comes with a command-line interface to the client (`cccli`) (see [README](htt
 
 setuptools.setup(
     name='cruise-control-client',
-    version='1.0.0',
+    version='1.0.1',
     author='mgrubent',
     author_email='mgrubentrejo@linkedin.com',
     description='A Python client for cruise-control',


### PR DESCRIPTION
This should make progress on #897 by adding `drop_recently_demoted_brokers` and `drop_recently_removed_brokers` to the `admin` Endpoint.