### PR TITLE
Fix wrong concurrent intra broker movement parameter name 

### DIFF
--- a/docs/wiki/User Guide/REST-APIs.md
+++ b/docs/wiki/User Guide/REST-APIs.md
@@ -270,7 +270,7 @@ Supported parameters are:
 | kafka_assigner     | boolean    |   whether use Kafka assigner mode to general proposal  | false|   yes |
 | allow_capacity_estimation     | boolean    | whether allow broker capacity to be estimated     | true      |   yes |
 | concurrent_partition_movements_per_broker     | integer    | upper bound of ongoing replica movements going into/out of each broker     | null      |   yes |
-| concurrent_intra_partition_movements     | integer    | upper bound of ongoing replica movements between disks within each broker     | null      |   yes |
+| concurrent_intra_broker_partition_movements     | integer    | upper bound of ongoing replica movements between disks within each broker     | null      |   yes |
 | concurrent_leader_movements     | integer    | upper bound of ongoing leadership movements     | null      |   yes |
 | skip_hard_goal_check     | boolean    | Whether allow hard goals be skipped in proposal generation     | false      |   yes |
 | excluded_topics     | regex    |  regular expression to specify topic not to be considered for replica movement   | null|   yes |
@@ -279,7 +279,7 @@ Supported parameters are:
 | exclude_recently_removed_brokers     | boolean    | whether allow replicas to be moved to recently removed broker  | false|   yes |
 | replica_movement_strategies     | string    |  [replica movement strategy](https://github.com/linkedin/cruise-control/wiki/Pluggable-Components#replica-movement-strategy) to use   | null|   yes |
 | ignore_proposal_cache     | boolean    | whether ignore the cached proposal or not| false|   yes | 
-| replication_throttle     | long    | upper bound on the bandwidth used to move replicas   | null|   yes |
+| replication_throttle     | long    | upper bound on the bandwidth used to move replicas (in bytes per second)  | null|   yes |
 | destination_broker_ids     | list    |  specify brokers to move replicas to   | null|   yes |
 | rebalance_disk     | boolean    |  whether balance load between disks within each broker or between brokers in cluster  | false|   yes |
 | json     | boolean    | return in JSON format or not      | false      |   yes | 
@@ -319,7 +319,7 @@ Supported parameters are:
 | exclude_recently_demoted_brokers     | boolean    | whether allow leader replicas to be moved to recently demoted broker    | false|   yes |
 | exclude_recently_removed_brokers     | boolean    | whether allow replicas to be moved to recently removed broker  | false|   yes |
 | replica_movement_strategies     | string    |  [replica movement strategy](https://github.com/linkedin/cruise-control/wiki/Pluggable-Components#replica-movement-strategy) to use   | null|   yes |
-| replication_throttle     | long    | Upper bound on the bandwidth used to move replicas   | null|   yes |
+| replication_throttle     | long    | Upper bound on the bandwidth used to move replicas (in bytes per second)  | null|   yes |
 | throttle_added_broker     | boolean    | whether throttle replica movement to new broker or not   | false|   yes |
 | json     | boolean    | return in JSON format or not      | false      |   yes | 
 | verbose     | boolean    | return detailed state information      | false      |   yes | 
@@ -354,7 +354,7 @@ Supported parameters are:
 | exclude_recently_demoted_brokers     | boolean    | whether allow leader replicas to be moved to recently demoted broker    | false|   yes |
 | exclude_recently_removed_brokers     | boolean    | whether allow replicas to be moved to recently removed broker  | false|   yes |
 | replica_movement_strategies     | string    |  [replica movement strategy](https://github.com/linkedin/cruise-control/wiki/Pluggable-Components#replica-movement-strategy) to use   | null|   yes |
-| replication_throttle     | long    | upper bound on the bandwidth used to move replicas   | false|   yes |
+| replication_throttle     | long    | upper bound on the bandwidth used to move replicas (in bytes per second)  | false|   yes |
 | throttle_removed_broker     | boolean    | whether throttle replica movement out of the removed broker or not   | false|   yes |
 | destination_broker_ids     | list    |  specify brokers to move replicas to   | null|   yes |
 | json     | boolean    | return in JSON format or not      | false      |   yes | 
@@ -391,7 +391,7 @@ Supported parameters are:
 | exclude_recently_demoted_brokers     | boolean    | whether allow leader replicas to be moved to recently demoted broker    | false|   yes |
 | exclude_recently_removed_brokers     | boolean    | whether allow replicas to be moved to recently removed broker  | false|   yes |
 | replica_movement_strategies     | string    |  [replica movement strategy](https://github.com/linkedin/cruise-control/wiki/Pluggable-Components#replica-movement-strategy) to use   | null|   yes |
-| replication_throttle     | long    | upper bound on the bandwidth used to move replicas   | null|   yes |
+| replication_throttle     | long    | upper bound on the bandwidth used to move replicas (in bytes per second)  | null|   yes |
 | json     | boolean    | return in JSON format or not      | false      |   yes | 
 | verbose     | boolean    | return detailed state information      | false      |   yes |  
 | reason     | string    | reason for the request     | "No reason provided"      |   yes |
@@ -423,7 +423,7 @@ Supported parameters are:
 | exclude_follower_demotion     | boolean    | whether skip demoting follower replicas on the broker to be demoted     | true      |   yes |
 | exclude_recently_demoted_brokers     | boolean    | whether allow leader replicas to be moved to recently demoted broker    | false|   yes |
 | replica_movement_strategies     | string    |  [replica movement strategy](https://github.com/linkedin/cruise-control/wiki/Pluggable-Components#replica-movement-strategy) to use   | null|   yes |
-| replication_throttle     | long    | upper bound on the bandwidth used to move replicas   | null|   yes |
+| replication_throttle     | long    | upper bound on the bandwidth used to move replicas (in bytes per second)  | null|   yes |
 | json     | boolean    | return in JSON format or not      | false      |   yes | 
 | verbose     | boolean    | return detailed state information      | false      |   yes | 
 | reason     | string    | reason for the request     | "No reason provided"      |   yes |
@@ -501,7 +501,7 @@ Supported parameters are:
 | exclude_recently_demoted_brokers     | Boolean    | Whether allow leader replicas to be moved to recently demoted broker    | false|   yes |
 | exclude_recently_removed_brokers     | Boolean    | Whether allow replicas to be moved to recently removed broker  | false|   yes |
 | replica_movement_strategies     | string    |  [replica movement strategy](https://github.com/linkedin/cruise-control/wiki/Pluggable-Components#replica-movement-strategy) to use   | null|   yes | 
-| replication_throttle     | long    | upper bound on the bandwidth used to move replicas   | null|   yes |
+| replication_throttle     | long    | upper bound on the bandwidth used to move replicas (in bytes per second)  | null|   yes |
 | json     | boolean    | return in JSON format or not      | false      |   yes | 
 | verbose     | boolean    | return detailed state information      | false      |   yes | 
 | reason     | string    | reason for the request     | "No reason provided"      |   yes |


### PR DESCRIPTION
The intra-broker concurrent partition movement parameter name is wrong in the REST API wiki. This PR fixes that and adds the expected units for the replication throttle parameter.
