### PR TITLE
Fix java.lang.NoClassDefFoundError: org/apache/kafka/clients/admin/Admin in Cruise Control Metrics Reporter

### DIFF
--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsUtils.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsUtils.java
@@ -62,8 +62,20 @@ public class CruiseControlMetricsUtils {
     closeAdminClientWithTimeout(adminClient, ADMIN_CLIENT_CLOSE_TIMEOUT_MS);
   }
 
+  /**
+   * Close the given AdminClient with the given timeout.
+   *
+   * @param adminClient AdminClient to be closed.
+   * @param timeoutMs the timeout.
+   */
   public static void closeAdminClientWithTimeout(AdminClient adminClient, long timeoutMs) {
-    closeClientWithTimeout(adminClient::close, timeoutMs);
+    closeClientWithTimeout(() -> {
+      try {
+        ((AutoCloseable) adminClient).close();
+      } catch (Exception e) {
+        throw new IllegalStateException("Failed to close the Admin Client.", e);
+      }
+    }, timeoutMs);
   }
 
   /**


### PR DESCRIPTION
This PR resolves #1239.
