### PR TITLE
Additional fixes for user tasks endpoint

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
@@ -770,7 +770,7 @@ public class UserTaskManager implements Closeable {
           if (_state == TaskState.COMPLETED_WITH_ERROR) {
             // If the state is completed with error and fetch completed task is true then just return "CompletedWithError"
             // as the "originalResponse".
-            jsonObjectMap.put(ORIGINAL_RESPONSE, TaskState.COMPLETED_WITH_ERROR);
+            jsonObjectMap.put(ORIGINAL_RESPONSE, TaskState.COMPLETED_WITH_ERROR.toString());
           } else {
             throw new IllegalStateException("Error happened in fetching response for task " + _userTaskId.toString(), e);
           }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/UserTaskState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/UserTaskState.java
@@ -169,7 +169,12 @@ public class UserTaskState extends AbstractCruiseControlResponse {
       CruiseControlResponse response = userTaskInfo.futures().get(userTaskInfo.futures().size() - 1).get();
       return response.cachedResponse();
     } catch (InterruptedException | ExecutionException e) {
-      throw new IllegalStateException("Error happened in fetching response for task " + userTaskInfo.userTaskId().toString(), e);
+      if (userTaskInfo.state().equals(UserTaskManager.TaskState.COMPLETED_WITH_ERROR)) {
+        // TODO: Ideally this should return a meaningful description of the server-side error
+        return UserTaskManager.TaskState.COMPLETED_WITH_ERROR.toString();
+      } else {
+        throw new IllegalStateException("Error happened in fetching response for task " + userTaskInfo.userTaskId().toString(), e);
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes the response for `completedWithError` tasks on the `user_tasks` endpoint for requests where `json=false`. The previous fix (#1188) only applied to `json=true` requests.

Signed-off-by: Thomas Cooper <tom.n.cooper@gmail.com>

Addresses the issue #1187 
