### PR TITLE
Compile using java 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,16 +4,21 @@ jobs:
 
   build:
     environment:
-      _JAVA_OPTIONS: "-Xms512m -Xmx512m"
+      _JAVA_OPTIONS: "-Xms512m -Xmx1g"
     working_directory: ~/workspace
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:11-jdk
     steps:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "build.gradle" }}
       - run:
-          command: ./gradlew --no-daemon -PmaxParallelForks=1 clean javadoc build
+          command: ./gradlew --no-daemon clean javadoc
+      - run:
+          # run static analysis tasks standalone to avoid OOME in CircleCI
+          command: ./gradlew --max-workers=1 --no-daemon analyze
+      - run:
+          command: ./gradlew --no-daemon -PmaxParallelForks=1 build
       - save_cache:
           key: dependency-cache-{{ checksum "build.gradle" }}
           paths:
@@ -32,7 +37,7 @@ jobs:
   publish:
     working_directory: ~/workspace
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:11-jdk
     steps:
       - checkout
       - restore_cache:

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ plugins {
   id "idea"
   id "jacoco" // Java Code Coverage plugin
   id "com.github.ben-manes.versions" version "0.28.0"
+  id "com.github.spotbugs" version "4.2.4" apply false
 }
 
 group = 'com.linkedin.cruisecontrol'
@@ -76,7 +77,7 @@ subprojects {
 
   apply plugin: 'java'
   apply plugin: 'checkstyle'
-  apply plugin: 'findbugs'
+  apply plugin: "com.github.spotbugs"
   apply plugin: 'jacoco'
 
   task sourcesJar(type: Jar, dependsOn: classes) {
@@ -91,25 +92,38 @@ subprojects {
 
   //code quality and inspections
   checkstyle {
-    toolVersion = '8.1'
+    project.ext.checkstyleVersion = '8.20'
     ignoreFailures = false
-    configFile = rootProject.file('checkstyle/checkstyle.xml')
+    configDir = file("$rootDir/checkstyle")
   }
 
-  findbugs {
-    toolVersion = "3.0.1"
+  spotbugs {
+    toolVersion = '4.0.3'
     excludeFilter = file("$rootDir/gradle/findbugs-exclude.xml")
     ignoreFailures = false
+    jvmArgs = [ '-Xms512m' ]
+    maxHeapSize = '768m'
+    showProgress = true
   }
-
-  test.dependsOn('checkstyleMain', 'checkstyleTest', 'findbugsMain', 'findbugsTest')
-
-  tasks.withType(FindBugs) {
+  spotbugsMain {
     reports {
-      xml.enabled (project.hasProperty('xmlFindBugsReport'))
-      html.enabled (!project.hasProperty('xmlFindBugsReport'))
+      xml.enabled = (project.hasProperty('xmlFindBugsReport'))
+      html.enabled = (!project.hasProperty('xmlFindBugsReport'))
     }
   }
+  spotbugsTest {
+    reports {
+      xml.enabled = (project.hasProperty('xmlFindBugsReport'))
+      html.enabled = (!project.hasProperty('xmlFindBugsReport'))
+    }
+  }
+  // aggregated task for checkstyle and spotbugs static analyzers
+  task('analyze') {
+    dependsOn('checkstyleMain', 'checkstyleTest', 'spotbugsMain', 'spotbugsTest')
+    doLast {}
+  }
+
+  test.dependsOn('checkstyleMain', 'checkstyleTest', 'spotbugsMain', 'spotbugsTest')
 
   jar {
     from "$rootDir/LICENSE"
@@ -140,8 +154,8 @@ project(':cruise-control-core') {
     compile "org.slf4j:slf4j-api:1.7.30"
     compile 'junit:junit:4.13'
     compile 'org.apache.commons:commons-math3:3.6.1'
-    compile 'org.eclipse.jetty:jetty-servlet:9.4.26.v20200117'
-
+    compile 'org.eclipse.jetty:jetty-servlet:9.4.29.v20200521'
+    implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
     testOutput sourceSets.test.output
   }
 
@@ -220,7 +234,7 @@ project(':cruise-control') {
     compile 'org.apache.commons:commons-math3:3.6.1'
     compile 'org.apache.httpcomponents:httpclient:4.5.11'
     compile 'com.google.code.gson:gson:2.8.6'
-    compile 'org.eclipse.jetty:jetty-server:9.4.26.v20200117'
+    compile 'org.eclipse.jetty:jetty-server:9.4.29.v20200521'
     compile 'io.dropwizard.metrics:metrics-core:3.2.6'
     compile 'com.nimbusds:nimbus-jose-jwt:8.5'
     compile 'com.101tec:zkclient:0.11'
@@ -236,6 +250,8 @@ project(':cruise-control') {
     testCompile 'commons-io:commons-io:2.6'
     testCompile 'org.bouncycastle:bcpkix-jdk15on:1.64'
     testCompile 'org.apache.kerby:kerb-simplekdc:2.0.0'
+
+    implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
 
   }
 
@@ -341,6 +357,8 @@ project(':cruise-control-metrics-reporter') {
     testCompile "org.apache.kafka:kafka-clients:$kafkaVersion"
     testCompile 'commons-io:commons-io:2.6'
     testOutput sourceSets.test.output
+
+    implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
   }
 
   publishing {

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -11,7 +11,7 @@ LinkedIn Java style.
 -->
 <module name="Checker">
     <module name="SuppressionFilter">
-        <property name="file" value="checkstyle/suppressions.xml"/>
+        <property name="file" value="${config_loc}/suppressions.xml"/>
     </module>
 
     <!-- header -->
@@ -22,7 +22,6 @@ LinkedIn Java style.
     <property name="severity" value="${checkstyle.severity}" default="error"/>
 
     <module name="TreeWalker">
-        <module name="FileContentsHolder"/>
 
         <!-- ANNOTATIONS -->
 

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/utils/CCKafkaClientsIntegrationTestHarness.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/utils/CCKafkaClientsIntegrationTestHarness.java
@@ -24,6 +24,7 @@ public abstract class CCKafkaClientsIntegrationTestHarness extends CCKafkaIntegr
     super.setUp();
   }
 
+  @javax.annotation.Nonnull
   protected Producer<String, String> createProducer(Properties overrides) {
     Properties props = getProducerProperties(overrides);
     return new KafkaProducer<>(props);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/MonitorConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/MonitorConfig.java
@@ -197,6 +197,7 @@ public class MonitorConfig {
    * @deprecated (i.e. cannot be configured to a value other than 1).
    * <code>num.metric.fetchers</code>
    */
+  @Deprecated
   public static final String NUM_METRIC_FETCHERS_CONFIG = "num.metric.fetchers";
   public static final int DEFAULT_NUM_METRIC_FETCHERS = 1;
   public static final String NUM_METRIC_FETCHERS_DOC = "The number of metric fetchers to fetch from the Kafka cluster.";

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DiskFailures.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DiskFailures.java
@@ -64,7 +64,7 @@ public class DiskFailures extends KafkaAnomaly {
     StringBuilder sb = new StringBuilder().append("{\n");
     _failedDisksByBroker.forEach((brokerId, failures) -> {
       failures.forEach((logdir, eventTime) -> {
-        sb.append(String.format("\tDisk %s on broker %d failed at %s\n ", logdir, brokerId, toDateString(eventTime)));
+        sb.append(String.format("\tDisk %s on broker %d failed at %s%n ", logdir, brokerId, toDateString(eventTime)));
       });
     });
     sb.append("}");

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSamplerPartitionAssignor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSamplerPartitionAssignor.java
@@ -17,7 +17,7 @@ import java.util.Set;
 public interface MetricSamplerPartitionAssignor extends CruiseControlConfigurable {
 
   /**
-   * Please use {@link #assignPartitions(Cluster)}.
+   * @deprecated Please use {@link #assignPartitions(Cluster)}.
    * Assign the partitions in the cluster to the metric fetchers.
    *
    * @param cluster        The Kafka cluster.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSamplerPartitionAssignor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSamplerPartitionAssignor.java
@@ -17,13 +17,14 @@ import java.util.Set;
 public interface MetricSamplerPartitionAssignor extends CruiseControlConfigurable {
 
   /**
-   * @deprecated Please use {@link #assignPartitions(Cluster)}.
+   * Please use {@link #assignPartitions(Cluster)}.
    * Assign the partitions in the cluster to the metric fetchers.
    *
    * @param cluster        The Kafka cluster.
    * @param numFetchers    The number of metric fetchers.
    * @return A List of partition assignment for each of the fetchers.
    */
+  @Deprecated
   List<Set<TopicPartition>> assignPartitions(Cluster cluster, int numFetchers);
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/SecurityUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/SecurityUtils.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.security;
+
+import org.eclipse.jetty.util.security.Credential;
+
+public final class SecurityUtils {
+    public static final Credential NO_CREDENTIAL = new Credential() {
+        @Override
+        public boolean check(Object credentials) {
+            return false;
+        }
+    };
+
+    private SecurityUtils() {
+    }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxyAuthorizationService.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxyAuthorizationService.java
@@ -9,6 +9,7 @@ import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.security.authentication.AuthorizationService;
 import org.eclipse.jetty.server.UserIdentity;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.eclipse.jetty.util.security.Credential;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -20,12 +21,18 @@ import java.util.regex.Pattern;
  */
 public class TrustedProxyAuthorizationService extends AbstractLifeCycle implements AuthorizationService {
 
+  private static final Credential NO_CREDENTIAL = new Credential() {
+    @Override
+    public boolean check(Object credentials) {
+      return false;
+    }
+  };
   private final UserStore _adminUserStore;
   private final Pattern _trustedProxyIpPattern;
 
   TrustedProxyAuthorizationService(List<String> userNames, String trustedProxyIpPattern) {
     _adminUserStore = new UserStore();
-    userNames.forEach(u -> _adminUserStore.addUser(u, null, new String[] { DefaultRoleSecurityProvider.ADMIN }));
+    userNames.forEach(u -> _adminUserStore.addUser(u, NO_CREDENTIAL, new String[] { DefaultRoleSecurityProvider.ADMIN }));
     if (trustedProxyIpPattern != null) {
       _trustedProxyIpPattern = Pattern.compile(trustedProxyIpPattern);
     } else {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxyAuthorizationService.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxyAuthorizationService.java
@@ -5,11 +5,11 @@
 package com.linkedin.kafka.cruisecontrol.servlet.security.trustedproxy;
 
 import com.linkedin.kafka.cruisecontrol.servlet.security.DefaultRoleSecurityProvider;
+import com.linkedin.kafka.cruisecontrol.servlet.security.SecurityUtils;
 import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.security.authentication.AuthorizationService;
 import org.eclipse.jetty.server.UserIdentity;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
-import org.eclipse.jetty.util.security.Credential;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -21,18 +21,12 @@ import java.util.regex.Pattern;
  */
 public class TrustedProxyAuthorizationService extends AbstractLifeCycle implements AuthorizationService {
 
-  private static final Credential NO_CREDENTIAL = new Credential() {
-    @Override
-    public boolean check(Object credentials) {
-      return false;
-    }
-  };
   private final UserStore _adminUserStore;
   private final Pattern _trustedProxyIpPattern;
 
   TrustedProxyAuthorizationService(List<String> userNames, String trustedProxyIpPattern) {
     _adminUserStore = new UserStore();
-    userNames.forEach(u -> _adminUserStore.addUser(u, NO_CREDENTIAL, new String[] { DefaultRoleSecurityProvider.ADMIN }));
+    userNames.forEach(u -> _adminUserStore.addUser(u, SecurityUtils.NO_CREDENTIAL, new String[] { DefaultRoleSecurityProvider.ADMIN }));
     if (trustedProxyIpPattern != null) {
       _trustedProxyIpPattern = Pattern.compile(trustedProxyIpPattern);
     } else {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtAuthenticatorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtAuthenticatorTest.java
@@ -3,6 +3,7 @@
  */
 package com.linkedin.kafka.cruisecontrol.servlet.security.jwt;
 
+import com.linkedin.kafka.cruisecontrol.servlet.security.SecurityUtils;
 import com.linkedin.kafka.cruisecontrol.servlet.security.UserStoreAuthorizationService;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
@@ -14,7 +15,6 @@ import org.eclipse.jetty.security.UserAuthentication;
 import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.Authentication;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.util.security.Credential;
 import org.junit.Test;
 
 import javax.servlet.http.Cookie;
@@ -44,12 +44,6 @@ public class JwtAuthenticatorTest {
   private static final String CRUISE_CONTROL_ENDPOINT = "http://cruisecontrol.mycompany.com/state";
   private static final String USER_ROLE = "USER";
   private static final String BASIC_SCHEME = "Basic";
-  private static final Credential NO_CREDENTIAL = new Credential() {
-    @Override
-    public boolean check(Object credentials) {
-      return false;
-    }
-  };
 
   @Test
   public void testParseTokenFromAuthHeader() {
@@ -119,7 +113,7 @@ public class JwtAuthenticatorTest {
   @Test
   public void testSuccessfulLogin() throws Exception {
     UserStore testUserStore = new UserStore();
-    testUserStore.addUser(TEST_USER, NO_CREDENTIAL, new String[]{USER_ROLE});
+    testUserStore.addUser(TEST_USER, SecurityUtils.NO_CREDENTIAL, new String[]{USER_ROLE});
     TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER);
     JwtLoginService loginService = new JwtLoginService(new UserStoreAuthorizationService(testUserStore), tokenAndKeys.publicKey(), null);
 
@@ -154,7 +148,7 @@ public class JwtAuthenticatorTest {
   @Test
   public void testFailedLoginWithUserNotFound() throws Exception {
     UserStore testUserStore = new UserStore();
-    testUserStore.addUser(TEST_USER_2, NO_CREDENTIAL, new String[] {USER_ROLE});
+    testUserStore.addUser(TEST_USER_2, SecurityUtils.NO_CREDENTIAL, new String[] {USER_ROLE});
     TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER);
     JwtLoginService loginService = new JwtLoginService(new UserStoreAuthorizationService(testUserStore), tokenAndKeys.publicKey(), null);
 
@@ -188,7 +182,7 @@ public class JwtAuthenticatorTest {
   @Test
   public void testFailedLoginWithInvalidToken() throws Exception {
     UserStore testUserStore = new UserStore();
-    testUserStore.addUser(TEST_USER_2, NO_CREDENTIAL, new String[] {USER_ROLE});
+    testUserStore.addUser(TEST_USER_2, SecurityUtils.NO_CREDENTIAL, new String[] {USER_ROLE});
     TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER);
     TokenGenerator.TokenAndKeys tokenAndKeys2 = TokenGenerator.generateToken(TEST_USER);
     JwtLoginService loginService = new JwtLoginService(new UserStoreAuthorizationService(testUserStore), tokenAndKeys.publicKey(), null);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtAuthenticatorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtAuthenticatorTest.java
@@ -14,6 +14,7 @@ import org.eclipse.jetty.security.UserAuthentication;
 import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.Authentication;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.util.security.Credential;
 import org.junit.Test;
 
 import javax.servlet.http.Cookie;
@@ -43,6 +44,12 @@ public class JwtAuthenticatorTest {
   private static final String CRUISE_CONTROL_ENDPOINT = "http://cruisecontrol.mycompany.com/state";
   private static final String USER_ROLE = "USER";
   private static final String BASIC_SCHEME = "Basic";
+  private static final Credential NO_CREDENTIAL = new Credential() {
+    @Override
+    public boolean check(Object credentials) {
+      return false;
+    }
+  };
 
   @Test
   public void testParseTokenFromAuthHeader() {
@@ -112,7 +119,7 @@ public class JwtAuthenticatorTest {
   @Test
   public void testSuccessfulLogin() throws Exception {
     UserStore testUserStore = new UserStore();
-    testUserStore.addUser(TEST_USER, null, new String[] {USER_ROLE});
+    testUserStore.addUser(TEST_USER, NO_CREDENTIAL, new String[]{USER_ROLE});
     TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER);
     JwtLoginService loginService = new JwtLoginService(new UserStoreAuthorizationService(testUserStore), tokenAndKeys.publicKey(), null);
 
@@ -147,7 +154,7 @@ public class JwtAuthenticatorTest {
   @Test
   public void testFailedLoginWithUserNotFound() throws Exception {
     UserStore testUserStore = new UserStore();
-    testUserStore.addUser(TEST_USER_2, null, new String[] {USER_ROLE});
+    testUserStore.addUser(TEST_USER_2, NO_CREDENTIAL, new String[] {USER_ROLE});
     TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER);
     JwtLoginService loginService = new JwtLoginService(new UserStoreAuthorizationService(testUserStore), tokenAndKeys.publicKey(), null);
 
@@ -181,7 +188,7 @@ public class JwtAuthenticatorTest {
   @Test
   public void testFailedLoginWithInvalidToken() throws Exception {
     UserStore testUserStore = new UserStore();
-    testUserStore.addUser(TEST_USER_2, null, new String[] {USER_ROLE});
+    testUserStore.addUser(TEST_USER_2, NO_CREDENTIAL, new String[] {USER_ROLE});
     TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER);
     TokenGenerator.TokenAndKeys tokenAndKeys2 = TokenGenerator.generateToken(TEST_USER);
     JwtLoginService loginService = new JwtLoginService(new UserStoreAuthorizationService(testUserStore), tokenAndKeys.publicKey(), null);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtLoginServiceTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/jwt/JwtLoginServiceTest.java
@@ -4,11 +4,11 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.security.jwt;
 
+import com.linkedin.kafka.cruisecontrol.servlet.security.SecurityUtils;
 import com.linkedin.kafka.cruisecontrol.servlet.security.UserStoreAuthorizationService;
 import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.UserIdentity;
-import org.eclipse.jetty.util.security.Credential;
 import org.junit.Test;
 
 import javax.servlet.http.HttpServletRequest;
@@ -31,17 +31,11 @@ import static org.junit.Assert.assertTrue;
 public class JwtLoginServiceTest {
 
   private static final String TEST_USER = "testUser";
-  private static final Credential NO_CREDENTIAL = new Credential() {
-    @Override
-    public boolean check(Object credentials) {
-      return false;
-    }
-  };
 
   @Test
   public void testValidateTokenSuccessfully() throws Exception {
     UserStore testUserStore = new UserStore();
-    testUserStore.addUser(TEST_USER, NO_CREDENTIAL, new String[] {"USER"});
+    testUserStore.addUser(TEST_USER, SecurityUtils.NO_CREDENTIAL, new String[] {"USER"});
     TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER);
     JwtLoginService loginService = new JwtLoginService(new UserStoreAuthorizationService(testUserStore), tokenAndKeys.publicKey(), null);
 
@@ -59,7 +53,7 @@ public class JwtLoginServiceTest {
   @Test
   public void testFailSignatureValidation() throws Exception {
     UserStore testUserStore = new UserStore();
-    testUserStore.addUser(TEST_USER, NO_CREDENTIAL, new String[] {"USER"});
+    testUserStore.addUser(TEST_USER, SecurityUtils.NO_CREDENTIAL, new String[] {"USER"});
     TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER);
     TokenGenerator.TokenAndKeys tokenAndKeys2 = TokenGenerator.generateToken(TEST_USER); // this will be signed with a different key
     JwtLoginService loginService = new JwtLoginService(new UserStoreAuthorizationService(testUserStore), tokenAndKeys2.publicKey(), null);
@@ -74,7 +68,7 @@ public class JwtLoginServiceTest {
   @Test
   public void testFailAudienceValidation() throws Exception {
     UserStore testUserStore = new UserStore();
-    testUserStore.addUser(TEST_USER, NO_CREDENTIAL, new String[] {"USER"});
+    testUserStore.addUser(TEST_USER, SecurityUtils.NO_CREDENTIAL, new String[] {"USER"});
     TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER, Arrays.asList("A", "B"));
     JwtLoginService loginService = new JwtLoginService(
         new UserStoreAuthorizationService(testUserStore), tokenAndKeys.publicKey(), Arrays.asList("C", "D"));
@@ -89,7 +83,7 @@ public class JwtLoginServiceTest {
   @Test
   public void testFailExpirationValidation() throws Exception {
     UserStore testUserStore = new UserStore();
-    testUserStore.addUser(TEST_USER, NO_CREDENTIAL, new String[] {"USER"});
+    testUserStore.addUser(TEST_USER, SecurityUtils.NO_CREDENTIAL, new String[] {"USER"});
     TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER, 1L);
     JwtLoginService loginService = new JwtLoginService(new UserStoreAuthorizationService(testUserStore), tokenAndKeys.publicKey(), null);
 
@@ -103,7 +97,7 @@ public class JwtLoginServiceTest {
   @Test
   public void testRevalidateTokenPasses() throws Exception {
     UserStore testUserStore = new UserStore();
-    testUserStore.addUser(TEST_USER, NO_CREDENTIAL, new String[] {"USER"});
+    testUserStore.addUser(TEST_USER, SecurityUtils.NO_CREDENTIAL, new String[] {"USER"});
     TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER);
     JwtLoginService loginService = new JwtLoginService(new UserStoreAuthorizationService(testUserStore), tokenAndKeys.publicKey(), null);
 
@@ -122,7 +116,7 @@ public class JwtLoginServiceTest {
   @Test
   public void testRevalidateTokenFails() throws Exception {
     UserStore testUserStore = new UserStore();
-    testUserStore.addUser(TEST_USER, NO_CREDENTIAL, new String[] {"USER"});
+    testUserStore.addUser(TEST_USER, SecurityUtils.NO_CREDENTIAL, new String[] {"USER"});
     Instant now = Instant.now();
     TokenGenerator.TokenAndKeys tokenAndKeys = TokenGenerator.generateToken(TEST_USER, now.plusSeconds(10).toEpochMilli());
     Clock fixedClock = Clock.fixed(now, ZoneOffset.UTC);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/spnego/SpnegoUserStoreAuthorizationServiceTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/spnego/SpnegoUserStoreAuthorizationServiceTest.java
@@ -5,10 +5,10 @@
 package com.linkedin.kafka.cruisecontrol.servlet.security.spnego;
 
 import com.linkedin.kafka.cruisecontrol.servlet.security.DefaultRoleSecurityProvider;
+import com.linkedin.kafka.cruisecontrol.servlet.security.SecurityUtils;
 import com.linkedin.kafka.cruisecontrol.servlet.security.UserStoreAuthorizationService;
 import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.UserIdentity;
-import org.eclipse.jetty.util.security.Credential;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -17,17 +17,11 @@ import static org.junit.Assert.assertNotNull;
 public class SpnegoUserStoreAuthorizationServiceTest {
 
   private static final String TEST_USER = "testUser";
-  private static final Credential NO_CREDENTIAL = new Credential() {
-    @Override
-    public boolean check(Object credentials) {
-      return false;
-    }
-  };
 
   @Test
   public void testPrincipalNames() {
     UserStore users = new UserStore();
-    users.addUser(TEST_USER, NO_CREDENTIAL, new String[] { DefaultRoleSecurityProvider.ADMIN });
+    users.addUser(TEST_USER, SecurityUtils.NO_CREDENTIAL, new String[] { DefaultRoleSecurityProvider.ADMIN });
     UserStoreAuthorizationService usas = new SpnegoUserStoreAuthorizationService(users);
 
     UserIdentity result = usas.getUserIdentity(null, TEST_USER + "/host@REALM");

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/spnego/SpnegoUserStoreAuthorizationServiceTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/spnego/SpnegoUserStoreAuthorizationServiceTest.java
@@ -8,6 +8,7 @@ import com.linkedin.kafka.cruisecontrol.servlet.security.DefaultRoleSecurityProv
 import com.linkedin.kafka.cruisecontrol.servlet.security.UserStoreAuthorizationService;
 import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.UserIdentity;
+import org.eclipse.jetty.util.security.Credential;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -16,11 +17,17 @@ import static org.junit.Assert.assertNotNull;
 public class SpnegoUserStoreAuthorizationServiceTest {
 
   private static final String TEST_USER = "testUser";
+  private static final Credential NO_CREDENTIAL = new Credential() {
+    @Override
+    public boolean check(Object credentials) {
+      return false;
+    }
+  };
 
   @Test
   public void testPrincipalNames() {
     UserStore users = new UserStore();
-    users.addUser(TEST_USER, null, new String[] { DefaultRoleSecurityProvider.ADMIN });
+    users.addUser(TEST_USER, NO_CREDENTIAL, new String[] { DefaultRoleSecurityProvider.ADMIN });
     UserStoreAuthorizationService usas = new SpnegoUserStoreAuthorizationService(users);
 
     UserIdentity result = usas.getUserIdentity(null, TEST_USER + "/host@REALM");

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxyLoginServiceTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxyLoginServiceTest.java
@@ -11,6 +11,7 @@ import org.eclipse.jetty.security.SpnegoUserPrincipal;
 import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.security.authentication.AuthorizationService;
 import org.eclipse.jetty.server.UserIdentity;
+import org.eclipse.jetty.util.security.Credential;
 import org.junit.Test;
 
 import javax.security.auth.Subject;
@@ -34,13 +35,19 @@ public class TrustedProxyLoginServiceTest {
   public static final String TEST_SERVICE_USER = "testServiceUser";
   public static final String ENCODED_TOKEN = "encoded_token";
   public static final String TEST_USER = "testUser";
+  private static final Credential NO_CREDENTIAL = new Credential() {
+    @Override
+    public boolean check(Object credentials) {
+      return false;
+    }
+  };
 
   private static class TestAuthorizer implements AuthorizationService {
 
     private final UserStore _adminUserStore = new UserStore();
 
     TestAuthorizer(String testUser) {
-      _adminUserStore.addUser(testUser, null, new String[] { DefaultRoleSecurityProvider.ADMIN });
+      _adminUserStore.addUser(testUser, NO_CREDENTIAL, new String[] { DefaultRoleSecurityProvider.ADMIN });
     }
 
     @Override

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxyLoginServiceTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxyLoginServiceTest.java
@@ -5,13 +5,13 @@
 package com.linkedin.kafka.cruisecontrol.servlet.security.trustedproxy;
 
 import com.linkedin.kafka.cruisecontrol.servlet.security.DefaultRoleSecurityProvider;
+import com.linkedin.kafka.cruisecontrol.servlet.security.SecurityUtils;
 import org.eclipse.jetty.security.ConfigurableSpnegoLoginService;
 import org.eclipse.jetty.security.SpnegoUserIdentity;
 import org.eclipse.jetty.security.SpnegoUserPrincipal;
 import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.security.authentication.AuthorizationService;
 import org.eclipse.jetty.server.UserIdentity;
-import org.eclipse.jetty.util.security.Credential;
 import org.junit.Test;
 
 import javax.security.auth.Subject;
@@ -35,19 +35,13 @@ public class TrustedProxyLoginServiceTest {
   public static final String TEST_SERVICE_USER = "testServiceUser";
   public static final String ENCODED_TOKEN = "encoded_token";
   public static final String TEST_USER = "testUser";
-  private static final Credential NO_CREDENTIAL = new Credential() {
-    @Override
-    public boolean check(Object credentials) {
-      return false;
-    }
-  };
 
   private static class TestAuthorizer implements AuthorizationService {
 
     private final UserStore _adminUserStore = new UserStore();
 
     TestAuthorizer(String testUser) {
-      _adminUserStore.addUser(testUser, NO_CREDENTIAL, new String[] { DefaultRoleSecurityProvider.ADMIN });
+      _adminUserStore.addUser(testUser, SecurityUtils.NO_CREDENTIAL, new String[] { DefaultRoleSecurityProvider.ADMIN });
     }
 
     @Override


### PR DESCRIPTION
use java-11 to compile:
- migrated from findbugs to spotbugs (findbugs won't work with java 11). This required separation of spotBugs gradle task in a separate run in CircleCI to avoid out of memory issues
- fixed checkstyle config files discovery
- fixed on prio 1 bug `VO_VOLATILE_INCREMENT` reported in AnomalyDetector.java
- upgraded org.eclipse.jetty.security and fixed tests to provide a non-null Credential

