### PR TITLE
Fixed java11 javadocs errors

### DIFF
--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/common/LongGenerationed.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/common/LongGenerationed.java
@@ -26,7 +26,7 @@ public class LongGenerationed implements Generationed<Long> {
 
   /**
    * {@inheritDoc}
-   * When <tt>other</tt> is null, this LongGenerationed will be considered as a later generation.
+   * When {@code other} is null, this LongGenerationed will be considered as a later generation.
    */
   @Override
   public int compareGeneration(Generationed<Long> other) {

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/AggregationOptions.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/AggregationOptions.java
@@ -32,8 +32,8 @@ public class AggregationOptions<G, E extends Entity<G>> {
    * @param minValidEntityGroupRatio The minimum required percentage of the valid entity groups out of all the interested
    *                               entities groups (the groups of interested entities).
    * @param minValidWindows The minimum required number of valid windows required in the result. A valid window
-   *                        is a window within which both <tt>Min Valid Entity Ratio</tt> and
-   *                        <tt>Min Valid Entity Group Ratio</tt> are met.
+   *                        is a window within which both {@code Min Valid Entity Ratio} and
+   *                        {@code Min Valid Entity Group Ratio} are met.
    * @param maxAllowedExtrapolationsPerEntity the maximum allowed {@link Extrapolation}s per entity in the aggregation.
    * @param interestedEntities All the entities to include in this aggregation. Sometimes not all the entities are
    *                           interested. This option allows users to aggregate only part of the entities.

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregationResult.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregationResult.java
@@ -63,10 +63,10 @@ public class MetricSampleAggregationResult<G, E extends Entity<G>> extends LongG
    * </p>
    * <p>
    *   If the {@link AggregationOptions} specifies aggregation granularity to be
-   *   {@link AggregationOptions.Granularity#ENTITY_GROUP} and an <tt>entity</tt> belongs to a group which has
-   *   other invalid entities. In this case, <tt>entity</tt> itself is still a valid entity therefore it will
+   *   {@link AggregationOptions.Granularity#ENTITY_GROUP} and an {@code entity} belongs to a group which has
+   *   other invalid entities. In this case, {@code entity} itself is still a valid entity therefore it will
    *   not be in the set returned by this method. But since the entity group does not meet the completeness
-   *   requirement, the entire entity group is not considered as <i>"covered"</i>. So <tt>entity</tt> will not
+   *   requirement, the entire entity group is not considered as <i>"covered"</i>. So {@code entity} will not
    *   be included in the {@link MetricSampleCompleteness#validEntities()} either.
    * </p>
    *

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregator.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregator.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  *   From per entity's perspective, each entity would have sufficient metrics from all the windows when everything
  *   works fine. However, it is also possible that some metrics may be missing from the MetricSampleAggregator
  *   in one or more windows. If that happens, some {@link Extrapolation} will be used to fill in the missing data.
- *   If none of the {@link Extrapolation} works. We claim the entity is <tt>invalid</tt> in this window. With above,
+ *   If none of the {@link Extrapolation} works. We claim the entity is {@code invalid} in this window. With above,
  *   a given entity may have the following three states in any given window from the {@link MetricSampleAggregator}'s
  *   perspective:
  *   <ul>
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory;
  *   </ul>
  *
  * <p>
- *   From per window's perspective, for each window, there is a given set of <tt>valid</tt> entities and entity
+ *   From per window's perspective, for each window, there is a given set of {@code valid} entities and entity
  *   groups as described above. The validity of a window depends on the requirements specified in the
  *   {@link AggregationOptions} during the aggregation. More specifically whether the entity coverage (valid entity
  *   ratio) and entity group coverage (valid entity group ratio) meet the requirements.

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleCompleteness.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleCompleteness.java
@@ -139,8 +139,8 @@ public class MetricSampleCompleteness<G, E extends Entity<G>> extends LongGenera
   }
 
   /**
-   * Get the valid window indices. A window starts from <I><tt>(windowIndex - 1) * windowMs</tt></I> and ends at
-   * <I><tt>windowIndex * windowMs</tt></I>.
+   * Get the valid window indices. A window starts from <I>{@code (windowIndex - 1) * windowMs}</I> and ends at
+   * <I>{@code windowIndex * windowMs}</I>.
    * The entity and valid entity group ratio requirements can still meet the requirement after all these windows
    * are included.
    *

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/RawMetricValues.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/RawMetricValues.java
@@ -157,7 +157,7 @@ public class RawMetricValues extends WindowIndexedArrays {
 
   /**
    * Check whether this raw metric value is valid or not. The raw metric value is valid if:
-   * 1. All the stable windows are <tt>valid</tt> (See {@link MetricSampleAggregator}, AND
+   * 1. All the stable windows are {@code valid} (See {@link MetricSampleAggregator}, AND
    * 2. The number of windows with extrapolation is less than the given maxAllowedWindowsWithExtrapolation.
    *
    * @param maxAllowedWindowsWithExtrapolation the maximum number of allowed windows with extrapolation.

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/ValuesAndExtrapolations.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/ValuesAndExtrapolations.java
@@ -53,7 +53,7 @@ public class ValuesAndExtrapolations {
   }
 
   /**
-   * Get the window list for the metric values. The time window of metric value at <tt>index</tt> is the time window
+   * Get the window list for the metric values. The time window of metric value at {@code index} is the time window
    * at the same index of the array returned by this this method.
    *
    * @return The window time list associated with the metric values array in the {@link AggregatedMetricValues} returned

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoal.java
@@ -233,11 +233,11 @@ public class KafkaAssignerDiskUsageDistributionGoal implements Goal {
    * Swap replica between two brokers. The method should achieve the result that the overall usage of the two
    * brokers are improved. More specifically, the following result is reduced.
    * <pre>
-   * (<tt>UsageOfBroker1</tt> - <tt>MeanUsage</tt>) + (<tt>UsageOfBroker2</tt> - <tt>MeanUsage</tt>)
+   * ({@code UsageOfBroker1} - {@code MeanUsage}) + ({@code UsageOfBroker2} - {@code MeanUsage})
    * </pre>
    *
    * @param toSwap the broker that needs to swap a replica with the other broker.
-   * @param toSwapWith the broker that provides a replica to swap with the broker <tt>toSwap</tt>
+   * @param toSwapWith the broker that provides a replica to swap with the broker {@code toSwap}
    * @param meanDiskUsage the average usage of the cluster.
    * @param clusterModel the cluster model.
    * @param excludedTopics the topics to exclude from swapping.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTask.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTask.java
@@ -31,13 +31,13 @@ import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTask.State.*;
  *                  |          v
  *                  |-------------------&gt; DEAD
  *
- * A newly created task is in <tt>PENDING</tt> state.
- * A <tt>PENDING</tt> task becomes <tt>IN_PROGRESS</tt> when it is drained from the {@link ExecutionTaskPlanner}
- * An <tt>IN_PROGRESS</tt> task becomes <tt>COMPLETED</tt> if the execution is done without error.
- * An <tt>IN_PROGRESS</tt> task becomes <tt>ABORTING</tt> if an error is encountered and the rollback is possible.
- * An <tt>IN_PROGRESS</tt> task becomes <tt>DEAD</tt> if an error is encountered and the rollback is not possible.
- * An <tt>ABORTING</tt> task becomes <tt>ABORTED</tt> if the rollback of the original task is successfully done.
- * An <tt>ABORTING</tt> task becomes <tt>DEAD</tt> if the rollback of the original task encountered an error.
+ * A newly created task is in {@code PENDING} state.
+ * A {@code PENDING} task becomes {@code IN_PROGRESS} when it is drained from the {@link ExecutionTaskPlanner}
+ * An {@code IN_PROGRESS} task becomes {@code COMPLETED} if the execution is done without error.
+ * An {@code IN_PROGRESS} task becomes {@code ABORTING} if an error is encountered and the rollback is possible.
+ * An {@code IN_PROGRESS} task becomes {@code DEAD} if an error is encountered and the rollback is not possible.
+ * An {@code ABORTING} task becomes {@code ABORTED} if the rollback of the original task is successfully done.
+ * An {@code ABORTING} task becomes {@code DEAD} if the rollback of the original task encountered an error.
  * </pre>
  */
 @JsonResponseClass

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicas.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicas.java
@@ -21,20 +21,20 @@ import java.util.function.Function;
  *  The SortedReplicas uses three type of functions to sort the replicas in the broker/disk.
  *  <ul>
  *     <li>
- *      <tt>ScoreFunction</tt>(optional): the score function generates a score for each replica to sort. The replicas are
+ *      {@code ScoreFunction}(optional): the score function generates a score for each replica to sort. The replicas are
  *      sorted based on their score in ascending order.
  *    </li>
  *    <li>
- *      <tt>SelectionFunction</tt>(optional): the selection function decides which replicas to include in the sorted
+ *      {@code SelectionFunction}(optional): the selection function decides which replicas to include in the sorted
  *      replica list. For example, in some cases, the users may only want to have sorted leader replicas. Note there can
  *      be multiple selection functions, only replica which satisfies requirement of all selection functions will be included.
  *    </li>
  *    <li>
- *      <tt>PriorityFunction</tt>(optional): the priority function allows users to prioritize certain replicas in the
+ *      {@code PriorityFunction}(optional): the priority function allows users to prioritize certain replicas in the
  *      sorted replicas. The replicas will be sorted by their priority first. There can be multiple priority functions,
  *      which will be applied one by one based on the order in {@link #_priorityFuncs} to resolve priority between two replicas.
- *      In the end, the replicas with the same priority are sorted with their score from the <tt>scoreFunction</tt>.
- *      Note that if a priority function is provided, the <tt>SortedSet</tt> returned by the
+ *      In the end, the replicas with the same priority are sorted with their score from the {@code scoreFunction}.
+ *      Note that if a priority function is provided, the {@code SortedSet} returned by the
  *      {@link #sortedReplicas(boolean)} is no longer binary searchable based on the score.
  *    </li>
  *  </ul>

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregator.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/aggregator/KafkaPartitionMetricSampleAggregator.java
@@ -261,7 +261,7 @@ public class KafkaPartitionMetricSampleAggregator extends MetricSampleAggregator
    *
    * @param sample the sample to do the sanity check.
    * @param leaderValidation whether do the leader validation or not.
-   * @return <tt>true</tt> if the sample is valid.
+   * @return {@code true} if the sample is valid.
    */
   private boolean isValidSample(PartitionMetricSample sample, boolean leaderValidation) {
     boolean validLeader = true;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/SessionManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/SessionManager.java
@@ -153,7 +153,7 @@ public class SessionManager {
    * Get the {@link OperationFuture} for the request.
    * @param request the request to get the operation future.
    * @param <T> the returned future type.
-   * @return The operation future for the request if it exists, otherwise <tt>null</tt> is returned.
+   * @return The operation future for the request if it exists, otherwise {@code null} is returned.
    */
   @SuppressWarnings("unchecked")
   synchronized <T> T getFuture(HttpServletRequest request) {


### PR DESCRIPTION
Compiling cruise-control with java-11 rendered errors in javadocs target due to invalid (in java-11) `tt` html tag.