### PR TITLE
Add rack information to load response.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     environment:
-      _JAVA_OPTIONS: "-Xms512m -Xmx1024m"
+      _JAVA_OPTIONS: "-Xms512m -Xmx512m"
     working_directory: ~/workspace
     docker:
       - image: circleci/openjdk:8-jdk
@@ -13,7 +13,7 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "build.gradle" }}
       - run:
-          command: ./gradlew -PmaxParallelForks=1 clean javadoc build
+          command: ./gradlew --no-daemon -PmaxParallelForks=1 clean javadoc build
       - save_cache:
           key: dependency-cache-{{ checksum "build.gradle" }}
           paths:

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ import com.linkedin.gradle.build.DistributeTask
 plugins {
   id "com.jfrog.artifactory"
   id "idea"
+  id "jacoco" // Java Code Coverage plugin
   id "com.github.ben-manes.versions" version "0.28.0"
 }
 
@@ -76,6 +77,7 @@ subprojects {
   apply plugin: 'java'
   apply plugin: 'checkstyle'
   apply plugin: 'findbugs'
+  apply plugin: 'jacoco'
 
   task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -106,13 +106,9 @@ public class KafkaCruiseControl {
 
     // Instantiate the components.
     _anomalyDetector = new AnomalyDetector(this, _time, dropwizardMetricRegistry);
-    long demotionHistoryRetentionTimeMs = config.getLong(ExecutorConfig.DEMOTION_HISTORY_RETENTION_TIME_MS_CONFIG);
-    long removalHistoryRetentionTimeMs = config.getLong(ExecutorConfig.REMOVAL_HISTORY_RETENTION_TIME_MS_CONFIG);
-    _executor = new Executor(config, _time, dropwizardMetricRegistry, demotionHistoryRetentionTimeMs,
-                             removalHistoryRetentionTimeMs, _anomalyDetector);
+    _executor = new Executor(config, _time, dropwizardMetricRegistry, _anomalyDetector);
     _loadMonitor = new LoadMonitor(config, _time, _executor, dropwizardMetricRegistry, KafkaMetricDef.commonMetricDef());
-    _goalOptimizerExecutor =
-        Executors.newSingleThreadExecutor(new KafkaCruiseControlThreadFactory("GoalOptimizerExecutor", true, null));
+    _goalOptimizerExecutor = Executors.newSingleThreadExecutor(new KafkaCruiseControlThreadFactory("GoalOptimizerExecutor", true, null));
     _goalOptimizer = new GoalOptimizer(config, _loadMonitor, _time, dropwizardMetricRegistry, _executor);
   }
 
@@ -122,6 +118,7 @@ public class KafkaCruiseControl {
   public LoadMonitor loadMonitor() {
     return _loadMonitor;
   }
+
   /**
    * Refresh the cluster metadata and get the corresponding cluster and generation information.
    *

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetector.java
@@ -311,6 +311,7 @@ public class AnomalyDetector {
    * @param anomalyId Unique id of anomaly which triggered self-healing operation.
    */
   public void markSelfHealingFinished(String anomalyId) {
+    LOG.debug("Self healing with id {} has finished.", anomalyId);
     _anomalyDetectorState.markSelfHealingFinished(anomalyId);
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -142,11 +142,9 @@ public class Executor {
   public Executor(KafkaCruiseControlConfig config,
                   Time time,
                   MetricRegistry dropwizardMetricRegistry,
-                  long demotionHistoryRetentionTimeMs,
-                  long removalHistoryRetentionTimeMs,
                   AnomalyDetector anomalyDetector) {
-    this(config, time, dropwizardMetricRegistry, null, demotionHistoryRetentionTimeMs, removalHistoryRetentionTimeMs,
-         null, null, anomalyDetector);
+    this(config, time, dropwizardMetricRegistry, null, config.getLong(ExecutorConfig.DEMOTION_HISTORY_RETENTION_TIME_MS_CONFIG),
+         config.getLong(ExecutorConfig.REMOVAL_HISTORY_RETENTION_TIME_MS_CONFIG), null, null, anomalyDetector);
   }
 
   /**
@@ -698,11 +696,11 @@ public class Executor {
   private class ProposalExecutionRunnable implements Runnable {
     private final LoadMonitor _loadMonitor;
     private ExecutorState.State _state;
-    private Set<Integer> _recentlyDemotedBrokers;
-    private Set<Integer> _recentlyRemovedBrokers;
+    private final Set<Integer> _recentlyDemotedBrokers;
+    private final Set<Integer> _recentlyRemovedBrokers;
     private final Long _replicationThrottle;
     private Throwable _executionException;
-    private boolean _isTriggeredByUserRequest;
+    private final boolean _isTriggeredByUserRequest;
     private long _lastSlowTaskReportingTimeMs;
 
     ProposalExecutionRunnable(LoadMonitor loadMonitor,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ModelParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ModelParameters.java
@@ -45,7 +45,7 @@ public class ModelParameters {
         config.getDouble(MonitorConfig.LEADER_NETWORK_OUTBOUND_WEIGHT_FOR_CPU_UTIL_CONFIG);
     CPU_WEIGHT_OF_FOLLOWER_BYTES_IN_RATE =
         config.getDouble(MonitorConfig.FOLLOWER_NETWORK_INBOUND_WEIGHT_FOR_CPU_UTIL_CONFIG);
-    LINEAR_REGRESSION_PARAMETERS.init(config);
+    LinearRegressionModelParameters.init(config);
   }
 
   public static Double getCoefficient(LinearRegressionModelParameters.ModelCoefficient name) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
@@ -421,6 +421,7 @@ public class UserTaskManager implements Closeable {
    * @param completeWithError Whether the task execution finished with error or not.
    */
   public synchronized void markTaskExecutionFinished(String uuid, boolean completeWithError) {
+    LOG.debug("Task execution with uuid {} completed{}.", uuid, completeWithError ? " with error" : "");
     if (!_inExecutionUserTaskInfo.userTaskId().equals(UUID.fromString(uuid))) {
       throw new IllegalStateException(String.format("Task %s is not found in UserTaskManager.", uuid));
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/stats/BasicStats.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/stats/BasicStats.java
@@ -11,7 +11,7 @@ import com.linkedin.kafka.cruisecontrol.servlet.response.JsonResponseClass;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.linkedin.kafka.cruisecontrol.monitor.MonitorUtils.*;
+import static com.linkedin.kafka.cruisecontrol.monitor.MonitorUtils.UNIT_INTERVAL_TO_PERCENTAGE;
 
 
 @JsonResponseClass

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/stats/SingleBrokerStats.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/stats/SingleBrokerStats.java
@@ -18,6 +18,8 @@ public class SingleBrokerStats extends BasicStats {
   @JsonResponseField
   protected static final String BROKER = "Broker";
   @JsonResponseField
+  protected static final String RACK = "Rack";
+  @JsonResponseField
   protected static final String BROKER_STATE = "BrokerState";
   @JsonResponseField(required = false)
   protected static final String DISK_STATE = "DiskState";
@@ -26,18 +28,16 @@ public class SingleBrokerStats extends BasicStats {
   protected final Broker.State _state;
   protected final boolean _isEstimated;
   protected final Map<String, DiskStats> _diskStatsByLogdir;
+  protected final String _rack;
 
-  SingleBrokerStats(String host, int id, Broker.State state, double diskUtil, double cpuUtil, double leaderBytesInRate,
-                    double followerBytesInRate, double bytesOutRate, double potentialBytesOutRate, int numReplicas,
-                    int numLeaders, boolean isEstimated, double diskCapacity, Map<String, DiskStats> diskStatsByLogdir,
-                    double networkInCapacity, double networkOutCapacity, int numCore) {
-    super(diskUtil, cpuUtil, leaderBytesInRate, followerBytesInRate, bytesOutRate,
-          potentialBytesOutRate, numReplicas, numLeaders, diskCapacity, networkInCapacity, networkOutCapacity, numCore);
-    _host = host;
-    _id = id;
-    _state = state;
+  SingleBrokerStats(Broker broker, double potentialBytesOutRate, boolean isEstimated) {
+    super(broker, potentialBytesOutRate);
+    _host = broker.host().name();
+    _id = broker.id();
+    _state = broker.state();
     _isEstimated = isEstimated;
-    _diskStatsByLogdir = diskStatsByLogdir;
+    _diskStatsByLogdir = broker.diskStats();
+    _rack = broker.rack().id();
   }
 
   public String host() {
@@ -50,6 +50,10 @@ public class SingleBrokerStats extends BasicStats {
 
   public int id() {
     return _id;
+  }
+
+  public String rack() {
+    return _rack;
   }
 
   /**
@@ -83,6 +87,7 @@ public class SingleBrokerStats extends BasicStats {
       _diskStatsByLogdir.forEach((k, v) -> diskStates.put(k, v.getJSONStructure()));
       entry.put(DISK_STATE, diskStates);
     }
+    entry.put(RACK, _rack);
     return entry;
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/stats/SingleHostStats.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/stats/SingleHostStats.java
@@ -12,15 +12,15 @@ import java.util.Map;
 public class SingleHostStats extends BasicStats {
   @JsonResponseField
   protected static final String HOST = "Host";
-  private String _host;
+  @JsonResponseField
+  protected static final String RACK = "Rack";
+  private final String _host;
+  private final String _rack;
 
-  SingleHostStats(String host, double diskUtil, double cpuUtil, double leaderBytesInRate,
-                  double followerBytesInRate, double bytesOutRate, double potentialBytesOutRate,
-                  int numReplicas, int numLeaders, double capacity,  double networkInCapacity,
-                  double networkOutCapacity, int numCore) {
-    super(diskUtil, cpuUtil, leaderBytesInRate, followerBytesInRate, bytesOutRate,
-          potentialBytesOutRate, numReplicas, numLeaders, capacity, networkInCapacity, networkOutCapacity, numCore);
+  SingleHostStats(String host, String rack) {
+    super();
     _host = host;
+    _rack = rack;
   }
 
   /**
@@ -31,6 +31,7 @@ public class SingleHostStats extends BasicStats {
   public Map<String, Object> getJSONStructure() {
     Map<String, Object> hostEntry = super.getJSONStructure();
     hostEntry.put(HOST, _host);
+    hostEntry.put(RACK, _rack);
     return hostEntry;
   }
 }

--- a/cruise-control/src/yaml/responses/brokerStats.yaml
+++ b/cruise-control/src/yaml/responses/brokerStats.yaml
@@ -21,6 +21,7 @@ SingleBrokerStats:
   required:
     - Host
     - Broker
+    - Rack
     - BrokerState
     - DiskMB
     - DiskPct
@@ -41,6 +42,8 @@ SingleBrokerStats:
     Broker:
       type: integer
       format: int32
+    Rack:
+      type: string
     BrokerState:
       type: string
       enum:
@@ -127,6 +130,7 @@ SingleHostStats:
   type: object
   required:
     - Host
+    - Rack
     - DiskMB
     - DiskPct
     - CpuPct
@@ -142,6 +146,8 @@ SingleHostStats:
     - NumCore
   properties:
     Host:
+      type: string
+    Rack:
       type: string
     DiskMB:
       type: number


### PR DESCRIPTION
Addresses the issue #1192.
* This patch also picks up `CircleCI` config updates, jacoco plugin, and relevant executor refactoring merged in https://github.com/linkedin/cruise-control/pull/1196.
* The plaintext output format has been verified on local deployment.