### PR TITLE
Evolve BrokerCapacityConfigResolver interface to be aware whether capacity estimation is allowed or not in broker capacity resolution.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -19,6 +19,7 @@ import com.linkedin.kafka.cruisecontrol.config.TopicConfigProvider;
 import com.linkedin.kafka.cruisecontrol.config.constants.ExecutorConfig;
 import com.linkedin.kafka.cruisecontrol.detector.AnomalyDetector;
 import com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorState;
+import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolvingException;
 import com.linkedin.kafka.cruisecontrol.exception.KafkaCruiseControlException;
 import com.linkedin.kafka.cruisecontrol.executor.ExecutionProposal;
 import com.linkedin.kafka.cruisecontrol.executor.Executor;
@@ -256,15 +257,18 @@ public class KafkaCruiseControl {
   /**
    * Get the cluster model cutting off at the current timestamp.
    * @param requirements the model completeness requirements.
-   * @param allowBrokerCapacityEstimation Whether allow broker capacity resolver to estimate broker capacity.
+   * @param allowCapacityEstimation whether allow capacity estimation in cluster model if the underlying live broker capacity is unavailable.
    * @param operationProgress the progress of the job to report.
    * @return The cluster workload model.
    * @throws NotEnoughValidWindowsException If there is not enough sample to generate cluster model.
    * @throws TimeoutException If broker capacity resolver is unable to resolve broker capacity.
+   * @throws BrokerCapacityResolvingException If broker capacity resolver fails to resolve broker capacity.
    */
-  public ClusterModel clusterModel(ModelCompletenessRequirements requirements, Boolean allowBrokerCapacityEstimation, OperationProgress operationProgress)
-      throws NotEnoughValidWindowsException, TimeoutException {
-    return _loadMonitor.clusterModel(timeMs(), requirements, allowBrokerCapacityEstimation, operationProgress);
+  public ClusterModel clusterModel(ModelCompletenessRequirements requirements,
+                                   boolean allowCapacityEstimation,
+                                   OperationProgress operationProgress)
+      throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolvingException {
+    return _loadMonitor.clusterModel(timeMs(), requirements, allowCapacityEstimation, operationProgress);
   }
 
   /**
@@ -273,20 +277,21 @@ public class KafkaCruiseControl {
    * @param to the end time of the window
    * @param requirements the load completeness requirements.
    * @param populateReplicaPlacementInfo whether populate replica placement information.
-   * @param allowBrokerCapacityEstimation Whether allow broker capacity resolver to estimate broker capacity.
+   * @param allowCapacityEstimation whether allow capacity estimation in cluster model if the underlying live broker capacity is unavailable.
    * @param operationProgress the progress of the job to report.
    * @return The cluster workload model.
    * @throws NotEnoughValidWindowsException If there is not enough sample to generate cluster model.
    * @throws TimeoutException If broker capacity resolver is unable to resolve broker capacity.
+   * @throws BrokerCapacityResolvingException If broker capacity resolver fails to resolve broker capacity.
    */
   public ClusterModel clusterModel(long from,
                                    long to,
                                    ModelCompletenessRequirements requirements,
                                    boolean populateReplicaPlacementInfo,
-                                   boolean allowBrokerCapacityEstimation,
+                                   boolean allowCapacityEstimation,
                                    OperationProgress operationProgress)
-      throws NotEnoughValidWindowsException, TimeoutException {
-    return _loadMonitor.clusterModel(from, to, requirements, populateReplicaPlacementInfo, allowBrokerCapacityEstimation, operationProgress);
+      throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolvingException {
+    return _loadMonitor.clusterModel(from, to, requirements, populateReplicaPlacementInfo, allowCapacityEstimation, operationProgress);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -256,14 +256,15 @@ public class KafkaCruiseControl {
   /**
    * Get the cluster model cutting off at the current timestamp.
    * @param requirements the model completeness requirements.
+   * @param allowBrokerCapacityEstimation Whether allow broker capacity resolver to estimate broker capacity.
    * @param operationProgress the progress of the job to report.
    * @return The cluster workload model.
    * @throws NotEnoughValidWindowsException If there is not enough sample to generate cluster model.
    * @throws TimeoutException If broker capacity resolver is unable to resolve broker capacity.
    */
-  public ClusterModel clusterModel(ModelCompletenessRequirements requirements, OperationProgress operationProgress)
+  public ClusterModel clusterModel(ModelCompletenessRequirements requirements, Boolean allowBrokerCapacityEstimation, OperationProgress operationProgress)
       throws NotEnoughValidWindowsException, TimeoutException {
-    return _loadMonitor.clusterModel(timeMs(), requirements, operationProgress);
+    return _loadMonitor.clusterModel(timeMs(), requirements, allowBrokerCapacityEstimation, operationProgress);
   }
 
   /**
@@ -272,6 +273,7 @@ public class KafkaCruiseControl {
    * @param to the end time of the window
    * @param requirements the load completeness requirements.
    * @param populateReplicaPlacementInfo whether populate replica placement information.
+   * @param allowBrokerCapacityEstimation Whether allow broker capacity resolver to estimate broker capacity.
    * @param operationProgress the progress of the job to report.
    * @return The cluster workload model.
    * @throws NotEnoughValidWindowsException If there is not enough sample to generate cluster model.
@@ -281,9 +283,10 @@ public class KafkaCruiseControl {
                                    long to,
                                    ModelCompletenessRequirements requirements,
                                    boolean populateReplicaPlacementInfo,
+                                   boolean allowBrokerCapacityEstimation,
                                    OperationProgress operationProgress)
       throws NotEnoughValidWindowsException, TimeoutException {
-    return _loadMonitor.clusterModel(from, to, requirements, populateReplicaPlacementInfo, operationProgress);
+    return _loadMonitor.clusterModel(from, to, requirements, populateReplicaPlacementInfo, allowBrokerCapacityEstimation, operationProgress);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -19,7 +19,7 @@ import com.linkedin.kafka.cruisecontrol.config.TopicConfigProvider;
 import com.linkedin.kafka.cruisecontrol.config.constants.ExecutorConfig;
 import com.linkedin.kafka.cruisecontrol.detector.AnomalyDetector;
 import com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorState;
-import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolvingException;
+import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolutionException;
 import com.linkedin.kafka.cruisecontrol.exception.KafkaCruiseControlException;
 import com.linkedin.kafka.cruisecontrol.executor.ExecutionProposal;
 import com.linkedin.kafka.cruisecontrol.executor.Executor;
@@ -261,13 +261,13 @@ public class KafkaCruiseControl {
    * @param operationProgress the progress of the job to report.
    * @return The cluster workload model.
    * @throws NotEnoughValidWindowsException If there is not enough sample to generate cluster model.
-   * @throws TimeoutException If broker capacity resolver is unable to resolve broker capacity.
-   * @throws BrokerCapacityResolvingException If broker capacity resolver fails to resolve broker capacity.
+   * @throws TimeoutException If broker capacity resolver is unable to resolve broker capacity in time.
+   * @throws BrokerCapacityResolutionException If broker capacity resolver fails to resolve broker capacity.
    */
   public ClusterModel clusterModel(ModelCompletenessRequirements requirements,
                                    boolean allowCapacityEstimation,
                                    OperationProgress operationProgress)
-      throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolvingException {
+      throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolutionException {
     return _loadMonitor.clusterModel(timeMs(), requirements, allowCapacityEstimation, operationProgress);
   }
 
@@ -281,8 +281,8 @@ public class KafkaCruiseControl {
    * @param operationProgress the progress of the job to report.
    * @return The cluster workload model.
    * @throws NotEnoughValidWindowsException If there is not enough sample to generate cluster model.
-   * @throws TimeoutException If broker capacity resolver is unable to resolve broker capacity.
-   * @throws BrokerCapacityResolvingException If broker capacity resolver fails to resolve broker capacity.
+   * @throws TimeoutException If broker capacity resolver is unable to resolve broker capacity in time.
+   * @throws BrokerCapacityResolutionException If broker capacity resolver fails to resolve broker capacity.
    */
   public ClusterModel clusterModel(long from,
                                    long to,
@@ -290,7 +290,7 @@ public class KafkaCruiseControl {
                                    boolean populateReplicaPlacementInfo,
                                    boolean allowCapacityEstimation,
                                    OperationProgress operationProgress)
-      throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolvingException {
+      throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolutionException {
     return _loadMonitor.clusterModel(from, to, requirements, populateReplicaPlacementInfo, allowCapacityEstimation, operationProgress);
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -221,26 +221,6 @@ public class KafkaCruiseControlUtils {
   }
 
   /**
-   * Check whether the given capacity estimation info indicates estimations for any broker when capacity estimation is
-   * not permitted.
-   *
-   * @param allowCapacityEstimation Allow capacity estimation in cluster model if the requested broker capacity is unavailable.
-   * @param capacityEstimationInfoByBrokerId Capacity estimation info by broker id for which there has been an estimation.
-   */
-  public static void sanityCheckCapacityEstimation(boolean allowCapacityEstimation,
-                                                   Map<Integer, String> capacityEstimationInfoByBrokerId) {
-    if (!(allowCapacityEstimation || capacityEstimationInfoByBrokerId.isEmpty())) {
-      StringBuilder sb = new StringBuilder();
-      sb.append(String.format("Failed to capture some broker capacities in the generated cluster model. Either "
-                              + "allow capacity estimation or fix dependencies that capture broker capacities.%n"));
-      for (Map.Entry<Integer, String> entry : capacityEstimationInfoByBrokerId.entrySet()) {
-        sb.append(String.format("Broker: %d: info: %s%n", entry.getKey(), entry.getValue()));
-      }
-      throw new IllegalStateException(sb.toString());
-    }
-  }
-
-  /**
    * Get a goals by priority based on the goal list.
    *
    * @param goals A list of goals.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
@@ -47,7 +47,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.balancednessCostByGoal;
-import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.sanityCheckCapacityEstimation;
 import static com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.BOOTSTRAPPING;
 import static com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.LOADING;
 
@@ -556,8 +555,7 @@ public class GoalOptimizer implements Runnable {
         // We compute the proposal even if there is not enough modeled partitions.
         ModelCompletenessRequirements requirements = _loadMonitor.meetCompletenessRequirements(_defaultModelCompletenessRequirements) ?
                                                      _defaultModelCompletenessRequirements : _requirementsWithAvailableValidWindows;
-        ClusterModel clusterModel = _loadMonitor.clusterModel(_time.milliseconds(), requirements, operationProgress);
-        sanityCheckCapacityEstimation(_allowCapacityEstimation, clusterModel.capacityEstimationInfoByBrokerId());
+        ClusterModel clusterModel = _loadMonitor.clusterModel(_time.milliseconds(), requirements, _allowCapacityEstimation, operationProgress);
         if (!clusterModel.topics().isEmpty()) {
           OptimizerResult result = optimizations(clusterModel, _goalsByPriority, operationProgress);
           LOG.debug("Generated a proposal candidate in {} ms.", _time.milliseconds() - startMs);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolver.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolver.java
@@ -8,7 +8,7 @@ import com.google.gson.Gson;
 import com.google.gson.stream.JsonReader;
 import com.linkedin.kafka.cruisecontrol.common.Resource;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils;
-import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolvingException;
+import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolutionException;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -156,10 +156,9 @@ public class BrokerCapacityConfigFileResolver implements BrokerCapacityConfigRes
 
   @Override
   public void configure(Map<String, ?> configs) {
-    String configFile = KafkaCruiseControlUtils.getRequiredConfig(configs, CAPACITY_CONFIG_FILE);
-    _configFile = configFile;
+    _configFile = KafkaCruiseControlUtils.getRequiredConfig(configs, CAPACITY_CONFIG_FILE);
     try {
-      loadCapacities(configFile);
+      loadCapacities();
     } catch (FileNotFoundException e) {
       throw new IllegalArgumentException(e);
     }
@@ -167,7 +166,7 @@ public class BrokerCapacityConfigFileResolver implements BrokerCapacityConfigRes
 
   @Override
   public BrokerCapacityInfo capacityForBroker(String rack, String host, int brokerId, long timeoutMs, boolean allowCapacityEstimation)
-      throws BrokerCapacityResolvingException {
+      throws BrokerCapacityResolutionException {
     if (brokerId >= 0) {
       BrokerCapacityInfo capacity = _capacitiesForBrokers.get(brokerId);
       if (capacity != null) {
@@ -179,8 +178,8 @@ public class BrokerCapacityConfigFileResolver implements BrokerCapacityConfigRes
                                         _capacitiesForBrokers.get(DEFAULT_CAPACITY_BROKER_ID).diskCapacityByLogDir(),
                                         _capacitiesForBrokers.get(DEFAULT_CAPACITY_BROKER_ID).numCpuCores());
         } else {
-          throw new BrokerCapacityResolvingException(String.format("Unable to resolve capacity of broker %d.Either (1) adding the "
-              + "default broker capacity (via adding capacity for broker %d and allowing capacity estimation or (2) add missing "
+          throw new BrokerCapacityResolutionException(String.format("Unable to resolve capacity of broker %d. Either (1) adding the "
+              + "default broker capacity (via adding capacity for broker %d and allowing capacity estimation) or (2) adding missing "
               + "broker's capacity in file %s.", brokerId, DEFAULT_CAPACITY_BROKER_ID, _configFile));
         }
       }
@@ -291,10 +290,10 @@ public class BrokerCapacityConfigFileResolver implements BrokerCapacityConfigRes
     return brokerCapacityInfo;
   }
 
-  private void loadCapacities(String capacityConfigFile) throws FileNotFoundException {
+  private void loadCapacities() throws FileNotFoundException {
     JsonReader reader = null;
     try {
-      reader = new JsonReader(new InputStreamReader(new FileInputStream(capacityConfigFile), StandardCharsets.UTF_8));
+      reader = new JsonReader(new InputStreamReader(new FileInputStream(_configFile), StandardCharsets.UTF_8));
       Gson gson = new Gson();
       Set<BrokerCapacity> brokerCapacities = ((BrokerCapacities) gson.fromJson(reader, BrokerCapacities.class)).brokerCapacities;
       _capacitiesForBrokers = new HashMap<>(brokerCapacities.size());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigResolver.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigResolver.java
@@ -5,7 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.config;
 
 import com.linkedin.cruisecontrol.common.CruiseControlConfigurable;
-import com.linkedin.kafka.cruisecontrol.common.Resource;
+import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolvingException;
 import java.util.concurrent.TimeoutException;
 
 
@@ -17,13 +17,6 @@ import java.util.concurrent.TimeoutException;
 public interface BrokerCapacityConfigResolver extends CruiseControlConfigurable, AutoCloseable {
   /**
    * Get the capacity of a broker based on rack, host and broker id.
-   * The response must contain all the resources defined in {@link Resource}. The units for each resource are:
-   * DISK - MegaBytes
-   * CPU - Percentage (0 - 100)
-   * Network Inbound - KB/s
-   * Network Outbounds - KB/s
-   *
-   * The response also contains the number of CPU cores and may contain disk capacities by logDirs (i.e. for JBOD).
    * May estimate the capacity of a broker, if it is not directly available.
    *
    * @param rack The rack of the broker
@@ -32,9 +25,10 @@ public interface BrokerCapacityConfigResolver extends CruiseControlConfigurable,
    * @param timeoutMs The timeout in millisecond.
    * @param allowCapacityEstimation Whether allow resolver to estimate broker capacity if resolver is unable to get
    *                                capacity information of the broker.
-   * @return The capacity of each resource for the broker
+   * @return A instance of {@link BrokerCapacityInfo}.
    * @throws TimeoutException if resolver is unable to resolve broker capacity in time.
+   * @throws BrokerCapacityResolvingException if resolver fails to resolve broker capacity.
    */
   BrokerCapacityInfo capacityForBroker(String rack, String host, int brokerId, long timeoutMs, boolean allowCapacityEstimation)
-      throws TimeoutException;
+      throws TimeoutException, BrokerCapacityResolvingException;
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigResolver.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigResolver.java
@@ -5,7 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.config;
 
 import com.linkedin.cruisecontrol.common.CruiseControlConfigurable;
-import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolvingException;
+import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolutionException;
 import java.util.concurrent.TimeoutException;
 
 
@@ -25,10 +25,10 @@ public interface BrokerCapacityConfigResolver extends CruiseControlConfigurable,
    * @param timeoutMs The timeout in millisecond.
    * @param allowCapacityEstimation Whether allow resolver to estimate broker capacity if resolver is unable to get
    *                                capacity information of the broker.
-   * @return A instance of {@link BrokerCapacityInfo}.
+   * @return An instance of {@link BrokerCapacityInfo}.
    * @throws TimeoutException if resolver is unable to resolve broker capacity in time.
-   * @throws BrokerCapacityResolvingException if resolver fails to resolve broker capacity.
+   * @throws BrokerCapacityResolutionException if resolver fails to resolve broker capacity.
    */
   BrokerCapacityInfo capacityForBroker(String rack, String host, int brokerId, long timeoutMs, boolean allowCapacityEstimation)
-      throws TimeoutException, BrokerCapacityResolvingException;
+      throws TimeoutException, BrokerCapacityResolutionException;
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigResolver.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigResolver.java
@@ -30,8 +30,11 @@ public interface BrokerCapacityConfigResolver extends CruiseControlConfigurable,
    * @param host The host of the broker
    * @param brokerId The id of the broker
    * @param timeoutMs The timeout in millisecond.
+   * @param allowCapacityEstimation Whether allow resolver to estimate broker capacity if resolver is unable to get
+   *                                capacity information of the broker.
    * @return The capacity of each resource for the broker
    * @throws TimeoutException if resolver is unable to resolve broker capacity in time.
    */
-  BrokerCapacityInfo capacityForBroker(String rack, String host, int brokerId, long timeoutMs) throws TimeoutException;
+  BrokerCapacityInfo capacityForBroker(String rack, String host, int brokerId, long timeoutMs, boolean allowCapacityEstimation)
+      throws TimeoutException;
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityInfo.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityInfo.java
@@ -10,6 +10,17 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 
+/**
+ * A class encapsulate the capacity information of a broker, which includes all the resources defined in {@link Resource}.
+ *
+ * The units for each resource are:
+ * DISK - MegaBytes
+ * CPU - Percentage (0 - 100)
+ * Network Inbound - KB/s
+ * Network Outbounds - KB/s
+ *
+ * The information also contains the number of CPU cores and may contain disk capacities by logDirs (i.e. for JBOD).
+ */
 public class BrokerCapacityInfo {
   public final static short DEFAULT_NUM_CPU_CORES = 1;
   private final static String DEFAULT_ESTIMATION_INFO = "";

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityInfo.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityInfo.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 
 
 /**
- * A class encapsulate the capacity information of a broker, which includes all the resources defined in {@link Resource}.
+ * A class encapsulating the capacity information of a broker, which includes all the resources defined in {@link Resource}.
  *
  * The units for each resource are:
  * DISK - MegaBytes

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.balancednessCostByGoal;
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.MAX_BALANCEDNESS_SCORE;
-import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.sanityCheckCapacityEstimation;
 import static com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorUtils.ANOMALY_DETECTION_TIME_MS_OBJECT_CONFIG;
 import static com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorUtils.shouldSkipAnomalyDetection;
 import static com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorUtils.KAFKA_CRUISE_CONTROL_OBJECT_CONFIG;
@@ -144,6 +143,7 @@ public class GoalViolationDetector implements Runnable {
             // Make cluster model null before generating a new cluster model so the current one can be GCed.
             clusterModel = null;
             clusterModel = _kafkaCruiseControl.clusterModel(goal.clusterModelCompletenessRequirements(),
+                                                            _allowCapacityEstimation,
                                                             new OperationProgress());
 
             // If the clusterModel contains dead brokers or disks, goal violation detector will ignore any goal violations.
@@ -151,7 +151,6 @@ public class GoalViolationDetector implements Runnable {
             if (skipDueToOfflineReplicas(clusterModel)) {
               return;
             }
-            sanityCheckCapacityEstimation(_allowCapacityEstimation, clusterModel.capacityEstimationInfoByBrokerId());
             _lastCheckedModelGeneration = clusterModel.generation();
           }
           newModelNeeded = optimizeForGoal(clusterModel, goal, goalViolations, excludedBrokersForLeadership, excludedBrokersForReplicaMove);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/exception/BrokerCapacityResolutionException.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/exception/BrokerCapacityResolutionException.java
@@ -7,13 +7,13 @@ package com.linkedin.kafka.cruisecontrol.exception;
 /**
  * The exception indicating something went wrong during the broker capacity resolving.
  */
-public class BrokerCapacityResolvingException extends KafkaCruiseControlException {
+public class BrokerCapacityResolutionException extends KafkaCruiseControlException {
 
-  public BrokerCapacityResolvingException(String message, Throwable cause) {
+  public BrokerCapacityResolutionException(String message, Throwable cause) {
     super(message, cause);
   }
 
-  public BrokerCapacityResolvingException(String message) {
+  public BrokerCapacityResolutionException(String message) {
     super(message);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/exception/BrokerCapacityResolvingException.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/exception/BrokerCapacityResolvingException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.exception;
+
+/**
+ * The exception indicating something went wrong during the broker capacity resolving.
+ */
+public class BrokerCapacityResolvingException extends KafkaCruiseControlException {
+
+  public BrokerCapacityResolvingException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public BrokerCapacityResolvingException(String message) {
+    super(message);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/MonitorUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/MonitorUtils.java
@@ -13,7 +13,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityConfigResolver;
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
-import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolvingException;
+import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolutionException;
 import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import com.linkedin.kafka.cruisecontrol.model.ModelUtils;
@@ -470,7 +470,7 @@ public class MonitorUtils {
           // Do not allow capacity estimation for dead brokers.
           brokerCapacity = brokerCapacityConfigResolver.capacityForBroker(rack, replica.host(), replica.id(), BROKER_CAPACITY_FETCH_TIMEOUT_MS,
                                                                           aliveBrokers.contains(replica.id()) && allowCapacityEstimation);
-        } catch (TimeoutException | BrokerCapacityResolvingException e) {
+        } catch (TimeoutException | BrokerCapacityResolutionException e) {
           // Capacity resolver may not be able to return the capacity information of dead brokers.
           if (!aliveBrokers.contains(replica.id())) {
             brokerCapacity = new BrokerCapacityInfo(EMPTY_BROKER_CAPACITY);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/MonitorUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/MonitorUtils.java
@@ -13,6 +13,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityConfigResolver;
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
+import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolvingException;
 import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import com.linkedin.kafka.cruisecontrol.model.ModelUtils;
@@ -445,7 +446,7 @@ public class MonitorUtils {
    * @param valuesAndExtrapolations The values and extrapolations of the leader replica.
    * @param replicaPlacementInfo The distribution of replicas over broker logdirs if available, {@code null} otherwise.
    * @param brokerCapacityConfigResolver The resolver for retrieving broker capacities.
-   * @param allowBrokerCapacityEstimation Whether allow broker capacity resolver to estimate broker capacity
+   * @param allowCapacityEstimation whether allow capacity estimation in cluster model if the underlying live broker capacity is unavailable.
    */
   static void populatePartitionLoad(Cluster cluster,
                                     ClusterModel clusterModel,
@@ -453,7 +454,8 @@ public class MonitorUtils {
                                     ValuesAndExtrapolations valuesAndExtrapolations,
                                     Map<TopicPartition, Map<Integer, String>> replicaPlacementInfo,
                                     BrokerCapacityConfigResolver brokerCapacityConfigResolver,
-                                    boolean allowBrokerCapacityEstimation) throws TimeoutException {
+                                    boolean allowCapacityEstimation)
+      throws TimeoutException {
     PartitionInfo partitionInfo = cluster.partition(tp);
     // If partition info does not exist, the topic may have been deleted.
     if (partitionInfo != null) {
@@ -467,8 +469,8 @@ public class MonitorUtils {
         try {
           // Do not allow capacity estimation for dead brokers.
           brokerCapacity = brokerCapacityConfigResolver.capacityForBroker(rack, replica.host(), replica.id(), BROKER_CAPACITY_FETCH_TIMEOUT_MS,
-                                                                          aliveBrokers.contains(replica.id()) && allowBrokerCapacityEstimation);
-        } catch (TimeoutException tme) {
+                                                                          aliveBrokers.contains(replica.id()) && allowCapacityEstimation);
+        } catch (TimeoutException | BrokerCapacityResolvingException e) {
           // Capacity resolver may not be able to return the capacity information of dead brokers.
           if (!aliveBrokers.contains(replica.id())) {
             brokerCapacity = new BrokerCapacityInfo(EMPTY_BROKER_CAPACITY);
@@ -476,7 +478,7 @@ public class MonitorUtils {
           } else {
             String errorMessage = String.format("Unable to retrieve capacity for broker %d. This may be caused by churn in "
                                                 + "the cluster, please retry.", replica.id());
-            LOG.warn(errorMessage, tme);
+            LOG.warn(errorMessage, e);
             throw new TimeoutException(errorMessage);
           }
         }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsProcessor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsProcessor.java
@@ -6,7 +6,7 @@ package com.linkedin.kafka.cruisecontrol.monitor.sampling;
 
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityConfigResolver;
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
-import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolvingException;
+import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolutionException;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.CruiseControlMetric;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.holder.BrokerLoad;
@@ -86,7 +86,7 @@ public class CruiseControlMetricsProcessor {
               _brokerCapacityConfigResolver.capacityForBroker(getRackHandleNull(node), node.host(), bid, BROKER_CAPACITY_FETCH_TIMEOUT_MS,
                                                               _allowCpuCapacityEstimation);
           return capacity == null ? null : capacity.numCpuCores();
-        } catch (TimeoutException | BrokerCapacityResolvingException e) {
+        } catch (TimeoutException | BrokerCapacityResolutionException e) {
           LOG.warn("Unable to get number of CPU cores for broker {}.", node.id(), e);
           return null;
         }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsProcessor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsProcessor.java
@@ -6,6 +6,7 @@ package com.linkedin.kafka.cruisecontrol.monitor.sampling;
 
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityConfigResolver;
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
+import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolvingException;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.CruiseControlMetric;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.holder.BrokerLoad;
@@ -84,9 +85,9 @@ public class CruiseControlMetricsProcessor {
           BrokerCapacityInfo capacity =
               _brokerCapacityConfigResolver.capacityForBroker(getRackHandleNull(node), node.host(), bid, BROKER_CAPACITY_FETCH_TIMEOUT_MS,
                                                               _allowCpuCapacityEstimation);
-          return capacity.numCpuCores();
-        } catch (TimeoutException tme) {
-          LOG.warn("Unable to get number of CPU cores for broker {}.", node.id(), tme);
+          return capacity == null ? null : capacity.numCpuCores();
+        } catch (TimeoutException | BrokerCapacityResolvingException e) {
+          LOG.warn("Unable to get number of CPU cores for broker {}.", node.id(), e);
           return null;
         }
       });

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsProcessor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsProcessor.java
@@ -82,9 +82,9 @@ public class CruiseControlMetricsProcessor {
         }
         try {
           BrokerCapacityInfo capacity =
-              _brokerCapacityConfigResolver.capacityForBroker(getRackHandleNull(node), node.host(), bid, BROKER_CAPACITY_FETCH_TIMEOUT_MS);
-          // No mapping shall be recorded if capacity is estimated, but estimation is not allowed.
-          return (!_allowCpuCapacityEstimation && capacity.isEstimated()) ? null : capacity.numCpuCores();
+              _brokerCapacityConfigResolver.capacityForBroker(getRackHandleNull(node), node.host(), bid, BROKER_CAPACITY_FETCH_TIMEOUT_MS,
+                                                              _allowCpuCapacityEstimation);
+          return capacity.numCpuCores();
         } catch (TimeoutException tme) {
           LOG.warn("Unable to get number of CPU cores for broker {}.", node.id(), tme);
           return null;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/AddBrokersRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/AddBrokersRunnable.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.goalsByPriority;
-import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.sanityCheckCapacityEstimation;
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.sanityCheckGoals;
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.sanityCheckLoadMonitorReadiness;
 import static com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.RunnableUtils.isKafkaAssignerMode;
@@ -109,14 +108,13 @@ public class AddBrokersRunnable extends OperationRunnable {
     sanityCheckLoadMonitorReadiness(modelCompletenessRequirements, _kafkaCruiseControl.getLoadMonitorTaskRunnerState());
     try (AutoCloseable ignored = _kafkaCruiseControl.acquireForModelGeneration(operationProgress)) {
       _kafkaCruiseControl.sanityCheckBrokerPresence(_brokerIds);
-      ClusterModel clusterModel = _kafkaCruiseControl.clusterModel(modelCompletenessRequirements, operationProgress);
+      ClusterModel clusterModel = _kafkaCruiseControl.clusterModel(modelCompletenessRequirements, _allowCapacityEstimation, operationProgress);
       sanityCheckBrokersHavingOfflineReplicasOnBadDisks(_goals, clusterModel);
       _brokerIds.forEach(id -> clusterModel.setBrokerState(id, Broker.State.NEW));
 
       if (!clusterModel.isClusterAlive()) {
         throw new IllegalArgumentException("All brokers are dead in the cluster.");
       }
-      sanityCheckCapacityEstimation(_allowCapacityEstimation, clusterModel.capacityEstimationInfoByBrokerId());
       ExecutorState executorState = _kafkaCruiseControl.executorState();
       Set<Integer> excludedBrokersForLeadership = _excludeRecentlyDemotedBrokers ? executorState.recentlyDemotedBrokers()
                                                                                  : Collections.emptySet();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/LoadRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/LoadRunnable.java
@@ -13,7 +13,6 @@ import com.linkedin.kafka.cruisecontrol.servlet.parameters.ClusterLoadParameters
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.PartitionLoadParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.response.stats.BrokerStats;
 
-import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.sanityCheckCapacityEstimation;
 import static com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig.MIN_VALID_PARTITION_RATIO_CONFIG;
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.DEFAULT_START_TIME_FOR_CLUSTER_MODEL;
 
@@ -97,8 +96,8 @@ public class LoadRunnable extends OperationRunnable {
                                                                    _end,
                                                                    requirements,
                                                                    _populateDiskInfo,
+                                                                   _allowCapacityEstimation,
                                                                    operationProgress);
-      sanityCheckCapacityEstimation(_allowCapacityEstimation, clusterModel.capacityEstimationInfoByBrokerId());
       return clusterModel;
     } catch (KafkaCruiseControlException kcce) {
       throw kcce;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/ProposalsRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/ProposalsRunnable.java
@@ -23,7 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.goalsByPriority;
-import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.sanityCheckCapacityEstimation;
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.sanityCheckGoals;
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.sanityCheckLoadMonitorReadiness;
 import static com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.RunnableUtils.sanityCheckBrokersHavingOfflineReplicasOnBadDisks;
@@ -120,12 +119,12 @@ public class ProposalsRunnable extends OperationRunnable {
                                                                      _kafkaCruiseControl.timeMs(),
                                                                      completenessRequirements,
                                                                      _isRebalanceDiskMode,
+                                                                     _allowCapacityEstimation,
                                                                      operationProgress);
         sanityCheckBrokersHavingOfflineReplicasOnBadDisks(_goals, clusterModel);
         if (!clusterModel.isClusterAlive()) {
           throw new IllegalArgumentException("All brokers are dead in the cluster.");
         }
-        sanityCheckCapacityEstimation(_allowCapacityEstimation, clusterModel.capacityEstimationInfoByBrokerId());
         if (!_destinationBrokerIds.isEmpty()) {
           _kafkaCruiseControl.sanityCheckBrokerPresence(_destinationBrokerIds);
         }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/UpdateTopicConfigurationRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/UpdateTopicConfigurationRunnable.java
@@ -36,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.goalsByPriority;
-import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.sanityCheckCapacityEstimation;
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.sanityCheckGoals;
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.sanityCheckLoadMonitorReadiness;
 import static com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.RunnableUtils.SELF_HEALING_DRYRUN;
@@ -211,9 +210,7 @@ public class UpdateTopicConfigurationRunnable extends OperationRunnable {
                                                                                   : Collections.emptySet();
       populateRackInfoForReplicationFactorChange(topicsToChangeByReplicationFactor, cluster, excludedBrokersForReplicaMove,
                                                  _skipRackAwarenessCheck, brokersByRack, rackByBroker);
-
-      ClusterModel clusterModel = _kafkaCruiseControl.clusterModel(completenessRequirements, operationProgress);
-      sanityCheckCapacityEstimation(_allowCapacityEstimation, clusterModel.capacityEstimationInfoByBrokerId());
+      ClusterModel clusterModel = _kafkaCruiseControl.clusterModel(completenessRequirements, _allowCapacityEstimation, operationProgress);
       Map<TopicPartition, List<ReplicaPlacementInfo>> initReplicaDistribution = clusterModel.getReplicaDistribution();
 
       // First try to add and remove replicas to achieve the replication factor for topics of interest.

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolverTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolverTest.java
@@ -5,7 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.config;
 
 import com.linkedin.kafka.cruisecontrol.common.Resource;
-import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolvingException;
+import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolutionException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -32,8 +32,8 @@ public class BrokerCapacityConfigFileResolverTest {
     return configResolver;
   }
 
-  @Test(expected = BrokerCapacityResolvingException.class)
-  public void testParseConfigFile() throws TimeoutException, BrokerCapacityResolvingException {
+  @Test(expected = BrokerCapacityResolutionException.class)
+  public void testParseConfigFile() throws TimeoutException, BrokerCapacityResolutionException {
     BrokerCapacityConfigResolver configResolver = getBrokerCapacityConfigResolver("testCapacityConfig.json", this.getClass());
 
     assertEquals(200000.0, configResolver.capacityForBroker("", "", 0, BROKER_CAPACITY_FETCH_TIMEOUT_MS, false)
@@ -50,12 +50,12 @@ public class BrokerCapacityConfigFileResolverTest {
     assertTrue(configResolver.capacityForBroker("", "", 2, BROKER_CAPACITY_FETCH_TIMEOUT_MS, true).isEstimated());
     assertTrue(configResolver.capacityForBroker("", "", 2, BROKER_CAPACITY_FETCH_TIMEOUT_MS, true).estimationInfo().length() > 0);
 
-    // If resolver is unable to get broker capacity and not allowed to estimate, an BrokerCapacityResolvingException will be thrown.
+    // If resolver is unable to get broker capacity and not allowed to estimate, a BrokerCapacityResolutionException will be thrown.
     configResolver.capacityForBroker("", "", 2, BROKER_CAPACITY_FETCH_TIMEOUT_MS, false);
   }
 
   @Test
-  public void testParseConfigJBODFile() throws TimeoutException, BrokerCapacityResolvingException {
+  public void testParseConfigJBODFile() throws TimeoutException, BrokerCapacityResolutionException {
     BrokerCapacityConfigResolver configResolver = getBrokerCapacityConfigResolver("testCapacityConfigJBOD.json", this.getClass());
 
     assertEquals(2000000.0, configResolver.capacityForBroker("", "", 0, BROKER_CAPACITY_FETCH_TIMEOUT_MS, false)
@@ -71,7 +71,7 @@ public class BrokerCapacityConfigFileResolverTest {
   }
 
   @Test
-  public void testParseConfigCoresFile() throws TimeoutException, BrokerCapacityResolvingException {
+  public void testParseConfigCoresFile() throws TimeoutException, BrokerCapacityResolutionException {
     BrokerCapacityConfigResolver configResolver = getBrokerCapacityConfigResolver("testCapacityConfigCores.json", this.getClass());
 
     assertEquals(BrokerCapacityConfigFileResolver.DEFAULT_CPU_CAPACITY_WITH_CORES, configResolver

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolverTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolverTest.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.config;
 
 import com.linkedin.kafka.cruisecontrol.common.Resource;
+import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolvingException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -31,8 +32,8 @@ public class BrokerCapacityConfigFileResolverTest {
     return configResolver;
   }
 
-  @Test
-  public void testParseConfigFile() throws TimeoutException {
+  @Test(expected = BrokerCapacityResolvingException.class)
+  public void testParseConfigFile() throws TimeoutException, BrokerCapacityResolvingException {
     BrokerCapacityConfigResolver configResolver = getBrokerCapacityConfigResolver("testCapacityConfig.json", this.getClass());
 
     assertEquals(200000.0, configResolver.capacityForBroker("", "", 0, BROKER_CAPACITY_FETCH_TIMEOUT_MS, false)
@@ -48,10 +49,13 @@ public class BrokerCapacityConfigFileResolverTest {
 
     assertTrue(configResolver.capacityForBroker("", "", 2, BROKER_CAPACITY_FETCH_TIMEOUT_MS, true).isEstimated());
     assertTrue(configResolver.capacityForBroker("", "", 2, BROKER_CAPACITY_FETCH_TIMEOUT_MS, true).estimationInfo().length() > 0);
+
+    // If resolver is unable to get broker capacity and not allowed to estimate, an BrokerCapacityResolvingException will be thrown.
+    configResolver.capacityForBroker("", "", 2, BROKER_CAPACITY_FETCH_TIMEOUT_MS, false);
   }
 
   @Test
-  public void testParseConfigJBODFile() throws TimeoutException {
+  public void testParseConfigJBODFile() throws TimeoutException, BrokerCapacityResolvingException {
     BrokerCapacityConfigResolver configResolver = getBrokerCapacityConfigResolver("testCapacityConfigJBOD.json", this.getClass());
 
     assertEquals(2000000.0, configResolver.capacityForBroker("", "", 0, BROKER_CAPACITY_FETCH_TIMEOUT_MS, false)
@@ -67,7 +71,7 @@ public class BrokerCapacityConfigFileResolverTest {
   }
 
   @Test
-  public void testParseConfigCoresFile() throws TimeoutException {
+  public void testParseConfigCoresFile() throws TimeoutException, BrokerCapacityResolvingException {
     BrokerCapacityConfigResolver configResolver = getBrokerCapacityConfigResolver("testCapacityConfigCores.json", this.getClass());
 
     assertEquals(BrokerCapacityConfigFileResolver.DEFAULT_CPU_CAPACITY_WITH_CORES, configResolver

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolverTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolverTest.java
@@ -35,35 +35,35 @@ public class BrokerCapacityConfigFileResolverTest {
   public void testParseConfigFile() throws TimeoutException {
     BrokerCapacityConfigResolver configResolver = getBrokerCapacityConfigResolver("testCapacityConfig.json", this.getClass());
 
-    assertEquals(200000.0, configResolver.capacityForBroker("", "", 0, BROKER_CAPACITY_FETCH_TIMEOUT_MS)
+    assertEquals(200000.0, configResolver.capacityForBroker("", "", 0, BROKER_CAPACITY_FETCH_TIMEOUT_MS, false)
                                          .capacity().get(Resource.NW_IN), 0.01);
-    assertEquals(100000.0, configResolver.capacityForBroker("", "", 2, BROKER_CAPACITY_FETCH_TIMEOUT_MS)
+    assertEquals(100000.0, configResolver.capacityForBroker("", "", 2, BROKER_CAPACITY_FETCH_TIMEOUT_MS, true)
                                          .capacity().get(Resource.NW_IN), 0.01);
     try {
-      configResolver.capacityForBroker("", "", BrokerCapacityConfigFileResolver.DEFAULT_CAPACITY_BROKER_ID, BROKER_CAPACITY_FETCH_TIMEOUT_MS);
+      configResolver.capacityForBroker("", "", BrokerCapacityConfigFileResolver.DEFAULT_CAPACITY_BROKER_ID, BROKER_CAPACITY_FETCH_TIMEOUT_MS, false);
       fail("Should have thrown exception for negative broker id");
     } catch (IllegalArgumentException e) {
       // let it go
     }
 
-    assertTrue(configResolver.capacityForBroker("", "", 2, BROKER_CAPACITY_FETCH_TIMEOUT_MS).isEstimated());
-    assertTrue(configResolver.capacityForBroker("", "", 2, BROKER_CAPACITY_FETCH_TIMEOUT_MS).estimationInfo().length() > 0);
+    assertTrue(configResolver.capacityForBroker("", "", 2, BROKER_CAPACITY_FETCH_TIMEOUT_MS, true).isEstimated());
+    assertTrue(configResolver.capacityForBroker("", "", 2, BROKER_CAPACITY_FETCH_TIMEOUT_MS, true).estimationInfo().length() > 0);
   }
 
   @Test
   public void testParseConfigJBODFile() throws TimeoutException {
     BrokerCapacityConfigResolver configResolver = getBrokerCapacityConfigResolver("testCapacityConfigJBOD.json", this.getClass());
 
-    assertEquals(2000000.0, configResolver.capacityForBroker("", "", 0, BROKER_CAPACITY_FETCH_TIMEOUT_MS)
+    assertEquals(2000000.0, configResolver.capacityForBroker("", "", 0, BROKER_CAPACITY_FETCH_TIMEOUT_MS, false)
                                          .capacity().get(Resource.DISK), 0.01);
-    assertEquals(2200000.0, configResolver.capacityForBroker("", "", 3, BROKER_CAPACITY_FETCH_TIMEOUT_MS)
+    assertEquals(2200000.0, configResolver.capacityForBroker("", "", 3, BROKER_CAPACITY_FETCH_TIMEOUT_MS, true)
                                          .capacity().get(Resource.DISK), 0.01);
-    assertEquals(200000.0, configResolver.capacityForBroker("", "", 3, BROKER_CAPACITY_FETCH_TIMEOUT_MS)
+    assertEquals(200000.0, configResolver.capacityForBroker("", "", 3, BROKER_CAPACITY_FETCH_TIMEOUT_MS, true)
                                          .diskCapacityByLogDir().get("/tmp/kafka-logs-4"), 0.01);
 
-    assertFalse(configResolver.capacityForBroker("", "", 2, BROKER_CAPACITY_FETCH_TIMEOUT_MS).isEstimated());
-    assertTrue(configResolver.capacityForBroker("", "", 3, BROKER_CAPACITY_FETCH_TIMEOUT_MS).isEstimated());
-    assertTrue(configResolver.capacityForBroker("", "", 3, BROKER_CAPACITY_FETCH_TIMEOUT_MS).estimationInfo().length() > 0);
+    assertFalse(configResolver.capacityForBroker("", "", 2, BROKER_CAPACITY_FETCH_TIMEOUT_MS, false).isEstimated());
+    assertTrue(configResolver.capacityForBroker("", "", 3, BROKER_CAPACITY_FETCH_TIMEOUT_MS, true).isEstimated());
+    assertTrue(configResolver.capacityForBroker("", "", 3, BROKER_CAPACITY_FETCH_TIMEOUT_MS, true).estimationInfo().length() > 0);
   }
 
   @Test
@@ -71,16 +71,16 @@ public class BrokerCapacityConfigFileResolverTest {
     BrokerCapacityConfigResolver configResolver = getBrokerCapacityConfigResolver("testCapacityConfigCores.json", this.getClass());
 
     assertEquals(BrokerCapacityConfigFileResolver.DEFAULT_CPU_CAPACITY_WITH_CORES, configResolver
-        .capacityForBroker("", "", 0, BROKER_CAPACITY_FETCH_TIMEOUT_MS).capacity().get(Resource.CPU), 0.01);
+        .capacityForBroker("", "", 0, BROKER_CAPACITY_FETCH_TIMEOUT_MS, false).capacity().get(Resource.CPU), 0.01);
     assertEquals(BrokerCapacityConfigFileResolver.DEFAULT_CPU_CAPACITY_WITH_CORES, configResolver
-        .capacityForBroker("", "", 3, BROKER_CAPACITY_FETCH_TIMEOUT_MS).capacity().get(Resource.CPU), 0.01);
+        .capacityForBroker("", "", 3, BROKER_CAPACITY_FETCH_TIMEOUT_MS, true).capacity().get(Resource.CPU), 0.01);
 
-    assertEquals(8, configResolver.capacityForBroker("", "", 0, BROKER_CAPACITY_FETCH_TIMEOUT_MS).numCpuCores());
-    assertEquals(64, configResolver.capacityForBroker("", "", 1, BROKER_CAPACITY_FETCH_TIMEOUT_MS).numCpuCores());
-    assertEquals(16, configResolver.capacityForBroker("", "", 3, BROKER_CAPACITY_FETCH_TIMEOUT_MS).numCpuCores());
+    assertEquals(8, configResolver.capacityForBroker("", "", 0, BROKER_CAPACITY_FETCH_TIMEOUT_MS, false).numCpuCores());
+    assertEquals(64, configResolver.capacityForBroker("", "", 1, BROKER_CAPACITY_FETCH_TIMEOUT_MS, false).numCpuCores());
+    assertEquals(16, configResolver.capacityForBroker("", "", 3, BROKER_CAPACITY_FETCH_TIMEOUT_MS, true).numCpuCores());
 
-    assertFalse(configResolver.capacityForBroker("", "", 1, BROKER_CAPACITY_FETCH_TIMEOUT_MS).isEstimated());
-    assertTrue(configResolver.capacityForBroker("", "", 3, BROKER_CAPACITY_FETCH_TIMEOUT_MS).isEstimated());
-    assertTrue(configResolver.capacityForBroker("", "", 3, BROKER_CAPACITY_FETCH_TIMEOUT_MS).estimationInfo().length() > 0);
+    assertFalse(configResolver.capacityForBroker("", "", 1, BROKER_CAPACITY_FETCH_TIMEOUT_MS, false).isEstimated());
+    assertTrue(configResolver.capacityForBroker("", "", 3, BROKER_CAPACITY_FETCH_TIMEOUT_MS, true).isEstimated());
+    assertTrue(configResolver.capacityForBroker("", "", 3, BROKER_CAPACITY_FETCH_TIMEOUT_MS, true).estimationInfo().length() > 0);
   }
 }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -377,7 +377,7 @@ public class AnomalyDetectorTest {
       EasyMock.expect(mockAnomalyNotifier.onMetricAnomaly(EasyMock.isA(SlowBrokers.class))).andReturn(AnomalyNotificationResult.fix());
     } else if (anomalyType == KafkaAnomalyType.TOPIC_ANOMALY) {
       ClusterModel clusterModel = unbalanced();
-      EasyMock.expect(mockKafkaCruiseControl.clusterModel(EasyMock.anyObject(), EasyMock.anyObject())).andReturn(clusterModel);
+      EasyMock.expect(mockKafkaCruiseControl.clusterModel(EasyMock.anyObject(), EasyMock.eq(true), EasyMock.anyObject())).andReturn(clusterModel);
       EasyMock.expect(mockKafkaCruiseControl.kafkaCluster()).andReturn(generateClusterFromClusterModel(clusterModel));
       EasyMock.expect(mockKafkaCruiseControl.acquireForModelGeneration(EasyMock.anyObject())).andReturn(null);
       ExecutorState executorState = EasyMock.mock(ExecutorState.class);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -317,7 +317,7 @@ public class AnomalyDetectorTest {
       EasyMock.expect(mockAnomalyNotifier.onGoalViolation(EasyMock.isA(GoalViolations.class))).andReturn(AnomalyNotificationResult.fix());
     } else if (anomalyType == KafkaAnomalyType.DISK_FAILURE) {
       ClusterModel singleBrokerWithBadDisk = singleBrokerWithBadDisk();
-      EasyMock.expect(mockKafkaCruiseControl.clusterModel(EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject())).andReturn(singleBrokerWithBadDisk);
+      EasyMock.expect(mockKafkaCruiseControl.clusterModel(EasyMock.anyObject(), EasyMock.eq(true), EasyMock.anyObject())).andReturn(singleBrokerWithBadDisk);
       ExecutorState executorState = EasyMock.mock(ExecutorState.class);
       EasyMock.expect(mockKafkaCruiseControl.executorState()).andReturn(executorState);
       EasyMock.expect(executorState.recentlyDemotedBrokers()).andReturn(Collections.emptySet());
@@ -348,7 +348,7 @@ public class AnomalyDetectorTest {
       EasyMock.expect(mockAnomalyNotifier.onDiskFailure(EasyMock.isA(DiskFailures.class))).andReturn(AnomalyNotificationResult.fix());
     } else if (anomalyType == KafkaAnomalyType.METRIC_ANOMALY) {
       ClusterModel smallCluster = smallClusterModel(TestConstants.BROKER_CAPACITY);
-      EasyMock.expect(mockKafkaCruiseControl.clusterModel(EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject())).andReturn(smallCluster);
+      EasyMock.expect(mockKafkaCruiseControl.clusterModel(EasyMock.anyObject(), EasyMock.eq(true), EasyMock.anyObject())).andReturn(smallCluster);
       EasyMock.expect(mockKafkaCruiseControl.kafkaCluster()).andReturn(Cluster.empty());
       EasyMock.expect(mockKafkaCruiseControl.acquireForModelGeneration(EasyMock.anyObject())).andReturn(null);
       mockKafkaCruiseControl.sanityCheckBrokerPresence(EasyMock.anyObject());

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -317,7 +317,7 @@ public class AnomalyDetectorTest {
       EasyMock.expect(mockAnomalyNotifier.onGoalViolation(EasyMock.isA(GoalViolations.class))).andReturn(AnomalyNotificationResult.fix());
     } else if (anomalyType == KafkaAnomalyType.DISK_FAILURE) {
       ClusterModel singleBrokerWithBadDisk = singleBrokerWithBadDisk();
-      EasyMock.expect(mockKafkaCruiseControl.clusterModel(EasyMock.anyObject(), EasyMock.anyObject())).andReturn(singleBrokerWithBadDisk);
+      EasyMock.expect(mockKafkaCruiseControl.clusterModel(EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject())).andReturn(singleBrokerWithBadDisk);
       ExecutorState executorState = EasyMock.mock(ExecutorState.class);
       EasyMock.expect(mockKafkaCruiseControl.executorState()).andReturn(executorState);
       EasyMock.expect(executorState.recentlyDemotedBrokers()).andReturn(Collections.emptySet());
@@ -348,7 +348,7 @@ public class AnomalyDetectorTest {
       EasyMock.expect(mockAnomalyNotifier.onDiskFailure(EasyMock.isA(DiskFailures.class))).andReturn(AnomalyNotificationResult.fix());
     } else if (anomalyType == KafkaAnomalyType.METRIC_ANOMALY) {
       ClusterModel smallCluster = smallClusterModel(TestConstants.BROKER_CAPACITY);
-      EasyMock.expect(mockKafkaCruiseControl.clusterModel(EasyMock.anyObject(), EasyMock.anyObject())).andReturn(smallCluster);
+      EasyMock.expect(mockKafkaCruiseControl.clusterModel(EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject())).andReturn(smallCluster);
       EasyMock.expect(mockKafkaCruiseControl.kafkaCluster()).andReturn(Cluster.empty());
       EasyMock.expect(mockKafkaCruiseControl.acquireForModelGeneration(EasyMock.anyObject())).andReturn(null);
       mockKafkaCruiseControl.sanityCheckBrokerPresence(EasyMock.anyObject());

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/RandomCluster.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/RandomCluster.java
@@ -10,6 +10,7 @@ import com.linkedin.kafka.cruisecontrol.common.ClusterProperty;
 import com.linkedin.kafka.cruisecontrol.common.Resource;
 import com.linkedin.kafka.cruisecontrol.common.TestConstants;
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityConfigFileResolver;
+import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolvingException;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelGeneration;
 
 import java.util.ArrayList;
@@ -25,7 +26,6 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.TimeoutException;
 import org.apache.kafka.common.TopicPartition;
 
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.JBOD_BROKER_CAPACITY_CONFIG_FILE;
@@ -46,9 +46,10 @@ public class RandomCluster {
    *
    * @param clusterProperties Cluster properties specifying number of racks and brokers.
    * @return Cluster with the specified number of racks and brokers.
-   * @throws TimeoutException If broker capacity is unable to be determined.
+   * @throws BrokerCapacityResolvingException If broker capacity resolver fails to resolve broker capacity.
    */
-  public static ClusterModel generate(Map<ClusterProperty, Number> clusterProperties) throws TimeoutException {
+  public static ClusterModel generate(Map<ClusterProperty, Number> clusterProperties)
+      throws BrokerCapacityResolvingException {
     int numRacks = clusterProperties.get(ClusterProperty.NUM_RACKS).intValue();
     int numBrokers = clusterProperties.get(ClusterProperty.NUM_BROKERS).intValue();
     BrokerCapacityConfigFileResolver configFileResolver = new BrokerCapacityConfigFileResolver();
@@ -491,7 +492,7 @@ public class RandomCluster {
   /**
    * @return Get a cluster model having a single broker with bad disk.
    */
-  public static ClusterModel singleBrokerWithBadDisk() throws TimeoutException {
+  public static ClusterModel singleBrokerWithBadDisk() throws BrokerCapacityResolvingException {
     Map<ClusterProperty, Number> singleBrokerWithBadDisk = new HashMap<>();
     singleBrokerWithBadDisk.put(ClusterProperty.NUM_BROKERS, 3);
     singleBrokerWithBadDisk.put(ClusterProperty.NUM_RACKS, 3);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/RandomCluster.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/RandomCluster.java
@@ -10,7 +10,7 @@ import com.linkedin.kafka.cruisecontrol.common.ClusterProperty;
 import com.linkedin.kafka.cruisecontrol.common.Resource;
 import com.linkedin.kafka.cruisecontrol.common.TestConstants;
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityConfigFileResolver;
-import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolvingException;
+import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolutionException;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelGeneration;
 
 import java.util.ArrayList;
@@ -46,10 +46,10 @@ public class RandomCluster {
    *
    * @param clusterProperties Cluster properties specifying number of racks and brokers.
    * @return Cluster with the specified number of racks and brokers.
-   * @throws BrokerCapacityResolvingException If broker capacity resolver fails to resolve broker capacity.
+   * @throws BrokerCapacityResolutionException If broker capacity resolver fails to resolve broker capacity.
    */
   public static ClusterModel generate(Map<ClusterProperty, Number> clusterProperties)
-      throws BrokerCapacityResolvingException {
+      throws BrokerCapacityResolutionException {
     int numRacks = clusterProperties.get(ClusterProperty.NUM_RACKS).intValue();
     int numBrokers = clusterProperties.get(ClusterProperty.NUM_BROKERS).intValue();
     BrokerCapacityConfigFileResolver configFileResolver = new BrokerCapacityConfigFileResolver();
@@ -492,7 +492,7 @@ public class RandomCluster {
   /**
    * @return Get a cluster model having a single broker with bad disk.
    */
-  public static ClusterModel singleBrokerWithBadDisk() throws BrokerCapacityResolvingException {
+  public static ClusterModel singleBrokerWithBadDisk() throws BrokerCapacityResolutionException {
     Map<ClusterProperty, Number> singleBrokerWithBadDisk = new HashMap<>();
     singleBrokerWithBadDisk.put(ClusterProperty.NUM_BROKERS, 3);
     singleBrokerWithBadDisk.put(ClusterProperty.NUM_RACKS, 3);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
@@ -250,6 +250,7 @@ public class LoadMonitorTest {
 
     ClusterModel clusterModel = loadMonitor.clusterModel(-1, Long.MAX_VALUE,
                                                          new ModelCompletenessRequirements(2, 1.0, false),
+                                                         true,
                                                          new OperationProgress());
     assertEquals(6.5, clusterModel.partition(T0P0).leader().load().expectedUtilizationFor(Resource.CPU), 0.0);
     assertEquals(13, clusterModel.partition(T0P0).leader().load().expectedUtilizationFor(Resource.NW_IN), 0.0);
@@ -271,6 +272,7 @@ public class LoadMonitorTest {
 
     ClusterModel clusterModel = loadMonitor.clusterModel(DEFAULT_START_TIME_FOR_CLUSTER_MODEL, Long.MAX_VALUE,
                                                          new ModelCompletenessRequirements(2, 1.0, false),
+                                                         true,
                                                          true,
                                                          new OperationProgress());
 
@@ -303,13 +305,13 @@ public class LoadMonitorTest {
     CruiseControlUnitTestUtils.populateSampleAggregator(2, 4, aggregator, PE_T1P0, 0, WINDOW_MS, METRIC_DEF);
 
     try {
-      loadMonitor.clusterModel(-1, Long.MAX_VALUE, requirements1, new OperationProgress());
+      loadMonitor.clusterModel(-1, Long.MAX_VALUE, requirements1, true, new OperationProgress());
       fail("Should have thrown NotEnoughValidWindowsException.");
     } catch (NotEnoughValidWindowsException nevwe) {
       // let it go
     }
 
-    ClusterModel clusterModel = loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements2, new OperationProgress());
+    ClusterModel clusterModel = loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements2, true, new OperationProgress());
     assertNotNull(clusterModel.partition(T1P0));
     assertNull(clusterModel.partition(T1P1));
     assertEquals(1, clusterModel.partition(T0P0).leader().load().numWindows());
@@ -319,14 +321,14 @@ public class LoadMonitorTest {
     assertEquals(3.0, clusterModel.partition(T0P0).leader().load().expectedUtilizationFor(Resource.NW_OUT), 0.0);
 
     try {
-      loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements3, new OperationProgress());
+      loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements3, true, new OperationProgress());
       fail("Should have thrown NotEnoughValidWindowsException.");
     } catch (NotEnoughValidWindowsException nevwe) {
       // let it go
     }
 
     try {
-      loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements4, new OperationProgress());
+      loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements4, true, new OperationProgress());
       fail("Should have thrown NotEnoughValidWindowsException.");
     } catch (NotEnoughValidWindowsException nevwe) {
       // let it go
@@ -352,13 +354,13 @@ public class LoadMonitorTest {
     CruiseControlUnitTestUtils.populateSampleAggregator(3, 4, aggregator, PE_T1P0, 0, WINDOW_MS, METRIC_DEF);
 
     try {
-      loadMonitor.clusterModel(-1, Long.MAX_VALUE, requirements1, new OperationProgress());
+      loadMonitor.clusterModel(-1, Long.MAX_VALUE, requirements1, true, new OperationProgress());
       fail("Should have thrown NotEnoughValidWindowsException.");
     } catch (NotEnoughValidWindowsException nevwe) {
       // let it go
     }
 
-    ClusterModel clusterModel = loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements2, new OperationProgress());
+    ClusterModel clusterModel = loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements2, true, new OperationProgress());
     assertNotNull(clusterModel.partition(T1P0));
     assertNull(clusterModel.partition(T1P1));
     assertEquals(2, clusterModel.partition(T0P0).leader().load().numWindows());
@@ -368,13 +370,13 @@ public class LoadMonitorTest {
     assertEquals(13, clusterModel.partition(T0P0).leader().load().expectedUtilizationFor(Resource.NW_OUT), 0.0);
 
     try {
-      loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements3, new OperationProgress());
+      loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements3, true, new OperationProgress());
       fail("Should have thrown NotEnoughValidWindowsException.");
     } catch (NotEnoughValidWindowsException nevwe) {
       // let it go
     }
 
-    clusterModel = loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements4, new OperationProgress());
+    clusterModel = loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements4, true, new OperationProgress());
     assertNotNull(clusterModel.partition(T1P0));
     assertNull(clusterModel.partition(T1P1));
     assertEquals(2, clusterModel.partition(T0P0).leader().load().numWindows());
@@ -403,7 +405,7 @@ public class LoadMonitorTest {
     CruiseControlUnitTestUtils.populateSampleAggregator(3, 4, aggregator, PE_T1P0, 0, WINDOW_MS, METRIC_DEF);
     CruiseControlUnitTestUtils.populateSampleAggregator(1, 1, aggregator, PE_T1P1, 1, WINDOW_MS, METRIC_DEF);
 
-    ClusterModel clusterModel =  loadMonitor.clusterModel(-1, Long.MAX_VALUE, requirements1, new OperationProgress());
+    ClusterModel clusterModel =  loadMonitor.clusterModel(-1, Long.MAX_VALUE, requirements1, true, new OperationProgress());
     for (TopicPartition tp : Arrays.asList(T0P0, T0P1, T1P0, T1P1)) {
       assertNotNull(clusterModel.partition(tp));
     }
@@ -418,7 +420,7 @@ public class LoadMonitorTest {
     assertEquals(20, clusterModel.partition(T1P1).leader().load().expectedUtilizationFor(Resource.NW_IN), 0.0);
     assertEquals(20, clusterModel.partition(T1P1).leader().load().expectedUtilizationFor(Resource.NW_OUT), 0.0);
 
-    clusterModel = loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements2, new OperationProgress());
+    clusterModel = loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements2, true, new OperationProgress());
     assertNotNull(clusterModel.partition(T1P0));
     assertNull(clusterModel.partition(T1P1));
     assertEquals(2, clusterModel.partition(T0P0).leader().load().numWindows());
@@ -428,13 +430,13 @@ public class LoadMonitorTest {
     assertEquals(13.0, clusterModel.partition(T0P0).leader().load().expectedUtilizationFor(Resource.NW_OUT), 0.0);
 
     try {
-      loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements3, new OperationProgress());
+      loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements3, true, new OperationProgress());
       fail("Should have thrown NotEnoughValidWindowsException.");
     } catch (NotEnoughValidWindowsException nevwe) {
       // let it go
     }
 
-    clusterModel = loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements4, new OperationProgress());
+    clusterModel = loadMonitor.clusterModel(-1L, Long.MAX_VALUE, requirements4, true, new OperationProgress());
     assertNotNull(clusterModel.partition(T1P0));
     assertNull(clusterModel.partition(T1P1));
     assertEquals(2, clusterModel.partition(T0P0).leader().load().numWindows());
@@ -466,8 +468,9 @@ public class LoadMonitorTest {
     CruiseControlUnitTestUtils.populateSampleAggregator(1, 4, aggregator, PE_T1P1, 4, WINDOW_MS, METRIC_DEF);
 
     ClusterModel clusterModel = loadMonitor.clusterModel(-1, Long.MAX_VALUE,
-        new ModelCompletenessRequirements(2, 0, false),
-        new OperationProgress());
+                                                         new ModelCompletenessRequirements(2, 0, false),
+                                                         true,
+                                                         new OperationProgress());
 
     assertEquals(2, clusterModel.partition(T0P0).leader().load().numWindows());
     assertEquals(16.5, clusterModel.partition(T0P0).leader().load().expectedUtilizationFor(Resource.CPU), 0.0);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
@@ -16,7 +16,7 @@ import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityConfigFileResolver;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.ExecutorConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
-import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolvingException;
+import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolutionException;
 import com.linkedin.kafka.cruisecontrol.executor.Executor;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import com.linkedin.kafka.cruisecontrol.model.ModelParameters;
@@ -240,19 +240,19 @@ public class LoadMonitorTest {
   // Test the case with enough snapshot windows and valid partitions.
   @Test
   public void testBasicClusterModelWithCapacityEstimationAllowed()
-      throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolvingException {
+      throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolutionException {
     testBasicClusterModel(true);
   }
 
   // Test the case that broker capacity resolver is not allowed to estimate broker capacity.
-  @Test(expected = BrokerCapacityResolvingException.class)
+  @Test(expected = BrokerCapacityResolutionException.class)
   public void testBasicClusterModelWithCapacityEstimationNotAllowed()
-      throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolvingException {
+      throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolutionException {
     testBasicClusterModel(false);
   }
 
   private void testBasicClusterModel(boolean allowCapacityEstimation)
-      throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolvingException {
+      throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolutionException {
     TestContext context = prepareContext();
     LoadMonitor loadMonitor = context.loadmonitor();
     KafkaPartitionMetricSampleAggregator aggregator = context.aggregator();
@@ -274,7 +274,7 @@ public class LoadMonitorTest {
 
   // Test build cluster model for JBOD broker.
   @Test
-  public void testJBODClusterModel() throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolvingException {
+  public void testJBODClusterModel() throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolutionException {
     TestContext context = prepareContext(NUM_WINDOWS, true);
     LoadMonitor loadMonitor = context.loadmonitor();
     KafkaPartitionMetricSampleAggregator aggregator = context.aggregator();
@@ -302,7 +302,7 @@ public class LoadMonitorTest {
   // Not enough snapshot windows and some partitions are missing from all snapshot windows.
   @Test
   public void testClusterModelWithInvalidPartitionAndInsufficientSnapshotWindows()
-      throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolvingException {
+      throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolutionException {
     TestContext context = prepareContext();
     LoadMonitor loadMonitor = context.loadmonitor();
     KafkaPartitionMetricSampleAggregator aggregator = context.aggregator();
@@ -351,7 +351,7 @@ public class LoadMonitorTest {
 
   // Enough snapshot windows, some partitions are invalid in all snapshot windows.
   @Test
-  public void testClusterWithInvalidPartitions() throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolvingException {
+  public void testClusterWithInvalidPartitions() throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolutionException {
     TestContext context = prepareContext();
     LoadMonitor loadMonitor = context.loadmonitor();
     KafkaPartitionMetricSampleAggregator aggregator = context.aggregator();
@@ -402,7 +402,7 @@ public class LoadMonitorTest {
 
   // Enough snapshot windows, some partitions are not available in some snapshot windows.
   @Test
-  public void testClusterModelWithPartlyInvalidPartitions() throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolvingException {
+  public void testClusterModelWithPartlyInvalidPartitions() throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolutionException {
     TestContext context = prepareContext();
     LoadMonitor loadMonitor = context.loadmonitor();
     KafkaPartitionMetricSampleAggregator aggregator = context.aggregator();
@@ -461,7 +461,7 @@ public class LoadMonitorTest {
   }
 
   @Test
-  public void testClusterModelWithInvalidSnapshotWindows() throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolvingException {
+  public void testClusterModelWithInvalidSnapshotWindows() throws NotEnoughValidWindowsException, TimeoutException, BrokerCapacityResolutionException {
     TestContext context = prepareContext(4, false);
     LoadMonitor loadMonitor = context.loadmonitor();
     KafkaPartitionMetricSampleAggregator aggregator = context.aggregator();

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsProcessorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsProcessorTest.java
@@ -117,7 +117,8 @@ public class CruiseControlMetricsProcessorTest {
 
   private static BrokerCapacityConfigResolver mockBrokerCapacityConfigResolver() throws TimeoutException {
     BrokerCapacityConfigResolver brokerCapacityConfigResolver = EasyMock.mock(BrokerCapacityConfigResolver.class);
-    EasyMock.expect(brokerCapacityConfigResolver.capacityForBroker(EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyInt(), EasyMock.anyLong()))
+    EasyMock.expect(brokerCapacityConfigResolver.capacityForBroker(EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyInt(),
+                                                                   EasyMock.anyLong(), EasyMock.anyBoolean()))
             .andReturn(new BrokerCapacityInfo(EMPTY_BROKER_CAPACITY, Collections.emptyMap(), MOCK_NUM_CPU_CORES)).anyTimes();
     EasyMock.replay(brokerCapacityConfigResolver);
     return brokerCapacityConfigResolver;
@@ -129,8 +130,8 @@ public class CruiseControlMetricsProcessorTest {
     // All estimated.
     BrokerCapacityConfigResolver brokerCapacityConfigResolverAllEstimated = EasyMock.mock(BrokerCapacityConfigResolver.class);
     EasyMock.expect(brokerCapacityConfigResolverAllEstimated.capacityForBroker(EasyMock.anyString(), EasyMock.anyString(),
-                                                                               EasyMock.anyInt(), EasyMock.anyLong()))
-            .andReturn(new BrokerCapacityInfo(EMPTY_BROKER_CAPACITY, "All estimated", Collections.emptyMap(), MOCK_NUM_CPU_CORES)).anyTimes();
+                                                                               EasyMock.anyInt(), EasyMock.anyLong(), EasyMock.eq(false)))
+            .andThrow(new TimeoutException("Unable to resolve capacity.")).anyTimes();
     EasyMock.replay(brokerCapacityConfigResolverAllEstimated);
 
     CruiseControlMetricsProcessor processor = new CruiseControlMetricsProcessor(brokerCapacityConfigResolverAllEstimated, false);
@@ -147,7 +148,7 @@ public class CruiseControlMetricsProcessorTest {
     // Capacity resolver unable to retrieve broker capacity.
     BrokerCapacityConfigResolver brokerCapacityConfigResolverTimeout = EasyMock.mock(BrokerCapacityConfigResolver.class);
     EasyMock.expect(brokerCapacityConfigResolverTimeout.capacityForBroker(EasyMock.anyString(), EasyMock.anyString(),
-                                                                          EasyMock.anyInt(), EasyMock.anyLong()))
+                                                                          EasyMock.anyInt(), EasyMock.anyLong(), EasyMock.anyBoolean()))
             .andThrow(new TimeoutException("Unable to resolve capacity.")).anyTimes();
     EasyMock.replay(brokerCapacityConfigResolverTimeout);
 
@@ -165,10 +166,10 @@ public class CruiseControlMetricsProcessorTest {
     // Some estimated.
     BrokerCapacityConfigResolver brokerCapacityConfigResolverSomeEstimated = EasyMock.mock(BrokerCapacityConfigResolver.class);
     EasyMock.expect(brokerCapacityConfigResolverSomeEstimated.capacityForBroker(EasyMock.anyString(), EasyMock.anyString(),
-                                                                                EasyMock.eq(BROKER_ID_1), EasyMock.anyLong()))
-            .andReturn(new BrokerCapacityInfo(EMPTY_BROKER_CAPACITY, "1 estimated", Collections.emptyMap(), MOCK_NUM_CPU_CORES)).anyTimes();
+                                                                                EasyMock.eq(BROKER_ID_1), EasyMock.anyLong(), EasyMock.anyBoolean()))
+        .andThrow(new TimeoutException("Unable to resolve capacity.")).anyTimes();
     EasyMock.expect(brokerCapacityConfigResolverSomeEstimated.capacityForBroker(EasyMock.anyString(), EasyMock.anyString(),
-                                                                                EasyMock.eq(BROKER_ID_0), EasyMock.anyLong()))
+                                                                                EasyMock.eq(BROKER_ID_0), EasyMock.anyLong(), EasyMock.anyBoolean()))
             .andReturn(new BrokerCapacityInfo(EMPTY_BROKER_CAPACITY, Collections.emptyMap(), MOCK_NUM_CPU_CORES)).anyTimes();
     EasyMock.replay(brokerCapacityConfigResolverSomeEstimated);
 
@@ -320,7 +321,8 @@ public class CruiseControlMetricsProcessorTest {
     Set<CruiseControlMetric> metrics = getCruiseControlMetrics();
     // All estimated.
     BrokerCapacityConfigResolver brokerCapacityConfigResolver = EasyMock.mock(BrokerCapacityConfigResolver.class);
-    EasyMock.expect(brokerCapacityConfigResolver.capacityForBroker(EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyInt(), EasyMock.anyLong()))
+    EasyMock.expect(brokerCapacityConfigResolver.capacityForBroker(EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyInt(),
+                                                                   EasyMock.anyLong(), EasyMock.anyBoolean()))
             .andReturn(new BrokerCapacityInfo(Collections.emptyMap(), Collections.emptyMap(), MOCK_NUM_CPU_CORES)).anyTimes();
     EasyMock.replay(brokerCapacityConfigResolver);
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsProcessorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsProcessorTest.java
@@ -6,7 +6,7 @@ package com.linkedin.kafka.cruisecontrol.monitor.sampling;
 
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityConfigResolver;
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
-import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolvingException;
+import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolutionException;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.BrokerMetric;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.CruiseControlMetric;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.RawMetricType;
@@ -116,7 +116,7 @@ public class CruiseControlMetricsProcessorTest {
   }
   private final Time _time = new MockTime(0, 100L, TimeUnit.NANOSECONDS.convert(100L, TimeUnit.MILLISECONDS));
 
-  private static BrokerCapacityConfigResolver mockBrokerCapacityConfigResolver() throws TimeoutException, BrokerCapacityResolvingException {
+  private static BrokerCapacityConfigResolver mockBrokerCapacityConfigResolver() throws TimeoutException, BrokerCapacityResolutionException {
     BrokerCapacityConfigResolver brokerCapacityConfigResolver = EasyMock.mock(BrokerCapacityConfigResolver.class);
     EasyMock.expect(brokerCapacityConfigResolver.capacityForBroker(EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyInt(),
                                                                    EasyMock.anyLong(), EasyMock.anyBoolean()))
@@ -126,13 +126,13 @@ public class CruiseControlMetricsProcessorTest {
   }
 
   @Test
-  public void testWithCpuCapacityEstimation() throws TimeoutException, BrokerCapacityResolvingException {
+  public void testWithCpuCapacityEstimation() throws TimeoutException, BrokerCapacityResolutionException {
     Set<CruiseControlMetric> metrics = getCruiseControlMetrics();
     // All estimated.
     BrokerCapacityConfigResolver brokerCapacityConfigResolverAllEstimated = EasyMock.mock(BrokerCapacityConfigResolver.class);
     EasyMock.expect(brokerCapacityConfigResolverAllEstimated.capacityForBroker(EasyMock.anyString(), EasyMock.anyString(),
                                                                                EasyMock.anyInt(), EasyMock.anyLong(), EasyMock.eq(false)))
-            .andThrow(new BrokerCapacityResolvingException("Unable to resolve capacity.")).anyTimes();
+            .andThrow(new BrokerCapacityResolutionException("Unable to resolve capacity.")).anyTimes();
     EasyMock.replay(brokerCapacityConfigResolverAllEstimated);
 
     CruiseControlMetricsProcessor processor = new CruiseControlMetricsProcessor(brokerCapacityConfigResolverAllEstimated, false);
@@ -184,7 +184,7 @@ public class CruiseControlMetricsProcessorTest {
   }
 
   @Test
-  public void testBasic() throws TimeoutException, BrokerCapacityResolvingException {
+  public void testBasic() throws TimeoutException, BrokerCapacityResolutionException {
     CruiseControlMetricsProcessor processor = new CruiseControlMetricsProcessor(mockBrokerCapacityConfigResolver(), false);
     Set<CruiseControlMetric> metrics = getCruiseControlMetrics();
     Cluster cluster = getCluster();
@@ -231,7 +231,7 @@ public class CruiseControlMetricsProcessorTest {
   }
 
   @Test
-  public void testMissingBrokerCpuUtilization() throws TimeoutException, BrokerCapacityResolvingException {
+  public void testMissingBrokerCpuUtilization() throws TimeoutException, BrokerCapacityResolutionException {
     CruiseControlMetricsProcessor processor = new CruiseControlMetricsProcessor(mockBrokerCapacityConfigResolver(), false);
     Set<CruiseControlMetric> metrics = getCruiseControlMetrics();
     for (CruiseControlMetric metric : metrics) {
@@ -248,7 +248,7 @@ public class CruiseControlMetricsProcessorTest {
   }
 
   @Test
-  public void testMissingOtherBrokerMetrics() throws TimeoutException, BrokerCapacityResolvingException {
+  public void testMissingOtherBrokerMetrics() throws TimeoutException, BrokerCapacityResolutionException {
     CruiseControlMetricsProcessor processor = new CruiseControlMetricsProcessor(mockBrokerCapacityConfigResolver(), false);
     Set<CruiseControlMetric> metrics = getCruiseControlMetrics();
     Cluster cluster = getCluster();
@@ -265,7 +265,7 @@ public class CruiseControlMetricsProcessorTest {
   }
 
   @Test
-  public void testMissingPartitionSizeMetric() throws TimeoutException, BrokerCapacityResolvingException {
+  public void testMissingPartitionSizeMetric() throws TimeoutException, BrokerCapacityResolutionException {
     CruiseControlMetricsProcessor processor = new CruiseControlMetricsProcessor(mockBrokerCapacityConfigResolver(), false);
     Set<CruiseControlMetric> metrics = getCruiseControlMetrics();
     for (CruiseControlMetric metric : metrics) {
@@ -287,7 +287,7 @@ public class CruiseControlMetricsProcessorTest {
   }
 
   @Test
-  public void testMissingTopicBytesInMetric() throws TimeoutException, BrokerCapacityResolvingException {
+  public void testMissingTopicBytesInMetric() throws TimeoutException, BrokerCapacityResolutionException {
     CruiseControlMetricsProcessor processor = new CruiseControlMetricsProcessor(mockBrokerCapacityConfigResolver(), false);
     Set<CruiseControlMetric> metrics = getCruiseControlMetrics();
     Set<RawMetricType> metricTypeToExclude = new HashSet<>(Arrays.asList(TOPIC_BYTES_IN,
@@ -318,7 +318,7 @@ public class CruiseControlMetricsProcessorTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testMissingBrokerCapacity() throws TimeoutException, BrokerCapacityResolvingException {
+  public void testMissingBrokerCapacity() throws TimeoutException, BrokerCapacityResolutionException {
     Set<CruiseControlMetric> metrics = getCruiseControlMetrics();
     // All estimated.
     BrokerCapacityConfigResolver brokerCapacityConfigResolver = EasyMock.mock(BrokerCapacityConfigResolver.class);

--- a/cruise-control/src/test/resources/DefaultCapacityConfig.json
+++ b/cruise-control/src/test/resources/DefaultCapacityConfig.json
@@ -11,14 +11,14 @@
       "doc": "This is the default capacity. Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB."
     },
     {
-      "brokerId": "314",
+      "brokerId": "1",
       "capacity": {
         "DISK": "150000",
         "CPU": "100",
         "NW_IN": "150000",
         "NW_OUT": "150000"
       },
-      "doc": "This overrides the capacity for broker 314."
+      "doc": "This overrides the capacity for broker 1."
     }
   ]
 }


### PR DESCRIPTION
Addresses the issue #1107 .
The main change in this PR to evolve [BrokerCapacityConfigResolver#capacityForBroker](https://github.com/linkedin/cruise-control/blob/c84af32fcc96d1c4d026e8e4dd5aac54bb8ace6f/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigResolver.java#L38) method signature by adding a new argument `allowCapacityEstimation `. 

Doing so have multiple advantages. 
 1. Now `BrokerCapacityConfigResolver` is aware that estimation is allowed or not, so it no longer makes blindly assumption.
2. Now in cluster model generation process, if `BrokerCapacityConfigResolver`  returns failing response, we can fail early; if `BrokerCapacityConfigResolver`  returns success response, we are certain that the generated cluster model satisfies estimation requirement so sanity check can be avoided.