### PR TITLE
[ccclient-1.1.0] Add force_stop parameter

### DIFF
--- a/cruise-control-client/cruisecontrolclient/client/CCParameter/BooleanParameter.py
+++ b/cruise-control-client/cruisecontrolclient/client/CCParameter/BooleanParameter.py
@@ -81,6 +81,18 @@ class ExcludeRecentlyRemovedBrokersParameter(AbstractBooleanParameter):
     }
 
 
+class ForceStopParameter(AbstractBooleanParameter):
+    """force_stop=[true/false]"""
+    name = 'force_stop'
+    description = 'Whether to make cruise-control trigger a ' \
+                  'kafka controller switch to clear ongoing partition movements'
+    argparse_properties = {
+        'args': ('--force-stop', '--force_stop'),
+        # Presume that the lack of --force-stop affirmatively means no force stop
+        'kwargs': dict(help=description, action='store_true')
+    }
+
+
 class IgnoreProposalCacheParameter(AbstractBooleanParameter):
     """ignore_proposal_cache=[true/false]"""
     name = 'ignore_proposal_cache'

--- a/cruise-control-client/cruisecontrolclient/client/Endpoint.py
+++ b/cruise-control-client/cruisecontrolclient/client/Endpoint.py
@@ -531,6 +531,7 @@ class StopProposalExecutionEndpoint(AbstractEndpoint):
     http_method = "POST"
     can_execute_proposal = False
     available_Parameters = (
+        CCParameter.ForceStopParameter,
         CCParameter.JSONParameter,
         CCParameter.ReviewIDParameter,
     )

--- a/cruise-control-client/setup.py
+++ b/cruise-control-client/setup.py
@@ -11,7 +11,7 @@ It comes with a command-line interface to the client (`cccli`) (see [README](htt
 
 setuptools.setup(
     name='cruise-control-client',
-    version='1.0.6',
+    version='1.0.7',
     author='mgrubent',
     author_email='mgrubentrejo@linkedin.com',
     description='A Python client for cruise-control',

--- a/cruise-control-client/setup.py
+++ b/cruise-control-client/setup.py
@@ -11,7 +11,7 @@ It comes with a command-line interface to the client (`cccli`) (see [README](htt
 
 setuptools.setup(
     name='cruise-control-client',
-    version='1.0.7',
+    version='1.1.0',
     author='mgrubent',
     author_email='mgrubentrejo@linkedin.com',
     description='A Python client for cruise-control',


### PR DESCRIPTION
Fixes #1189.

Note that, under this implementation, the `force_stop` parameter will always be supplied to `cruise-control` when `cccli` executes the `stop_proposal_execution` command.  
If `--force-stop` is not provided, the value of this parameter will be `False`.  
If `--force-stop` is provided, the value of this parameter will be `True`.

Force stop is a potentially disruptive action, so there is a sensible default here, which is `False`.

Older versions of `cruise-control` which do not understand the `force_stop` parameter will return an exception when using `1.1.*` of `cccli`.

`cccli` compatibility with these older versions of `cruise-control` can be achieved in one of two ways:  
1. Remaining on `ccclient` `1.0.*`.  There are no plans to back-port `force_stop` support to `1.0.*`.  
2. With `ccclient` `1.1.*`, using the `--remove-parameter force_stop` option, so that no `force_stop` parameter is passed to `cruise-control`.