### PR TITLE
Fix #1187: User tasks endpoint returns error for CompletedWithError tasks when fetch_complete_task=true

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
@@ -763,9 +763,16 @@ public class UserTaskManager implements Closeable {
       // Populate original response of completed task if requested so.
       if (fetchCompletedTask) {
         try {
+          // TODO: For CompletedWithError tasks the cached response should contain the original server side error information
           jsonObjectMap.put(ORIGINAL_RESPONSE, lastFuture().get().cachedResponse());
         } catch (InterruptedException | ExecutionException e) {
-          throw new IllegalStateException("Error happened in fetching response for task " + _userTaskId.toString(), e);
+          if (_state == TaskState.COMPLETED_WITH_ERROR) {
+            // If the state is completed with error and fetch completed task is true then just return "CompletedWithError"
+            // as the "originalResponse".
+            jsonObjectMap.put(ORIGINAL_RESPONSE, TaskState.COMPLETED_WITH_ERROR);
+          } else {
+            throw new IllegalStateException("Error happened in fetching response for task " + _userTaskId.toString(), e);
+          }
         }
       }
       return jsonObjectMap;

--- a/docs/wiki/User Guide/REST-APIs.md
+++ b/docs/wiki/User Guide/REST-APIs.md
@@ -231,7 +231,7 @@ Supported parameters are:
 
 User can use `user_task_ids`/`client_ids`/`endpoints`/`types` make Cruise Control only return requests they are interested. By default all the requests get returned.
 
-If `fetch_completed_task` is set to `true`, the original response of each requests will be returned.
+If `fetch_completed_task` is set to `true`, the original response of each request will be returned. In the case where a task completed with errors the response will be `CompletedWithError`.
 
 ## POST Requests
 The post requests of Kafka Cruise Control REST API are operations that will have impact on the Kafka cluster. The post operations include:


### PR DESCRIPTION
Addresses issue #1187, where the user tasks endpoint returns an error if a task `CompletedWithError` and `fetch_complete_task=true` is in the request. This prevents the user from learning the state of these tasks.

This changes the `getJSonStructure` method to not throw an error for `CompletedWithError` tasks when `fetch_complete_task=true` and instead just return `"CompletedWithError"` in the `originalResponse` field.
