### PR TITLE
Fix typos and invalid types in OAS3 yaml

### DIFF
--- a/cruise-control/src/yaml/endpoints/demoteBroker.yaml
+++ b/cruise-control/src/yaml/endpoints/demoteBroker.yaml
@@ -7,9 +7,10 @@ DemoteBrokerEndpoint:
         in: query
         description: List of target broker ids.
         schema:
-          type: set
+          type: array
           items:
-            type: int32
+            type: integer
+            format: int32
         required: true
       - name: dryrun
         in: query
@@ -21,7 +22,8 @@ DemoteBrokerEndpoint:
         in: query
         description: The upper bound of ongoing leadership movements.
         schema:
-          type: int32
+          type: integer
+          format: int32
           default: 1000
           minimum: 1
       - name: allow_capacity_estimation
@@ -45,7 +47,7 @@ DemoteBrokerEndpoint:
       - name: exclude_follower_demotion
         in: query
         description: Whether to operate on partitions which only have follower replicas on the specified broker(s).
-        schma:
+        schema:
           type: boolean
           default: true
       - name: verbose
@@ -73,11 +75,9 @@ DemoteBrokerEndpoint:
         in: query
         description: List of broker id and logdir pair to be demoted in the cluster.
         schema:
-          type: map
-          key:
-            type: int32
-          items:
-            type: set
+          type: object
+          additionalProperties:
+            type: array
             items:
               type: string
         # default is an empty map

--- a/cruise-control/src/yaml/endpoints/fixOfflineReplicas.yaml
+++ b/cruise-control/src/yaml/endpoints/fixOfflineReplicas.yaml
@@ -55,7 +55,7 @@ FixOfflineReplicasEndpoint:
         schema:
           type: string # topics regex
           default: null
-        exmaple: "__CruiseControl.%2A"
+        example: "__CruiseControl.%2A"
       - name: use_ready_default_goals
         in: query
         description: Whether to only use ready goals to generate proposal.

--- a/cruise-control/src/yaml/endpoints/load.yaml
+++ b/cruise-control/src/yaml/endpoints/load.yaml
@@ -7,7 +7,7 @@ LoadEndpoint:
         in: query
         description: Start time of the cluster load. Default is time of earliest valid window.
         schema:
-          type: long
+          type: integer
           default: -1
           format: int64
           minimum: -1
@@ -15,14 +15,14 @@ LoadEndpoint:
         in: query
         description: End time of the cluster load. Default is current system time.
         schema:
-          type: long
+          type: integer
           format: int64
           minimum: 0
       - name: time
         in: query
         description: End time of the clutser load. Default is current system time, mutually exclusive with end parameter.
         schema:
-          type: long
+          type: integer
           format: int64
           minimum: 0
       - name: allow_capacity_estimation

--- a/cruise-control/src/yaml/endpoints/partitionLoad.yaml
+++ b/cruise-control/src/yaml/endpoints/partitionLoad.yaml
@@ -95,7 +95,7 @@ PartitionLoadEndpoint:
           items:
             type: integer
             format: int32
-          exmaple: [1, 2, 3]
+          example: [1, 2, 3]
       - name: json
         in: query
         description: Whether to return in JSON format or not.

--- a/cruise-control/src/yaml/endpoints/proposals.yaml
+++ b/cruise-control/src/yaml/endpoints/proposals.yaml
@@ -18,7 +18,7 @@ ProposalsEndpoint:
             type: integer
             format: int32
           default: null
-          exmaple: [1,2,3]
+          example: [1,2,3]
       - name: ignore_proposal_cache
         in: query
         description: Whether ignore the cached proposal or not.
@@ -52,7 +52,7 @@ ProposalsEndpoint:
         schema:
           type: string # topics regex
           default: null
-        exmaple: "__CruiseControl.%2A"
+        example: "__CruiseControl.%2A"
       - name: exclude_recently_removed_brokers
         in: query
         description: Whether allow replicas to be moved to recently removed broker.

--- a/cruise-control/src/yaml/endpoints/rebalance.yaml
+++ b/cruise-control/src/yaml/endpoints/rebalance.yaml
@@ -120,7 +120,7 @@ RebalanceEndpoint:
           type: array
           items:
             type: string
-          exmaples: [1,2,3]
+          example: [1,2,3]
       - name: kafka_assigner
         in: query
         description: Whether to use Kafka assigner mode to general proposal.

--- a/cruise-control/src/yaml/endpoints/removeBroker.yaml
+++ b/cruise-control/src/yaml/endpoints/removeBroker.yaml
@@ -7,7 +7,7 @@ RemoveBrokerEndpoint:
         in: query
         description: List of target broker ids.
         schema:
-          type: set
+          type: array
           items:
             type: integer
         required: true
@@ -116,9 +116,8 @@ RemoveBrokerEndpoint:
         in: query
         description: Comma-separated and/or space-separated list of broker IDs.
         schema:
-          type: set
+          type: array
           items:
-            items:
             type: integer
           # default is a empty set if no values are provided
       - name: execution_progress_check_interval_ms

--- a/cruise-control/src/yaml/endpoints/reviewBoard.yaml
+++ b/cruise-control/src/yaml/endpoints/reviewBoard.yaml
@@ -34,14 +34,14 @@ ReviewBoardEndpoint:
           text/plain:
             schema:
               type: string
-        # Response for all errors
-        default:
-          description: Error response.
-          content:
-            application/json:
-              schema:
-                $ref: '../responses/errorResponse.yaml#/ErrorResponse'
-            text/plain:
-              schema:
-                type: string
+      # Response for all errors
+      default:
+        description: Error response.
+        content:
+          application/json:
+            schema:
+              $ref: '../responses/errorResponse.yaml#/ErrorResponse'
+          text/plain:
+            schema:
+              type: string
 


### PR DESCRIPTION
Fixes a couple of typos in the OAS3 API yaml descriptor files, such as typos, type errors (set and map definitions) so that the yaml will be compilable with the openapi-generator tool too.
