### PR TITLE
Environment variable resolution in configs

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlMain.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlMain.java
@@ -7,10 +7,7 @@ package com.linkedin.kafka.cruisecontrol;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.WebServerConfig;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.readConfig;
 
 /**
  * The main class to run Kafka Cruise Control.
@@ -35,14 +32,6 @@ public class KafkaCruiseControlMain {
     KafkaCruiseControlApp app = new KafkaCruiseControlApp(config, port, hostname);
     app.registerShutdownHook();
     app.start();
-  }
-
-  private static KafkaCruiseControlConfig readConfig(String propertiesFile) throws IOException {
-    Properties props = new Properties();
-    try (InputStream propStream = new FileInputStream(propertiesFile)) {
-      props.load(propStream);
-    }
-    return new KafkaCruiseControlConfig(props);
   }
 
   private static Integer parsePort(String[] args, KafkaCruiseControlConfig config) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
@@ -69,6 +70,8 @@ public class KafkaCruiseControlUtils {
   public static final String OPERATION_LOGGER = "operationLogger";
   // This will make MetaData.update() trigger a real metadata fetch.
   public static final int REQUEST_VERSION_UPDATE = -1;
+  public static final String ENV_CONFIG_PROVIDER_NAME = "env";
+  public static final String ENV_CONFIG_PROVIDER_CLASS_CONFIG = ".env.class";
 
   private KafkaCruiseControlUtils() {
 
@@ -549,7 +552,8 @@ public class KafkaCruiseControlUtils {
   }
 
   /**
-   * Reads the configuration file, parses and validates the configs.
+   * Reads the configuration file, parses and validates the configs. Enables the configs to be passed
+   * in from environment variables.
    * @param propertiesFile is the file containing the Cruise Control configuration.
    * @return a parsed {@link KafkaCruiseControlConfig}
    * @throws IOException if the configuration file can't be read.
@@ -557,8 +561,8 @@ public class KafkaCruiseControlUtils {
   public static KafkaCruiseControlConfig readConfig(String propertiesFile) throws IOException {
     Properties props = new Properties();
     try (InputStream propStream = new FileInputStream(propertiesFile)) {
-      props.put("config.providers", "env");
-      props.put("config.providers.env.class", EnvConfigProvider.class.getName());
+      props.put(AbstractConfig.CONFIG_PROVIDERS_CONFIG, ENV_CONFIG_PROVIDER_NAME);
+      props.put(AbstractConfig.CONFIG_PROVIDERS_CONFIG + ENV_CONFIG_PROVIDER_CLASS_CONFIG, EnvConfigProvider.class.getName());
       props.load(propStream);
     }
     return new KafkaCruiseControlConfig(props);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -5,34 +5,24 @@
 package com.linkedin.kafka.cruisecontrol;
 
 import com.linkedin.kafka.cruisecontrol.analyzer.AnalyzerUtils;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.PreferredLeaderElectionGoal;
+import com.linkedin.kafka.cruisecontrol.config.EnvConfigProvider;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 import com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunner;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import kafka.zk.KafkaZkClient;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.DescribeLogDirsResult;
-import java.util.TimeZone;
-import java.util.stream.Collectors;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.AbstractResponse;
@@ -40,6 +30,22 @@ import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.SystemTime;
 import scala.Option;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.stream.Collectors;
 
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.SKIP_HARD_GOAL_CHECK_PARAM;
 
@@ -540,5 +546,21 @@ public class KafkaCruiseControlUtils {
     }
 
     return balancednessCostByGoal;
+  }
+
+  /**
+   * Reads the configuration file, parses and validates the configs.
+   * @param propertiesFile is the file containing the Cruise Control configuration.
+   * @return a parsed {@link KafkaCruiseControlConfig}
+   * @throws IOException if the configuration file can't be read.
+   */
+  public static KafkaCruiseControlConfig readConfig(String propertiesFile) throws IOException {
+    Properties props = new Properties();
+    try (InputStream propStream = new FileInputStream(propertiesFile)) {
+      props.put("config.providers", "env");
+      props.put("config.providers.env.class", EnvConfigProvider.class.getName());
+      props.load(propStream);
+    }
+    return new KafkaCruiseControlConfig(props);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/EnvConfigProvider.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/EnvConfigProvider.java
@@ -33,7 +33,7 @@ public class EnvConfigProvider implements ConfigProvider {
 
   @Override
   public void close() {
-    // nop
+    _preConfiguredEnvironmentVariables.clear();
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/EnvConfigProvider.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/EnvConfigProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.config;
+
+import org.apache.kafka.common.config.ConfigData;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.provider.ConfigProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class EnvConfigProvider implements ConfigProvider {
+
+  private Map<String, String> _preConfiguredEnvironmentVariables;
+
+  @Override
+  public ConfigData get(String path) {
+    assertNoPath(path);
+    return new ConfigData(getenv());
+  }
+
+  @Override
+  public ConfigData get(String path, Set<String> keys) {
+    assertNoPath(path);
+    Map<String, String> filtered = new HashMap<>(getenv());
+    filtered.keySet().retainAll(keys);
+    return new ConfigData(filtered);
+  }
+
+  @Override
+  public void close() {
+    // nop
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    _preConfiguredEnvironmentVariables = configs.entrySet()
+        .stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, kv -> (String) kv.getValue()));
+  }
+
+  private static void assertNoPath(String path) {
+    if (path != null && !path.isEmpty()) {
+      throw new ConfigException("EnvConfigProvider does not support paths. Found: " + path);
+    }
+  }
+
+  private Map<String, String> getenv() {
+    if (_preConfiguredEnvironmentVariables == null) {
+      return System.getenv();
+    } else {
+      return _preConfiguredEnvironmentVariables;
+    }
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/EnvConfigProviderTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/EnvConfigProviderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.config;
+
+import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils;
+import com.linkedin.kafka.cruisecontrol.config.constants.WebServerConfig;
+import org.apache.kafka.common.config.types.Password;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+
+public class EnvConfigProviderTest {
+
+  public static final String TEST_PASSWORD = "testPassword123";
+  public static final String NOT_SUBSTITUTED_CONFIG = "${env:SSL_KEY_PASSWORD}";
+
+  @Test
+  public void testEnvConfigProvider() throws IOException {
+    KafkaCruiseControlConfig configs = KafkaCruiseControlUtils.readConfig(
+        Objects.requireNonNull(this.getClass().getClassLoader().getResource("envConfigProviderTest.properties")).getPath());
+
+    // Test password substitution
+    Password actualSslKeystorePassword = configs.getPassword(WebServerConfig.WEBSERVER_SSL_KEYSTORE_PASSWORD_CONFIG);
+    Password expectedSslKeystorePassword = new Password(TEST_PASSWORD);
+    assertEquals(expectedSslKeystorePassword, actualSslKeystorePassword);
+
+    // Test when the environment variable is not defined and the password isn't substituted
+    Password actualSslKeyPassword = configs.getPassword(WebServerConfig.WEBSERVER_SSL_KEY_PASSWORD_CONFIG);
+    Password expectedSslKeyPassword = new Password(NOT_SUBSTITUTED_CONFIG);
+    assertEquals(expectedSslKeyPassword, actualSslKeyPassword);
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/EnvConfigProviderTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/EnvConfigProviderTest.java
@@ -18,11 +18,12 @@ public class EnvConfigProviderTest {
 
   public static final String TEST_PASSWORD = "testPassword123";
   public static final String NOT_SUBSTITUTED_CONFIG = "${env:SSL_KEY_PASSWORD}";
+  public static final String ENV_CONFIG_PROVIDER_TEST_PROPERTIES = "envConfigProviderTest.properties";
 
   @Test
   public void testEnvConfigProvider() throws IOException {
     KafkaCruiseControlConfig configs = KafkaCruiseControlUtils.readConfig(
-        Objects.requireNonNull(this.getClass().getClassLoader().getResource("envConfigProviderTest.properties")).getPath());
+        Objects.requireNonNull(this.getClass().getClassLoader().getResource(ENV_CONFIG_PROVIDER_TEST_PROPERTIES)).getPath());
 
     // Test password substitution
     Password actualSslKeystorePassword = configs.getPassword(WebServerConfig.WEBSERVER_SSL_KEYSTORE_PASSWORD_CONFIG);

--- a/cruise-control/src/test/resources/envConfigProviderTest.properties
+++ b/cruise-control/src/test/resources/envConfigProviderTest.properties
@@ -1,0 +1,7 @@
+bootstrap.servers=localhost:9092
+zookeeper.connect=localhost:2181/
+webserver.ssl.keystore.password=${env:SSL_KEYSTORE_PASSWORD}
+webserver.ssl.key.password=${env:SSL_KEY_PASSWORD}
+# the only way to initialize this for testing is to pass a preconfigured list of environment variables
+# but this shouldn't be configured in production but taken from System.getenv()
+config.providers.env.param.SSL_KEYSTORE_PASSWORD=testPassword123

--- a/docs/wiki/User Guide/Configurations.md
+++ b/docs/wiki/User Guide/Configurations.md
@@ -282,5 +282,11 @@ with a non-default capacity. See:
 
 Besides the above configurations, CruiseControlMetricsReporter takes all the configurations for vanilla KafkaProducer with a prefix of "cruise.control.metrics.reporter."
 
+##Resolving environment variables as config values
+It is often required to resolve an environment variable as a config value. Such case is when a password is set by the environment to avoid putting them into config files.
+
+For instance the following config will resolve the `SSL_KEYSTORE_PASSWORD` environment variable and set its value as the actual value of the `webserver.ssl.keystore.password` config:
+
+`webserver.ssl.keystore.password=${env:SSL_KEYSTORE_PASSWORD}`
 
 


### PR DESCRIPTION
This commit enables parsing config values from environment variables.
This is particularly useful if passwords can't be hardcoded in the config
files but instead passed to Cruise Control via an environment variable.
For instance if there is a MY_PASSWORD=test123 then defining the following
config in cruisecontrol.properties will be resolved on startup to the
actual password.

Config file on the disk: config.name=${env:MY_ENV_VAR}
Resolved runtime config: config.name=test123

This fixes #1197