### PR TITLE
Add support to retrieve capacity only via load endpoint.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -318,6 +318,14 @@ public class KafkaCruiseControl {
   }
 
   /**
+   * Get cluster capacity, and skip populating cluster load. Enables quick retrieval of capacity without the load.
+   * @return Cluster capacity without cluster load.
+   */
+  public ClusterModel clusterCapacity() throws TimeoutException, BrokerCapacityResolutionException {
+    return _loadMonitor.clusterCapacity();
+  }
+
+  /**
    * Bootstrap the load monitor for a given period.
    *
    * @param startMs the starting time of the bootstrap period, or null if no time period will be used.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -13,10 +13,7 @@ import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelGeneration;
 import com.linkedin.kafka.cruisecontrol.servlet.response.stats.BrokerStats;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,7 +28,6 @@ import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.apache.commons.math3.stat.descriptive.moment.Variance;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
@@ -1243,23 +1239,6 @@ public class ClusterModel implements Serializable {
   }
 
   /**
-   * The variance of the derived resources.
-   * @return A non-null array where the ith index is the variance of RawAndDerivedResource.ordinal().
-   */
-  public double[] variance() {
-    RawAndDerivedResource[] resources = RawAndDerivedResource.values();
-    double[][] utilization = utilizationMatrix();
-
-    double[] variance = new double[resources.length];
-
-    for (int resourceIndex = 0; resourceIndex < resources.length; resourceIndex++) {
-      Variance varianceCalculator = new Variance();
-      variance[resourceIndex] = varianceCalculator.evaluate(utilization[resourceIndex]);
-    }
-    return variance;
-  }
-
-  /**
    *
    * @return A RawAndDerivedResource x nBroker matrix of derived resource utilization.
    */
@@ -1297,20 +1276,6 @@ public class ClusterModel implements Serializable {
       brokerIndex++;
     }
     return utilization;
-  }
-
-  /**
-   * Write to the given output stream.
-   *
-   * @param out Output stream.
-   */
-  public void writeTo(OutputStream out) throws IOException {
-    String cluster = String.format("<Cluster maxPartitionReplicationFactor=\"%d\">%n", _maxReplicationFactor);
-    out.write(cluster.getBytes(StandardCharsets.UTF_8));
-    for (Rack rack : _racksById.values()) {
-      rack.writeTo(out);
-    }
-    out.write("</Cluster>".getBytes(StandardCharsets.UTF_8));
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ClusterLoadParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ClusterLoadParameters.java
@@ -17,6 +17,7 @@ import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.START_MS_PARAM;
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.ALLOW_CAPACITY_ESTIMATION_PARAM;
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.POPULATE_DISK_INFO_PARAM;
+import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.CAPACITY_ONLY_PARAM;
 
 
 /**
@@ -29,7 +30,7 @@ import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils
  * <pre>
  * Get the cluster load
  *    GET /kafkacruisecontrol/load?start=[START_TIMESTAMP]&amp;end=[END_TIMESTAMP]&amp;time=[END_TIMESTAMP]&amp;allow_capacity_estimation=[true/false]
- *    &amp;json=[true/false]&amp;populate_disk_info=[true/false]&amp;get_response_schema=[true/false]
+ *    &amp;json=[true/false]&amp;populate_disk_info=[true/false]&amp;get_response_schema=[true/false]&amp;capacity_only=[true/false]
  * </pre>
  */
 public class ClusterLoadParameters extends AbstractParameters {
@@ -41,6 +42,7 @@ public class ClusterLoadParameters extends AbstractParameters {
     validParameterNames.add(START_MS_PARAM);
     validParameterNames.add(ALLOW_CAPACITY_ESTIMATION_PARAM);
     validParameterNames.add(POPULATE_DISK_INFO_PARAM);
+    validParameterNames.add(CAPACITY_ONLY_PARAM);
     validParameterNames.addAll(AbstractParameters.CASE_INSENSITIVE_PARAMETER_NAMES);
     CASE_INSENSITIVE_PARAMETER_NAMES = Collections.unmodifiableSortedSet(validParameterNames);
   }
@@ -49,6 +51,7 @@ public class ClusterLoadParameters extends AbstractParameters {
   protected ModelCompletenessRequirements _requirements;
   protected boolean _allowCapacityEstimation;
   protected boolean _populateDiskInfo;
+  protected boolean _capacityOnly;
 
   public ClusterLoadParameters() {
     super();
@@ -63,6 +66,7 @@ public class ClusterLoadParameters extends AbstractParameters {
     _requirements = new ModelCompletenessRequirements(1, 0.0, true);
     _allowCapacityEstimation = ParameterUtils.allowCapacityEstimation(_request);
     _populateDiskInfo = ParameterUtils.populateDiskInfo(_request);
+    _capacityOnly = ParameterUtils.capacityOnly(_request);
   }
 
   public long startMs() {
@@ -83,6 +87,10 @@ public class ClusterLoadParameters extends AbstractParameters {
 
   public boolean populateDiskInfo() {
     return _populateDiskInfo;
+  }
+
+  public boolean capacityOnly() {
+    return _capacityOnly;
   }
 
   @Override

--- a/cruise-control/src/yaml/endpoints/load.yaml
+++ b/cruise-control/src/yaml/endpoints/load.yaml
@@ -43,6 +43,12 @@ LoadEndpoint:
         schema:
           type: boolean
           default: false
+      - name: capacity_only
+        in: query
+        description: Whether show only the cluster capacity or the utilization, as well.
+        schema:
+          type: boolean
+          default: false
       - name: get_response_schema
         in: query
         description: Whether to return in JSON schema in response header or not.

--- a/docs/wiki/User Guide/REST-APIs.md
+++ b/docs/wiki/User Guide/REST-APIs.md
@@ -99,16 +99,17 @@ Once Cruise Control Load Monitor shows it is in the `RUNNING` state, Users can u
 
 Supported parameters are:
 
-| PARAMETER   | TYPE       | DESCPRIPTION | DEFAULT  | OPTIONAL|
-|-------------|------------|----------------------|----------|---------|
-| start     | long    | start time of the cluster load     | time of earliest valid window|   yes |
-| end     | long    | end time of the cluster load     | current system time|   yes |
-| time     | long    | end time of the cluster load     | current system time|   yes | 
-| allow_capacity_estimation     | boolean    | whether allow broker capacity to be estimated from other broker in the cluster    | true      |   yes | 
-| populate_disk_info     | boolean    | whether show the load of each disk of broker    | false     |   yes | 
-| json     | boolean    | return in JSON format or not      | false      |   yes | 
-| verbose     | boolean    | return detailed state information      | false      |   yes |
-| doAs     | string    | propagated user by the trusted proxy service      | null      |   yes | 
+| PARAMETER                 | TYPE      | DESCPRIPTION                                                                      | DEFAULT                       | OPTIONAL  |
+|---------------------------|-----------|-----------------------------------------------------------------------------------|-------------------------------|-----------|
+| start                     | long      | start time of the cluster load                                                    | time of earliest valid window | yes       |
+| end                       | long      | end time of the cluster load                                                      | current system time           | yes       |
+| time                      | long      | end time of the cluster load                                                      | current system time           | yes       | 
+| allow_capacity_estimation | boolean   | whether allow broker capacity to be estimated from other broker in the cluster    | true                          | yes       | 
+| populate_disk_info        | boolean   | whether show the load of each disk of broker                                      | false                         | yes       | 
+| capacity_only             | boolean   | whether show only the cluster capacity or the utilization, as well.               | false                         | yes       |
+| json                      | boolean   | return in JSON format or not                                                      | false                         | yes       | 
+| verbose                   | boolean   | return detailed state information                                                 | false                         | yes       |
+| doAs                      | string    | propagated user by the trusted proxy service                                      | null                          | yes       | 
 
 If the number of workload snapshots for the given timestamp is not sufficient to generate a good load model, an exception will be returned.
 


### PR DESCRIPTION
This PR resolves #1191.

-- 
Example plaintext response, where values are defined for entries in `<...>`:
```
           HOST         BROKER      RACK         DISK_CAP(MB)            DISK(MB)/_(%)_            CORE_NUM         CPU(%)          NW_IN_CAP(KB/s)       LEADER_NW_IN(KB/s)     FOLLOWER_NW_IN(KB/s)         NW_OUT_CAP(KB/s)        NW_OUT(KB/s)       PNW_OUT(KB/s)    LEADERS/REPLICAS
<hostname-here>,          <id>,     <id>,        <diskCap-mb>,              0.000/00.00,            <cores>,         0.000,              <capacity>,                   0.000,                   0.000,              <capacity>,              0.000,              0.000,             0/0
<hostname-here>,          <id>,     <id>,        <diskCap-mb>,              0.000/00.00,            <cores>,         0.000,              <capacity>,                   0.000,                   0.000,              <capacity>,              0.000,              0.000,             0/0
...
<hostname-here>,          <id>,     <id>,        <diskCap-mb>,              0.000/00.00,            <cores>,         0.000,              <capacity>,                   0.000,                   0.000,              <capacity>,              0.000,              0.000,             0/0
```
