### PR TITLE
JWT Authentication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -220,6 +220,7 @@ project(':cruise-control') {
     compile 'com.google.code.gson:gson:2.8.6'
     compile 'org.eclipse.jetty:jetty-server:9.4.26.v20200117'
     compile 'io.dropwizard.metrics:metrics-core:3.2.6'
+    compile 'com.nimbusds:nimbus-jose-jwt:8.5'
     compile group: 'io.swagger.parser.v3', name: 'swagger-parser', version: '2.0.18'
     compile group: 'io.github.classgraph', name: 'classgraph', version: '4.8.65'
 
@@ -230,6 +231,7 @@ project(':cruise-control') {
     testCompile "org.apache.kafka:kafka_2.11:$kafkaVersion:test"
     testCompile "org.apache.kafka:kafka-clients:$kafkaVersion:test"
     testCompile 'commons-io:commons-io:2.6'
+    testCompile 'org.bouncycastle:bcpkix-jdk15on:1.64'
   }
 
   publishing {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -329,7 +329,7 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
       if (JwtSecurityProvider.class == securityProvider) {
         String providerUrl = getString(WebServerConfig.JWT_AUTHENTICATION_PROVIDER_URL_CONFIG);
         if (providerUrl == null || providerUrl.isEmpty()) {
-          throw new ConfigException(String.format("When %s is used, %s must be set",
+          throw new ConfigException(String.format("When %s is used, %s must be set.",
               JwtSecurityProvider.class.getName(), WebServerConfig.JWT_AUTHENTICATION_PROVIDER_URL_CONFIG));
         }
         String certificateFile = getString(WebServerConfig.JWT_AUTH_CERTIFICATE_LOCATION_CONFIG);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -320,7 +320,7 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
         throw new ConfigException(String.format("If webserver security is enabled, a valid security provider must be set " +
             "that is an implementation of %s.", SecurityProvider.class.getName()));
       }
-      String basicAuthCredentialsFile = getString(WebServerConfig.BASIC_AUTH_CREDENTIALS_FILE_CONFIG);
+      String basicAuthCredentialsFile = getString(WebServerConfig.WEBSERVER_AUTH_CREDENTIALS_FILE_CONFIG);
       if (BasicSecurityProvider.class.isAssignableFrom(securityProvider) && (basicAuthCredentialsFile == null
           || !Files.exists(Paths.get(basicAuthCredentialsFile)))) {
         throw new ConfigException(String.format("If %s is used, an existing credentials file must be set.",

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -23,6 +23,7 @@ import java.util.TreeSet;
 
 import com.linkedin.kafka.cruisecontrol.servlet.security.BasicSecurityProvider;
 import com.linkedin.kafka.cruisecontrol.servlet.security.SecurityProvider;
+import com.linkedin.kafka.cruisecontrol.servlet.security.jwt.JwtSecurityProvider;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import java.util.Map;
@@ -320,13 +321,33 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
         throw new ConfigException(String.format("If webserver security is enabled, a valid security provider must be set " +
             "that is an implementation of %s.", SecurityProvider.class.getName()));
       }
-      String basicAuthCredentialsFile = getString(WebServerConfig.WEBSERVER_AUTH_CREDENTIALS_FILE_CONFIG);
-      if (BasicSecurityProvider.class.isAssignableFrom(securityProvider) && (basicAuthCredentialsFile == null
-          || !Files.exists(Paths.get(basicAuthCredentialsFile)))) {
+      String authCredentialsFile = getString(WebServerConfig.WEBSERVER_AUTH_CREDENTIALS_FILE_CONFIG);
+      if (BasicSecurityProvider.class == securityProvider && !fileExists(authCredentialsFile)) {
         throw new ConfigException(String.format("If %s is used, an existing credentials file must be set.",
             BasicSecurityProvider.class.getName()));
       }
+      if (JwtSecurityProvider.class == securityProvider) {
+        String providerUrl = getString(WebServerConfig.JWT_AUTHENTICATION_PROVIDER_URL_CONFIG);
+        if (providerUrl == null || providerUrl.isEmpty()) {
+          throw new ConfigException(String.format("When %s is used, %s must be set",
+              JwtSecurityProvider.class.getName(), WebServerConfig.JWT_AUTHENTICATION_PROVIDER_URL_CONFIG));
+        }
+        String certificateFile = getString(WebServerConfig.JWT_AUTH_CERTIFICATE_LOCATION_CONFIG);
+        if (!fileExists(certificateFile)) {
+          throw new ConfigException(String.format("If %s is used, an existing certificate file must be set.",
+              JwtSecurityProvider.class.getName()));
+        }
+        String privilegesFile = getString(WebServerConfig.WEBSERVER_AUTH_CREDENTIALS_FILE_CONFIG);
+        if (!fileExists(privilegesFile)) {
+          throw new ConfigException(String.format("If %s is used, an existing certificate file must be set.",
+              JwtSecurityProvider.class.getName()));
+        }
+      }
     }
+  }
+
+  private boolean fileExists(String file) {
+    return file != null && Files.exists(Paths.get(file));
   }
 
   public KafkaCruiseControlConfig(Map<?, ?> originals) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/WebServerConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/WebServerConfig.java
@@ -174,13 +174,13 @@ public class WebServerConfig {
   private static final String WEBSERVER_SECURITY_ENABLE_DOCS = "Enables the use of authentication and authorization features.";
 
   /**
-   * <code>basic.auth.credentials.file</code>
+   * <code>webserver.auth.credentials.file</code>
    */
-  public static final String BASIC_AUTH_CREDENTIALS_FILE_CONFIG = "basic.auth.credentials.file";
+  public static final String WEBSERVER_AUTH_CREDENTIALS_FILE_CONFIG = "webserver.auth.credentials.file";
   public static final String DEFAULT_BASIC_AUTH_CREDENTIALS_FILE = "/etc/cruisecontrol-basic-auth.credentials";
-  private static final String BASIC_AUTH_CREDENTIALS_FILE_DOCS = "A file that contains credentials for basic authentication." +
-      "The format of the file is the following: username: password [,rolename ...] which corresponds to Jetty's " +
-      "HashLoginService's credentials file format.";
+  private static final String WEBSERVER_AUTH_CREDENTIALS_FILE_DOCS = "A file that contains credentials for authentication " +
+      "and roles for authorization. The format of the file is the following: username: password [,rolename ...] which " +
+      "corresponds to Jetty's HashLoginService's credentials file format.";
 
   /**
    * <code>webserver.ssl.enable</code>
@@ -225,6 +225,38 @@ public class WebServerConfig {
   public static final String WEBSERVER_SSL_PROTOCOL_CONFIG = "webserver.ssl.protocol";
   public static final String DEFAULT_WEBSERVER_SSL_PROTOCOL = "TLS";
   private static final String WEBSERVER_SSL_PROTOCOL_DOC = "Sets the SSL protocol to use. By default it's TLS.";
+
+  /**
+   * <code>jwt.authentication.provider.url</code>
+   */
+  public static final String JWT_AUTHENTICATION_PROVIDER_URL_CONFIG = "jwt.authentication.provider.url";
+  private static final String JWT_AUTHENTICATION_PROVIDER_URL_DOCS = "This is an endpoint of the token issuer. " +
+      "Requests without tokens will be redirected to this endpoint for authentication. The given url can contain " +
+      "the {redirectUrl} string which is an instruction to the authentication service to redirect to the original " +
+      "Cruise Control URL after a successful login. For instance www.my-auth.service.com/websso?origin={redirectUrl}.";
+
+  /**
+   * <code>jwt.cookie.name</code>
+   */
+  public static final String JWT_COOKIE_NAME_CONFIG = "jwt.cookie.name";
+  private static final String JWT_COOKIE_NAME_DOCS = "Cruise Control expects issued tokens to be forwarded in a cookie. " +
+      "This config specifies which one will contain the token.";
+
+  /**
+   * <code>jwt.auth.certificate.location</code>
+   */
+  public static final String JWT_AUTH_CERTIFICATE_LOCATION_CONFIG = "jwt.auth.certificate.location";
+  private static final String JWT_AUTH_CERTIFICATE_LOCATION_DOCS = "A private key is used to sign the JWT token by the " +
+      "authentication service and its public key pair is used to validate the signature in the token. This config points " +
+      "to the location of the file containing that public key.";
+
+  /**
+   * <code>jwt.expected.audiences</code>
+   */
+  public static final String JWT_EXPECTED_AUDIENCES_CONFIG = "jwt.expected.audiences";
+  private static final String JWT_EXPECTED_AUDIENCES_DOCS = "A comma separated list of audiences that Cruise Control accepts. " +
+      "Audience is a way for the issuer to indicate what entities the token is intended for. The default value is null, " +
+      "which means all audiences are accepted.";
 
   /**
    * Define configs for Web Server.
@@ -345,11 +377,11 @@ public class WebServerConfig {
                             DEFAULT_WEBSERVER_SECURITY_PROVIDER,
                             ConfigDef.Importance.MEDIUM,
                             WEBSERVER_SECURITY_PROVIDER_DOC)
-                    .define(BASIC_AUTH_CREDENTIALS_FILE_CONFIG,
+                    .define(WEBSERVER_AUTH_CREDENTIALS_FILE_CONFIG,
                             ConfigDef.Type.STRING,
                             DEFAULT_BASIC_AUTH_CREDENTIALS_FILE,
                             ConfigDef.Importance.MEDIUM,
-                            BASIC_AUTH_CREDENTIALS_FILE_DOCS)
+                        WEBSERVER_AUTH_CREDENTIALS_FILE_DOCS)
                     .define(WEBSERVER_SSL_ENABLE_CONFIG,
                             ConfigDef.Type.BOOLEAN,
                             DEFAULT_WEBSERVER_SSL_ENABLE,
@@ -379,6 +411,26 @@ public class WebServerConfig {
                             ConfigDef.Type.STRING,
                             DEFAULT_WEBSERVER_SSL_PROTOCOL,
                             ConfigDef.Importance.MEDIUM,
-                            WEBSERVER_SSL_PROTOCOL_DOC);
+                            WEBSERVER_SSL_PROTOCOL_DOC)
+                    .define(JWT_AUTHENTICATION_PROVIDER_URL_CONFIG,
+                            ConfigDef.Type.STRING,
+                            null,
+                            ConfigDef.Importance.MEDIUM,
+                            JWT_AUTHENTICATION_PROVIDER_URL_DOCS)
+                    .define(JWT_COOKIE_NAME_CONFIG,
+                            ConfigDef.Type.STRING,
+                            null,
+                            ConfigDef.Importance.MEDIUM,
+                            JWT_COOKIE_NAME_DOCS)
+                    .define(JWT_AUTH_CERTIFICATE_LOCATION_CONFIG,
+                            ConfigDef.Type.STRING,
+                            null,
+                            ConfigDef.Importance.MEDIUM,
+                            JWT_AUTH_CERTIFICATE_LOCATION_DOCS)
+                    .define(JWT_EXPECTED_AUDIENCES_CONFIG,
+                            ConfigDef.Type.LIST,
+                            null,
+                            ConfigDef.Importance.MEDIUM,
+                            JWT_EXPECTED_AUDIENCES_DOCS);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/WebServerConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/WebServerConfig.java
@@ -171,14 +171,14 @@ public class WebServerConfig {
    */
   public static final String WEBSERVER_SECURITY_ENABLE_CONFIG = "webserver.security.enable";
   public static final boolean DEFAULT_WEBSERVER_SECURITY_ENABLE = false;
-  private static final String WEBSERVER_SECURITY_ENABLE_DOCS = "Enables the use of authentication and authorization features.";
+  private static final String WEBSERVER_SECURITY_ENABLE_DOC = "Enables the use of authentication and authorization features.";
 
   /**
    * <code>webserver.auth.credentials.file</code>
    */
   public static final String WEBSERVER_AUTH_CREDENTIALS_FILE_CONFIG = "webserver.auth.credentials.file";
-  public static final String DEFAULT_BASIC_AUTH_CREDENTIALS_FILE = "/etc/cruisecontrol-basic-auth.credentials";
-  private static final String WEBSERVER_AUTH_CREDENTIALS_FILE_DOCS = "A file that contains credentials for authentication " +
+  public static final String DEFAULT_WEBSERVER_AUTH_CREDENTIALS_FILE = "/etc/cruisecontrol-basic-auth.credentials";
+  private static final String WEBSERVER_AUTH_CREDENTIALS_FILE_DOC = "A file that contains credentials for authentication " +
       "and roles for authorization. The format of the file is the following: username: password [,rolename ...] which " +
       "corresponds to Jetty's HashLoginService's credentials file format.";
 
@@ -230,7 +230,8 @@ public class WebServerConfig {
    * <code>jwt.authentication.provider.url</code>
    */
   public static final String JWT_AUTHENTICATION_PROVIDER_URL_CONFIG = "jwt.authentication.provider.url";
-  private static final String JWT_AUTHENTICATION_PROVIDER_URL_DOCS = "This is an endpoint of the token issuer. " +
+  public static final String DEFAULT_JWT_AUTHENTICATION_PROVIDER_URL = null;
+  private static final String JWT_AUTHENTICATION_PROVIDER_URL_DOC = "This is an endpoint of the token issuer. " +
       "Requests without tokens will be redirected to this endpoint for authentication. The given url can contain " +
       "the {redirectUrl} string which is an instruction to the authentication service to redirect to the original " +
       "Cruise Control URL after a successful login. For instance www.my-auth.service.com/websso?origin={redirectUrl}.";
@@ -239,14 +240,16 @@ public class WebServerConfig {
    * <code>jwt.cookie.name</code>
    */
   public static final String JWT_COOKIE_NAME_CONFIG = "jwt.cookie.name";
-  private static final String JWT_COOKIE_NAME_DOCS = "Cruise Control expects issued tokens to be forwarded in a cookie. " +
+  public static final String DEFAULT_JWT_COOKIE_NAME = null;
+  private static final String JWT_COOKIE_NAME_DOC = "Cruise Control expects issued tokens to be forwarded in a cookie. " +
       "This config specifies which one will contain the token.";
 
   /**
    * <code>jwt.auth.certificate.location</code>
    */
   public static final String JWT_AUTH_CERTIFICATE_LOCATION_CONFIG = "jwt.auth.certificate.location";
-  private static final String JWT_AUTH_CERTIFICATE_LOCATION_DOCS = "A private key is used to sign the JWT token by the " +
+  public static final String DEFAULT_JWT_AUTH_CERTIFICATE_LOCATION = null;
+  private static final String JWT_AUTH_CERTIFICATE_LOCATION_DOC = "A private key is used to sign the JWT token by the " +
       "authentication service and its public key pair is used to validate the signature in the token. This config points " +
       "to the location of the file containing that public key.";
 
@@ -254,7 +257,8 @@ public class WebServerConfig {
    * <code>jwt.expected.audiences</code>
    */
   public static final String JWT_EXPECTED_AUDIENCES_CONFIG = "jwt.expected.audiences";
-  private static final String JWT_EXPECTED_AUDIENCES_DOCS = "A comma separated list of audiences that Cruise Control accepts. " +
+  public static final String DEFAULT_JWT_EXPECTED_AUDIENCES = null;
+  private static final String JWT_EXPECTED_AUDIENCES_DOC = "A comma separated list of audiences that Cruise Control accepts. " +
       "Audience is a way for the issuer to indicate what entities the token is intended for. The default value is null, " +
       "which means all audiences are accepted.";
 
@@ -371,7 +375,7 @@ public class WebServerConfig {
                             ConfigDef.Type.BOOLEAN,
                             DEFAULT_WEBSERVER_SECURITY_ENABLE,
                             ConfigDef.Importance.MEDIUM,
-                            WEBSERVER_SECURITY_ENABLE_DOCS)
+                            WEBSERVER_SECURITY_ENABLE_DOC)
                     .define(WEBSERVER_SECURITY_PROVIDER_CONFIG,
                             ConfigDef.Type.CLASS,
                             DEFAULT_WEBSERVER_SECURITY_PROVIDER,
@@ -379,9 +383,9 @@ public class WebServerConfig {
                             WEBSERVER_SECURITY_PROVIDER_DOC)
                     .define(WEBSERVER_AUTH_CREDENTIALS_FILE_CONFIG,
                             ConfigDef.Type.STRING,
-                            DEFAULT_BASIC_AUTH_CREDENTIALS_FILE,
+                            DEFAULT_WEBSERVER_AUTH_CREDENTIALS_FILE,
                             ConfigDef.Importance.MEDIUM,
-                        WEBSERVER_AUTH_CREDENTIALS_FILE_DOCS)
+                            WEBSERVER_AUTH_CREDENTIALS_FILE_DOC)
                     .define(WEBSERVER_SSL_ENABLE_CONFIG,
                             ConfigDef.Type.BOOLEAN,
                             DEFAULT_WEBSERVER_SSL_ENABLE,
@@ -414,23 +418,23 @@ public class WebServerConfig {
                             WEBSERVER_SSL_PROTOCOL_DOC)
                     .define(JWT_AUTHENTICATION_PROVIDER_URL_CONFIG,
                             ConfigDef.Type.STRING,
-                            null,
+                            DEFAULT_JWT_AUTHENTICATION_PROVIDER_URL,
                             ConfigDef.Importance.MEDIUM,
-                            JWT_AUTHENTICATION_PROVIDER_URL_DOCS)
+                            JWT_AUTHENTICATION_PROVIDER_URL_DOC)
                     .define(JWT_COOKIE_NAME_CONFIG,
                             ConfigDef.Type.STRING,
-                            null,
+                            DEFAULT_JWT_COOKIE_NAME,
                             ConfigDef.Importance.MEDIUM,
-                            JWT_COOKIE_NAME_DOCS)
+                            JWT_COOKIE_NAME_DOC)
                     .define(JWT_AUTH_CERTIFICATE_LOCATION_CONFIG,
                             ConfigDef.Type.STRING,
-                            null,
+                            DEFAULT_JWT_AUTH_CERTIFICATE_LOCATION,
                             ConfigDef.Importance.MEDIUM,
-                            JWT_AUTH_CERTIFICATE_LOCATION_DOCS)
+                            JWT_AUTH_CERTIFICATE_LOCATION_DOC)
                     .define(JWT_EXPECTED_AUDIENCES_CONFIG,
                             ConfigDef.Type.LIST,
-                            null,
+                            DEFAULT_JWT_EXPECTED_AUDIENCES,
                             ConfigDef.Importance.MEDIUM,
-                            JWT_EXPECTED_AUDIENCES_DOCS);
+                            JWT_EXPECTED_AUDIENCES_DOC);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/BasicSecurityProvider.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/BasicSecurityProvider.java
@@ -11,6 +11,8 @@ import org.eclipse.jetty.security.HashLoginService;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
 
+import javax.servlet.ServletException;
+
 /**
  * This class defines a HTTP Basic authenticator with a file based {@link HashLoginService} and uses the default
  * Cruise Control role structure.
@@ -20,9 +22,9 @@ public class BasicSecurityProvider extends DefaultRoleSecurityProvider {
   private String _userCredentialsFile;
 
   @Override
-  public void init(KafkaCruiseControlConfig config) {
+  public void init(KafkaCruiseControlConfig config) throws ServletException {
     super.init(config);
-    this._userCredentialsFile = config.getString(WebServerConfig.BASIC_AUTH_CREDENTIALS_FILE_CONFIG);
+    this._userCredentialsFile = config.getString(WebServerConfig.WEBSERVER_AUTH_CREDENTIALS_FILE_CONFIG);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/BasicSecurityProvider.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/BasicSecurityProvider.java
@@ -11,8 +11,6 @@ import org.eclipse.jetty.security.HashLoginService;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
 
-import javax.servlet.ServletException;
-
 /**
  * This class defines a HTTP Basic authenticator with a file based {@link HashLoginService} and uses the default
  * Cruise Control role structure.
@@ -22,7 +20,7 @@ public class BasicSecurityProvider extends DefaultRoleSecurityProvider {
   private String _userCredentialsFile;
 
   @Override
-  public void init(KafkaCruiseControlConfig config) throws ServletException {
+  public void init(KafkaCruiseControlConfig config) {
     super.init(config);
     this._userCredentialsFile = config.getString(WebServerConfig.WEBSERVER_AUTH_CREDENTIALS_FILE_CONFIG);
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/DefaultRoleSecurityProvider.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/DefaultRoleSecurityProvider.java
@@ -10,7 +10,6 @@ import com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.util.security.Constraint;
 
-import javax.servlet.ServletException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -40,7 +39,7 @@ public abstract class DefaultRoleSecurityProvider implements SecurityProvider {
   private String _webServerApiUrlPrefix;
 
   @Override
-  public void init(KafkaCruiseControlConfig config) throws ServletException {
+  public void init(KafkaCruiseControlConfig config) {
     this._webServerApiUrlPrefix = config.getString(WebServerConfig.WEBSERVER_API_URLPREFIX_CONFIG);
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/DefaultRoleSecurityProvider.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/DefaultRoleSecurityProvider.java
@@ -10,6 +10,7 @@ import com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.util.security.Constraint;
 
+import javax.servlet.ServletException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,7 +40,7 @@ public abstract class DefaultRoleSecurityProvider implements SecurityProvider {
   private String _webServerApiUrlPrefix;
 
   @Override
-  public void init(KafkaCruiseControlConfig config) {
+  public void init(KafkaCruiseControlConfig config) throws ServletException {
     this._webServerApiUrlPrefix = config.getString(WebServerConfig.WEBSERVER_API_URLPREFIX_CONFIG);
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/UserStoreAuthorizationService.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/UserStoreAuthorizationService.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.security;
+
+import org.eclipse.jetty.security.PropertyUserStore;
+import org.eclipse.jetty.security.UserStore;
+import org.eclipse.jetty.security.authentication.AuthorizationService;
+import org.eclipse.jetty.server.UserIdentity;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Can be used for authorization scenarios where a file can be created in a secure location with a relatively
+ * low amount of users. It follows the <code>username: password [,rolename ...]</code> format which corresponds to
+ * the format used with {@link org.eclipse.jetty.security.HashLoginService}.
+ */
+public class UserStoreAuthorizationService extends AbstractLifeCycle implements AuthorizationService {
+
+  private final UserStore _userStore;
+
+  public UserStoreAuthorizationService(String privilegesFilePath) {
+    this(userStoreFromFile(privilegesFilePath));
+  }
+
+  public UserStoreAuthorizationService(UserStore userStore) {
+    _userStore = userStore;
+  }
+
+  @Override
+  public UserIdentity getUserIdentity(HttpServletRequest request, String name) {
+    return _userStore.getUserIdentity(name);
+  }
+
+  @Override
+  protected void doStart() throws Exception {
+    super.doStart();
+    _userStore.start();
+  }
+
+  @Override
+  protected void doStop() throws Exception {
+    _userStore.stop();
+    super.doStop();
+  }
+
+  private static UserStore userStoreFromFile(String privilegesFilePath) {
+    PropertyUserStore userStore = new PropertyUserStore();
+    userStore.setConfig(privilegesFilePath);
+    return userStore;
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/UserStoreAuthorizationService.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/UserStoreAuthorizationService.java
@@ -14,7 +14,7 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * Can be used for authorization scenarios where a file can be created in a secure location with a relatively
- * low amount of users. It follows the <code>username: password [,rolename ...]</code> format which corresponds to
+ * low number of users. It follows the <code>username: password [,rolename ...]</code> format which corresponds to
  * the format used with {@link org.eclipse.jetty.security.HashLoginService}.
  */
 public class UserStoreAuthorizationService extends AbstractLifeCycle implements AuthorizationService {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtAuthenticator.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtAuthenticator.java
@@ -55,7 +55,7 @@ public class JwtAuthenticator extends LoginAuthenticator {
   static final Logger JWT_LOGGER = LoggerFactory.getLogger("kafka.cruisecontrol.jwt.logger");
 
   private static final String METHOD = "JWT";
-  private static final String BEARER = "Bearer ";
+  private static final String BEARER = "Bearer";
 
   private final String _cookieName;
   private final Function<HttpServletRequest, String> _authenticationProviderUrlGenerator;
@@ -161,7 +161,7 @@ public class JwtAuthenticator extends LoginAuthenticator {
     if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER)) {
       return null;
     } else {
-      return authorizationHeader.substring(BEARER.length());
+      return authorizationHeader.substring(BEARER.length()).trim();
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtAuthenticator.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtAuthenticator.java
@@ -7,6 +7,7 @@ package com.linkedin.kafka.cruisecontrol.servlet.security.jwt;
 import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.security.ServerAuthException;
 import org.eclipse.jetty.security.UserAuthentication;
 import org.eclipse.jetty.security.authentication.LoginAuthenticator;
@@ -123,6 +124,7 @@ public class JwtAuthenticator extends LoginAuthenticator {
         request.setAttribute(JWT_TOKEN_REQUEST_ATTRIBUTE, serializedJWT);
         UserIdentity identity = login(userName, jwtToken, request);
         if (identity == null) {
+          ((HttpServletResponse) response).setStatus(HttpStatus.UNAUTHORIZED_401);
           return Authentication.SEND_FAILURE;
         } else {
           return new UserAuthentication(getAuthMethod(), identity);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtAuthenticator.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtAuthenticator.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.security.jwt;
+
+import com.nimbusds.jwt.SignedJWT;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.security.ServerAuthException;
+import org.eclipse.jetty.security.UserAuthentication;
+import org.eclipse.jetty.security.authentication.LoginAuthenticator;
+import org.eclipse.jetty.server.Authentication;
+import org.eclipse.jetty.server.UserIdentity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.function.Function;
+
+/**
+ * <p>The {@link JwtAuthenticator} adds SSO capabilites to Cruise Control. The expected token is a Json Web Token (JWT).
+ * This class should be used with {@link JwtLoginService} as the token check is carried out by that one. This class
+ * handles redirects for unauthenticated requests and CORS preflight requests.</p>
+ * <p>The workflow can be described with the following diagram:
+ * <pre>
+ *       Client -----1., 4.----> Cruise Control
+ *        |  ^                        |
+ *        |  |________2.______________|
+ *        |
+ *        |
+ *        |------3.------------> Authentication
+ *                                 provider
+ * </pre>
+ * <ol>
+ * <li>The client makes an initial call to Cruise Control
+ * <li>If the request doesn't have a JWT cookie by the specified cookie name, it will be redirected to the authentication
+ *     service to obtain it. If the request is an OPTIONS request we presume it's a CORS preflight request so it'll skip
+ *     the authentication (if the user is authenticated at this point we'll use the existing credentials).
+ * <li>The client authenticates with the provider and obtains the SSO token.
+ * <li>The client can present the JWT cookie to Cruise Control. Cruise Control will validate the cookie with the
+ *    {@link JwtLoginService} by checking its signature, audience and expiration.
+ * </ol>
+ * </p>
+ */
+public class JwtAuthenticator extends LoginAuthenticator {
+
+  public static final String JWT_TOKEN_REQUEST_ATTRIBUTE = "com.linkedin.kafka.cruisecontrol.JwtTokenAttribute";
+  static final Logger JWT_LOGGER = LoggerFactory.getLogger("kafka.cruisecontrol.jwt.logger");
+
+  private static final String METHOD = "JWT";
+  private static final String BEARER = "Bearer ";
+
+  private final String _cookieName;
+  private final Function<HttpServletRequest, String> _authenticationProviderUrlGenerator;
+
+  /**
+   * Creates a new {@link JwtAuthenticator} instance with a custom authentication provider url and a cookie name that
+   * will be populated by the authentication service with the JWT token.
+   * @param authenticationProviderUrl is the HTTP(S) address of the authentication service. It will be used to create
+   *                                  the redirection url. For instance <code>https://www.my-auth-service.com/websso?origin={redirectUrl}</code>
+   *                                  will generate <code>https://www.my-auth-service.com/websso?origin=https://www.cruise-control.cc/state</code>
+   *                                  which should redirect from <code>my-auth-service.com</code> to <code>cruise-control.cc/state</code>
+   *                                  after obtaining the JWT token.
+   * @param cookieName is the cookie name which will contain the cookie obtained from the authentication service.
+   *                   <code>null</code> is an acceptable value when the token is always returned
+   */
+  public JwtAuthenticator(String authenticationProviderUrl, String cookieName) {
+    _cookieName = cookieName;
+    Function<String, Function<HttpServletRequest, String>> urlGen =
+        url -> req -> url.replace("{redirectUrl}", req.getRequestURL().toString() + getOriginalQueryString(req));
+    _authenticationProviderUrlGenerator = urlGen.apply(authenticationProviderUrl);
+  }
+
+  @Override
+  public String getAuthMethod() {
+    return METHOD;
+  }
+
+  @Override
+  public void prepareRequest(ServletRequest request) {
+
+  }
+
+  @Override
+  public Authentication validateRequest(ServletRequest request, ServletResponse response, boolean mandatory) throws ServerAuthException {
+    JWT_LOGGER.trace("Authentication request received for " + request.toString());
+    if (!(request instanceof HttpServletRequest) && !(response instanceof HttpServletResponse)) {
+      return Authentication.UNAUTHENTICATED;
+    }
+
+    String serializedJWT;
+    HttpServletRequest req = (HttpServletRequest) request;
+    // we'll skip the authentication for CORS preflight requests
+    if (HttpMethod.OPTIONS.name().toLowerCase().equals(req.getMethod().toLowerCase())) {
+      return Authentication.NOT_CHECKED;
+    }
+    serializedJWT = getJwtFromBearerAuthorization(req);
+    if (serializedJWT == null) {
+      serializedJWT = getJwtFromCookie(req);
+    }
+    if (serializedJWT == null) {
+      String loginURL = _authenticationProviderUrlGenerator.apply(req);
+      JWT_LOGGER.info("No JWT token found, sending redirect to " + loginURL);
+      try {
+        ((HttpServletResponse) response).sendRedirect(loginURL);
+        return Authentication.SEND_CONTINUE;
+      } catch (IOException e) {
+        JWT_LOGGER.error("Couldn't authenticate request", e);
+        throw new ServerAuthException(e);
+      }
+    } else {
+      try {
+        SignedJWT jwtToken = SignedJWT.parse(serializedJWT);
+        String userName = jwtToken.getJWTClaimsSet().getSubject();
+        request.setAttribute(JWT_TOKEN_REQUEST_ATTRIBUTE, serializedJWT);
+        UserIdentity identity = login(userName, jwtToken, request);
+        return new UserAuthentication(getAuthMethod(), identity);
+      } catch (ParseException pe) {
+        String loginURL = _authenticationProviderUrlGenerator.apply(req);
+        JWT_LOGGER.warn("Unable to parse the JWT token, redirecting back to the login page", pe);
+        try {
+          ((HttpServletResponse) response).sendRedirect(loginURL);
+        } catch (IOException e) {
+          throw new ServerAuthException(e);
+        }
+      }
+    }
+
+    return Authentication.SEND_FAILURE;
+  }
+
+  @Override
+  public boolean secureResponse(ServletRequest request, ServletResponse response, boolean mandatory, Authentication.User validatedUser) {
+    return true;
+  }
+
+  String getJwtFromCookie(HttpServletRequest req) {
+    String serializedJWT = null;
+    Cookie[] cookies = req.getCookies();
+    if (cookies != null) {
+      for (Cookie cookie : cookies) {
+        if (_cookieName != null && _cookieName.equals(cookie.getName())) {
+          JWT_LOGGER.trace(_cookieName + " cookie has been found and is being processed");
+          serializedJWT = cookie.getValue();
+          break;
+        }
+      }
+    }
+    return serializedJWT;
+  }
+
+  String getJwtFromBearerAuthorization(HttpServletRequest req) {
+    String authorizationHeader = req.getHeader(HttpHeader.AUTHORIZATION.asString());
+    if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER)) {
+      return null;
+    } else {
+      return authorizationHeader.substring(BEARER.length());
+    }
+  }
+
+  private String getOriginalQueryString(HttpServletRequest request) {
+    String originalQueryString = request.getQueryString();
+    return (originalQueryString == null) ? "" : "?" + originalQueryString;
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtLoginService.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtLoginService.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.security.jwt;
+
+import com.linkedin.kafka.cruisecontrol.servlet.security.UserStoreAuthorizationService;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSObject;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jwt.SignedJWT;
+import org.eclipse.jetty.security.DefaultIdentityService;
+import org.eclipse.jetty.security.IdentityService;
+import org.eclipse.jetty.security.LoginService;
+import org.eclipse.jetty.security.authentication.AuthorizationService;
+import org.eclipse.jetty.server.UserIdentity;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.eclipse.jetty.util.component.LifeCycle;
+
+import javax.security.auth.Subject;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.List;
+
+import static com.linkedin.kafka.cruisecontrol.servlet.security.jwt.JwtAuthenticator.JWT_LOGGER;
+
+/**
+ * <p>This class validates a JWT token. The token must be cryptographically encrypted an It uses an RSA public key for
+ * validation that is expected to be stored in a PEM formatted file.</p>
+ * <p>This class implements {@link AbstractLifeCycle} which means it is a managed bean, its lifecycle will be managed
+ * by Jetty. It's {@link AuthorizationService} can also be an {@link AbstractLifeCycle} in which case it delegates to
+ * this class, so opening and closing connections should be done by implementing the {@link AbstractLifeCycle} interface's
+ * {@link #doStart()} and {@link #doStop()} methods respectively. For a simple example see
+ * {@link UserStoreAuthorizationService}.</p>
+ */
+public class JwtLoginService extends AbstractLifeCycle implements LoginService {
+
+  private final AuthorizationService _authorizationService;
+  private IdentityService _identityService = new DefaultIdentityService();
+  private final RSAPublicKey _publicKey;
+  private final List<String> _audiences;
+
+  public JwtLoginService(AuthorizationService authorizationService, String publicKeyLocation, List<String> audiences)
+      throws IOException, CertificateException {
+    this(authorizationService, readPublicKey(publicKeyLocation), audiences);
+  }
+
+  public JwtLoginService(AuthorizationService authorizationService, RSAPublicKey publicKey, List<String> audiences) {
+    _authorizationService = authorizationService;
+    _publicKey = publicKey;
+    _audiences = audiences;
+  }
+
+  @Override
+  protected void doStart() throws Exception {
+    super.doStart();
+    // The authorization service might want to start a connection or access a file
+    if (_authorizationService instanceof LifeCycle) {
+      ((LifeCycle) _authorizationService).start();
+    }
+  }
+
+  @Override
+  protected void doStop() throws Exception {
+    if (_authorizationService instanceof LifeCycle) {
+      ((LifeCycle) _authorizationService).stop();
+    }
+    super.doStop();
+  }
+
+  @Override
+  public String getName() {
+    return null;
+  }
+
+  @Override
+  public UserIdentity login(String username, Object credentials, ServletRequest request) {
+    if (!(credentials instanceof SignedJWT)) {
+      return null;
+    }
+    if (!(request instanceof HttpServletRequest)) {
+      return null;
+    }
+
+    SignedJWT jwtToken = (SignedJWT) credentials;
+    boolean valid;
+    try {
+      valid = validateToken(jwtToken, username);
+    } catch (ParseException e) {
+      JWT_LOGGER.warn(String.format("%s: Couldn't parse a JWT token", username), e);
+      return null;
+    }
+    if (valid) {
+      String serializedToken = (String) request.getAttribute(JwtAuthenticator.JWT_TOKEN_REQUEST_ATTRIBUTE);
+      UserIdentity rolesDelegate = _authorizationService.getUserIdentity((HttpServletRequest) request, username);
+      return getUserIdentity(jwtToken, serializedToken, username, rolesDelegate);
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public boolean validate(UserIdentity user) {
+    return false;
+  }
+
+  @Override
+  public IdentityService getIdentityService() {
+    return _identityService;
+  }
+
+  @Override
+  public void setIdentityService(IdentityService service) {
+    _identityService = service;
+  }
+
+  @Override
+  public void logout(UserIdentity user) {
+
+  }
+
+  private boolean validateToken(SignedJWT jwtToken, String username) throws ParseException {
+    boolean sigValid = validateSignature(jwtToken);
+    if (!sigValid) {
+      JWT_LOGGER.warn(String.format("%s: Signature could not be verified", username));
+    }
+    boolean audValid = validateAudiences(jwtToken);
+    if (!audValid) {
+      JWT_LOGGER.warn(String.format("%s: Audience validation failed", username));
+    }
+    boolean expValid = validateExpiration(jwtToken);
+    if (!expValid) {
+      JWT_LOGGER.warn(String.format("%s: Expiration validation failed", username));
+    }
+
+    return sigValid && audValid && expValid;
+  }
+
+  private boolean validateSignature(SignedJWT jwtToken) {
+    if (JWSObject.State.SIGNED != jwtToken.getState() || jwtToken.getSignature() == null) {
+      return false;
+    }
+    JWSVerifier verifier = new RSASSAVerifier(_publicKey);
+    try {
+      return jwtToken.verify(verifier);
+    } catch (JOSEException e) {
+      JWT_LOGGER.warn("Couldn't verify the signature of a token", e);
+      return false;
+    }
+  }
+
+  private boolean validateAudiences(SignedJWT jwtToken) throws ParseException {
+    if (_audiences == null) {
+      return true;
+    }
+    List<String> tokenAudienceList = jwtToken.getJWTClaimsSet().getAudience();
+    for (String aud : tokenAudienceList) {
+      if (_audiences.contains(aud)) {
+        JWT_LOGGER.trace("JWT token audience has been successfully validated");
+        return true;
+      }
+    }
+    JWT_LOGGER.trace("Couldn't find a valid audience");
+    return false;
+  }
+
+  private static RSAPublicKey readPublicKey(String location) throws CertificateException, IOException {
+    byte[] publicKeyBytes = Files.readAllBytes(Paths.get(location));
+    CertificateFactory fact = CertificateFactory.getInstance("X.509");
+    X509Certificate cer = (X509Certificate) fact.generateCertificate(new ByteArrayInputStream(publicKeyBytes));
+    return (RSAPublicKey) cer.getPublicKey();
+  }
+
+  private static boolean validateExpiration(SignedJWT jwtToken) throws ParseException {
+    Date expires = jwtToken.getJWTClaimsSet().getExpirationTime();
+    return expires == null || new Date().before(expires);
+  }
+
+  private static UserIdentity getUserIdentity(SignedJWT jwtToken, String serializedToken, String username, UserIdentity rolesDelegate) {
+    JwtUserPrincipal principal = new JwtUserPrincipal(username, serializedToken);
+    Subject subject = new Subject();
+    subject.getPrincipals().add(principal);
+    subject.getPrivateCredentials(SignedJWT.class).add(jwtToken);
+    return new JwtUserIdentity(subject, principal, rolesDelegate);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtSecurityProvider.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtSecurityProvider.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.security.jwt;
+
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
+import com.linkedin.kafka.cruisecontrol.config.constants.WebServerConfig;
+import com.linkedin.kafka.cruisecontrol.servlet.security.DefaultRoleSecurityProvider;
+import com.linkedin.kafka.cruisecontrol.servlet.security.UserStoreAuthorizationService;
+import org.eclipse.jetty.security.Authenticator;
+import org.eclipse.jetty.security.LoginService;
+import org.eclipse.jetty.security.authentication.AuthorizationService;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.security.cert.CertificateException;
+import java.util.List;
+
+/**
+ * A security provider implementation for JWT based authentication. It has to be configured with
+ * <ul>
+ *   <li>{@link WebServerConfig#JWT_AUTHENTICATION_PROVIDER_URL_CONFIG} that is the url of the token issuer,
+ *   <li>{@link WebServerConfig#JWT_COOKIE_NAME_CONFIG} that is the name of the cookie that contains the issued token
+ *   <li>{@link WebServerConfig#JWT_AUTH_CERTIFICATE_LOCATION_CONFIG} which is shared by the issuer to validate tokens
+ *   <li>{@link WebServerConfig#JWT_EXPECTED_AUDIENCES_CONFIG} which is the expected audiences of the token (so a token
+ *   will be rejected if it contains anything other than what is listed here)
+ *   <li>{@link WebServerConfig#WEBSERVER_AUTH_CREDENTIALS_FILE_CONFIG} which contains the username-role associations
+ *   without any passwords.
+ * </ul>
+ */
+public class JwtSecurityProvider extends DefaultRoleSecurityProvider {
+
+  private String _authenticationProviderUrl;
+  private String _cookieName;
+  private String _publicKeyLocation;
+  private String _privilegesFilePath;
+  private List<String> _audiences;
+
+  @Override
+  public void init(KafkaCruiseControlConfig config) throws ServletException {
+    super.init(config);
+    _authenticationProviderUrl = config.getString(WebServerConfig.JWT_AUTHENTICATION_PROVIDER_URL_CONFIG);
+    _cookieName = config.getString(WebServerConfig.JWT_COOKIE_NAME_CONFIG);
+    _publicKeyLocation = config.getString(WebServerConfig.JWT_AUTH_CERTIFICATE_LOCATION_CONFIG);
+    _audiences = config.getList(WebServerConfig.JWT_EXPECTED_AUDIENCES_CONFIG);
+    _privilegesFilePath = config.getString(WebServerConfig.WEBSERVER_AUTH_CREDENTIALS_FILE_CONFIG);
+  }
+
+  @Override
+  public LoginService loginService() throws ServletException {
+    try {
+      return new JwtLoginService(authorizationService(), _publicKeyLocation, _audiences);
+    } catch (IOException | CertificateException e) {
+      throw new ServletException(e);
+    }
+  }
+
+  @Override
+  public Authenticator authenticator() {
+    return new JwtAuthenticator(_authenticationProviderUrl, _cookieName);
+  }
+
+  public AuthorizationService authorizationService() {
+    return new UserStoreAuthorizationService(_privilegesFilePath);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtSecurityProvider.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtSecurityProvider.java
@@ -38,7 +38,7 @@ public class JwtSecurityProvider extends DefaultRoleSecurityProvider {
   private List<String> _audiences;
 
   @Override
-  public void init(KafkaCruiseControlConfig config) throws ServletException {
+  public void init(KafkaCruiseControlConfig config) {
     super.init(config);
     _authenticationProviderUrl = config.getString(WebServerConfig.JWT_AUTHENTICATION_PROVIDER_URL_CONFIG);
     _cookieName = config.getString(WebServerConfig.JWT_COOKIE_NAME_CONFIG);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtUserIdentity.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtUserIdentity.java
@@ -11,9 +11,9 @@ import java.security.Principal;
 
 public class JwtUserIdentity implements UserIdentity {
 
-  private Subject _subject;
-  private Principal _principal;
-  private UserIdentity _roleDelegate;
+  private final Subject _subject;
+  private final Principal _principal;
+  private final UserIdentity _roleDelegate;
 
   JwtUserIdentity(Subject subject, Principal principal, UserIdentity roleDelegate) {
     _subject = subject;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtUserIdentity.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtUserIdentity.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.security.jwt;
+
+import org.eclipse.jetty.server.UserIdentity;
+
+import javax.security.auth.Subject;
+import java.security.Principal;
+
+public class JwtUserIdentity implements UserIdentity {
+
+  private Subject _subject;
+  private Principal _principal;
+  private UserIdentity _roleDelegate;
+
+  JwtUserIdentity(Subject subject, Principal principal, UserIdentity roleDelegate) {
+    _subject = subject;
+    _principal = principal;
+    _roleDelegate = roleDelegate;
+  }
+
+  @Override
+  public Subject getSubject() {
+    return _subject;
+  }
+
+  @Override
+  public Principal getUserPrincipal() {
+    return _principal;
+  }
+
+  @Override
+  public boolean isUserInRole(String role, Scope scope) {
+    return _roleDelegate != null && _roleDelegate.isUserInRole(role, scope);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtUserIdentity.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtUserIdentity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
  */
 
 package com.linkedin.kafka.cruisecontrol.servlet.security.jwt;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtUserPrincipal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtUserPrincipal.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.security.jwt;
+
+import java.security.Principal;
+
+public class JwtUserPrincipal implements Principal {
+
+  private String _username;
+  private String _serializedToken;
+
+  JwtUserPrincipal(String username, String serializedToken) {
+    _username = username;
+    _serializedToken = serializedToken;
+  }
+
+  @Override
+  public String getName() {
+    return _username;
+  }
+
+  public String getSerializedToken() {
+    return _serializedToken;
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtUserPrincipal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtUserPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
  */
 
 package com.linkedin.kafka.cruisecontrol.servlet.security.jwt;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtUserPrincipal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtUserPrincipal.java
@@ -8,8 +8,8 @@ import java.security.Principal;
 
 public class JwtUserPrincipal implements Principal {
 
-  private String _username;
-  private String _serializedToken;
+  private final String _username;
+  private final String _serializedToken;
 
   JwtUserPrincipal(String username, String serializedToken) {
     _username = username;

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/CruiseControlIntegrationTestHarness.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/CruiseControlIntegrationTestHarness.java
@@ -10,8 +10,6 @@ import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCEmbeddedBroker;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaIntegrationTestHarness;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.KafkaSampleStore;
-import org.junit.After;
-import org.junit.Before;
 
 import java.util.Map;
 import java.util.Properties;
@@ -40,7 +38,6 @@ public abstract class CruiseControlIntegrationTestHarness extends CCKafkaIntegra
    * Starts up an embedded Cruise Control environment with Zookeeper, Kafka brokers and a Cruise Control instance.
    * @throws Exception
    */
-  @Before
   public void start() throws Exception {
     super.setUp();
     _brokers.values().forEach(CCEmbeddedBroker::startup);
@@ -53,7 +50,6 @@ public abstract class CruiseControlIntegrationTestHarness extends CCKafkaIntegra
    * Shuts down the CruiseControl instance, Kafka brokers and the Zookeeper instance.
    * @throws Exception
    */
-  @After
   public void stop() {
     if (_app != null) {
       _app.stop();

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/SecurityAndSslConfigTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/SecurityAndSslConfigTest.java
@@ -117,7 +117,7 @@ public class SecurityAndSslConfigTest {
     expect(config.getBoolean(WebServerConfig.WEBSERVER_SSL_ENABLE_CONFIG)).andReturn(false);
     expect(config.getBoolean(WebServerConfig.WEBSERVER_SECURITY_ENABLE_CONFIG)).andReturn(true);
     expect(config.getClass(WebServerConfig.WEBSERVER_SECURITY_PROVIDER_CONFIG)).andReturn((Class) BasicSecurityProvider.class);
-    expect(config.getString(WebServerConfig.BASIC_AUTH_CREDENTIALS_FILE_CONFIG))
+    expect(config.getString(WebServerConfig.WEBSERVER_AUTH_CREDENTIALS_FILE_CONFIG))
         .andReturn(getClass().getClassLoader().getResource("basic-auth.credentials").getPath());
 
     replay(config);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/AuthenticationIntegrationTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/AuthenticationIntegrationTest.java
@@ -19,6 +19,8 @@ import org.eclipse.jetty.security.authentication.BasicAuthenticator;
 import org.eclipse.jetty.server.UserIdentity;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Credential;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import javax.security.auth.Subject;
@@ -47,6 +49,16 @@ public class AuthenticationIntegrationTest extends CruiseControlIntegrationTestH
   private static final String ADMIN_ROLE = "admin";
   private static final String CRUISE_CONTROL_STATE_ENDPOINT = "kafkacruisecontrol/" + STATE;
   private static final String ANY_PATH = "/*";
+
+  @Before
+  public void setup() throws Exception {
+    super.start();
+  }
+
+  @After
+  public void teardown() {
+    super.stop();
+  }
 
   @Override
   protected Map<String, Object> withConfigs() {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/BasicAuthenticationIntegrationTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/BasicAuthenticationIntegrationTest.java
@@ -7,6 +7,8 @@ package com.linkedin.kafka.cruisecontrol.servlet.security;
 import com.linkedin.kafka.cruisecontrol.CruiseControlIntegrationTestHarness;
 import com.linkedin.kafka.cruisecontrol.config.constants.WebServerConfig;
 import org.eclipse.jetty.http.HttpHeader;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import javax.servlet.http.HttpServletResponse;
@@ -29,11 +31,21 @@ public class BasicAuthenticationIntegrationTest extends CruiseControlIntegration
   private static final String CRUISE_CONTROL_STATE_ENDPOINT = "kafkacruisecontrol/" + STATE;
   private static final String CRUISE_CONTROL_PAUSE_SAMPLING_ENDPOINT = "kafkacruisecontrol/" + STOP_PROPOSAL_EXECUTION;
 
+  @Before
+  public void setup() throws Exception {
+    super.start();
+  }
+
+  @After
+  public void teardown() {
+    super.stop();
+  }
+
   @Override
   protected Map<String, Object> withConfigs() {
     Map<String, Object> configs = new HashMap<>();
     configs.put(WebServerConfig.WEBSERVER_SECURITY_ENABLE_CONFIG, true);
-    configs.put(WebServerConfig.BASIC_AUTH_CREDENTIALS_FILE_CONFIG,
+    configs.put(WebServerConfig.WEBSERVER_AUTH_CREDENTIALS_FILE_CONFIG,
         Objects.requireNonNull(this.getClass().getClassLoader().getResource("basic-auth.credentials")).getPath());
     return configs;
   }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/SslConnectionIntegrationTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/SslConnectionIntegrationTest.java
@@ -6,6 +6,8 @@ package com.linkedin.kafka.cruisecontrol.servlet.security;
 
 import com.linkedin.kafka.cruisecontrol.CruiseControlIntegrationTestHarness;
 import com.linkedin.kafka.cruisecontrol.config.constants.WebServerConfig;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -21,13 +23,24 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import static com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint.STATE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class SslConnectionIntegrationTest extends CruiseControlIntegrationTestHarness {
 
-  private static final String CRUISE_CONTROL_STATE_ENDPOINT = "kafkacruisecontrol/state";
+  private static final String CRUISE_CONTROL_STATE_ENDPOINT = "kafkacruisecontrol/" + STATE;
   public static final String HTTPS = "https";
+
+  @Before
+  public void setup() throws Exception {
+    super.start();
+  }
+
+  @After
+  public void teardown() {
+    super.stop();
+  }
 
   @Override
   protected Map<String, Object> withConfigs() {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtAuthenticatorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtAuthenticatorTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+package com.linkedin.kafka.cruisecontrol.servlet.security.jwt;
+
+import com.linkedin.kafka.cruisecontrol.servlet.security.UserStoreAuthorizationService;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.security.Authenticator;
+import org.eclipse.jetty.security.DefaultIdentityService;
+import org.eclipse.jetty.security.ServerAuthException;
+import org.eclipse.jetty.security.UserAuthentication;
+import org.eclipse.jetty.security.UserStore;
+import org.eclipse.jetty.server.Authentication;
+import org.eclipse.jetty.server.Request;
+import org.junit.Test;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.niceMock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class JwtAuthenticatorTest {
+
+  private static final String TEST_USER = "testUser";
+  private static final String JWT_TOKEN = "jwt_token";
+  private static final String EXPECTED_TOKEN = "token";
+  private static final String RANDOM_COOKIE_NAME = "random_cookie_name";
+  private static final String TOKEN_PROVIDER = "http://mytokenprovider.com?origin={redirectUrl}";
+  private static final String CRUISE_CONTROL_ENDPOINT = "http://cruisecontrol.mycompany.com/state";
+
+  @Test
+  public void testParseTokenFromAuthHeader() {
+    JwtAuthenticator authenticator = new JwtAuthenticator(TOKEN_PROVIDER, JWT_TOKEN);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    expect(request.getHeader(HttpHeader.AUTHORIZATION.asString())).andReturn("Bearer " + EXPECTED_TOKEN);
+    replay(request);
+    String actualToken = authenticator.getJwtFromBearerAuthorization(request);
+    verify(request);
+    assertEquals(EXPECTED_TOKEN, actualToken);
+  }
+
+  @Test
+  public void testParseTokenFromAuthHeaderNoBearer() {
+    JwtAuthenticator authenticator = new JwtAuthenticator(TOKEN_PROVIDER, JWT_TOKEN);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    expect(request.getHeader(HttpHeader.AUTHORIZATION.asString())).andReturn("Basic " + EXPECTED_TOKEN);
+    replay(request);
+    String actualToken = authenticator.getJwtFromBearerAuthorization(request);
+    verify(request);
+    assertNull(actualToken);
+  }
+
+  @Test
+  public void testParseTokenFromCookie() {
+    JwtAuthenticator authenticator = new JwtAuthenticator(TOKEN_PROVIDER, JWT_TOKEN);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    expect(request.getCookies()).andReturn(new Cookie[] {new Cookie(JWT_TOKEN, EXPECTED_TOKEN)});
+    replay(request);
+    String actualToken = authenticator.getJwtFromCookie(request);
+    verify(request);
+    assertEquals(EXPECTED_TOKEN, actualToken);
+  }
+
+  @Test
+  public void testParseTokenFromCookieNoJwtCookie() {
+    JwtAuthenticator authenticator = new JwtAuthenticator(TOKEN_PROVIDER, JWT_TOKEN);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    expect(request.getCookies()).andReturn(new Cookie[] {new Cookie(RANDOM_COOKIE_NAME, "")});
+    replay(request);
+    String actualToken = authenticator.getJwtFromCookie(request);
+    verify(request);
+    assertNull(actualToken);
+  }
+
+  @Test
+  public void testRedirect() throws IOException, ServerAuthException {
+    JwtAuthenticator authenticator = new JwtAuthenticator(TOKEN_PROVIDER, JWT_TOKEN);
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    expect(request.getMethod()).andReturn(HttpMethod.GET.asString());
+    expect(request.getQueryString()).andReturn(null);
+    expect(request.getHeader(HttpHeader.AUTHORIZATION.asString())).andReturn(null);
+    expect(request.getCookies()).andReturn(new Cookie[] {});
+    expect(request.getRequestURL()).andReturn(new StringBuffer(CRUISE_CONTROL_ENDPOINT));
+
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    response.sendRedirect(TOKEN_PROVIDER.replace("{redirectUrl}", CRUISE_CONTROL_ENDPOINT));
+    expectLastCall().andVoid();
+
+    replay(request, response);
+    Authentication actualAuthentication = authenticator.validateRequest(request, response, true);
+    verify(request, response);
+    assertEquals(Authentication.SEND_CONTINUE, actualAuthentication);
+  }
+
+  @Test
+  public void testSuccessfulLogin() throws Exception {
+    UserStore testUserStore = new UserStore();
+    testUserStore.addUser(TEST_USER, null, new String[] {"USER"});
+    TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER);
+    JwtLoginService loginService = new JwtLoginService(new UserStoreAuthorizationService(testUserStore), tokenAndKeys.publicKey(), null);
+
+    Authenticator.AuthConfiguration configuration = mock(Authenticator.AuthConfiguration.class);
+    expect(configuration.getLoginService()).andReturn(loginService);
+    expect(configuration.getIdentityService()).andReturn(new DefaultIdentityService());
+    expect(configuration.isSessionRenewedOnAuthentication()).andReturn(true);
+
+    Request request = niceMock(Request.class);
+    expect(request.getMethod()).andReturn(HttpMethod.GET.asString());
+    expect(request.getHeader(HttpHeader.AUTHORIZATION.asString())).andReturn(null);
+    request.setAttribute(JwtAuthenticator.JWT_TOKEN_REQUEST_ATTRIBUTE, tokenAndKeys.token());
+    expectLastCall().andVoid();
+    expect(request.getCookies()).andReturn(new Cookie[] {new Cookie(JWT_TOKEN, tokenAndKeys.token())});
+    expect(request.getAttribute(JwtAuthenticator.JWT_TOKEN_REQUEST_ATTRIBUTE)).andReturn(tokenAndKeys.token());
+
+    HttpServletResponse response = mock(HttpServletResponse.class);
+
+    replay(configuration, request, response);
+    JwtAuthenticator authenticator = new JwtAuthenticator(TOKEN_PROVIDER, JWT_TOKEN);
+    authenticator.setConfiguration(configuration);
+    UserAuthentication authentication = (UserAuthentication) authenticator.validateRequest(request, response, true);
+    verify(configuration, request, response);
+
+    assertNotNull(authentication);
+    assertTrue(authentication.getUserIdentity().getUserPrincipal() instanceof JwtUserPrincipal);
+    JwtUserPrincipal userPrincipal = (JwtUserPrincipal) authentication.getUserIdentity().getUserPrincipal();
+    assertEquals(TEST_USER, userPrincipal.getName());
+    assertEquals(tokenAndKeys.token(), userPrincipal.getSerializedToken());
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtAuthenticatorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtAuthenticatorTest.java
@@ -6,6 +6,7 @@ package com.linkedin.kafka.cruisecontrol.servlet.security.jwt;
 import com.linkedin.kafka.cruisecontrol.servlet.security.UserStoreAuthorizationService;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.security.Authenticator;
 import org.eclipse.jetty.security.DefaultIdentityService;
 import org.eclipse.jetty.security.ServerAuthException;
@@ -164,6 +165,8 @@ public class JwtAuthenticatorTest {
     expect(request.getAttribute(JwtAuthenticator.JWT_TOKEN_REQUEST_ATTRIBUTE)).andReturn(tokenAndKeys.token());
 
     HttpServletResponse response = mock(HttpServletResponse.class);
+    response.setStatus(HttpStatus.UNAUTHORIZED_401);
+    expectLastCall().andVoid();
 
     replay(configuration, request, response);
     JwtAuthenticator authenticator = new JwtAuthenticator(TOKEN_PROVIDER, JWT_TOKEN);
@@ -196,6 +199,8 @@ public class JwtAuthenticatorTest {
     expect(request.getCookies()).andReturn(new Cookie[] {new Cookie(JWT_TOKEN, tokenAndKeys2.token())});
 
     HttpServletResponse response = mock(HttpServletResponse.class);
+    response.setStatus(HttpStatus.UNAUTHORIZED_401);
+    expectLastCall().andVoid();
 
     replay(configuration, request, response);
     JwtAuthenticator authenticator = new JwtAuthenticator(TOKEN_PROVIDER, JWT_TOKEN);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtLoginServiceTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtLoginServiceTest.java
@@ -69,7 +69,8 @@ public class JwtLoginServiceTest {
     UserStore testUserStore = new UserStore();
     testUserStore.addUser(TEST_USER, null, new String[] {"USER"});
     TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER, Arrays.asList("A", "B"));
-    JwtLoginService loginService = new JwtLoginService(new UserStoreAuthorizationService(testUserStore), tokenAndKeys.publicKey(), Arrays.asList("C", "D"));
+    JwtLoginService loginService = new JwtLoginService(
+        new UserStoreAuthorizationService(testUserStore), tokenAndKeys.publicKey(), Arrays.asList("C", "D"));
 
     SignedJWT jwtToken = SignedJWT.parse(tokenAndKeys.token());
     HttpServletRequest request = mock(HttpServletRequest.class);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtLoginServiceTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtLoginServiceTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.security.jwt;
+
+import com.linkedin.kafka.cruisecontrol.servlet.security.UserStoreAuthorizationService;
+import com.nimbusds.jwt.SignedJWT;
+import org.eclipse.jetty.security.UserStore;
+import org.eclipse.jetty.server.UserIdentity;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class JwtLoginServiceTest {
+
+  private static final String TEST_USER = "testUser";
+
+  @Test
+  public void testValidateTokenSuccessfully() throws Exception {
+    UserStore testUserStore = new UserStore();
+    testUserStore.addUser(TEST_USER, null, new String[] {"USER"});
+    TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER);
+    JwtLoginService loginService = new JwtLoginService(new UserStoreAuthorizationService(testUserStore), tokenAndKeys.publicKey(), null);
+
+    SignedJWT jwtToken = SignedJWT.parse(tokenAndKeys.token());
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    expect(request.getAttribute(JwtAuthenticator.JWT_TOKEN_REQUEST_ATTRIBUTE)).andReturn(tokenAndKeys.token());
+
+    replay(request);
+    UserIdentity identity = loginService.login(TEST_USER, jwtToken, request);
+    verify(request);
+    assertNotNull(identity);
+    assertEquals(TEST_USER, identity.getUserPrincipal().getName());
+  }
+
+  @Test
+  public void testFailSignatureValidation() throws Exception {
+    UserStore testUserStore = new UserStore();
+    testUserStore.addUser(TEST_USER, null, new String[] {"USER"});
+    TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER);
+    TokenGenerator.TokenAndKeys tokenAndKeys2 = TokenGenerator.generateToken(TEST_USER); // this will be signed with a different key
+    JwtLoginService loginService = new JwtLoginService(new UserStoreAuthorizationService(testUserStore), tokenAndKeys2.publicKey(), null);
+
+    SignedJWT jwtToken = SignedJWT.parse(tokenAndKeys.token());
+    HttpServletRequest request = mock(HttpServletRequest.class);
+
+    UserIdentity identity = loginService.login(TEST_USER, jwtToken, request);
+    assertNull(identity);
+  }
+
+  @Test
+  public void testFailAudienceValidation() throws Exception {
+    UserStore testUserStore = new UserStore();
+    testUserStore.addUser(TEST_USER, null, new String[] {"USER"});
+    TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER, Arrays.asList("A", "B"));
+    JwtLoginService loginService = new JwtLoginService(new UserStoreAuthorizationService(testUserStore), tokenAndKeys.publicKey(), Arrays.asList("C", "D"));
+
+    SignedJWT jwtToken = SignedJWT.parse(tokenAndKeys.token());
+    HttpServletRequest request = mock(HttpServletRequest.class);
+
+    UserIdentity identity = loginService.login(TEST_USER, jwtToken, request);
+    assertNull(identity);
+  }
+
+  @Test
+  public void testFailExpirationValidation() throws Exception {
+    UserStore testUserStore = new UserStore();
+    testUserStore.addUser(TEST_USER, null, new String[] {"USER"});
+    TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER, 1L);
+    JwtLoginService loginService = new JwtLoginService(new UserStoreAuthorizationService(testUserStore), tokenAndKeys.publicKey(), null);
+
+    SignedJWT jwtToken = SignedJWT.parse(tokenAndKeys.token());
+    HttpServletRequest request = mock(HttpServletRequest.class);
+
+    UserIdentity identity = loginService.login(TEST_USER, jwtToken, request);
+    assertNull(identity);
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtSecurityProviderIntegrationTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtSecurityProviderIntegrationTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.security.jwt;
+
+import com.linkedin.kafka.cruisecontrol.CruiseControlIntegrationTestHarness;
+import com.linkedin.kafka.cruisecontrol.config.constants.WebServerConfig;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.UserIdentity;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.Provider;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint.STATE;
+import static org.junit.Assert.assertEquals;
+
+public class JwtSecurityProviderIntegrationTest extends CruiseControlIntegrationTestHarness {
+
+  private static final String CRUISE_CONTROL_STATE_ENDPOINT = "kafkacruisecontrol/" + STATE;
+  private static final String TEST_USERNAME_KEY = "username";
+  private static final String TEST_PASSWORD_KEY = "password";
+  private static final String TEST_USERNAME = "ccTestUser";
+  private static final String TEST_PASSWORD = "TestPwd123";
+  private static final String ORIGIN = "origin";
+  public static final String JWT_TOKEN_COOKIE_NAME = "jwt_token";
+
+  private final TokenGenerator.TokenAndKeys _tokenAndKeys;
+  private final Server _tokenProviderServer;
+  private final File _publicKeyFile;
+
+  class TestAuthenticatorHandler extends AbstractHandler {
+
+    HashLoginService _loginService;
+
+    TestAuthenticatorHandler() {
+      _loginService = new HashLoginService();
+      _loginService.setConfig(
+          Objects.requireNonNull(this.getClass().getClassLoader().getResource("basic-auth.credentials")).getPath());
+    }
+
+    @Override
+    public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
+      String username = request.getParameter(TEST_USERNAME_KEY);
+      String password = request.getParameter(TEST_PASSWORD_KEY);
+
+      String cruiseControlUrl = request.getParameter(ORIGIN);
+
+      System.out.println(String.format("Handling login: %s %s %s", username, password, cruiseControlUrl));
+      UserIdentity identity = _loginService.login(username, password, request);
+      if (identity != null) {
+        response.addCookie(new Cookie(JWT_TOKEN_COOKIE_NAME, _tokenAndKeys.token()));
+      } else {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+      }
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+      super.doStart();
+      _loginService.start();
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+      _loginService.stop();
+      super.doStop();
+    }
+  }
+
+  public JwtSecurityProviderIntegrationTest() throws Exception {
+    _tokenAndKeys = TokenGenerator.generateToken(TEST_USERNAME);
+    _publicKeyFile = createCertificate(_tokenAndKeys);
+    _tokenProviderServer = new Server(0);
+    _tokenProviderServer.setHandler(new TestAuthenticatorHandler());
+  }
+
+  /**
+   * Starts the token provider and the Kafka environment before test
+   * @throws Exception
+   */
+  @Before
+  public void setup() throws Exception {
+    _tokenProviderServer.start();
+    super.start();
+  }
+
+  /**
+   * Stops the token provider and the Kafka environment after test
+   * @throws Exception
+   */
+  @After
+  public void teardown() throws Exception {
+    super.stop();
+    _tokenProviderServer.stop();
+  }
+
+  @Override
+  protected Map<String, Object> withConfigs() {
+    Map<String, Object> securityConfigs = new HashMap<>();
+    securityConfigs.put(WebServerConfig.WEBSERVER_SECURITY_ENABLE_CONFIG, true);
+    securityConfigs.put(WebServerConfig.WEBSERVER_SECURITY_PROVIDER_CONFIG, JwtSecurityProvider.class);
+    securityConfigs.put(WebServerConfig.JWT_AUTHENTICATION_PROVIDER_URL_CONFIG,
+        _tokenProviderServer.getURI().toString() + "?" +
+            TEST_USERNAME_KEY + "=" + TEST_USERNAME +
+            "&" + TEST_PASSWORD_KEY + "=" + TEST_PASSWORD +
+            "&origin={redirectUrl}");
+    securityConfigs.put(WebServerConfig.WEBSERVER_AUTH_CREDENTIALS_FILE_CONFIG,
+        Objects.requireNonNull(this.getClass().getClassLoader().getResource("jwt-auth.credentials")).getPath());
+    securityConfigs.put(WebServerConfig.JWT_COOKIE_NAME_CONFIG, JWT_TOKEN_COOKIE_NAME);
+    securityConfigs.put(WebServerConfig.JWT_AUTH_CERTIFICATE_LOCATION_CONFIG, _publicKeyFile.getAbsolutePath());
+
+    return securityConfigs;
+  }
+
+  @Test
+  public void testSuccessfulLogin() throws Exception {
+    HttpURLConnection stateEndpointConnection = (HttpURLConnection) new URI(_app.serverUrl())
+        .resolve(CRUISE_CONTROL_STATE_ENDPOINT).toURL().openConnection();
+    String cookie = stateEndpointConnection.getHeaderField(HttpHeader.SET_COOKIE.asString());
+    stateEndpointConnection = (HttpURLConnection) new URI(_app.serverUrl())
+        .resolve(CRUISE_CONTROL_STATE_ENDPOINT).toURL().openConnection();
+    stateEndpointConnection.setRequestProperty(HttpHeader.COOKIE.asString(), cookie);
+    assertEquals(HttpServletResponse.SC_OK, stateEndpointConnection.getResponseCode());
+  }
+
+  private File createCertificate(TokenGenerator.TokenAndKeys tokenAndKeys) throws Exception {
+    String subjectDN = "C=US, ST=California, L=Santa Clara, O=LinkedIn, CN=localhost";
+    Provider bcProvider = new BouncyCastleProvider();
+    Security.addProvider(bcProvider);
+
+    long now = System.currentTimeMillis();
+    Date startDate = new Date(now);
+
+    X500Name dnName = new X500Name(subjectDN);
+    BigInteger certSerialNumber = new BigInteger(Long.toString(now));
+
+    Calendar calendar = Calendar.getInstance();
+    calendar.setTime(startDate);
+    calendar.add(Calendar.YEAR, 100);
+
+    Date endDate = calendar.getTime();
+    String signatureAlgorithm = "SHA256WithRSA";
+    ContentSigner contentSigner = new JcaContentSignerBuilder(signatureAlgorithm).build(tokenAndKeys.privateKey());
+
+    JcaX509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(dnName, certSerialNumber, startDate, endDate, dnName, tokenAndKeys.publicKey());
+
+    X509Certificate cert = new JcaX509CertificateConverter().setProvider(bcProvider).getCertificate(certBuilder.build(contentSigner));
+
+    File certificate = File.createTempFile("test-certificate", ".pub");
+
+    try (OutputStream os = new FileOutputStream(certificate)) {
+      Base64.Encoder encoder = Base64.getEncoder();
+      os.write("-----BEGIN CERTIFICATE-----\n".getBytes(StandardCharsets.UTF_8));
+      os.write(encoder.encodeToString(cert.getEncoded()).getBytes(StandardCharsets.UTF_8));
+      os.write("\n-----END CERTIFICATE-----\n".getBytes(StandardCharsets.UTF_8));
+    }
+
+    return certificate;
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtSecurityProviderIntegrationTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtSecurityProviderIntegrationTest.java
@@ -135,7 +135,7 @@ public class JwtSecurityProviderIntegrationTest extends CruiseControlIntegration
         _tokenProviderServer.getURI().toString() + "?" +
             TEST_USERNAME_KEY + "=" + TEST_USERNAME +
             "&" + TEST_PASSWORD_KEY + "=" + TEST_PASSWORD +
-            "&origin={redirectUrl}");
+            "&origin=" + JwtAuthenticator.REDIRECT_URL);
     securityConfigs.put(WebServerConfig.WEBSERVER_AUTH_CREDENTIALS_FILE_CONFIG,
         Objects.requireNonNull(this.getClass().getClassLoader().getResource("jwt-auth.credentials")).getPath());
     securityConfigs.put(WebServerConfig.JWT_COOKIE_NAME_CONFIG, JWT_TOKEN_COOKIE_NAME);
@@ -174,7 +174,8 @@ public class JwtSecurityProviderIntegrationTest extends CruiseControlIntegration
     String signatureAlgorithm = "SHA256WithRSA";
     ContentSigner contentSigner = new JcaContentSignerBuilder(signatureAlgorithm).build(tokenAndKeys.privateKey());
 
-    JcaX509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(dnName, certSerialNumber, startDate, endDate, dnName, tokenAndKeys.publicKey());
+    JcaX509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
+        dnName, certSerialNumber, startDate, endDate, dnName, tokenAndKeys.publicKey());
 
     X509Certificate cert = new JcaX509CertificateConverter().setProvider(bcProvider).getCertificate(certBuilder.build(contentSigner));
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/TokenGenerator.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/TokenGenerator.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.security.jwt;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+class TokenGenerator {
+
+  static class TokenAndKeys {
+    private String _token;
+    private RSAPrivateKey _privateKey;
+    private RSAPublicKey _publicKey;
+
+    private TokenAndKeys(String token, RSAPrivateKey privateKey, RSAPublicKey publicKey) {
+      _token = token;
+      _privateKey = privateKey;
+      _publicKey = publicKey;
+    }
+
+    String token() {
+      return _token;
+    }
+
+    RSAPublicKey publicKey() {
+      return _publicKey;
+    }
+
+    RSAPrivateKey privateKey() {
+      return _privateKey;
+    }
+  }
+
+  private TokenGenerator() {
+  }
+
+  static TokenAndKeys generateToken(String subject) throws JOSEException {
+    return generateToken(subject, null, -1);
+  }
+
+  static TokenAndKeys generateToken(String subject, long expirationTime) throws JOSEException {
+    return generateToken(subject, null, expirationTime);
+  }
+
+  static TokenAndKeys generateToken(String subject, List<String> audience) throws JOSEException {
+    return generateToken(subject, audience, -1);
+  }
+
+  static TokenAndKeys generateToken(String subject, List<String> audience, long expirationTime) throws JOSEException {
+    RSAKey rsaJwk = new RSAKeyGenerator(2048)
+        .keyID("123")
+        .generate();
+    RSAKey rsaPublicJWK = rsaJwk.toPublicJWK();
+    RSASSASigner signer = new RSASSASigner(rsaJwk);
+
+    JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+        .type(JOSEObjectType.JWT)
+        .build();
+    JWTClaimsSet.Builder claimsSet = new JWTClaimsSet.Builder()
+        .subject(subject)
+        .issuer("https://linkedin.com");
+
+    if (audience != null) {
+      claimsSet.audience(audience);
+    }
+
+    if (expirationTime > 0) {
+      claimsSet.expirationTime(new Date(expirationTime));
+    } else {
+      claimsSet.expirationTime(Date.from(Instant.now().plusSeconds(120)));
+    }
+
+    SignedJWT signedJWT = new SignedJWT(header, claimsSet.build());
+    signedJWT.sign(signer);
+
+    return new TokenAndKeys(signedJWT.serialize(), (RSAPrivateKey) signer.getPrivateKey(), rsaPublicJWK.toRSAPublicKey());
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/TokenGenerator.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/TokenGenerator.java
@@ -23,9 +23,9 @@ import java.util.List;
 class TokenGenerator {
 
   static class TokenAndKeys {
-    private String _token;
-    private RSAPrivateKey _privateKey;
-    private RSAPublicKey _publicKey;
+    private final String _token;
+    private final RSAPrivateKey _privateKey;
+    private final RSAPublicKey _publicKey;
 
     private TokenAndKeys(String token, RSAPrivateKey privateKey, RSAPublicKey publicKey) {
       _token = token;

--- a/cruise-control/src/test/resources/jwt-auth.credentials
+++ b/cruise-control/src/test/resources/jwt-auth.credentials
@@ -1,0 +1,2 @@
+ccTestAdmin: ,ADMIN
+ccTestUser: ,USER

--- a/docs/wiki/User Guide/Security.md
+++ b/docs/wiki/User Guide/Security.md
@@ -31,6 +31,7 @@ Cruise Control can use token based authentication. To enable this, use the follo
   to be secured so that only Cruise Control can access it.
 
 #### Configuring JWT authentication with Apache Knox
+To set up an environment for *demo purposes*, please follow these instructions.
 Testing with Apache Knox:
 1. Download Knox (http://www.apache.org/dyn/closer.cgi/knox or https://knox.apache.org/books/knox-1-3-0/user-guide.html#Quick+Start)
 2. `cd {KNOX_HOME}`

--- a/docs/wiki/User Guide/Security.md
+++ b/docs/wiki/User Guide/Security.md
@@ -22,7 +22,7 @@ Cruise Control can use token based authentication. To enable this, use the follo
 * `webserver.security.provider`: This must be changed to com.linkedin.kafka.cruisecontrol.servlet.security.jwt.JwtSecurityProvider.
 * `webserver.auth.credentials.file`: It must point to a file in the `HashLoginService`'s file format introduced above
    but without the password part so `username: ,ROLE`. The possible roles are explained below.
-* `jwt.authentication.provider.url`: This must point to the token prodiver's endpoint. It can contain a `{redirectUrl}`
+* `jwt.authentication.provider.url`: This must point to the token provider's endpoint. It can contain a `{redirectUrl}`
    part which will be replaced by Cruise Control and points to the accessed Cruise Control endpoint.
 * `jwt.cookie.name`: This can be set to provide a cookie name that points to a cookie issued by the token provider and
    which contains the JSON web token.

--- a/docs/wiki/User Guide/Security.md
+++ b/docs/wiki/User Guide/Security.md
@@ -32,7 +32,6 @@ Cruise Control can use token based authentication. To enable this, use the follo
 
 #### Configuring JWT authentication with Apache Knox
 To set up an environment for *demo purposes*, please follow these instructions.
-Testing with Apache Knox:
 1. Download Knox (http://www.apache.org/dyn/closer.cgi/knox or https://knox.apache.org/books/knox-1-3-0/user-guide.html#Quick+Start)
 2. `cd {KNOX_HOME}`
 3. `bin/ldap.sh start`

--- a/docs/wiki/User Guide/Security.md
+++ b/docs/wiki/User Guide/Security.md
@@ -10,10 +10,53 @@ the properties file.
 ### HTTP Basic
 
 By configuring Cruise Control with the `BasicSecurityProvider`, the user will gain simple HTTP Basic
-authentication where the users' credentials are stored in a file given by the `basic.auth.credentials.file` config.
+authentication where the users' credentials are stored in a file given by the `webserver.auth.credentials.file` config.
 This file is assumed to be stored in a safe, protected location and only accessible by Cruise Control. The format of the
 file follows Jetty's `HashLoginService`'s file format:
 ```username: password [,rolename ...]```
+
+### Json Web Token authentication
+
+Cruise Control can use token based authentication. To enable this, use the following configs:
+* `webserver.security.enable`: This must be enabled to use the authentication features.
+* `webserver.security.provider`: This must be changed to com.linkedin.kafka.cruisecontrol.servlet.security.jwt.JwtSecurityProvider.
+* `webserver.auth.credentials.file`: It must point to a file in the `HashLoginService`'s file format introduced above
+   but without the password part so `username: ,ROLE`. The possible roles are explained below.
+* `jwt.authentication.provider.url`: This must point to the token prodiver's endpoint. It can contain a `{redirectUrl}`
+   part which will be replaced by Cruise Control and points to the accessed Cruise Control endpoint.
+* `jwt.cookie.name`: This can be set to provide a cookie name that points to a cookie issued by the token provider and
+   which contains the JSON web token.
+* `jwt.auth.certificate.location`: Tokens can be encrypted by the token provider and in this case there need to be a
+  public key certificate that can be used for validating the token. This config points to a location that is assumed
+  to be secured so that only Cruise Control can access it.
+
+#### Configuring JWT authentication with Apache Knox
+Testing with Apache Knox:
+1. Download Knox (http://www.apache.org/dyn/closer.cgi/knox or https://knox.apache.org/books/knox-1-3-0/user-guide.html#Quick+Start)
+2. `cd {KNOX_HOME}`
+3. `bin/ldap.sh start`
+4. Change `knoxsso.cookie.secure.only` to `false` in `conf/topologies/knoxsso.xml` to allow cookies over unsecured network
+5. `bin/knoxcli.sh create-master`
+6. `bin/gateway.sh start`
+7. Create a credentials file containing this (for instance in `/tmp/test-roles.credentials`:
+```
+admin: ,ADMIN
+sam: ,USER
+```
+8. `bin/knoxcli.sh create-cert` to create a validation certificate
+9. `bin/knoxcli.sh export-cert` to export it (by default as PEM)
+10. Start Cruise Control with the following extra configs:
+```
+webserver.security.enable=true
+webserver.security.provider=com.linkedin.kafka.cruisecontrol.servlet.security.jwt.JwtSecurityProvider
+jwt.authentication.provider.url=https://localhost:8443/gateway/idp/api/v1/websso?originalUrl={redirectUrl}
+webserver.auth.credentials.file=/tmp/test-roles.credentials
+jwt.cookie.name=hadoop-jwt
+jwt.auth.certificate.location=/tmp/knox-1.3.0/data/security/keystores/gateway-identity.pem
+```
+11. Open http://localhost:9090/kafkacruisecontrol/state and see that it will redirect to the knox auth page (then log in
+with the admin/admin-password username/password pair). It should redirect to the CC page. It is important to use the same
+hostname (i.e. `localhost`) with CC otherwise Knox rejects the request.
 
 ## HTTPS
 


### PR DESCRIPTION
Addresses the issue #1065.

It defines a JwtAuthenticator and a JwtLoginService and bundles them together in a JwtSecurityProvider class. The authenticator can interpret tokens provided in the Authorization header using the Bearer scheme or provided in a cookie. The tokens are encrypted and a certification has to be present in Cruise Control to be able to verify the tokens.

Changed config names:
basic.auth.credentials.file -> webserver.auth.credentials.file: the motivation behind this is to change it into a more generic password file configuration.

New configs:
- jwt.authentication.provider.url
- jwt.cookie.name
- jwt.auth.certificate.location
- jwt.expected.audiences

Testing:
- unit tests for verifying JwtAuthenticator and JwtLoginService
- integration test to verify the whole end-to-end scenario