### PR TITLE
Add OpenAPI yaml spec for Load endpoint

### DIFF
--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RequestParameterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RequestParameterTest.java
@@ -58,7 +58,7 @@ public class RequestParameterTest {
     SwaggerParseResult parseResult = openApiParser.readLocation(OPENAPI_SPEC_PATH, null, options);
     _openAPI = parseResult.getOpenAPI();
     Map<String, Set<String>> schema = parseSchema();
-    // TODO: Check the number of entries in parsed schema is the same as _endpointsToClass
+    Assert.assertEquals(schema.keySet(), _endpointToClass.keySet());
     for (Map.Entry<String, Set<String>> endpoint: schema.entrySet()) {
       Assert.assertTrue(_endpointToClass.containsKey(endpoint.getKey()));
       CruiseControlParameters endpointParams = _endpointToClass.get(endpoint.getKey());

--- a/cruise-control/src/yaml/base.yaml
+++ b/cruise-control/src/yaml/base.yaml
@@ -16,6 +16,8 @@ paths:
     $ref: 'endpoints/fixOfflineReplicas.yaml#/FixOfflineReplicasEndpoint'
   /kafkacruisecontrol/kafka_cluster_state:
     $ref: 'endpoints/kafkaClusterState.yaml#/KafkaClusterStateEndpoint'
+  /kafkacruisecontrol/load:
+    $ref: 'endpoints/load.yaml#/LoadEndpoint'
   /kafkacruisecontrol/partition_load:
     $ref: 'endpoints/partitionLoad.yaml#/PartitionLoadEndpoint'
   /kafkacruisecontrol/pause_sampling:

--- a/cruise-control/src/yaml/endpoints/load.yaml
+++ b/cruise-control/src/yaml/endpoints/load.yaml
@@ -1,0 +1,64 @@
+LoadEndpoint:
+  get:
+    operationId: load
+    summary: Get the cluster load once Cruise Control Load Monitor is running.
+    parameters:
+      - name: start
+        in: query
+        description: Start time of the cluster load.
+        schema:
+          type: long
+          format: int64
+          # Default is time of earliest valid window.
+      - name: end
+        in: query
+        description: End time of the cluster load.
+        schema:
+          type: long
+          format: int64
+          # Default is current system time.
+      - name: time
+        in: query
+        description: End time of the clutser load.
+        schema:
+          type: long
+          format: int64
+        # Default is current system time, mutually exclusive from end parameter.
+      - name: allow_capacity_estimation
+        in: query
+        description: Whether to allow capacity estimation when cruise-control is unable to obtain all per-broker capacity information.
+        schema:
+          type: boolean
+          default: true
+      - name: json
+        in: query
+        description: Whether to return in JSON format or not.
+        schema:
+          type: boolean
+          default: false
+      - name: populate_disk_info
+        in: query
+        description: Whether show the load of each disk of broker.
+        schema:
+          type: boolean
+          default: false
+    responses:
+      '200':
+        description: Successful load from valid partitions response.
+        content:
+          application/json:
+            schema:
+              $ref: '../responses/brokerStats.yaml#/BrokerStats'
+          text/plain:
+             schema:
+               type: string
+      # Response for all errors.
+      default:
+        description: Error response.
+        content:
+          application/json:
+            schema:
+              $ref: '../responses/errorResponse.yaml#/ErrorResponse'
+          text/plain:
+            schema:
+              type: string

--- a/cruise-control/src/yaml/endpoints/load.yaml
+++ b/cruise-control/src/yaml/endpoints/load.yaml
@@ -5,25 +5,26 @@ LoadEndpoint:
     parameters:
       - name: start
         in: query
-        description: Start time of the cluster load.
+        description: Start time of the cluster load. Default is time of earliest valid window.
         schema:
           type: long
+          default: -1
           format: int64
-          # Default is time of earliest valid window.
+          minimum: -1
       - name: end
         in: query
-        description: End time of the cluster load.
+        description: End time of the cluster load. Default is current system time.
         schema:
           type: long
           format: int64
-          # Default is current system time.
+          minimum: 0
       - name: time
         in: query
-        description: End time of the clutser load.
+        description: End time of the clutser load. Default is current system time, mutually exclusive with end parameter.
         schema:
           type: long
           format: int64
-        # Default is current system time, mutually exclusive from end parameter.
+          minimum: 0
       - name: allow_capacity_estimation
         in: query
         description: Whether to allow capacity estimation when cruise-control is unable to obtain all per-broker capacity information.


### PR DESCRIPTION
Add OpenAPI Load endpoint for only cluster load as partition load is accessed via a different path and capacity is not yet merged.