### PR TITLE
Correct name for API parameter

### DIFF
--- a/docs/wiki/User Guide/REST-APIs.md
+++ b/docs/wiki/User Guide/REST-APIs.md
@@ -494,7 +494,7 @@ Supported parameters are:
 | disable_self_healing_for     | list    | list of anomaly types to disable self-healing|   N/A | yes|
 | enable_self_healing_for     | list    | list of anomaly types to enable self-healing|   N/A | yes|
 | concurrent_partition_movements_per_broker     | integer    | upper bound of ongoing replica movements into/out of a broker  |   N/A | yes|
-| concurrent_intra_partition_movements     | integer    | upper bound of ongoing replica movements between disks within a broker  |   N/A | yes|
+| concurrent_intra_broker_partition_movements     | integer    | upper bound of ongoing replica movements between disks within a broker  |   N/A | yes|
 | concurrent_leader_movements     | integer    | upper bound of ongoing leadership movements |    N/A | yes|
 | drop_recently_removed_brokers     | list    | list of id of recently removed brokers to be dropped  |   N/A | yes|
 | drop_recently_demoted_brokers     | list    | list of id of recently demoted brokers to be dropped  |   N/A | yes|


### PR DESCRIPTION
```
cruise-control-rest# curl -X POST localhost:9095/kafkacruisecontrol/admin?concurrent_intra_partition_movements=12
Unrecognized endpoint parameters in ADMIN POST request: [concurrent_intra_partition_movements]
cruise-control-rest# curl -X POST localhost:9095/kafkacruisecontrol/admin?concurrent_intra_broker_partition_movements=12
{
ongoingConcurrencyChangeRequest: Intra-broker partition movement concurrency is set to 12

}
```

Addresses the issue of parameter name incorrect

https://github.com/linkedin/cruise-control/blob/5ed774eb5c64f6e57a6a001c1306c520170416c5/cruise-control/src/yaml/endpoints/admin.yaml#L39