### PR TITLE
Use swagger-parser-v3 to eliminate compat dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -222,7 +222,7 @@ project(':cruise-control') {
     compile 'io.dropwizard.metrics:metrics-core:3.2.6'
     compile 'com.nimbusds:nimbus-jose-jwt:8.5'
     compile 'com.101tec:zkclient:0.11'
-    compile group: 'io.swagger.parser.v3', name: 'swagger-parser', version: '2.0.18'
+    compile group: 'io.swagger.parser.v3', name: 'swagger-parser-v3', version: '2.0.19'
     compile group: 'io.github.classgraph', name: 'classgraph', version: '4.8.65'
 
     testCompile project(path: ':cruise-control-metrics-reporter', configuration: 'testOutput')


### PR DESCRIPTION
Addresses the issue #1193
Upgrading to swagger-parser-v3 removes a good chunk of dependencies, and decreases the footprint of the project.
