### PR TITLE
Make LoadMonitor do not retieve capacity information for dead brokers.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
@@ -61,27 +61,35 @@ public class Broker implements Serializable, Comparable<Broker> {
    *
    * @param host           The host this broker is on
    * @param id             The id of the broker.
+   * @param isBrokerAlive  Whether broker is alive or not.
    * @param brokerCapacityInfo Capacity information of the created broker.
    * @param populateReplicaPlacementInfo Whether populate replica placement over disk information or not.
    */
-  Broker(Host host, int id, BrokerCapacityInfo brokerCapacityInfo, boolean populateReplicaPlacementInfo) {
-    Map<Resource, Double> brokerCapacity = brokerCapacityInfo.capacity();
-    if (brokerCapacity == null) {
-      throw new IllegalArgumentException("Attempt to create broker " + id + " on host " + host.name() + " with null capacity.");
-    }
+  Broker(Host host, int id, boolean isBrokerAlive, BrokerCapacityInfo brokerCapacityInfo, boolean populateReplicaPlacementInfo) {
     _host = host;
     _id = id;
     _brokerCapacity = new double[Resource.cachedValues().size()];
-    for (Map.Entry<Resource, Double> entry : brokerCapacity.entrySet()) {
-      Resource resource = entry.getKey();
-      _brokerCapacity[resource.id()] = (resource == Resource.CPU) ? (entry.getValue() * brokerCapacityInfo.numCpuCores())
-                                                                  : entry.getValue();
-    }
+    if (isBrokerAlive) {
+      Map<Resource, Double> brokerCapacity = brokerCapacityInfo.capacity();
+      if (brokerCapacity == null) {
+        throw new IllegalArgumentException("Attempt to create broker " + id + " on host " + host.name() + " with null capacity.");
+      }
+      for (Map.Entry<Resource, Double> entry : brokerCapacity.entrySet()) {
+        Resource resource = entry.getKey();
+        _brokerCapacity[resource.id()] = (resource == Resource.CPU) ? (entry.getValue() * brokerCapacityInfo.numCpuCores())
+                                                                    : entry.getValue();
+      }
 
-    if (populateReplicaPlacementInfo) {
-      _diskByLogdir = new TreeMap<>();
-      brokerCapacityInfo.diskCapacityByLogDir().forEach((key, value) -> _diskByLogdir.put(key, new Disk(key, this, value)));
+      if (populateReplicaPlacementInfo) {
+        _diskByLogdir = new TreeMap<>();
+        brokerCapacityInfo.diskCapacityByLogDir().forEach((key, value) -> _diskByLogdir.put(key, new Disk(key, this, value)));
+      } else {
+        _diskByLogdir = Collections.emptySortedMap();
+      }
     } else {
+      for (Resource resource: Resource.cachedValues()) {
+        _brokerCapacity[resource.id()] = DEAD_BROKER_CAPACITY;
+      }
       _diskByLogdir = Collections.emptySortedMap();
     }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Host.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Host.java
@@ -138,18 +138,21 @@ public class Host implements Serializable {
    * Create a broker under this host, and get the created broker.
    *
    * @param brokerId Id of the broker to be created.
+   * @param isBrokerAlive Whether broker is alive or not.
    * @param brokerCapacityInfo Capacity information of the created broker.
    * @param populateReplicaPlacementInfo Whether populate replica placement over disk information or not.
    * @return Created broker.
    */
-  Broker createBroker(Integer brokerId, BrokerCapacityInfo brokerCapacityInfo, boolean populateReplicaPlacementInfo) {
-    Broker broker = new Broker(this, brokerId, brokerCapacityInfo, populateReplicaPlacementInfo);
+  Broker createBroker(Integer brokerId, boolean isBrokerAlive, BrokerCapacityInfo brokerCapacityInfo, boolean populateReplicaPlacementInfo) {
+    Broker broker = new Broker(this, brokerId, isBrokerAlive, brokerCapacityInfo, populateReplicaPlacementInfo);
     _brokers.put(brokerId, broker);
-    _aliveBrokers++;
-    for (Map.Entry<Resource, Double> entry : brokerCapacityInfo.capacity().entrySet()) {
-      Resource resource = entry.getKey();
-      _hostCapacity[resource.id()] += (resource == Resource.CPU) ? (entry.getValue() * brokerCapacityInfo.numCpuCores())
-                                                                 : entry.getValue();
+    if (isBrokerAlive) {
+      _aliveBrokers++;
+      for (Map.Entry<Resource, Double> entry : brokerCapacityInfo.capacity().entrySet()) {
+        Resource resource = entry.getKey();
+        _hostCapacity[resource.id()] += (resource == Resource.CPU) ? (entry.getValue() * brokerCapacityInfo.numCpuCores())
+                                                                   : entry.getValue();
+      }
     }
     return broker;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Rack.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Rack.java
@@ -248,21 +248,25 @@ public class Rack implements Serializable {
    *
    * @param brokerId Id of the broker to be created.
    * @param hostName The hostName of the broker
+   * @param isBrokerAlive Whether broker is alive or not.
    * @param brokerCapacityInfo Capacity information of the created broker.
    * @param populateReplicaPlacementInfo Whether populate replica placement over disk information or not.
    * @return Created broker.
    */
   Broker createBroker(int brokerId,
                       String hostName,
+                      boolean isBrokerAlive,
                       BrokerCapacityInfo brokerCapacityInfo,
                       boolean populateReplicaPlacementInfo) {
     Host host = _hosts.computeIfAbsent(hostName, name -> new Host(name, this));
-    Broker broker = host.createBroker(brokerId, brokerCapacityInfo, populateReplicaPlacementInfo);
+    Broker broker = host.createBroker(brokerId, isBrokerAlive, brokerCapacityInfo, populateReplicaPlacementInfo);
     _brokers.put(brokerId, broker);
-    for (Map.Entry<Resource, Double> entry : brokerCapacityInfo.capacity().entrySet()) {
-      Resource resource = entry.getKey();
-      _rackCapacity[resource.id()] += (resource == Resource.CPU) ? (entry.getValue() * brokerCapacityInfo.numCpuCores())
-                                                                 : entry.getValue();
+    if (isBrokerAlive) {
+      for (Map.Entry<Resource, Double> entry : brokerCapacityInfo.capacity().entrySet()) {
+        Resource resource = entry.getKey();
+        _rackCapacity[resource.id()] += (resource == Resource.CPU) ? (entry.getValue() * brokerCapacityInfo.numCpuCores())
+                                                                   : entry.getValue();
+      }
     }
     return broker;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -513,7 +513,7 @@ public class LoadMonitor {
         BrokerCapacityInfo brokerCapacity = _brokerCapacityConfigResolver.capacityForBroker(rack, node.host(), node.id());
         LOG.debug("Get capacity info for broker {}: total capacity {}, capacity by logdir {}.",
                   node.id(), brokerCapacity.capacity().get(Resource.DISK), brokerCapacity.diskCapacityByLogDir());
-        clusterModel.createBroker(rack, node.host(), node.id(), brokerCapacity, populateReplicaPlacementInfo);
+        clusterModel.createBroker(rack, node.host(), node.id(), true, brokerCapacity, populateReplicaPlacementInfo);
       }
 
       // Populate replica placement information for the cluster model if requested.
@@ -526,7 +526,7 @@ public class LoadMonitor {
       for (Map.Entry<PartitionEntity, ValuesAndExtrapolations> entry : partitionValuesAndExtrapolations.entrySet()) {
         TopicPartition tp = entry.getKey().tp();
         ValuesAndExtrapolations leaderLoad = entry.getValue();
-        populatePartitionLoad(cluster, clusterModel, tp, leaderLoad, replicaPlacementInfo, _brokerCapacityConfigResolver);
+        populatePartitionLoad(cluster, clusterModel, tp, leaderLoad, replicaPlacementInfo);
         step.incrementPopulatedNumPartitions();
       }
       // Set the state of bad brokers in clusterModel based on the Kafka cluster state.

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/PreferredLeaderElectionGoalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/PreferredLeaderElectionGoalTest.java
@@ -293,10 +293,10 @@ public class PreferredLeaderElectionGoalTest {
                                                                      new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY);
     int i = 0;
     for (; i < 2; i++) {
-      clusterModel.createBroker("r0", "h" + i, i, commonBrokerCapacityInfo, populateDiskInfo);
+      clusterModel.createBroker("r0", "h" + i, i, true, commonBrokerCapacityInfo, populateDiskInfo);
     }
     for (int j = 1; j < NUM_RACKS; j++, i++) {
-      clusterModel.createBroker("r" + j, "h" + i, i, commonBrokerCapacityInfo, populateDiskInfo);
+      clusterModel.createBroker("r" + j, "h" + i, i, true, commonBrokerCapacityInfo, populateDiskInfo);
     }
 
     createReplicaAndSetLoad(clusterModel, "r0", 0, logdir(populateDiskInfo, 0, 0), T0P0, 0, true);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
@@ -204,7 +204,7 @@ public class RandomClusterTest {
       }
 
       BrokerCapacityInfo brokerCapacityInfo = new BrokerCapacityInfo(brokerCapacity);
-      clusterWithNewBroker.createBroker(b.rack().id(), Integer.toString(b.id()), b.id(), brokerCapacityInfo, false);
+      clusterWithNewBroker.createBroker(b.rack().id(), Integer.toString(b.id()), b.id(), true, brokerCapacityInfo, false);
     }
 
     for (Map.Entry<String, List<Partition>> entry : clusterModel.getPartitionsByTopic().entrySet()) {
@@ -230,6 +230,7 @@ public class RandomClusterTest {
       clusterWithNewBroker.createBroker(Integer.toString(i),
                                         Integer.toString(i + clusterModel.brokers().size() - 1),
                                         i + clusterModel.brokers().size() - 1,
+                                        true,
                                         commonBrokerCapacityInfo,
                                         false);
       clusterWithNewBroker.setBrokerState(i + clusterModel.brokers().size() - 1, Broker.State.NEW);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoalTest.java
@@ -228,10 +228,10 @@ public class KafkaAssignerDiskUsageDistributionGoalTest {
     BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY);
     int i = 0;
     for (; i < 2; i++) {
-      clusterModel.createBroker("r0", "h" + i, i, commonBrokerCapacityInfo, false);
+      clusterModel.createBroker("r0", "h" + i, i, true, commonBrokerCapacityInfo, false);
     }
     for (int j = 1; j < numRacks; j++, i++) {
-      clusterModel.createBroker("r" + j, "h" + i, i, commonBrokerCapacityInfo, false);
+      clusterModel.createBroker("r" + j, "h" + i, i, true, commonBrokerCapacityInfo, false);
     }
 
     clusterModel.createReplica("r0", 0, T0P0, 0, true);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/DeterministicCluster.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/DeterministicCluster.java
@@ -500,7 +500,7 @@ public class DeterministicCluster {
     BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(brokerCapacity, diskCapacityByLogDir);
     // Create brokers and assign a broker to each rack.
     rackByBroker.forEach(
-        (key, value) -> cluster.createBroker(value.toString(), Integer.toString(key), key, commonBrokerCapacityInfo, diskCapacityByLogDir != null));
+        (key, value) -> cluster.createBroker(value.toString(), Integer.toString(key), key, true, commonBrokerCapacityInfo, diskCapacityByLogDir != null));
     return cluster;
   }
 }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/RandomCluster.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/RandomCluster.java
@@ -69,13 +69,13 @@ public class RandomCluster {
     }
     // Create brokers and assign a broker to each rack.
     for (int i = 0; i < numRacks; i++) {
-      cluster.createBroker(Integer.toString(i), Integer.toString(i), i, configFileResolver.capacityForBroker("", "", i),
+      cluster.createBroker(Integer.toString(i), Integer.toString(i), i, true, configFileResolver.capacityForBroker("", "", i),
                            populateReplicaPlacementInfo);
     }
     // Assign the rest of the brokers over racks randomly.
     for (int i = numRacks; i < numBrokers; i++) {
       int randomRackId = uniformlyRandom(0, numRacks - 1, TestConstants.SEED_BASE + i);
-      cluster.createBroker(Integer.toString(randomRackId), Integer.toString(i), i, configFileResolver.capacityForBroker("", "", i),
+      cluster.createBroker(Integer.toString(randomRackId), Integer.toString(i), i, true, configFileResolver.capacityForBroker("", "", i),
                            populateReplicaPlacementInfo);
     }
     return cluster;

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicasTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicasTest.java
@@ -151,7 +151,7 @@ public class SortedReplicasTest {
   private static Broker generateBroker(int numReplicas) {
     Rack rack = new Rack("rack");
     Host host = new Host("host", rack);
-    Broker broker = new Broker(host, 0, new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY), false);
+    Broker broker = new Broker(host, 0, true, new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY), false);
 
     for (int i = 0; i < numReplicas; i++) {
       Replica r = new Replica(new TopicPartition(TOPIC0, i), broker, i % 3 == 0);


### PR DESCRIPTION
Addresses the issue #986 
