### PR TITLE
Enabling backoff on metrics topic creation

### DIFF
--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
@@ -69,6 +69,8 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
   private volatile boolean _shutdown = false;
   private NewTopic _metricsTopic;
   private AdminClient _adminClient;
+  private long _metricsTopicAutoCreateTimeout;
+  private int _metricsTopicAutoCreateRetries;
   protected static final String CRUISE_CONTROL_METRICS_TOPIC_CLEAN_UP_POLICY = "delete";
   protected static final Duration PRODUCER_CLOSE_TIMEOUT = Duration.ofSeconds(5);
 
@@ -152,6 +154,8 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
         _metricsTopic = createMetricsTopicFromReporterConfig(reporterConfig);
         Properties adminClientConfigs = CruiseControlMetricsUtils.addSslConfigs(producerProps, reporterConfig);
         _adminClient = CruiseControlMetricsUtils.createAdminClient(adminClientConfigs);
+        _metricsTopicAutoCreateTimeout = reporterConfig.getLong(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_TIMEOUT_CONFIG);
+        _metricsTopicAutoCreateRetries = reporterConfig.getInt(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_RETRIES_CONFIG);
       } catch (CruiseControlMetricsReporterException e) {
         LOG.warn("Cruise Control metrics topic auto creation was disabled", e);
       }
@@ -180,16 +184,20 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
   }
 
   protected void createCruiseControlMetricsTopic() throws TopicExistsException {
-    try {
-      CreateTopicsResult createTopicsResult = _adminClient.createTopics(Collections.singletonList(_metricsTopic));
-      createTopicsResult.values().get(_metricsTopic.name()).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-      LOG.info("Cruise Control metrics topic {} is created.", _metricsTopic.name());
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      if (e.getCause() instanceof TopicExistsException) {
-        throw (TopicExistsException) e.getCause();
+    CruiseControlMetricsUtils.retry(() -> {
+      try {
+        CreateTopicsResult createTopicsResult = _adminClient.createTopics(Collections.singletonList(_metricsTopic));
+        createTopicsResult.values().get(_metricsTopic.name()).get(_metricsTopicAutoCreateTimeout, TimeUnit.MILLISECONDS);
+        LOG.info("Cruise Control metrics topic {} is created.", _metricsTopic.name());
+        return false;
+      } catch (InterruptedException | ExecutionException | TimeoutException e) {
+        if (e.getCause() instanceof TopicExistsException) {
+          throw (TopicExistsException) e.getCause();
+        }
+        LOG.warn("Unable to create Cruise Control metrics topic {}.", _metricsTopic.name(), e);
+        return true;
       }
-      LOG.warn("Unable to create Cruise Control metrics topic {}.", _metricsTopic.name(), e);
-    }
+    }, _metricsTopicAutoCreateRetries);
   }
 
   protected void maybeUpdateCruiseControlMetricsTopic() {

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterConfig.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterConfig.java
@@ -27,6 +27,11 @@ public class CruiseControlMetricsReporterConfig extends AbstractConfig {
   public static final String CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_CONFIG = "cruise.control.metrics.topic.auto.create";
   private static final String CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_DOC = "Cruise Control metrics reporter will enforce " +
       " the creation of the topic at launch";
+  public static final String CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_TIMEOUT_CONFIG = "cruise.control.metrics.topic.auto.create.timeout";
+  private static final String CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_TIMEOUT_DOC = "Timeout on the Cruise Control metrics topic creation";
+  public static final String CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_RETRIES_CONFIG = "cruise.control.metrics.topic.auto.create.retries";
+  private static final String CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_RETRIES_DOC = "Number of retries of the" +
+      " Cruise Control metrics reporter for the topic creation";
   public static final String CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS_CONFIG = "cruise.control.metrics.topic.num.partitions";
   private static final String CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS_DOC = "The number of partitions of Cruise Control metrics topic";
   public static final String CRUISE_CONTROL_METRICS_TOPIC_REPLICATION_FACTOR_CONFIG = "cruise.control.metrics.topic.replication.factor";
@@ -49,6 +54,8 @@ public class CruiseControlMetricsReporterConfig extends AbstractConfig {
   public static final String DEFAULT_CRUISE_CONTROL_METRICS_TOPIC = "__CruiseControlMetrics";
   public static final Integer DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS = -1;
   public static final boolean DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE = false;
+  public static final long DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_TIMEOUT_MS = 10000L;
+  public static final Integer DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_RETRIES = 5;
   public static final Short DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_REPLICATION_FACTOR = -1;
   public static final long DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_RETENTION_MS = 18000000L;
   public static final long DEFAULT_CRUISE_CONTROL_METRICS_REPORTER_INTERVAL_MS = 60000;
@@ -84,6 +91,16 @@ public class CruiseControlMetricsReporterConfig extends AbstractConfig {
                 DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE,
                 ConfigDef.Importance.LOW,
                 CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_DOC)
+        .define(CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_TIMEOUT_CONFIG,
+                ConfigDef.Type.LONG,
+                DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_TIMEOUT_MS,
+                ConfigDef.Importance.LOW,
+                CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_TIMEOUT_DOC)
+        .define(CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_RETRIES_CONFIG,
+                ConfigDef.Type.INT,
+                DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_RETRIES,
+                ConfigDef.Importance.LOW,
+                CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_RETRIES_DOC)
         .define(CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS_CONFIG,
                 ConfigDef.Type.INT,
                 DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS,

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterAutoCreateTopicTest.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterAutoCreateTopicTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.metricsreporter;
+
+import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaClientsIntegrationTestHarness;
+import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaTestUtils;
+import kafka.server.KafkaConfig;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+public class CruiseControlMetricsReporterAutoCreateTopicTest extends CCKafkaClientsIntegrationTestHarness {
+    protected static final String TOPIC = "CruiseControlMetricsReporterTest";
+
+    @Before
+    public void setUp() {
+        super.setUp();
+
+        // creating the "TestTopic" explicitly because the topic auto-creation is disabled on the broker
+        Properties adminProps = new Properties();
+        adminProps.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
+        AdminClient adminClient = AdminClient.create(adminProps);
+        NewTopic testTopic = new NewTopic("TestTopic", 1, (short) 1);
+        CreateTopicsResult createTopicsResult = adminClient.createTopics(Collections.singleton(testTopic));
+
+        AtomicInteger adminFailed = new AtomicInteger(0);
+        createTopicsResult.all().whenComplete((v, e) -> {
+            if (e != null) {
+                adminFailed.incrementAndGet();
+            }
+        });
+        assertEquals(0, adminFailed.get());
+
+        // starting producer to verify that Kafka cluster is working fine
+        Properties producerProps = new Properties();
+        producerProps.setProperty(ProducerConfig.ACKS_CONFIG, "-1");
+        AtomicInteger producerFailed = new AtomicInteger(0);
+        try (Producer<String, String> producer = createProducer(producerProps)) {
+            for (int i = 0; i < 10; i++) {
+                producer.send(new ProducerRecord<>("TestTopic", Integer.toString(i)),
+                        (m, e) -> {
+                            if (e != null) {
+                                producerFailed.incrementAndGet();
+                            }
+                        });
+            }
+        }
+        assertEquals(0, producerFailed.get());
+    }
+
+    @After
+    public void tearDown() {
+        super.tearDown();
+    }
+
+    @Override
+    public Properties overridingProps() {
+        Properties props = new Properties();
+        int port = CCKafkaTestUtils.findLocalPort();
+        props.setProperty(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG, CruiseControlMetricsReporter.class.getName());
+        props.setProperty(KafkaConfig.ListenersProp(), "PLAINTEXT://127.0.0.1:" + port);
+        props.setProperty(CruiseControlMetricsReporterConfig.config(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG),
+                "127.0.0.1:" + port);
+        props.setProperty(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_REPORTER_INTERVAL_MS_CONFIG, "100");
+        props.setProperty(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_CONFIG, TOPIC);
+        // configure metrics topic auto-creation by the metrics reporter
+        props.setProperty(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_CONFIG, "true");
+        props.setProperty(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_TIMEOUT_CONFIG, "5000");
+        props.setProperty(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_RETRIES_CONFIG, "1");
+        props.setProperty(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS_CONFIG, "1");
+        props.setProperty(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_REPLICATION_FACTOR_CONFIG, "1");
+        // disable topic auto-creation to leave the metrics reporter to create the metrics topic
+        props.setProperty(KafkaConfig.AutoCreateTopicsEnableProp(), "false");
+        props.setProperty(KafkaConfig.LogFlushIntervalMessagesProp(), "1");
+        props.setProperty(KafkaConfig.OffsetsTopicReplicationFactorProp(), "1");
+        props.setProperty(KafkaConfig.DefaultReplicationFactorProp(), "2");
+        props.setProperty(KafkaConfig.NumPartitionsProp(), "2");
+        return props;
+    }
+
+    @Test
+    public void testAutoCreateMetricsTopic() throws ExecutionException, InterruptedException {
+        Properties props = new Properties();
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
+        AdminClient adminClient = AdminClient.create(props);
+        TopicDescription topicDescription = adminClient.describeTopics(Collections.singleton(TOPIC)).values().get(TOPIC).get();
+        // assert that the metrics topic was created with partitions and replicas as configured for the metrics report auto-creation
+        assertEquals(1, topicDescription.partitions().size());
+        assertEquals(1, topicDescription.partitions().get(0).replicas().size());
+    }
+}

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterSslTest.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterSslTest.java
@@ -7,6 +7,8 @@ package com.linkedin.kafka.cruisecontrol.metricsreporter;
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
+
+import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaTestUtils;
 import kafka.server.KafkaConfig;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -33,7 +35,7 @@ public class CruiseControlMetricsReporterSslTest extends CruiseControlMetricsRep
   @Override
   public Properties overridingProps() {
     Properties props = new Properties();
-    int port = findLocalPort();
+    int port = CCKafkaTestUtils.findLocalPort();
     // We need to convert all the properties to the Cruise Control properties.
     setSecurityConfigs(props, "producer");
     for (String configName : ProducerConfig.configNames()) {

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterTest.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterTest.java
@@ -8,8 +8,6 @@ import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.CruiseControlMetr
 import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.MetricSerde;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCEmbeddedBroker;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaClientsIntegrationTestHarness;
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -19,6 +17,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaTestUtils;
 import kafka.server.KafkaConfig;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -80,7 +80,7 @@ public class CruiseControlMetricsReporterTest extends CCKafkaClientsIntegrationT
   @Override
   public Properties overridingProps() {
     Properties props = new Properties();
-    int port = findLocalPort();
+    int port = CCKafkaTestUtils.findLocalPort();
     props.setProperty(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG, CruiseControlMetricsReporter.class.getName());
     props.setProperty(KafkaConfig.ListenersProp(), "PLAINTEXT://127.0.0.1:" + port);
     props.setProperty(CruiseControlMetricsReporterConfig.config(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG),
@@ -201,24 +201,5 @@ public class CruiseControlMetricsReporterTest extends CCKafkaClientsIntegrationT
     // Check whether the topic config is updated
     topicDescription = adminClient.describeTopics(Collections.singleton(TOPIC)).values().get(TOPIC).get();
     assertEquals(2, topicDescription.partitions().size());
-  }
-
-  protected int findLocalPort() {
-    int port = -1;
-    while (port < 0) {
-      try {
-        ServerSocket socket = new ServerSocket(0);
-        socket.setReuseAddress(true);
-        port = socket.getLocalPort();
-        try {
-          socket.close();
-        } catch (IOException e) {
-          // Ignore IOException on close()
-        }
-      } catch (IOException ie) {
-        // let it go.
-      }
-    }
-    return port;
   }
 }

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/utils/CCKafkaTestUtils.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/utils/CCKafkaTestUtils.java
@@ -6,6 +6,7 @@ package com.linkedin.kafka.cruisecontrol.metricsreporter.utils;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -159,6 +160,25 @@ public class CCKafkaTestUtils {
       stringBuiler.append(chars[Math.abs(random.nextInt()) % 16]);
     }
     return stringBuiler.toString();
+  }
+
+  public static int findLocalPort() {
+    int port = -1;
+    while (port < 0) {
+      try {
+        ServerSocket socket = new ServerSocket(0);
+        socket.setReuseAddress(true);
+        port = socket.getLocalPort();
+        try {
+          socket.close();
+        } catch (IOException e) {
+          // Ignore IOException on close()
+        }
+      } catch (IOException ie) {
+        // let it go.
+      }
+    }
+    return port;
   }
 
   @FunctionalInterface


### PR DESCRIPTION
Addresses the issue #1216.
This PR makes the timeout on metrics topic creation configurable but at same time adds a backoff mechanism with the number of retries configurable as well.

