### PR TITLE
Add AdminClient-based replica reassignment.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     environment:
-      _JAVA_OPTIONS: "-Xms512m -Xmx1024m"
+      _JAVA_OPTIONS: "-Xms512m -Xmx512m"
     working_directory: ~/workspace
     docker:
       - image: circleci/openjdk:8-jdk
@@ -13,7 +13,7 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "build.gradle" }}
       - run:
-          command: ./gradlew -PmaxParallelForks=1 clean javadoc build
+          command: ./gradlew --no-daemon -PmaxParallelForks=1 clean javadoc build
       - save_cache:
           key: dependency-cache-{{ checksum "build.gradle" }}
           paths:

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ import com.linkedin.gradle.build.DistributeTask
 plugins {
   id "com.jfrog.artifactory"
   id "idea"
+  id "jacoco" // Java Code Coverage plugin
   id "com.github.ben-manes.versions" version "0.28.0"
 }
 
@@ -76,6 +77,7 @@ subprojects {
   apply plugin: 'java'
   apply plugin: 'checkstyle'
   apply plugin: 'findbugs'
+  apply plugin: 'jacoco'
 
   task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/utils/CCEmbeddedBroker.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/utils/CCEmbeddedBroker.java
@@ -99,10 +99,6 @@ public class CCEmbeddedBroker implements AutoCloseable {
     _kafkaServer.awaitShutdown();
   }
 
-  public KafkaServer kafkaServer() {
-    return _kafkaServer;
-  }
-
   @Override
   public void close() {
     CCKafkaTestUtils.quietly(this::shutdown);

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/utils/CCEmbeddedBroker.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/utils/CCEmbeddedBroker.java
@@ -99,6 +99,10 @@ public class CCEmbeddedBroker implements AutoCloseable {
     _kafkaServer.awaitShutdown();
   }
 
+  public KafkaServer kafkaServer() {
+    return _kafkaServer;
+  }
+
   @Override
   public void close() {
     CCKafkaTestUtils.quietly(this::shutdown);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetector.java
@@ -311,6 +311,7 @@ public class AnomalyDetector {
    * @param anomalyId Unique id of anomaly which triggered self-healing operation.
    */
   public void markSelfHealingFinished(String anomalyId) {
+    LOG.debug("Self healing with id {} has finished.", anomalyId);
     _anomalyDetectorState.markSelfHealingFinished(anomalyId);
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.executor;
+
+import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AlterPartitionReassignmentsResult;
+import org.apache.kafka.clients.admin.ListPartitionReassignmentsResult;
+import org.apache.kafka.clients.admin.NewPartitionReassignment;
+import org.apache.kafka.clients.admin.PartitionReassignment;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ExecutionUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(ExecutionUtils.class);
+  // TODO: Make this configurable.
+  public static final long DEFAULT_LIST_PARTITION_REASSIGNMENTS_TIMEOUT_MS = 10000L;
+
+  private ExecutionUtils() { }
+
+  /**
+   * Retrieve the set of {@link TopicPartition partitions} that are currently being reassigned.
+   *
+   * @param adminClient The adminClient to ask for ongoing partition reassignments.
+   * @return The set of {@link TopicPartition partitions} that are being reassigned.
+   */
+  public static Set<TopicPartition> partitionsBeingReassigned(AdminClient adminClient)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return ongoingPartitionReassignments(adminClient).keySet();
+  }
+
+  /**
+   * Retrieve the map of {@link PartitionReassignment reassignment} by {@link TopicPartition partitions}.
+   *
+   * @param adminClient The adminClient to ask for ongoing partition reassignments.
+   * @return The map of {@link PartitionReassignment reassignment} by {@link TopicPartition partitions}.
+   */
+  public static Map<TopicPartition, PartitionReassignment> ongoingPartitionReassignments(AdminClient adminClient)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    ListPartitionReassignmentsResult responseResult = adminClient.listPartitionReassignments();
+    return responseResult.reassignments().get(DEFAULT_LIST_PARTITION_REASSIGNMENTS_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+  }
+
+  private static Optional<NewPartitionReassignment> cancelReassignmentValue() {
+    return java.util.Optional.empty();
+  }
+
+  private static Optional<NewPartitionReassignment> reassignmentValue(List<Integer> targetReplicas) {
+    return Optional.of(new NewPartitionReassignment(targetReplicas));
+  }
+
+  /**
+   * Submits the given inter-broker replica reassignment tasks for execution using the given admin client.
+   *
+   * @param adminClient The adminClient to retrieve ongoing replica reassignments and submit new reassignments.
+   * @param tasks Inter-broker replica reassignment tasks to execute.
+   * @return The {@link AlterPartitionReassignmentsResult result} of reassignment request, {@code null} otherwise.
+   */
+  public static AlterPartitionReassignmentsResult submitReplicaReassignmentTasks(AdminClient adminClient, List<ExecutionTask> tasks)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    if (tasks == null || tasks.isEmpty()) {
+      throw new IllegalArgumentException(String.format("Tasks to execute (%s) cannot be null or empty.", tasks));
+    }
+
+    Map<TopicPartition, PartitionReassignment> ongoingReassignments = ongoingPartitionReassignments(adminClient);
+    // Update the ongoing replica reassignments in case the task status has changed.
+    Map<TopicPartition, Optional<NewPartitionReassignment>> newReassignments = new HashMap<>(tasks.size());
+    for (ExecutionTask task : tasks) {
+      TopicPartition tp = task.proposal().topicPartition();
+      List<Integer> newReplicas = new ArrayList<>(task.proposal().newReplicas().size());
+      for (ReplicaPlacementInfo replicaPlacementInfo : task.proposal().newReplicas()) {
+        newReplicas.add(replicaPlacementInfo.brokerId());
+      }
+      PartitionReassignment ongoingReassignment = ongoingReassignments.get(tp);
+      switch (task.state()) {
+        case ABORTING:
+        case ABORTED:
+        case DEAD:
+          if (ongoingReassignment != null) {
+            // A task in one of these states should not have a corresponding partition movement -- cancel it.
+            newReassignments.put(tp, cancelReassignmentValue());
+            LOG.debug("The ongoing reassignment {} will be cancelled for task {}.", ongoingReassignment, task);
+          } else {
+            // No action needed.
+            LOG.debug("Task {} already has no corresponding replica reassignment.", task);
+          }
+          break;
+        case COMPLETED:
+          // No action needed.
+          LOG.debug("Task {} has already been completed.", task);
+          break;
+        case IN_PROGRESS:
+          if (ongoingReassignment != null) {
+            // Ensure that the order of new replicas is the same as the requested task replica order
+            if (!ongoingReassignment.addingReplicas().equals(newReplicas)) {
+              newReassignments.put(tp, reassignmentValue(newReplicas));
+              LOG.debug("Task {} will modify the ongoing reassignment {}.", task, ongoingReassignment);
+            }
+          } else {
+            // No need to check whether the topic exists or being deleted as the server response will indicate those.
+            newReassignments.put(tp, reassignmentValue(newReplicas));
+            LOG.debug("Task {} will be executed.", task);
+          }
+          break;
+        default:
+          throw new IllegalStateException(String.format("Unrecognized task state %s.", task.state()));
+      }
+    }
+
+    return newReassignments.isEmpty() ? null : adminClient.alterPartitionReassignments(newReassignments);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -25,10 +25,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
@@ -37,11 +40,13 @@ import kafka.zk.KafkaZkClient;
 import kafka.zk.ZkVersion;
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AlterPartitionReassignmentsResult;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
@@ -142,11 +147,9 @@ public class Executor {
   public Executor(KafkaCruiseControlConfig config,
                   Time time,
                   MetricRegistry dropwizardMetricRegistry,
-                  long demotionHistoryRetentionTimeMs,
-                  long removalHistoryRetentionTimeMs,
                   AnomalyDetector anomalyDetector) {
-    this(config, time, dropwizardMetricRegistry, null, demotionHistoryRetentionTimeMs, removalHistoryRetentionTimeMs,
-         null, null, anomalyDetector);
+    this(config, time, dropwizardMetricRegistry, null, config.getLong(ExecutorConfig.DEMOTION_HISTORY_RETENTION_TIME_MS_CONFIG),
+         config.getLong(ExecutorConfig.REMOVAL_HISTORY_RETENTION_TIME_MS_CONFIG), null, null, anomalyDetector);
   }
 
   /**
@@ -573,8 +576,15 @@ public class Executor {
    * Sanity check whether there are ongoing (1) inter-broker or intra-broker replica movements or (2) leadership movements.
    */
   private void sanityCheckOngoingMovement() throws OngoingExecutionException {
+    boolean hasOngoingPartitionReassignments;
+    try {
+      hasOngoingPartitionReassignments = hasOngoingPartitionReassignments();
+    } catch (TimeoutException | InterruptedException | ExecutionException e) {
+      // This may indicate transient (e.g. network) issues.
+      throw new IllegalStateException("Failed to retrieve whether the Kafka cluster has an already ongoing partition reassignment.", e);
+    }
     // Note that in case there is an ongoing partition reassignment, we do not unpause metric sampling.
-    if (hasOngoingPartitionReassignments()) {
+    if (hasOngoingPartitionReassignments) {
       processOngoingMovementSanityCheckFailure();
       throw new OngoingExecutionException("There are ongoing inter-broker partition movements.");
     } else if (isOngoingIntraBrokerReplicaMovement(_metadataClient.cluster().nodes().stream().mapToInt(Node::id).boxed()
@@ -667,16 +677,16 @@ public class Executor {
   }
 
   /**
-   * Check whether there is an ongoing partition reassignment.
-   * This method directly checks the existence of zNode in /admin/reassign_partitions.
-   * Note this method returning false does not guarantee that there is no ongoing execution because when there is an ongoing
-   * execution inside Cruise Control, partition reassignment task batches are writen to zookeeper periodically, there will be
-   * small intervals that /admin/partition_reassignment does not exist.
+   * Check whether there is an ongoing partition reassignment on Kafka cluster.
    *
-   * @return True if there is an ongoing partition reassignment.
+   * Note that a {@code false} response does not guarantee lack of an ongoing execution because when there is an ongoing
+   * execution inside Cruise Control, partition reassignment task batches are sent to Kafka periodically. So, there will
+   * be intervals without partition reassignments.
+   *
+   * @return True if there is an ongoing partition reassignment on Kafka cluster.
    */
-  public boolean hasOngoingPartitionReassignments() {
-    return !ExecutorUtils.partitionsBeingReassigned(_kafkaZkClient).isEmpty();
+  public boolean hasOngoingPartitionReassignments() throws InterruptedException, ExecutionException, TimeoutException {
+    return !ExecutionUtils.partitionsBeingReassigned(_adminClient).isEmpty();
   }
 
   /**
@@ -698,11 +708,11 @@ public class Executor {
   private class ProposalExecutionRunnable implements Runnable {
     private final LoadMonitor _loadMonitor;
     private ExecutorState.State _state;
-    private Set<Integer> _recentlyDemotedBrokers;
-    private Set<Integer> _recentlyRemovedBrokers;
+    private final Set<Integer> _recentlyDemotedBrokers;
+    private final Set<Integer> _recentlyRemovedBrokers;
     private final Long _replicationThrottle;
     private Throwable _executionException;
-    private boolean _isTriggeredByUserRequest;
+    private final boolean _isTriggeredByUserRequest;
     private long _lastSlowTaskReportingTimeMs;
 
     ProposalExecutionRunnable(LoadMonitor loadMonitor,
@@ -970,7 +980,7 @@ public class Executor {
       }
     }
 
-    private void interBrokerMoveReplicas() {
+    private void interBrokerMoveReplicas() throws InterruptedException, ExecutionException, TimeoutException {
       ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(_kafkaZkClient, _replicationThrottle);
       int numTotalPartitionMovements = _executionTaskManager.numRemainingInterBrokerPartitionMovements();
       long totalDataToMoveInMB = _executionTaskManager.remainingInterBrokerDataToMoveInMB();
@@ -983,15 +993,15 @@ public class Executor {
         List<ExecutionTask> tasksToExecute = _executionTaskManager.getInterBrokerReplicaMovementTasks();
         LOG.info("Executor will execute {} task(s)", tasksToExecute.size());
 
+        AlterPartitionReassignmentsResult result = null;
         if (!tasksToExecute.isEmpty()) {
-          throttleHelper.setThrottles(
-              tasksToExecute.stream().map(ExecutionTask::proposal).collect(Collectors.toList()));
+          throttleHelper.setThrottles(tasksToExecute.stream().map(ExecutionTask::proposal).collect(Collectors.toList()));
           // Execute the tasks.
           _executionTaskManager.markTasksInProgress(tasksToExecute);
-          ExecutorUtils.executeReplicaReassignmentTasks(_kafkaZkClient, tasksToExecute);
+          result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, tasksToExecute);
         }
         // Wait indefinitely for partition movements to finish.
-        List<ExecutionTask> completedTasks = waitForExecutionTaskToFinish();
+        List<ExecutionTask> completedTasks = waitForExecutionTaskToFinish(result);
         partitionsToMove = _executionTaskManager.numRemainingInterBrokerPartitionMovements();
         int numFinishedPartitionMovements = _executionTaskManager.numFinishedInterBrokerPartitionMovements();
         long finishedDataMovementInMB = _executionTaskManager.finishedInterBrokerDataMovementInMB();
@@ -1009,7 +1019,7 @@ public class Executor {
       while (!inExecutionTasks.isEmpty()) {
         LOG.info("Waiting for {} tasks moving {} MB to finish.", inExecutionTasks.size(),
                  _executionTaskManager.inExecutionInterBrokerDataToMoveInMB());
-        List<ExecutionTask> completedRemainingTasks = waitForExecutionTaskToFinish();
+        List<ExecutionTask> completedRemainingTasks = waitForExecutionTaskToFinish(null);
         inExecutionTasks = inExecutionTasks();
         throttleHelper.clearThrottles(completedRemainingTasks, new ArrayList<>(inExecutionTasks));
       }
@@ -1033,7 +1043,7 @@ public class Executor {
       }
     }
 
-    private void intraBrokerMoveReplicas() {
+    private void intraBrokerMoveReplicas() throws InterruptedException, ExecutionException, TimeoutException {
       int numTotalPartitionMovements = _executionTaskManager.numRemainingIntraBrokerPartitionMovements();
       long totalDataToMoveInMB = _executionTaskManager.remainingIntraBrokerDataToMoveInMB();
       LOG.info("Starting {} intra-broker partition movements.", numTotalPartitionMovements);
@@ -1051,7 +1061,7 @@ public class Executor {
           executeIntraBrokerReplicaMovements(tasksToExecute, _adminClient, _executionTaskManager, _config);
         }
         // Wait indefinitely for partition movements to finish.
-        waitForExecutionTaskToFinish();
+        waitForExecutionTaskToFinish(null);
         partitionsToMove = _executionTaskManager.numRemainingIntraBrokerPartitionMovements();
         int numFinishedPartitionMovements = _executionTaskManager.numFinishedIntraBrokerPartitionMovements();
         long finishedDataToMoveInMB = _executionTaskManager.finishedIntraBrokerDataToMoveInMB();
@@ -1066,7 +1076,7 @@ public class Executor {
       while (!inExecutionTasks.isEmpty()) {
         LOG.info("Waiting for {} tasks moving {} MB to finish", inExecutionTasks.size(),
                  _executionTaskManager.inExecutionIntraBrokerDataMovementInMB());
-        waitForExecutionTaskToFinish();
+        waitForExecutionTaskToFinish(null);
         inExecutionTasks = inExecutionTasks();
       }
       if (inExecutionTasks().isEmpty()) {
@@ -1088,7 +1098,7 @@ public class Executor {
       }
     }
 
-    private void moveLeaderships() {
+    private void moveLeaderships() throws InterruptedException, ExecutionException, TimeoutException {
       int numTotalLeadershipMovements = _executionTaskManager.numRemainingLeadershipMovements();
       LOG.info("Starting {} leadership movements.", numTotalLeadershipMovements);
       int numFinishedLeadershipMovements = 0;
@@ -1114,7 +1124,7 @@ public class Executor {
       }
     }
 
-    private int moveLeadershipInBatch() {
+    private int moveLeadershipInBatch() throws InterruptedException, ExecutionException, TimeoutException {
       List<ExecutionTask> leadershipMovementTasks = _executionTaskManager.getLeadershipMovementTasks();
       int numLeadershipToMove = leadershipMovementTasks.size();
       LOG.debug("Executing {} leadership movements in a batch.", numLeadershipToMove);
@@ -1136,7 +1146,7 @@ public class Executor {
         ExecutorUtils.executePreferredLeaderElection(_kafkaZkClient, leadershipMovementTasks);
         LOG.trace("Waiting for leadership movement batch to finish.");
         while (!inExecutionTasks().isEmpty() && _stopSignal.get() == NO_STOP_EXECUTION) {
-          waitForExecutionTaskToFinish();
+          waitForExecutionTaskToFinish(null);
         }
       }
       return numLeadershipToMove;
@@ -1157,7 +1167,8 @@ public class Executor {
     /**
      * This method periodically checks ZooKeeper to see if (1) partition or (2) leadership reassignment has finished or not.
      */
-    private List<ExecutionTask> waitForExecutionTaskToFinish() {
+    private List<ExecutionTask> waitForExecutionTaskToFinish(AlterPartitionReassignmentsResult result)
+        throws InterruptedException, ExecutionException, TimeoutException {
       List<ExecutionTask> finishedTasks = new ArrayList<>();
       Set<Long> forceStoppedTaskIds = new HashSet<>();
       Set<Long> deletedTaskIds = new HashSet<>();
@@ -1179,7 +1190,7 @@ public class Executor {
         if (LOG.isDebugEnabled()) {
           LOG.debug("Tasks in execution: {}", inExecutionTasks());
         }
-        Set<ExecutionTask> deadOrAbortingNonLeadershipTasks = new HashSet<>();
+        List<ExecutionTask> deadOrAbortingInterBrokerReplicaActions = new ArrayList<>();
         List<ExecutionTask> slowTasksToReport = new ArrayList<>();
         boolean shouldReportSlowTasks = _time.milliseconds() - _lastSlowTaskReportingTimeMs > SLOW_TASK_ALERTING_BACKOFF_TIME_MS;
         for (ExecutionTask task : inExecutionTasks()) {
@@ -1204,11 +1215,11 @@ public class Executor {
             if (shouldReportSlowTasks) {
               task.maybeReportExecutionTooSlow(_time.milliseconds(), slowTasksToReport);
             }
-            if (maybeMarkTaskAsDeadOrAborting(cluster, logDirInfoByTask, task)) {
+            if (maybeMarkTaskAsDeadOrAborting(cluster, logDirInfoByTask, task, result)) {
               deadOrAbortingTaskIds.add(task.executionId());
-              // Only add the dead or aborted tasks to execute if it is not a leadership movement.
-              if (task.type() != LEADER_ACTION) {
-                deadOrAbortingNonLeadershipTasks.add(task);
+              // Only add the dead or aborted tasks to execute if it is an inter-broker replica action.
+              if (task.type() == INTER_BROKER_REPLICA_ACTION) {
+                deadOrAbortingInterBrokerReplicaActions.add(task);
               }
               // A dead or aborted task is considered as finished.
               if (task.state() == DEAD || task.state() == ABORTED) {
@@ -1217,45 +1228,43 @@ public class Executor {
             }
           }
         }
-        handleDeadOrAbortingTasks(deadOrAbortingNonLeadershipTasks, slowTasksToReport);
+        sendSlowExecutionAlert(slowTasksToReport);
+        handleDeadOrAbortingReplicaActions(deadOrAbortingInterBrokerReplicaActions);
         updateOngoingExecutionState();
       } while (!inExecutionTasks().isEmpty() && finishedTasks.isEmpty());
 
       LOG.info("Completed tasks: {}.{}{}{}", finishedTasks,
-               forceStoppedTaskIds.isEmpty() ? "" : String.format("%n[Force-stopped: %s]", forceStoppedTaskIds),
-               deletedTaskIds.isEmpty() ? "" : String.format("%n[Deleted: %s]", deletedTaskIds),
-               deadOrAbortingTaskIds.isEmpty() ? "" : String.format("%n[Dead/aborting: %s]", deadOrAbortingTaskIds));
+               forceStoppedTaskIds.isEmpty() ? "" : String.format(". [Force-stopped: %s]", forceStoppedTaskIds),
+               deletedTaskIds.isEmpty() ? "" : String.format(". [Deleted: %s]", deletedTaskIds),
+               deadOrAbortingTaskIds.isEmpty() ? "" : String.format(". [Dead/aborting: %s]", deadOrAbortingTaskIds));
 
       return finishedTasks;
     }
 
-    private void handleDeadOrAbortingTasks(Set<ExecutionTask> deadOrAbortingNonLeadershipTasks,
-                                           List<ExecutionTask> slowTasksToReport) {
-      if (!slowTasksToReport.isEmpty()) {
-        sendSlowExecutionAlert(slowTasksToReport);
-      }
-
-      if (!deadOrAbortingNonLeadershipTasks.isEmpty()) {
-        // TODO: Rollback tasks when KIP-455 is available.
-        // ExecutorAdminUtils.executeReplicaReassignmentTasks(_kafkaZkClient, deadOrAbortingTasks);
+    private void handleDeadOrAbortingReplicaActions(List<ExecutionTask> deadOrAbortingInterBrokerReplicaActions)
+        throws InterruptedException, ExecutionException, TimeoutException {
+      if (!deadOrAbortingInterBrokerReplicaActions.isEmpty()) {
+        ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, deadOrAbortingInterBrokerReplicaActions);
         if (_stopSignal.get() == NO_STOP_EXECUTION) {
           // If there is task aborted or dead, we stop the execution.
           LOG.info("Stop the ongoing execution due to {} dead or aborting tasks: {}.",
-                   deadOrAbortingNonLeadershipTasks.size(), deadOrAbortingNonLeadershipTasks);
+                   deadOrAbortingInterBrokerReplicaActions.size(), deadOrAbortingInterBrokerReplicaActions);
           stopExecution(false);
         }
       }
     }
 
     private void sendSlowExecutionAlert(List<ExecutionTask> slowTasksToReport) {
-      StringBuilder sb = new StringBuilder();
-      sb.append("Slow tasks are detected:\n");
-      for (ExecutionTask task: slowTasksToReport) {
-        sb.append(String.format("\tID: %s\tstart_time:%s\tdetail:%s%n", task.executionId(),
-                                toDateString(task.startTimeMs(), DATE_FORMAT, TIME_ZONE), task));
+      if (!slowTasksToReport.isEmpty()) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Slow tasks are detected:\n");
+        for (ExecutionTask task: slowTasksToReport) {
+          sb.append(String.format("\tID: %s\tstart_time:%s\tdetail:%s%n", task.executionId(),
+                                  toDateString(task.startTimeMs(), DATE_FORMAT, TIME_ZONE), task));
+        }
+        _executorNotifier.sendAlert(sb.toString());
+        _lastSlowTaskReportingTimeMs = _time.milliseconds();
       }
-      _executorNotifier.sendAlert(sb.toString());
-      _lastSlowTaskReportingTimeMs = _time.milliseconds();
     }
 
     /**
@@ -1362,7 +1371,8 @@ public class Executor {
      */
     private boolean maybeMarkTaskAsDeadOrAborting(Cluster cluster,
                                                   Map<ExecutionTask, ReplicaLogDirInfo> logdirInfoByTask,
-                                                  ExecutionTask task) {
+                                                  ExecutionTask task,
+                                                  AlterPartitionReassignmentsResult result) {
       // Only check tasks with IN_PROGRESS or ABORTING state.
       if (task.state() == IN_PROGRESS || task.state() == ABORTING) {
         switch (task.type()) {
@@ -1380,9 +1390,13 @@ public class Executor {
 
           case INTER_BROKER_REPLICA_ACTION:
             for (ReplicaPlacementInfo broker : task.proposal().newReplicas()) {
-              if (cluster.nodeById(broker.brokerId()) == null) {
+              boolean requestFailedDueToDeadBroker =
+                  (result != null && verifyFutureError(result.values().get(task.proposal().topicPartition()),
+                                                       Errors.INVALID_REPLICA_ASSIGNMENT.exception().getClass()));
+              if (requestFailedDueToDeadBroker || cluster.nodeById(broker.brokerId()) == null) {
                 _executionTaskManager.markTaskDead(task);
-                LOG.warn("Killing execution for task {} because the new replica {} is down.", task, broker);
+                LOG.warn("Killing execution for task {} because the new replica {} {} down.", task, broker,
+                         requestFailedDueToDeadBroker ? "was" : "is");
                 return true;
               }
             }
@@ -1399,6 +1413,17 @@ public class Executor {
           default:
             throw new IllegalStateException("Unknown task type " + task.type());
         }
+      }
+      return false;
+    }
+
+    private boolean verifyFutureError(Future<?> future, Class<? extends Throwable> exceptionClass) {
+      try {
+        future.get();
+      } catch (ExecutionException ee) {
+        return exceptionClass == ee.getCause().getClass();
+      } catch (InterruptedException e) {
+        // let it go
       }
       return false;
     }
@@ -1424,22 +1449,31 @@ public class Executor {
     }
 
     /**
-     * Due to the race condition between the controller and Cruise Control, some of the submitted tasks may be
-     * deleted by controller without being executed. We will resubmit those tasks in that case.
+     * TODO: Verify whether this function is needed on Kafka 2.4+.
      */
-    private void maybeReexecuteTasks() {
+    private boolean maybeReexecuteInterBrokerReplicaActions() throws InterruptedException, ExecutionException, TimeoutException {
       List<ExecutionTask> interBrokerReplicaActionsToReexecute =
           new ArrayList<>(_executionTaskManager.inExecutionTasks(Collections.singleton(INTER_BROKER_REPLICA_ACTION)));
-      if (!isSubset(ExecutorUtils.partitionsBeingReassigned(_kafkaZkClient), interBrokerReplicaActionsToReexecute)) {
-        LOG.info("Reexecuting tasks {}", interBrokerReplicaActionsToReexecute);
-        ExecutorUtils.executeReplicaReassignmentTasks(_kafkaZkClient, interBrokerReplicaActionsToReexecute);
+      boolean shouldReexecute = false;
+      try {
+        shouldReexecute = !isSubset(ExecutionUtils.partitionsBeingReassigned(_adminClient), interBrokerReplicaActionsToReexecute);
+      } catch (TimeoutException | InterruptedException | ExecutionException e) {
+        // This may indicate transient (e.g. network) issues.
+        LOG.warn("Failed to retrieve partitions being reassigned. Skipping reexecution check for inter-broker replica actions.", e);
       }
+      if (shouldReexecute) {
+        LOG.info("Reexecuting tasks {}", interBrokerReplicaActionsToReexecute);
+        ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, interBrokerReplicaActionsToReexecute);
+      }
+      return !interBrokerReplicaActionsToReexecute.isEmpty();
+    }
 
+    private boolean maybeReexecuteIntraBrokerReplicaActions() {
       List<ExecutionTask> intraBrokerReplicaActionsToReexecute =
           new ArrayList<>(_executionTaskManager.inExecutionTasks(Collections.singleton(INTRA_BROKER_REPLICA_ACTION)));
       getLogdirInfoForExecutionTask(intraBrokerReplicaActionsToReexecute, _adminClient, _config).forEach((k, v) -> {
         String targetLogdir = k.proposal().replicasToMoveBetweenDisksByBroker().get(k.brokerId()).logdir();
-        // If task is completed or in-progess, do not reexecute the task.
+        // If task is completed or in-progress, do not reexecute the task.
         if (targetLogdir.equals(v.getCurrentReplicaLogDir()) || targetLogdir.equals(v.getFutureReplicaLogDir())) {
           intraBrokerReplicaActionsToReexecute.remove(k);
         }
@@ -1448,11 +1482,19 @@ public class Executor {
         LOG.info("Reexecuting tasks {}", intraBrokerReplicaActionsToReexecute);
         executeIntraBrokerReplicaMovements(intraBrokerReplicaActionsToReexecute, _adminClient, _executionTaskManager, _config);
       }
+      return !intraBrokerReplicaActionsToReexecute.isEmpty();
+    }
+
+    /**
+     * Due to the race condition between the controller and Cruise Control, some of the submitted tasks may be
+     * deleted by controller without being executed. We will resubmit those tasks in that case.
+     */
+    private void maybeReexecuteTasks() throws InterruptedException, ExecutionException, TimeoutException {
+      boolean hasOngoingInterBrokerReplicaActions = maybeReexecuteInterBrokerReplicaActions();
+      boolean hasOngoingIntraBrokerReplicaActions = maybeReexecuteIntraBrokerReplicaActions();
 
       // Only reexecute leader actions if there is no replica actions running.
-      if (interBrokerReplicaActionsToReexecute.isEmpty() &&
-          intraBrokerReplicaActionsToReexecute.isEmpty() &&
-          !hasOngoingLeaderElection()) {
+      if (!hasOngoingInterBrokerReplicaActions && !hasOngoingIntraBrokerReplicaActions && !hasOngoingLeaderElection()) {
         List<ExecutionTask> leaderActionsToReexecute = new ArrayList<>(_executionTaskManager.inExecutionTasks(Collections.singleton(LEADER_ACTION)));
         if (!leaderActionsToReexecute.isEmpty()) {
           LOG.info("Reexecuting tasks {}", leaderActionsToReexecute);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ModelParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ModelParameters.java
@@ -45,7 +45,7 @@ public class ModelParameters {
         config.getDouble(MonitorConfig.LEADER_NETWORK_OUTBOUND_WEIGHT_FOR_CPU_UTIL_CONFIG);
     CPU_WEIGHT_OF_FOLLOWER_BYTES_IN_RATE =
         config.getDouble(MonitorConfig.FOLLOWER_NETWORK_INBOUND_WEIGHT_FOR_CPU_UTIL_CONFIG);
-    LINEAR_REGRESSION_PARAMETERS.init(config);
+    LinearRegressionModelParameters.init(config);
   }
 
   public static Double getCoefficient(LinearRegressionModelParameters.ModelCoefficient name) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
@@ -421,6 +421,7 @@ public class UserTaskManager implements Closeable {
    * @param completeWithError Whether the task execution finished with error or not.
    */
   public synchronized void markTaskExecutionFinished(String uuid, boolean completeWithError) {
+    LOG.debug("Task execution with uuid {} completed{}.", uuid, completeWithError ? " with error" : "");
     if (!_inExecutionUserTaskInfo.userTaskId().equals(UUID.fromString(uuid))) {
       throw new IllegalStateException(String.format("Task %s is not found in UserTaskManager.", uuid));
     }

--- a/cruise-control/src/main/scala/com/linkedin/kafka/cruisecontrol/executor/ExecutorUtils.scala
+++ b/cruise-control/src/main/scala/com/linkedin/kafka/cruisecontrol/executor/ExecutorUtils.scala
@@ -26,16 +26,16 @@ object ExecutorUtils {
    * within the cluster, (2) introduce a new replica to the cluster (3) remove an existing replica from the cluster.
    *
    * @param kafkaZkClient the KafkaZkClient class to use for partition reassignment.
-   * @param reassignmentTasks Replica reassignment tasks to be executed.
+   * @param tasksToExecute Replica reassignment tasks to be executed.
    */
   def executeReplicaReassignmentTasks(kafkaZkClient: KafkaZkClient,
-                                      reassignmentTasks: java.util.List[ExecutionTask]) {
-    if (reassignmentTasks != null && !reassignmentTasks.isEmpty) {
+                                      tasksToExecute: java.util.List[ExecutionTask]) {
+    if (tasksToExecute != null && !tasksToExecute.isEmpty) {
       val inProgressReplicaReassignment = kafkaZkClient.getPartitionReassignment
       // Add the partition being assigned to the newReplicaAssignment because we are going to add the new
       // reassignment together.
       val newReplicaAssignment = scala.collection.mutable.Map(inProgressReplicaReassignment.toSeq: _*)
-      reassignmentTasks.foreach({ task =>
+      tasksToExecute.foreach({ task =>
         val tp = task.proposal.topicPartition()
         val oldReplicas = asScalaBuffer(task.proposal.oldReplicas()).map(_.brokerId.toInt)
         val newReplicas = asScalaBuffer(task.proposal().newReplicas()).map(_.brokerId.toInt)

--- a/cruise-control/src/main/scala/com/linkedin/kafka/cruisecontrol/executor/ExecutorUtils.scala
+++ b/cruise-control/src/main/scala/com/linkedin/kafka/cruisecontrol/executor/ExecutorUtils.scala
@@ -27,6 +27,7 @@ object ExecutorUtils {
    *
    * @param kafkaZkClient the KafkaZkClient class to use for partition reassignment.
    * @param tasksToExecute Replica reassignment tasks to be executed.
+   * @deprecated Use com.linkedin.kafka.cruisecontrol.executor.ExecutionUtils#submitReplicaReassignmentTasks() instead.
    */
   def executeReplicaReassignmentTasks(kafkaZkClient: KafkaZkClient,
                                       tasksToExecute: java.util.List[ExecutionTask]) {
@@ -100,6 +101,13 @@ object ExecutorUtils {
     preferredReplicaElectionCommand.moveLeaderToPreferredReplica()
   }
 
+  /**
+   * Retrieve the set of partitions that are currently being reassigned.
+   *
+   * @param kafkaZkClient the KafkaZkClient class to use for getting partition reassignment.
+   * @return Set of partitions with ongoing reassignments.
+   * @deprecated Use [[com.linkedin.kafka.cruisecontrol.executor.ExecutionUtils]]#partitionsBeingReassigned instead.
+   */
   def partitionsBeingReassigned(kafkaZkClient: KafkaZkClient): util.Set[TopicPartition] = {
     setAsJavaSet(kafkaZkClient.getPartitionReassignment.keys.toSet)
   }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol;
+
+import com.linkedin.kafka.cruisecontrol.analyzer.GoalOptimizer;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
+import com.linkedin.kafka.cruisecontrol.detector.AnomalyDetector;
+import com.linkedin.kafka.cruisecontrol.executor.Executor;
+import com.linkedin.kafka.cruisecontrol.monitor.LoadMonitor;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeoutException;
+import org.apache.kafka.common.utils.Time;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
+
+
+public class KafkaCruiseControlTest {
+
+  @Test
+  public void testSanityCheckDryRun() throws InterruptedException, ExecutionException, TimeoutException {
+    KafkaCruiseControlConfig config = EasyMock.mock(KafkaCruiseControlConfig.class);
+    Time time = EasyMock.mock(Time.class);
+    AnomalyDetector anomalyDetector = EasyMock.mock(AnomalyDetector.class);
+    Executor executor = EasyMock.strictMock(Executor.class);
+    LoadMonitor loadMonitor = EasyMock.mock(LoadMonitor.class);
+    ExecutorService goalOptimizerExecutor = EasyMock.mock(ExecutorService.class);
+    GoalOptimizer goalOptimizer = EasyMock.mock(GoalOptimizer.class);
+
+    // For sanityCheckDryRun(false, true) and sanityCheckDryRun(false, false) (see #1 and #2 below).
+    EasyMock.expect(executor.hasOngoingExecution()).andReturn(true).times(2);
+    // For sanityCheckDryRun(false, XXX) (see #3 below)
+    EasyMock.expect(executor.hasOngoingExecution()).andReturn(false).once();
+    EasyMock.expect(executor.hasOngoingPartitionReassignments()).andReturn(true);
+    // For sanityCheckDryRun(false, XXX) (see #4 below)
+    EasyMock.expect(executor.hasOngoingExecution()).andReturn(false).once();
+    EasyMock.expect(executor.hasOngoingPartitionReassignments()).andReturn(false);
+    EasyMock.expect(executor.hasOngoingLeaderElection()).andReturn(true);
+    // For sanityCheckDryRun(false, XXX) (see #5 below)
+    EasyMock.expect(executor.hasOngoingExecution()).andReturn(false).once();
+    EasyMock.expect(executor.hasOngoingPartitionReassignments()).andReturn(false);
+    EasyMock.expect(executor.hasOngoingLeaderElection()).andReturn(false);
+    // For sanityCheckDryRun(false, XXX) (see #6 below)
+    EasyMock.expect(executor.hasOngoingExecution()).andReturn(false).once();
+    EasyMock.expect(executor.hasOngoingPartitionReassignments()).andThrow(new TimeoutException()).once();
+
+    EasyMock.replay(config, time, anomalyDetector, executor, loadMonitor, goalOptimizerExecutor, goalOptimizer);
+    KafkaCruiseControl kafkaCruiseControl = new KafkaCruiseControl(config, time, anomalyDetector, executor,
+                                                                   loadMonitor, goalOptimizerExecutor, goalOptimizer);
+
+    // Expect no failure (dryrun = true) regardless of ongoing executions.
+    kafkaCruiseControl.sanityCheckDryRun(true, false);
+    kafkaCruiseControl.sanityCheckDryRun(true, true);
+    // 1. Expect no failure (dryrun = false), if there is ongoing execution started by CC, it must be requested to stop.
+    kafkaCruiseControl.sanityCheckDryRun(false, true);
+    // 2. Expect failure (dryrun = false), if there is ongoing execution started by CC, not requested to stop.
+    assertThrows(IllegalStateException.class, () -> kafkaCruiseControl.sanityCheckDryRun(false, false));
+    // 3. Expect failure (dryrun = false), there is no execution started by CC, but ongoing replica reassignment, request to stop is irrelevant.
+    assertThrows(IllegalStateException.class, () -> kafkaCruiseControl.sanityCheckDryRun(false, false));
+    // 4. Expect failure (dryrun = false), there is no execution started by CC, but ongoing leader election, request to stop is irrelevant.
+    assertThrows(IllegalStateException.class, () -> kafkaCruiseControl.sanityCheckDryRun(false, false));
+    // 5. Expect failure (dryrun = false), there is no execution started by CC or other tools, request to stop is irrelevant.
+    kafkaCruiseControl.sanityCheckDryRun(false, false);
+    // 6. Expect failure (dryrun = false), there is no execution started by CC, but checking ongoing executions started
+    // by other tools timed out, request to stop is irrelevant.
+    assertThrows(IllegalStateException.class, () -> kafkaCruiseControl.sanityCheckDryRun(false, false));
+
+    EasyMock.verify(config, time, anomalyDetector, executor, loadMonitor, goalOptimizerExecutor, goalOptimizer);
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUnitTestUtils.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUnitTestUtils.java
@@ -7,6 +7,7 @@ package com.linkedin.kafka.cruisecontrol;
 import com.linkedin.cruisecontrol.monitor.sampling.aggregator.AggregatedMetricValues;
 import com.linkedin.cruisecontrol.monitor.sampling.aggregator.MetricValues;
 import com.linkedin.kafka.cruisecontrol.common.Resource;
+import com.linkedin.kafka.cruisecontrol.common.TestConstants;
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityConfigFileResolver;
 import com.linkedin.kafka.cruisecontrol.config.KafkaTopicConfigProvider;
 import com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig;
@@ -17,8 +18,12 @@ import com.linkedin.kafka.cruisecontrol.config.constants.UserTaskManagerConfig;
 import com.linkedin.kafka.cruisecontrol.detector.NoopTopicAnomalyFinder;
 import com.linkedin.kafka.cruisecontrol.monitor.metricdefinition.KafkaMetricDef;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.NoopSampler;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.fail;
 
 
 /**
@@ -40,17 +45,21 @@ public class KafkaCruiseControlUnitTestUtils {
    */
   public static Properties getKafkaCruiseControlProperties() {
     Properties props = new Properties();
-    String capacityConfigFile =
-        KafkaCruiseControlUnitTestUtils.class.getClassLoader().getResource("DefaultCapacityConfig.json").getFile();
-    String clusterConfigsFile =
-        KafkaCruiseControlUnitTestUtils.class.getClassLoader().getResource("DefaultClusterConfigs.json").getFile();
+    String capacityConfigFile = Objects.requireNonNull(KafkaCruiseControlUnitTestUtils.class.getClassLoader().getResource(
+        TestConstants.DEFAULT_BROKER_CAPACITY_CONFIG_FILE)).getFile();
+    String clusterConfigsFile = Objects.requireNonNull(KafkaCruiseControlUnitTestUtils.class.getClassLoader().getResource(
+        TestConstants.DEFAULT_CLUSTER_CONFIGS_FILE)).getFile();
     props.setProperty(ExecutorConfig.ZOOKEEPER_CONNECT_CONFIG, "localhost:2121");
     props.setProperty(MonitorConfig.BOOTSTRAP_SERVERS_CONFIG, "aaa");
     props.setProperty(MonitorConfig.METRIC_SAMPLER_CLASS_CONFIG, NoopSampler.class.getName());
     props.setProperty(BrokerCapacityConfigFileResolver.CAPACITY_CONFIG_FILE, capacityConfigFile);
     props.setProperty(KafkaTopicConfigProvider.CLUSTER_CONFIGS_FILE, clusterConfigsFile);
-    props.setProperty(MonitorConfig.MIN_SAMPLES_PER_PARTITION_METRICS_WINDOW_CONFIG, "2");
-    props.setProperty(MonitorConfig.MIN_SAMPLES_PER_BROKER_METRICS_WINDOW_CONFIG, "2");
+    props.setProperty(MonitorConfig.MIN_SAMPLES_PER_PARTITION_METRICS_WINDOW_CONFIG,
+                      Integer.toString(MonitorConfig.DEFAULT_MIN_SAMPLES_PER_PARTITION_METRICS_WINDOW));
+    props.setProperty(MonitorConfig.MIN_SAMPLES_PER_BROKER_METRICS_WINDOW_CONFIG,
+                      Integer.toString(MonitorConfig.DEFAULT_MIN_SAMPLES_PER_BROKER_METRICS_WINDOW));
+    props.setProperty(ExecutorConfig.EXECUTION_PROGRESS_CHECK_INTERVAL_MS_CONFIG,
+                      Long.toString(ExecutorConfig.DEFAULT_EXECUTION_PROGRESS_CHECK_INTERVAL_MS));
     props.setProperty(UserTaskManagerConfig.COMPLETED_USER_TASK_RETENTION_TIME_MS_CONFIG, Long.toString(TimeUnit.HOURS.toMillis(6)));
     props.setProperty(ExecutorConfig.DEMOTION_HISTORY_RETENTION_TIME_MS_CONFIG, Long.toString(TimeUnit.HOURS.toMillis(24)));
     props.setProperty(ExecutorConfig.REMOVAL_HISTORY_RETENTION_TIME_MS_CONFIG, Long.toString(TimeUnit.HOURS.toMillis(12)));
@@ -63,22 +72,7 @@ public class KafkaCruiseControlUnitTestUtils {
                       Boolean.toString(AnomalyDetectorConfig.DEFAULT_SELF_HEALING_EXCLUDE_RECENT_BROKERS_CONFIG));
     props.setProperty(AnomalyDetectorConfig.TOPIC_ANOMALY_FINDER_CLASSES_CONFIG, NoopTopicAnomalyFinder.class.getName());
     props.setProperty(AnomalyDetectorConfig.SELF_HEALING_GOALS_CONFIG, "");
-    props.setProperty(
-        AnalyzerConfig.DEFAULT_GOALS_CONFIG,
-        "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal");
+    props.setProperty(AnalyzerConfig.DEFAULT_GOALS_CONFIG, TestConstants.DEFAULT_GOALS_VALUES);
 
     return props;
   }
@@ -96,6 +90,29 @@ public class KafkaCruiseControlUnitTestUtils {
     setValueForResource(aggregateMetricValues, Resource.NW_OUT, networkOutBoundUsage);
     setValueForResource(aggregateMetricValues, Resource.DISK, diskUsage);
     return aggregateMetricValues;
+  }
+
+  /**
+   * Wait until the given condition is {@code true} or throw an exception if the given wait time elapses.
+   *
+   * @param condition The condition to check
+   * @param errorMessage Error message.
+   * @param waitTimeMs The maximum time to wait in milliseconds.
+   * @param pauseMs The delay between condition checks in milliseconds.
+   */
+  public static void waitUntilTrue(Supplier<Boolean> condition, String errorMessage, long waitTimeMs, long pauseMs) {
+    long startTime = System.currentTimeMillis();
+    long pausePeriodMs = Math.min(waitTimeMs, pauseMs);
+    while (!condition.get()) {
+      if (System.currentTimeMillis() > startTime + waitTimeMs) {
+        fail(errorMessage);
+      }
+      try {
+        Thread.sleep(pausePeriodMs);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
   }
 
   /**

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizerTest.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.analyzer;
 
 import com.codahale.metrics.MetricRegistry;
+import com.linkedin.kafka.cruisecontrol.common.TestConstants;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.ExecutorConfig;
@@ -25,22 +26,7 @@ public class GoalOptimizerTest {
     props.setProperty(MonitorConfig.BOOTSTRAP_SERVERS_CONFIG, "bootstrap.servers");
     props.setProperty(ExecutorConfig.ZOOKEEPER_CONNECT_CONFIG, "connect:1234");
     props.setProperty(AnalyzerConfig.NUM_PROPOSAL_PRECOMPUTE_THREADS_CONFIG, "0");
-    props.setProperty(
-        AnalyzerConfig.DEFAULT_GOALS_CONFIG,
-        "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal");
+    props.setProperty(AnalyzerConfig.DEFAULT_GOALS_CONFIG, TestConstants.DEFAULT_GOALS_VALUES);
     KafkaCruiseControlConfig config = new KafkaCruiseControlConfig(props);
 
     GoalOptimizer goalOptimizer = new GoalOptimizer(config, EasyMock.mock(LoadMonitor.class), new SystemTime(),

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/TestConstants.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/TestConstants.java
@@ -12,7 +12,7 @@ import static com.linkedin.kafka.cruisecontrol.common.DeterministicCluster.T1;
 import static com.linkedin.kafka.cruisecontrol.detector.TopicReplicationFactorAnomaly.TopicReplicationFactorAnomalyEntry;
 
 
-public class TestConstants {
+public final class TestConstants {
   public static final String TOPIC0 = "topic0";
   public static final String TOPIC1 = "topic1";
   public static final String TOPIC2 = "topic2";
@@ -48,6 +48,44 @@ public class TestConstants {
 
   }
 
+  public static final String GOALS_VALUES;
+  static {
+    GOALS_VALUES = "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,"
+                   + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,"
+                   + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,"
+                   + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,"
+                   + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,"
+                   + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,"
+                   + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,"
+                   + "com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,"
+                   + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,"
+                   + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,"
+                   + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,"
+                   + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,"
+                   + "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,"
+                   + "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderReplicaDistributionGoal,"
+                   + "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal";
+  }
+
+  public static final String DEFAULT_GOALS_VALUES;
+  static {
+    DEFAULT_GOALS_VALUES = "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,"
+                           + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,"
+                           + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,"
+                           + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,"
+                           + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,"
+                           + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,"
+                           + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,"
+                           + "com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,"
+                           + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,"
+                           + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,"
+                           + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,"
+                           + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,"
+                           + "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,"
+                           + "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderReplicaDistributionGoal,"
+                           + "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal";
+  }
+
   public enum Distribution {
     UNIFORM, LINEAR, EXPONENTIAL
   }
@@ -72,7 +110,6 @@ public class TestConstants {
     properties.put(ClusterProperty.MEAN_NW_OUT, 100.0);
     properties.put(ClusterProperty.POPULATE_REPLICA_PLACEMENT_INFO, 0);
     BASE_PROPERTIES = Collections.unmodifiableMap(properties);
-
   }
 
   // Broker and disk capacity (homogeneous cluster is assumed).
@@ -98,6 +135,7 @@ public class TestConstants {
   // Broker capacity config file for test.
   public static final String JBOD_BROKER_CAPACITY_CONFIG_FILE = "testCapacityConfigJBOD.json";
   public static final String DEFAULT_BROKER_CAPACITY_CONFIG_FILE = "DefaultCapacityConfig.json";
+  public static final String DEFAULT_CLUSTER_CONFIGS_FILE = "DefaultClusterConfigs.json";
 
   // Topic replication factor anomaly test.
   public static final TopicReplicationFactorAnomalyEntry TOPIC_REPLICATION_FACTOR_ANOMALY_ENTRY =

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/CaseInsensitiveGoalConfigTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/CaseInsensitiveGoalConfigTest.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.config;
 
+import com.linkedin.kafka.cruisecontrol.common.TestConstants;
 import com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.ExecutorConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
@@ -48,37 +49,8 @@ public class CaseInsensitiveGoalConfigTest {
     // Test: With case insensitive goal names (No exception)
     Properties caseInsensitiveGoalProps = new Properties();
     caseInsensitiveGoalProps.putAll(sharedProps);
-    caseInsensitiveGoalProps.setProperty(AnalyzerConfig.GOALS_CONFIG,
-        "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,"
-            + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,"
-            + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,"
-            + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,"
-            + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,"
-            + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,"
-            + "com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,"
-            + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,"
-            + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,"
-            + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,"
-            + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,"
-            + "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal,"
-            + "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,"
-            + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal");
-    caseInsensitiveGoalProps.setProperty(
-        AnalyzerConfig.DEFAULT_GOALS_CONFIG,
-        "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal");
+    caseInsensitiveGoalProps.setProperty(AnalyzerConfig.GOALS_CONFIG, TestConstants.GOALS_VALUES);
+    caseInsensitiveGoalProps.setProperty(AnalyzerConfig.DEFAULT_GOALS_CONFIG, TestConstants.DEFAULT_GOALS_VALUES);
 
     Object[] withCaseInsensitiveGoalParams = {caseInsensitiveGoalProps, null};
     params.add(withCaseInsensitiveGoalParams);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -7,19 +7,19 @@ package com.linkedin.kafka.cruisecontrol.executor;
 import com.codahale.metrics.MetricRegistry;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils;
 import com.linkedin.kafka.cruisecontrol.common.MetadataClient;
+import com.linkedin.kafka.cruisecontrol.common.TestConstants;
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityConfigFileResolver;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.ExecutorConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
 import com.linkedin.kafka.cruisecontrol.exception.OngoingExecutionException;
-import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaIntegrationTestHarness;
+import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaClientsIntegrationTestHarness;
 import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
 import com.linkedin.kafka.cruisecontrol.detector.AnomalyDetector;
 import com.linkedin.kafka.cruisecontrol.monitor.LoadMonitor;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.NoopSampler;
 import com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunner;
-import com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint;
 import com.linkedin.kafka.cruisecontrol.servlet.UserTaskManager;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,13 +28,21 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
+import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import kafka.zk.KafkaZkClient;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
@@ -49,6 +57,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUnitTestUtils.waitUntilTrue;
+import static com.linkedin.kafka.cruisecontrol.common.TestConstants.DEFAULT_BROKER_CAPACITY_CONFIG_FILE;
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC0;
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC1;
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC2;
@@ -56,10 +66,12 @@ import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC3;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.isA;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
-public class ExecutorTest extends CCKafkaIntegrationTestHarness {
+
+public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
   private static final int PARTITION = 0;
   private static final TopicPartition TP0 = new TopicPartition(TOPIC0, PARTITION);
   private static final TopicPartition TP1 = new TopicPartition(TOPIC1, PARTITION);
@@ -68,6 +80,12 @@ public class ExecutorTest extends CCKafkaIntegrationTestHarness {
   private static final String RANDOM_UUID = "random_uuid";
   private static final long REMOVAL_HISTORY_RETENTION_TIME_MS = 43200000L;
   private static final long DEMOTION_HISTORY_RETENTION_TIME_MS = 86400000L;
+  private static final long PRODUCE_SIZE_IN_BYTES = 10000L;
+  private static final long EXECUTION_DEADLINE_MS = 30000L;
+  private static final long EXECUTION_SHORT_CHECK_MS = 10L;
+  private static final long EXECUTION_REGULAR_CHECK_MS = 100L;
+  private static final Random RANDOM = new Random(0xDEADBEEF);
+  private static final int MOCK_BROKER_ID_TO_DROP = 1;
 
   @Override
   public int clusterSize() {
@@ -85,62 +103,102 @@ public class ExecutorTest extends CCKafkaIntegrationTestHarness {
   }
 
   @Test
-  public void testBalanceMovement() throws InterruptedException, OngoingExecutionException {
+  public void testReplicaReassignment() throws InterruptedException, OngoingExecutionException {
     KafkaZkClient kafkaZkClient = KafkaCruiseControlUtils.createKafkaZkClient(zookeeper().connectionString(),
                                                                               "ExecutorTestMetricGroup",
-                                                                              "BasicBalanceMovement",
+                                                                              "ReplicaReassignment",
                                                                               false);
     try {
       List<ExecutionProposal> proposalsToExecute = new ArrayList<>();
       List<ExecutionProposal> proposalsToCheck = new ArrayList<>();
-      populateProposals(proposalsToExecute, proposalsToCheck);
-      executeAndVerifyProposals(kafkaZkClient, proposalsToExecute, proposalsToCheck);
+      populateProposals(proposalsToExecute, proposalsToCheck, 0);
+      executeAndVerifyProposals(kafkaZkClient, proposalsToExecute, proposalsToCheck, false, null, false);
     } finally {
       KafkaCruiseControlUtils.closeKafkaZkClientWithTimeout(kafkaZkClient);
     }
   }
 
   @Test
-  public void testBrokerDiesWhenMovePartitions() throws Exception {
+  public void testReplicaReassignmentProgressWithThrottle() throws InterruptedException, OngoingExecutionException {
     KafkaZkClient kafkaZkClient = KafkaCruiseControlUtils.createKafkaZkClient(zookeeper().connectionString(),
                                                                               "ExecutorTestMetricGroup",
-                                                                              "BrokerDiesWhenMovePartitions",
+                                                                              "ReplicaReassignmentProgressWithThrottle",
                                                                               false);
     try {
-      Map<String, TopicDescription> topicDescriptions = createTopics();
-      int initialLeader0 = topicDescriptions.get(TOPIC0).partitions().get(0).leader().id();
-      int initialLeader1 = topicDescriptions.get(TOPIC1).partitions().get(0).leader().id();
-
-      _brokers.get(initialLeader0 == 0 ? 1 : 0).shutdown();
-      ExecutionProposal proposal0 =
-          new ExecutionProposal(TP0, 0, new ReplicaPlacementInfo(initialLeader0),
-                                Collections.singletonList(new ReplicaPlacementInfo(initialLeader0)),
-                                Collections.singletonList(initialLeader0 == 0 ? new ReplicaPlacementInfo(1) :
-                                                                                new ReplicaPlacementInfo(0)));
-      ExecutionProposal proposal1 =
-          new ExecutionProposal(TP1, 0, new ReplicaPlacementInfo(initialLeader1),
-                                Arrays.asList(new ReplicaPlacementInfo(initialLeader1),
-                                              initialLeader1 == 0 ? new ReplicaPlacementInfo(1) :
-                                                                    new ReplicaPlacementInfo(0)),
-                                Arrays.asList(initialLeader1 == 0 ? new ReplicaPlacementInfo(1) :
-                                                                    new ReplicaPlacementInfo(0),
-                                              new ReplicaPlacementInfo(initialLeader1)));
-
-      Collection<ExecutionProposal> proposalsToExecute = Arrays.asList(proposal0, proposal1);
-      executeAndVerifyProposals(kafkaZkClient, proposalsToExecute, Collections.emptyList());
-
-      // We are not doing the rollback.
-      assertEquals(Collections.singletonList(initialLeader0 == 0 ? 1 : 0),
-                   ExecutorUtils.newAssignmentForPartition(kafkaZkClient, TP0));
-      assertEquals(initialLeader0, kafkaZkClient.getLeaderForPartition(new TopicPartition(TOPIC1, PARTITION)).get());
+      List<ExecutionProposal> proposalsToExecute = new ArrayList<>();
+      List<ExecutionProposal> proposalsToCheck = new ArrayList<>();
+      populateProposals(proposalsToExecute, proposalsToCheck, PRODUCE_SIZE_IN_BYTES);
+      // Throttle rate is set to the half of the produce size.
+      executeAndVerifyProposals(kafkaZkClient, proposalsToExecute, proposalsToCheck, false, PRODUCE_SIZE_IN_BYTES / 2, true);
     } finally {
       KafkaCruiseControlUtils.closeKafkaZkClientWithTimeout(kafkaZkClient);
     }
+  }
+
+  @Test
+  public void testBrokerDiesBeforeMovingPartition() throws Exception {
+    KafkaZkClient kafkaZkClient = KafkaCruiseControlUtils.createKafkaZkClient(zookeeper().connectionString(),
+                                                                              "ExecutorTestMetricGroup",
+                                                                              "BrokerDiesBeforeMovingPartition",
+                                                                              false);
+    try {
+      Map<String, TopicDescription> topicDescriptions = createTopics((int) PRODUCE_SIZE_IN_BYTES);
+      // initialLeader0 will be alive after killing a broker in cluster.
+      int initialLeader0 = topicDescriptions.get(TOPIC0).partitions().get(0).leader().id();
+      int initialLeader1 = topicDescriptions.get(TOPIC1).partitions().get(0).leader().id();
+      // Kill broker before starting the reassignment.
+      _brokers.get(initialLeader0 == 0 ? 1 : 0).shutdown();
+      ExecutionProposal proposal0 =
+          new ExecutionProposal(TP0, PRODUCE_SIZE_IN_BYTES, new ReplicaPlacementInfo(initialLeader0),
+                                Collections.singletonList(new ReplicaPlacementInfo(initialLeader0)),
+                                Collections.singletonList(new ReplicaPlacementInfo(initialLeader0 == 0 ? 1 : 0)));
+      ExecutionProposal proposal1 =
+          new ExecutionProposal(TP1, 0, new ReplicaPlacementInfo(initialLeader1),
+                                Arrays.asList(new ReplicaPlacementInfo(initialLeader1),
+                                              new ReplicaPlacementInfo(initialLeader1 == 0 ? 1 : 0)),
+                                Arrays.asList(new ReplicaPlacementInfo(initialLeader1 == 0 ? 1 : 0),
+                                              new ReplicaPlacementInfo(initialLeader1)));
+
+      Collection<ExecutionProposal> proposalsToExecute = Arrays.asList(proposal0, proposal1);
+      executeAndVerifyProposals(kafkaZkClient, proposalsToExecute, Collections.emptyList(), true, null, false);
+
+      // We are doing the rollback.
+      assertThrows(java.util.NoSuchElementException.class, () -> ExecutorUtils.newAssignmentForPartition(kafkaZkClient, TP0));
+      assertThrows(java.util.NoSuchElementException.class, () -> ExecutorUtils.newAssignmentForPartition(kafkaZkClient, TP1));
+      // The leadership should be on the alive broker.
+      assertEquals(initialLeader0, kafkaZkClient.getLeaderForPartition(TP0).get());
+      assertEquals(initialLeader0, kafkaZkClient.getLeaderForPartition(TP1).get());
+    } finally {
+      KafkaCruiseControlUtils.closeKafkaZkClientWithTimeout(kafkaZkClient);
+    }
+  }
+
+  @Test
+  public void testExecutionKnobs() {
+    KafkaCruiseControlConfig config = new KafkaCruiseControlConfig(getExecutorProperties());
+    Executor executor = new Executor(config, null, new MetricRegistry(), EasyMock.mock(MetadataClient.class), DEMOTION_HISTORY_RETENTION_TIME_MS,
+                                     REMOVAL_HISTORY_RETENTION_TIME_MS, null, null, null);
+
+    // Verify correctness of set/get requested execution progress check interval.
+    long defaultExecutionProgressCheckIntervalMs = config.getLong(ExecutorConfig.EXECUTION_PROGRESS_CHECK_INTERVAL_MS_CONFIG);
+    assertEquals(defaultExecutionProgressCheckIntervalMs, executor.executionProgressCheckIntervalMs());
+    executor.setRequestedExecutionProgressCheckIntervalMs(Executor.MIN_EXECUTION_PROGRESS_CHECK_INTERVAL_MS);
+    assertEquals(Executor.MIN_EXECUTION_PROGRESS_CHECK_INTERVAL_MS, executor.executionProgressCheckIntervalMs());
+    assertThrows(IllegalArgumentException.class,
+                 () -> executor.setRequestedExecutionProgressCheckIntervalMs(Executor.MIN_EXECUTION_PROGRESS_CHECK_INTERVAL_MS - 1));
+
+    // Verify correctness of add/drop recently removed/demoted brokers.
+    assertFalse(executor.dropRecentlyRemovedBrokers(Collections.emptySet()));
+    assertFalse(executor.dropRecentlyDemotedBrokers(Collections.emptySet()));
+    executor.addRecentlyRemovedBrokers(Collections.singleton(MOCK_BROKER_ID_TO_DROP));
+    executor.addRecentlyDemotedBrokers(Collections.singleton(MOCK_BROKER_ID_TO_DROP));
+    assertTrue(executor.dropRecentlyRemovedBrokers(Collections.singleton(MOCK_BROKER_ID_TO_DROP)));
+    assertTrue(executor.dropRecentlyDemotedBrokers(Collections.singleton(MOCK_BROKER_ID_TO_DROP)));
   }
 
   @Test
   public void testTimeoutAndForceExecutionStop() throws InterruptedException, OngoingExecutionException {
-    createTopics();
+    createTopics(0);
     // The proposal tries to move the leader. We fake the replica list to be unchanged so there is no replica
     // movement, but only leader movement.
     ExecutionProposal proposal =
@@ -150,7 +208,7 @@ public class ExecutorTest extends CCKafkaIntegrationTestHarness {
 
     KafkaCruiseControlConfig configs = new KafkaCruiseControlConfig(getExecutorProperties());
     Time time = new MockTime();
-    MetadataClient mockMetadataClient = EasyMock.createMock(MetadataClient.class);
+    MetadataClient mockMetadataClient = EasyMock.mock(MetadataClient.class);
     // Fake the metadata to never change so the leader movement will timeout.
     Node node0 = new Node(0, "host0", 100);
     Node node1 = new Node(1, "host1", 100);
@@ -163,21 +221,17 @@ public class ExecutorTest extends CCKafkaIntegrationTestHarness {
     MetadataClient.ClusterAndGeneration clusterAndGeneration = new MetadataClient.ClusterAndGeneration(cluster, 0);
     EasyMock.expect(mockMetadataClient.refreshMetadata()).andReturn(clusterAndGeneration).anyTimes();
     EasyMock.expect(mockMetadataClient.cluster()).andReturn(clusterAndGeneration.cluster()).anyTimes();
-    EasyMock.replay(mockMetadataClient);
-    LoadMonitor mockLoadMonitor = EasyMock.mock(LoadMonitor.class);
-    EasyMock.expect(mockLoadMonitor.taskRunnerState())
-            .andReturn(LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.RUNNING)
-            .anyTimes();
-    mockLoadMonitor.pauseMetricSampling(isA(String.class));
-    expectLastCall().anyTimes();
-    mockLoadMonitor.resumeMetricSampling(isA(String.class));
-    expectLastCall().anyTimes();
-    EasyMock.replay(mockLoadMonitor);
+    LoadMonitor mockLoadMonitor = getMockLoadMonitor();
+    AnomalyDetector mockAnomalyDetector = getMockAnomalyDetector(RANDOM_UUID);
+    UserTaskManager.UserTaskInfo mockUserTaskInfo = getMockUserTaskInfo();
+    // This tests runs two consecutive executions. First one completes w/o error, but the second one with error.
+    UserTaskManager mockUserTaskManager = getMockUserTaskManager(RANDOM_UUID, mockUserTaskInfo, Arrays.asList(false, true));
+    EasyMock.replay(mockMetadataClient, mockLoadMonitor, mockAnomalyDetector, mockUserTaskInfo, mockUserTaskManager);
 
     Collection<ExecutionProposal> proposalsToExecute = Collections.singletonList(proposal);
     Executor executor = new Executor(configs, time, new MetricRegistry(), mockMetadataClient, DEMOTION_HISTORY_RETENTION_TIME_MS,
-                                     REMOVAL_HISTORY_RETENTION_TIME_MS, null, getMockUserTaskManager(RANDOM_UUID),
-                                     getMockAnomalyDetector(RANDOM_UUID));
+                                     REMOVAL_HISTORY_RETENTION_TIME_MS, null, mockUserTaskManager,
+                                     mockAnomalyDetector);
     executor.setExecutionMode(false);
     executor.executeProposals(proposalsToExecute,
                               Collections.emptySet(),
@@ -191,15 +245,17 @@ public class ExecutorTest extends CCKafkaIntegrationTestHarness {
                               null,
                               true,
                               RANDOM_UUID,
-                              () -> "");
-    // Wait until the execution to start so the task timestamp is set to time.milliseconds.
-    while (executor.state().state() != ExecutorState.State.LEADER_MOVEMENT_TASK_IN_PROGRESS) {
-      Thread.sleep(10);
-    }
+                              ExecutorTest.class::getSimpleName);
+    waitUntilTrue(() -> (executor.state().state() == ExecutorState.State.LEADER_MOVEMENT_TASK_IN_PROGRESS),
+                  "Leader movement task did not start within the time limit",
+                  EXECUTION_DEADLINE_MS, EXECUTION_SHORT_CHECK_MS);
+
     // Sleep over 180000 (the hard coded timeout) with some margin for inter-thread synchronization.
     time.sleep(200000);
     // The execution should finish.
-    waitUntilExecutionFinishes(executor);
+    waitUntilTrue(() -> (!executor.hasOngoingExecution() && executor.state().state() == ExecutorState.State.NO_TASK_IN_PROGRESS),
+                  "Proposal execution did not finish within the time limit",
+                  EXECUTION_DEADLINE_MS, EXECUTION_REGULAR_CHECK_MS);
 
     // The proposal tries to move replicas.
     proposal = new ExecutionProposal(TP1, 0, new ReplicaPlacementInfo(1),
@@ -218,58 +274,68 @@ public class ExecutorTest extends CCKafkaIntegrationTestHarness {
                               null,
                               true,
                               RANDOM_UUID,
-                              () -> "");
-    // Wait until the inter-broker replica movement task hang.
-    while (executor.state().state() != ExecutorState.State.INTER_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS) {
-      Thread.sleep(10);
-    }
+                              ExecutorTest.class::getSimpleName);
+    waitUntilTrue(() -> (executor.state().state() == ExecutorState.State.INTER_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS),
+                  "Inter-broker replica movement task did not start within the time limit",
+                  EXECUTION_DEADLINE_MS, EXECUTION_SHORT_CHECK_MS);
     // Force execution to stop.
     executor.userTriggeredStopExecution(true);
     // The execution should finish.
-    waitUntilExecutionFinishes(executor);
+    waitUntilTrue(() -> (!executor.hasOngoingExecution() && executor.state().state() == ExecutorState.State.NO_TASK_IN_PROGRESS),
+                  "Proposal execution did not finish within the time limit",
+                  EXECUTION_DEADLINE_MS, EXECUTION_REGULAR_CHECK_MS);
+    EasyMock.verify(mockMetadataClient, mockLoadMonitor, mockAnomalyDetector, mockUserTaskInfo, mockUserTaskManager);
   }
 
+  /**
+   * Proposal#1: [TPO] move from original broker to the other one -- e.g. 0 -> 1
+   * Proposal#2: [TP1] change order and leader -- e.g. [0, 1] -> [1, 0]
+   */
   private void populateProposals(List<ExecutionProposal> proposalToExecute,
-                                 List<ExecutionProposal> proposalToVerify) throws InterruptedException {
-    Map<String, TopicDescription> topicDescriptions = createTopics();
+                                 List<ExecutionProposal> proposalToVerify,
+                                 long topicSize) throws InterruptedException {
+    Map<String, TopicDescription> topicDescriptions = createTopics((int) topicSize);
     int initialLeader0 = topicDescriptions.get(TOPIC0).partitions().get(0).leader().id();
     int initialLeader1 = topicDescriptions.get(TOPIC1).partitions().get(0).leader().id();
     // Valid proposals
     ExecutionProposal proposal0 =
-        new ExecutionProposal(TP0, 0, new ReplicaPlacementInfo(initialLeader0),
+        new ExecutionProposal(TP0, topicSize, new ReplicaPlacementInfo(initialLeader0),
                               Collections.singletonList(new ReplicaPlacementInfo(initialLeader0)),
-                              Collections.singletonList(initialLeader0 == 0 ? new ReplicaPlacementInfo(1) :
-                                                                              new ReplicaPlacementInfo(0)));
+                              Collections.singletonList(new ReplicaPlacementInfo(initialLeader0 == 0 ? 1 : 0)));
     ExecutionProposal proposal1 =
         new ExecutionProposal(TP1, 0, new ReplicaPlacementInfo(initialLeader1),
                               Arrays.asList(new ReplicaPlacementInfo(initialLeader1),
-                                            initialLeader1 == 0 ? new ReplicaPlacementInfo(1) :
-                                                                  new ReplicaPlacementInfo(0)),
-                              Arrays.asList(initialLeader1 == 0 ? new ReplicaPlacementInfo(1) :
-                                                                  new ReplicaPlacementInfo(0),
-                              new ReplicaPlacementInfo(initialLeader1)));
+                                            new ReplicaPlacementInfo(initialLeader1 == 0 ? 1 : 0)),
+                              Arrays.asList(new ReplicaPlacementInfo(initialLeader1 == 0 ? 1 : 0),
+                                            new ReplicaPlacementInfo(initialLeader1)));
     // Invalid proposals, the targeting topics of these proposals does not exist.
     ExecutionProposal proposal2 =
         new ExecutionProposal(TP2, 0, new ReplicaPlacementInfo(initialLeader0),
                               Collections.singletonList(new ReplicaPlacementInfo(initialLeader0)),
-                              Collections.singletonList(initialLeader0 == 0 ? new ReplicaPlacementInfo(1) :
-                                                                              new ReplicaPlacementInfo(0)));
+                              Collections.singletonList(new ReplicaPlacementInfo(initialLeader0 == 0 ? 1 : 0)));
     ExecutionProposal proposal3 =
         new ExecutionProposal(TP3, 0, new ReplicaPlacementInfo(initialLeader1),
                               Arrays.asList(new ReplicaPlacementInfo(initialLeader1),
-                                            initialLeader1 == 0 ? new ReplicaPlacementInfo(1) :
-                                                                  new ReplicaPlacementInfo(0)),
-                              Arrays.asList(initialLeader1 == 0 ? new ReplicaPlacementInfo(1) :
-                                                                  new ReplicaPlacementInfo(0),
-                              new ReplicaPlacementInfo(initialLeader1)));
+                                            new ReplicaPlacementInfo(initialLeader1 == 0 ? 1 : 0)),
+                              Arrays.asList(new ReplicaPlacementInfo(initialLeader1 == 0 ? 1 : 0),
+                                            new ReplicaPlacementInfo(initialLeader1)));
 
     proposalToExecute.addAll(Arrays.asList(proposal0, proposal1, proposal2, proposal3));
     proposalToVerify.addAll(Arrays.asList(proposal0, proposal1));
   }
 
-  private Map<String, TopicDescription> createTopics() throws InterruptedException {
+  /**
+   * Creates {@link com.linkedin.kafka.cruisecontrol.common.TestConstants#TOPIC0 topic0} with replication factor 1 and
+   * {@link com.linkedin.kafka.cruisecontrol.common.TestConstants#TOPIC1 topic1} with replication factor 2. Waits until
+   * both brokers in the mock cluster receive the metadata about created topics.
+   *
+   * @param produceSizeInBytes Size of random data in bytes to produce to
+   * {@link com.linkedin.kafka.cruisecontrol.common.TestConstants#TOPIC0 topic0}.
+   * @return A map from topic names to their description.
+   */
+  private Map<String, TopicDescription> createTopics(int produceSizeInBytes) throws InterruptedException {
     AdminClient adminClient = KafkaCruiseControlUtils.createAdminClient(Collections.singletonMap(
-                              AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()));
+        AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()));
     try {
       adminClient.createTopics(Arrays.asList(new NewTopic(TOPIC0, 1, (short) 1),
                                              new NewTopic(TOPIC1, 1, (short) 2)));
@@ -284,9 +350,9 @@ public class ExecutorTest extends CCKafkaIntegrationTestHarness {
     Map<String, TopicDescription> topicDescriptions1 = null;
     do {
       AdminClient adminClient0 = KafkaCruiseControlUtils.createAdminClient(Collections.singletonMap(
-                                 AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()));
+          AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()));
       AdminClient adminClient1 = KafkaCruiseControlUtils.createAdminClient(Collections.singletonMap(
-                                 AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(1).plaintextAddr()));
+          AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(1).plaintextAddr()));
       try {
         topicDescriptions0 = adminClient0.describeTopics(Arrays.asList(TOPIC0, TOPIC1)).all().get();
         topicDescriptions1 = adminClient1.describeTopics(Arrays.asList(TOPIC0, TOPIC1)).all().get();
@@ -302,55 +368,62 @@ public class ExecutorTest extends CCKafkaIntegrationTestHarness {
         KafkaCruiseControlUtils.closeAdminClientWithTimeout(adminClient1);
       }
     } while (topicDescriptions0 == null || topicDescriptions0.size() < 2
-        || topicDescriptions1 == null || topicDescriptions1.size() < 2);
+             || topicDescriptions1 == null || topicDescriptions1.size() < 2);
 
+    produceRandomDataToTopic(TOPIC0, produceSizeInBytes);
     return topicDescriptions0;
   }
 
-  private UserTaskManager getMockUserTaskManager(String uuid) {
+  private void verifyOngoingPartitionReassignments(Set<TopicPartition> partitions) {
+    AdminClient adminClient = KafkaCruiseControlUtils.createAdminClient(Collections.singletonMap(
+        AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()));
+    try {
+      waitUntilTrue(() -> {
+                      try {
+                        return (adminClient.listPartitionReassignments(partitions).reassignments()
+                                           .get(1, TimeUnit.SECONDS)
+                                           .keySet().containsAll(partitions));
+                      } catch (TimeoutException | InterruptedException | ExecutionException e) {
+                        throw new IllegalStateException("Failed to verify the start of a replica reassignment.");
+                      }
+                    },
+                    "Failed to verify the start of a partition reassignment",
+                    EXECUTION_DEADLINE_MS, EXECUTION_SHORT_CHECK_MS);
+    } finally {
+      KafkaCruiseControlUtils.closeAdminClientWithTimeout(adminClient);
+    }
+  }
+
+  private void produceRandomDataToTopic(String topic, int produceSize) {
+    if (produceSize > 0) {
+      Properties props = new Properties();
+      props.setProperty(ProducerConfig.ACKS_CONFIG, "-1");
+      try (Producer<String, String> producer = createProducer(props)) {
+        byte[] randomRecords = new byte[produceSize];
+        RANDOM.nextBytes(randomRecords);
+        producer.send(new ProducerRecord<>(topic, Arrays.toString(randomRecords)));
+      }
+    }
+  }
+
+  private static UserTaskManager getMockUserTaskManager(String uuid,
+                                                        UserTaskManager.UserTaskInfo userTaskInfo,
+                                                        List<Boolean> completeWithError) {
     UserTaskManager mockUserTaskManager = EasyMock.mock(UserTaskManager.class);
-    mockUserTaskManager.markTaskExecutionFinished(uuid, false);
-    EasyMock.expect(mockUserTaskManager.markTaskExecutionBegan(uuid)).andReturn(null).anyTimes();
-    EasyMock.replay(mockUserTaskManager);
+    // Handle the case that the execution started, but did not finish.
+    if (completeWithError.isEmpty()) {
+      EasyMock.expect(mockUserTaskManager.markTaskExecutionBegan(uuid)).andReturn(userTaskInfo).once();
+    } else {
+      // Return as many times as the executions to ensure that the same test can run multiple executions.
+      for (boolean completeStatus : completeWithError) {
+        EasyMock.expect(mockUserTaskManager.markTaskExecutionBegan(uuid)).andReturn(userTaskInfo).once();
+        mockUserTaskManager.markTaskExecutionFinished(uuid, completeStatus);
+      }
+    }
     return mockUserTaskManager;
   }
 
-  private AnomalyDetector getMockAnomalyDetector(String anomalyId) {
-    AnomalyDetector mockAnomalyDetector = EasyMock.mock(AnomalyDetector.class);
-    mockAnomalyDetector.maybeClearOngoingAnomalyDetectionTimeMs();
-    expectLastCall().anyTimes();
-    mockAnomalyDetector.resetHasUnfixableGoals();
-    expectLastCall().anyTimes();
-    mockAnomalyDetector.markSelfHealingFinished(anomalyId);
-    expectLastCall().anyTimes();
-    EasyMock.replay(mockAnomalyDetector);
-    return mockAnomalyDetector;
-  }
-
-  private void executeAndVerifyProposals(KafkaZkClient kafkaZkClient,
-                                         Collection<ExecutionProposal> proposalsToExecute,
-                                         Collection<ExecutionProposal> proposalsToCheck)
-      throws OngoingExecutionException {
-    KafkaCruiseControlConfig configs = new KafkaCruiseControlConfig(getExecutorProperties());
-    UserTaskManager.UserTaskInfo mockUserTaskInfo = EasyMock.mock(UserTaskManager.UserTaskInfo.class);
-    UserTaskManager mockUserTaskManager = EasyMock.mock(UserTaskManager.class);
-    ExecutorNotifier mockExecutorNotifier = EasyMock.mock(ExecutorNotifier.class);
-    Capture<String> captureNotification = Capture.newInstance(CaptureType.FIRST);
-
-    EasyMock.expect(mockUserTaskInfo.endPoint()).andReturn(CruiseControlEndPoint.REBALANCE).once();
-    EasyMock.expect(mockUserTaskManager.markTaskExecutionBegan(RANDOM_UUID)).andReturn(null).once();
-    mockUserTaskManager.markTaskExecutionFinished(RANDOM_UUID, false);
-    mockExecutorNotifier.sendNotification(EasyMock.capture(captureNotification));
-    mockExecutorNotifier.sendAlert(EasyMock.capture(captureNotification));
-
-    EasyMock.replay(mockUserTaskInfo);
-    EasyMock.replay(mockUserTaskManager);
-    EasyMock.replay(mockExecutorNotifier);
-
-    Executor executor = new Executor(configs, new SystemTime(), new MetricRegistry(), null, DEMOTION_HISTORY_RETENTION_TIME_MS,
-                                     REMOVAL_HISTORY_RETENTION_TIME_MS, mockExecutorNotifier, mockUserTaskManager,
-                                     getMockAnomalyDetector(RANDOM_UUID));
-    executor.setExecutionMode(false);
+  private static LoadMonitor getMockLoadMonitor() {
     LoadMonitor mockLoadMonitor = EasyMock.mock(LoadMonitor.class);
     EasyMock.expect(mockLoadMonitor.taskRunnerState())
             .andReturn(LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.RUNNING)
@@ -359,23 +432,74 @@ public class ExecutorTest extends CCKafkaIntegrationTestHarness {
     expectLastCall().anyTimes();
     mockLoadMonitor.resumeMetricSampling(isA(String.class));
     expectLastCall().anyTimes();
-    EasyMock.replay(mockLoadMonitor);
+    return mockLoadMonitor;
+  }
+
+  private static AnomalyDetector getMockAnomalyDetector(String anomalyId) {
+    AnomalyDetector mockAnomalyDetector = EasyMock.mock(AnomalyDetector.class);
+    mockAnomalyDetector.maybeClearOngoingAnomalyDetectionTimeMs();
+    expectLastCall().anyTimes();
+    mockAnomalyDetector.resetHasUnfixableGoals();
+    expectLastCall().anyTimes();
+    mockAnomalyDetector.markSelfHealingFinished(anomalyId);
+    expectLastCall().anyTimes();
+    return mockAnomalyDetector;
+  }
+
+  private static UserTaskManager.UserTaskInfo getMockUserTaskInfo() {
+    UserTaskManager.UserTaskInfo mockUserTaskInfo = EasyMock.mock(UserTaskManager.UserTaskInfo.class);
+    // Run it any times to enable consecutive executions in tests.
+    EasyMock.expect(mockUserTaskInfo.requestUrl()).andReturn("mock-request").anyTimes();
+    return mockUserTaskInfo;
+  }
+
+  private void executeAndVerifyProposals(KafkaZkClient kafkaZkClient,
+                                         Collection<ExecutionProposal> proposalsToExecute,
+                                         Collection<ExecutionProposal> proposalsToCheck,
+                                         boolean completeWithError,
+                                         Long replicationThrottle,
+                                         boolean verifyProgress)
+      throws OngoingExecutionException {
+    KafkaCruiseControlConfig configs = new KafkaCruiseControlConfig(getExecutorProperties());
+    UserTaskManager.UserTaskInfo mockUserTaskInfo = getMockUserTaskInfo();
+    UserTaskManager mockUserTaskManager = getMockUserTaskManager(RANDOM_UUID, mockUserTaskInfo,
+                                                                 Collections.singletonList(completeWithError));
+    ExecutorNotifier mockExecutorNotifier = EasyMock.mock(ExecutorNotifier.class);
+    LoadMonitor mockLoadMonitor = getMockLoadMonitor();
+    Capture<String> captureMessage = Capture.newInstance(CaptureType.FIRST);
+    AnomalyDetector mockAnomalyDetector = getMockAnomalyDetector(RANDOM_UUID);
+
+    if (completeWithError) {
+      mockExecutorNotifier.sendAlert(EasyMock.capture(captureMessage));
+    } else {
+      mockExecutorNotifier.sendNotification(EasyMock.capture(captureMessage));
+    }
+
+    EasyMock.replay(mockUserTaskInfo, mockUserTaskManager, mockExecutorNotifier, mockLoadMonitor, mockAnomalyDetector);
+    Executor executor = new Executor(configs, new SystemTime(), new MetricRegistry(), null, DEMOTION_HISTORY_RETENTION_TIME_MS,
+                                     REMOVAL_HISTORY_RETENTION_TIME_MS, mockExecutorNotifier, mockUserTaskManager,
+                                     mockAnomalyDetector);
+    executor.setExecutionMode(false);
+    Map<TopicPartition, Integer> replicationFactors = new HashMap<>(proposalsToCheck.size());
+    for (ExecutionProposal proposal : proposalsToCheck) {
+      TopicPartition tp = new TopicPartition(proposal.topic(), proposal.partitionId());
+      replicationFactors.put(tp, proposal.oldReplicas().size());
+    }
 
     executor.executeProposals(proposalsToExecute, Collections.emptySet(), null, mockLoadMonitor, null,
                               null, null, null,
-                              null, null, true, RANDOM_UUID, () -> "");
+                              null, replicationThrottle, true, RANDOM_UUID, ExecutorTest.class::getSimpleName);
 
-    Map<TopicPartition, Integer> replicationFactors = new HashMap<>();
-    for (ExecutionProposal proposal : proposalsToCheck) {
-      TopicPartition tp = new TopicPartition(proposal.topic(), proposal.partitionId());
-      int replicationFactor = kafkaZkClient.getReplicasForPartition(tp).size();
-      replicationFactors.put(tp, replicationFactor);
+    if (verifyProgress) {
+      verifyOngoingPartitionReassignments(Collections.singleton(TP0));
     }
 
-    waitUntilExecutionFinishes(executor);
+    waitUntilTrue(() -> (!executor.hasOngoingExecution() && executor.state().state() == ExecutorState.State.NO_TASK_IN_PROGRESS),
+                  "Proposal execution did not finish within the time limit",
+                  EXECUTION_DEADLINE_MS, EXECUTION_REGULAR_CHECK_MS);
 
     // Check notification is sent after execution has finished.
-    String notification = captureNotification.getValue();
+    String notification = captureMessage.getValue();
     assertTrue(notification.contains(RANDOM_UUID));
 
     for (ExecutionProposal proposal : proposalsToCheck) {
@@ -394,48 +518,20 @@ public class ExecutorTest extends CCKafkaIntegrationTestHarness {
                    proposal.newLeader().brokerId(), kafkaZkClient.getLeaderForPartition(tp).get());
 
     }
-  }
-
-  private void waitUntilExecutionFinishes(Executor executor) {
-    long now = System.currentTimeMillis();
-    while ((executor.hasOngoingExecution() || executor.state().state() != ExecutorState.State.NO_TASK_IN_PROGRESS)
-        && System.currentTimeMillis() < now + 30000) {
-      try {
-        Thread.sleep(100);
-      } catch (InterruptedException e) {
-        e.printStackTrace();
-      }
-    }
-    if (executor.state().state() != ExecutorState.State.NO_TASK_IN_PROGRESS) {
-      fail("The execution did not finish in 30 seconds.");
-    }
+    EasyMock.verify(mockUserTaskInfo, mockUserTaskManager, mockExecutorNotifier, mockLoadMonitor, mockAnomalyDetector);
   }
 
   private Properties getExecutorProperties() {
     Properties props = new Properties();
-    String capacityConfigFile = this.getClass().getClassLoader().getResource("DefaultCapacityConfig.json").getFile();
+    String capacityConfigFile = Objects.requireNonNull(
+        this.getClass().getClassLoader().getResource(DEFAULT_BROKER_CAPACITY_CONFIG_FILE)).getFile();
     props.setProperty(BrokerCapacityConfigFileResolver.CAPACITY_CONFIG_FILE, capacityConfigFile);
     props.setProperty(MonitorConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
     props.setProperty(MonitorConfig.METRIC_SAMPLER_CLASS_CONFIG, NoopSampler.class.getName());
     props.setProperty(ExecutorConfig.ZOOKEEPER_CONNECT_CONFIG, zookeeper().connectionString());
     props.setProperty(ExecutorConfig.NUM_CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER_CONFIG, "10");
-    props.setProperty(ExecutorConfig.EXECUTION_PROGRESS_CHECK_INTERVAL_MS_CONFIG, "1000");
-    props.setProperty(
-        AnalyzerConfig.DEFAULT_GOALS_CONFIG,
-        "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal,"
-        + "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal");
+    props.setProperty(ExecutorConfig.EXECUTION_PROGRESS_CHECK_INTERVAL_MS_CONFIG, "400");
+    props.setProperty(AnalyzerConfig.DEFAULT_GOALS_CONFIG, TestConstants.DEFAULT_GOALS_VALUES);
     return props;
   }
 }


### PR DESCRIPTION
Addresses the issue https://github.com/linkedin/cruise-control/issues/1167 by adopting the admin client-based replica reassignment API for `Kafka 2.4+` on development branch `migrate_to_kafka_2_4`.

-- This patch does not address https://github.com/linkedin/cruise-control/issues/1195.