### PR TITLE
Fix NPE if task execution takes longer than executionProgressCheckIntervalMs().

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -1431,6 +1431,9 @@ public class Executor {
     }
 
     private boolean verifyFutureError(Future<?> future, Class<? extends Throwable> exceptionClass) {
+      if (future == null) {
+        return false;
+      }
       try {
         // TODO: Make this configurable.
         future.get(5000L, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Addresses the issue #1207.