### PR TITLE
Fix HTTP test by checking the actual protocol

### DIFF
--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/SslConnectionIntegrationTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/SslConnectionIntegrationTest.java
@@ -16,6 +16,7 @@ import javax.net.ssl.X509TrustManager;
 import javax.servlet.http.HttpServletResponse;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -26,10 +27,12 @@ import static org.junit.Assert.fail;
 public class SslConnectionIntegrationTest extends CruiseControlIntegrationTestHarness {
 
   private static final String CRUISE_CONTROL_STATE_ENDPOINT = "kafkacruisecontrol/state";
+  public static final String HTTPS = "https";
 
   @Override
   protected Map<String, Object> withConfigs() {
     Map<String, Object> sslConfigs = new HashMap<>();
+    sslConfigs.put(WebServerConfig.WEBSERVER_SSL_ENABLE_CONFIG, true);
     sslConfigs.put(WebServerConfig.WEBSERVER_SSL_KEYSTORE_LOCATION_CONFIG, Objects.requireNonNull(
         this.getClass().getClassLoader().getResource("ssl_integration_test.keystore")).toString());
     sslConfigs.put(WebServerConfig.WEBSERVER_SSL_KEYSTORE_PASSWORD_CONFIG, "jetty");
@@ -55,6 +58,7 @@ public class SslConnectionIntegrationTest extends CruiseControlIntegrationTestHa
 
   @Test
   public void testSslConnection() throws Exception {
+    assertEquals(HTTPS, new URL(_app.serverUrl()).getProtocol());
     SSLSocketFactory defaultSslSocketFactory = HttpsURLConnection.getDefaultSSLSocketFactory();
     try {
       SSLContext sc = SSLContext.getInstance("SSL");


### PR DESCRIPTION
Fixes the test by adding the webserver.ssl.enable config and checks if the used protocol is HTTPS.
