### PR TITLE
Prevent Cruise Control from mistakenly believe that there is an ongoing execution

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.executor;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import kafka.zk.KafkaZkClient;
+import kafka.zk.ZkVersion;
+import org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public final class ExecutionUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(ExecutionUtils.class);
+
+  private ExecutionUtils() { }
+
+  /**
+   * Checks whether the topicPartitions of the execution tasks in the given subset is indeed a subset of the given set.
+   *
+   * @param set The original set.
+   * @param subset The subset to validate whether it is indeed a subset of the given set.
+   * @return True if the topicPartitions of the given subset constitute a subset of the given set, false otherwise.
+   */
+  public static boolean isSubset(Set<TopicPartition> set, Collection<ExecutionTask> subset) {
+    boolean isSubset = true;
+    for (ExecutionTask executionTask : subset) {
+      TopicPartition tp = executionTask.proposal().topicPartition();
+      if (!set.contains(tp)) {
+        isSubset = false;
+        break;
+      }
+    }
+
+    return isSubset;
+  }
+
+  /**
+   * Deletes zNodes for ongoing replica and leadership movement tasks. Then deletes controller zNode to trigger a
+   * controller re-election for the cancellation to take effect.
+   *
+   * This operation has side-effects that may leave partitions with extra replication factor and changes the controller.
+   * Hence, it will be deprecated in Kafka 2.4+, which introduced PartitionReassignment Kafka API to enable graceful and
+   * instant mechanism to cancel ongoing replica reassignments.
+   *
+   * @param kafkaZkClient KafkaZkClient to use for deleting the relevant zNodes to force stop the execution (if any).
+   */
+  public static void deleteZNodesToStopExecution(KafkaZkClient kafkaZkClient) {
+    // Delete zNode of ongoing replica movement tasks.
+    LOG.info("Deleting zNode for ongoing replica movements {}.", kafkaZkClient.getPartitionReassignment());
+    kafkaZkClient.deletePartitionReassignment(ZkVersion.MatchAnyVersion());
+    // delete zNode of ongoing leadership movement tasks.
+    LOG.info("Deleting zNode for ongoing leadership changes {}.", kafkaZkClient.getPreferredReplicaElection());
+    kafkaZkClient.deletePreferredReplicaElection(ZkVersion.MatchAnyVersion());
+    // Delete controller zNode to trigger a controller re-election.
+    LOG.info("Deleting controller zNode to re-elect a new controller. Old controller is {}.", kafkaZkClient.getControllerId());
+    kafkaZkClient.deleteController(ZkVersion.MatchAnyVersion());
+  }
+
+  /**
+   * Check if the given task is done.
+   * For what it means to be done, see {@link #isInterBrokerReplicaActionDone}, {@link #isIntraBrokerReplicaActionDone},
+   * and {@link #isLeadershipMovementDone}.
+   *
+   * @param cluster Kafka cluster.
+   * @param logdirInfoByTask Disk information for the intra-broker replica movement task, ignored otherwise.
+   * @param task Task to check for being done.
+   * @return {@code true} if task is done, {@code false} otherwise.
+   */
+  public static boolean isTaskDone(Cluster cluster,
+                                   Map<ExecutionTask, DescribeReplicaLogDirsResult.ReplicaLogDirInfo> logdirInfoByTask,
+                                   ExecutionTask task) {
+    switch (task.type()) {
+      case INTER_BROKER_REPLICA_ACTION:
+        return isInterBrokerReplicaActionDone(cluster, task);
+      case INTRA_BROKER_REPLICA_ACTION:
+        return isIntraBrokerReplicaActionDone(logdirInfoByTask, task);
+      case LEADER_ACTION:
+        return isLeadershipMovementDone(cluster, task);
+      default:
+        throw new IllegalStateException("Unknown task type " + task.type());
+    }
+  }
+
+  /**
+   * For an inter-broker replica movement action, the completion depends on the task state:
+   * <ul>
+   *   <li>{@link ExecutionTask.State#IN_PROGRESS}: when the current replica list is the same as the new replica list
+   *   and all replicas are in-sync.</li>
+   *   <li>{@link ExecutionTask.State#ABORTING}: done when the current replica list is the same as the old replica list.
+   *   Due to race condition, we also consider it done if the current replica list is the same as the new replica list
+   *   and all replicas are in-sync.</li>
+   *   <li>{@link ExecutionTask.State#DEAD}: always considered as done because we neither move forward or rollback.</li>
+   * </ul>
+   *
+   * There should be no other task state seen here.
+   *
+   * @param cluster Kafka cluster.
+   * @param task Task to check for being done.
+   * @return {@code true} if task is done, {@code false} otherwise.
+   */
+  private static boolean isInterBrokerReplicaActionDone(Cluster cluster, ExecutionTask task) {
+    PartitionInfo partitionInfo = cluster.partition(task.proposal().topicPartition());
+    switch (task.state()) {
+      case IN_PROGRESS:
+        return task.proposal().isInterBrokerMovementCompleted(partitionInfo);
+      case ABORTING:
+        return task.proposal().isInterBrokerMovementAborted(partitionInfo);
+      case DEAD:
+        return true;
+      default:
+        throw new IllegalStateException("Should never be here. State " + task.state());
+    }
+  }
+
+  /**
+   * Check whether intra-broker replica movement is done by comparing replica's current logdir with the logdir proposed
+   * by task's proposal.
+   *
+   * @param logdirInfoByTask Disk information by task.
+   * @param task Task to check for being done.
+   * @return {@code true} if task is done, {@code false} otherwise.
+   */
+  private static boolean isIntraBrokerReplicaActionDone(
+      Map<ExecutionTask, DescribeReplicaLogDirsResult.ReplicaLogDirInfo> logdirInfoByTask,
+      ExecutionTask task) {
+    if (logdirInfoByTask.containsKey(task)) {
+      return logdirInfoByTask.get(task).getCurrentReplicaLogDir()
+                             .equals(task.proposal().replicasToMoveBetweenDisksByBroker().get(task.brokerId()).logdir());
+    }
+    return false;
+  }
+
+  /**
+   * The completeness of leadership movement depends on the task state:
+   * <ul>
+   *   <li>{@link ExecutionTask.State#IN_PROGRESS}: Done when either (1) the proposed leader becomes the leader, (2) the
+   *   partition has no leader in the cluster (e.g. deleted or offline), or (3) the partition has another leader and the
+   *   proposed leader is out of ISR.</li>
+   *   <li>{@link ExecutionTask.State#ABORTING} or {@link ExecutionTask.State#DEAD}: Always considered as done. The
+   *   destination cannot become leader anymore.</li>
+   * </ul>
+   *
+   * There should be no other task state seen here.
+   *
+   * @param cluster Kafka cluster.
+   * @param task Task to check for being done.
+   * @return {@code true} if task is done, {@code false} otherwise.
+   */
+  private static boolean isLeadershipMovementDone(Cluster cluster, ExecutionTask task) {
+    switch (task.state()) {
+      case IN_PROGRESS:
+        TopicPartition tp = task.proposal().topicPartition();
+        Node leader = cluster.leaderFor(tp);
+        return (leader != null && leader.id() == task.proposal().newLeader().brokerId())
+               || leader == null
+               || !isInIsr(task.proposal().newLeader().brokerId(), cluster, tp);
+      case ABORTING:
+      case DEAD:
+        return true;
+      default:
+        throw new IllegalStateException("Should never be here.");
+    }
+  }
+
+  private static boolean isInIsr(Integer leader, Cluster cluster, TopicPartition tp) {
+    return Arrays.stream(cluster.partition(tp).inSyncReplicas()).anyMatch(node -> node.id() == leader);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
@@ -21,6 +21,16 @@ import org.slf4j.LoggerFactory;
 
 public final class ExecutionUtils {
   private static final Logger LOG = LoggerFactory.getLogger(ExecutionUtils.class);
+  public static final long METADATA_REFRESH_BACKOFF = 100L;
+  public static final long METADATA_EXPIRY_MS = Long.MAX_VALUE;
+  public static final String EXECUTION_STARTED = "execution-started";
+  public static final String KAFKA_ASSIGNER_MODE = "kafka_assigner";
+  public static final String EXECUTION_STOPPED = "execution-stopped";
+  public static final String GAUGE_EXECUTION_STOPPED = EXECUTION_STOPPED;
+  public static final String GAUGE_EXECUTION_STOPPED_BY_USER = EXECUTION_STOPPED + "-by-user";
+  public static final String GAUGE_EXECUTION_STARTED_IN_KAFKA_ASSIGNER_MODE = EXECUTION_STARTED + "-" + KAFKA_ASSIGNER_MODE;
+  public static final String GAUGE_EXECUTION_STARTED_IN_NON_KAFKA_ASSIGNER_MODE = EXECUTION_STARTED + "-non-" + KAFKA_ASSIGNER_MODE;
+
 
   private ExecutionUtils() { }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorState.java
@@ -125,16 +125,17 @@ public class ExecutorState {
     INTER_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS,
     INTRA_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS,
     LEADER_MOVEMENT_TASK_IN_PROGRESS,
-    STOPPING_EXECUTION
+    STOPPING_EXECUTION,
+    INITIALIZING_PROPOSAL_EXECUTION
   }
 
   public static final Set<State> IN_PROGRESS_STATES;
   static {
     Set<State> inProgressStates = new HashSet<>(4);
     inProgressStates.addAll(Arrays.asList(State.INTER_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS,
-                                            State.INTRA_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS,
-                                            State.LEADER_MOVEMENT_TASK_IN_PROGRESS,
-                                            State.STOPPING_EXECUTION));
+                                          State.INTRA_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS,
+                                          State.LEADER_MOVEMENT_TASK_IN_PROGRESS,
+                                          State.STOPPING_EXECUTION));
     IN_PROGRESS_STATES = Collections.unmodifiableSet(inProgressStates);
   }
   private final State _state;
@@ -197,14 +198,39 @@ public class ExecutorState {
    * @param recentlyDemotedBrokers Recently demoted broker IDs.
    * @param recentlyRemovedBrokers Recently removed broker IDs.
    * @param isTriggeredByUserRequest Whether the execution is triggered by a user request.
-   * @return Executor state when the execution has started.
+   * @return Executor state when the execution is starting.
    */
-  public static ExecutorState executionStarted(String uuid,
-                                               String reason,
-                                               Set<Integer> recentlyDemotedBrokers,
-                                               Set<Integer> recentlyRemovedBrokers,
-                                               boolean isTriggeredByUserRequest) {
+  public static ExecutorState executionStarting(String uuid,
+                                                String reason,
+                                                Set<Integer> recentlyDemotedBrokers,
+                                                Set<Integer> recentlyRemovedBrokers,
+                                                boolean isTriggeredByUserRequest) {
     return new ExecutorState(State.STARTING_EXECUTION,
+                             null,
+                             0,
+                             0,
+                             0,
+                             uuid,
+                             reason,
+                             recentlyDemotedBrokers,
+                             recentlyRemovedBrokers,
+                             isTriggeredByUserRequest);
+  }
+
+  /**
+   * @param uuid UUID of the current execution.
+   * @param reason Reason of the current execution.
+   * @param recentlyDemotedBrokers Recently demoted broker IDs.
+   * @param recentlyRemovedBrokers Recently removed broker IDs.
+   * @param isTriggeredByUserRequest Whether the execution is triggered by a user request.
+   * @return Executor state when initializing proposal execution.
+   */
+  public static ExecutorState initializeProposalExecution(String uuid,
+                                                          String reason,
+                                                          Set<Integer> recentlyDemotedBrokers,
+                                                          Set<Integer> recentlyRemovedBrokers,
+                                                          boolean isTriggeredByUserRequest) {
+    return new ExecutorState(State.INITIALIZING_PROPOSAL_EXECUTION,
                              null,
                              0,
                              0,
@@ -345,6 +371,7 @@ public class ExecutorState {
       case NO_TASK_IN_PROGRESS:
         break;
       case STARTING_EXECUTION:
+      case INITIALIZING_PROPOSAL_EXECUTION:
         populateUuidFieldInJsonStructure(execState, _uuid);
         execState.put(TRIGGERED_TASK_REASON, _reason);
         break;
@@ -448,6 +475,7 @@ public class ExecutorState {
       case NO_TASK_IN_PROGRESS:
         return String.format("{%s: %s%s%s}", STATE, _state, recentlyDemotedBrokers, recentlyRemovedBrokers);
       case STARTING_EXECUTION:
+      case INITIALIZING_PROPOSAL_EXECUTION:
         return String.format("{%s: %s, %s: %s, %s: %s%s%s}", STATE, _state,
                              _isTriggeredByUserRequest ? TRIGGERED_USER_TASK_ID : TRIGGERED_SELF_HEALING_TASK_ID,
                              _uuid, TRIGGERED_TASK_REASON, _reason, recentlyDemotedBrokers, recentlyRemovedBrokers);
@@ -473,18 +501,18 @@ public class ExecutorState {
                              TRIGGERED_TASK_REASON, _reason, recentlyDemotedBrokers, recentlyRemovedBrokers);
       case INTRA_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS:
         intraBrokerPartitionMovementStats = _executionTasksSummary.taskStat().get(INTRA_BROKER_REPLICA_ACTION);
-        return String.format("{%s: %s, pending/in-progress/aborting/finished/total intra-broker partition movement %d/%d/%d/%d/%d," +
-                " completed/total bytes(MB): %d/%d, maximum concurrent intra-broker partition movements per-broker: %d, %s: %s, %s: %s%s%s}",
-                STATE, _state,
-                intraBrokerPartitionMovementStats.get(PENDING),
-                intraBrokerPartitionMovementStats.get(IN_PROGRESS),
-                intraBrokerPartitionMovementStats.get(ABORTING),
-                numFinishedMovements(INTRA_BROKER_REPLICA_ACTION),
-                numTotalMovements(INTRA_BROKER_REPLICA_ACTION),
-                _executionTasksSummary.finishedIntraBrokerDataMovementInMB(),
-                numTotalIntraBrokerDataToMove(), _maximumConcurrentIntraBrokerPartitionMovementsPerBroker,
-                _isTriggeredByUserRequest ? TRIGGERED_USER_TASK_ID : TRIGGERED_SELF_HEALING_TASK_ID, _uuid,
-                TRIGGERED_TASK_REASON, _reason, recentlyDemotedBrokers, recentlyRemovedBrokers);
+        return String.format("{%s: %s, pending/in-progress/aborting/finished/total intra-broker partition movement %d/%d/%d/%d/%d, completed/total"
+                             + " bytes(MB): %d/%d, maximum concurrent intra-broker partition movements per-broker: %d, %s: %s, %s: %s%s%s}",
+                             STATE, _state,
+                             intraBrokerPartitionMovementStats.get(PENDING),
+                             intraBrokerPartitionMovementStats.get(IN_PROGRESS),
+                             intraBrokerPartitionMovementStats.get(ABORTING),
+                             numFinishedMovements(INTRA_BROKER_REPLICA_ACTION),
+                             numTotalMovements(INTRA_BROKER_REPLICA_ACTION),
+                             _executionTasksSummary.finishedIntraBrokerDataMovementInMB(),
+                             numTotalIntraBrokerDataToMove(), _maximumConcurrentIntraBrokerPartitionMovementsPerBroker,
+                             _isTriggeredByUserRequest ? TRIGGERED_USER_TASK_ID : TRIGGERED_SELF_HEALING_TASK_ID, _uuid,
+                             TRIGGERED_TASK_REASON, _reason, recentlyDemotedBrokers, recentlyRemovedBrokers);
       case STOPPING_EXECUTION:
         interBrokerPartitionMovementStats = _executionTasksSummary.taskStat().get(INTER_BROKER_REPLICA_ACTION);
         intraBrokerPartitionMovementStats = _executionTasksSummary.taskStat().get(INTRA_BROKER_REPLICA_ACTION);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/task/SampleLoadingTask.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/task/SampleLoadingTask.java
@@ -4,35 +4,25 @@
 
 package com.linkedin.kafka.cruisecontrol.monitor.task;
 
-import com.linkedin.kafka.cruisecontrol.executor.Executor;
 import com.linkedin.kafka.cruisecontrol.model.ModelParameters;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.SampleStore;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.aggregator.KafkaBrokerMetricSampleAggregator;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.aggregator.KafkaPartitionMetricSampleAggregator;
-
-import static com.linkedin.kafka.cruisecontrol.executor.ExecutorState.State.NO_TASK_IN_PROGRESS;
-
 
 public class SampleLoadingTask implements Runnable {
   private final SampleStore _sampleStore;
   private final KafkaPartitionMetricSampleAggregator _partitionMetricSampleAggregator;
   private final KafkaBrokerMetricSampleAggregator _brokerMetricSampleAggregator;
   private final LoadMonitorTaskRunner _loadMonitorTaskRunner;
-  private final Executor _executor;
 
   SampleLoadingTask(SampleStore sampleStore,
                     KafkaPartitionMetricSampleAggregator partitionMetricSampleAggregator,
                     KafkaBrokerMetricSampleAggregator brokerMetricSampleAggregator,
-                    LoadMonitorTaskRunner loadMonitorTaskRunner,
-                    Executor executor) {
+                    LoadMonitorTaskRunner loadMonitorTaskRunner) {
     _sampleStore = sampleStore;
     _partitionMetricSampleAggregator = partitionMetricSampleAggregator;
     _brokerMetricSampleAggregator = brokerMetricSampleAggregator;
     _loadMonitorTaskRunner = loadMonitorTaskRunner;
-    if (executor == null) {
-      throw new IllegalArgumentException("Executor is not provided.");
-    }
-    _executor = executor;
   }
 
   @Override
@@ -42,18 +32,9 @@ public class SampleLoadingTask implements Runnable {
                                                             _brokerMetricSampleAggregator));
       ModelParameters.updateModelCoefficient();
     } finally {
-      // If Cruise Control has triggered operations before loading is finished, transfer monitor state to paused state;
-      // otherwise transfer to running state.
-      synchronized (_loadMonitorTaskRunner) {
-        if (_executor.state().state() != NO_TASK_IN_PROGRESS) {
-          _loadMonitorTaskRunner.compareAndSetState(LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.LOADING,
-                                                    LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.PAUSED);
-          _loadMonitorTaskRunner.setReasonOfLatestPauseOrResume("Paused-By-Cruise-Control-Before-Starting-Execution");
-        } else {
-          _loadMonitorTaskRunner.compareAndSetState(LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.LOADING,
-                                                    LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.RUNNING);
-        }
-      }
+      // The sample loading task is run before the load monitor starts regardless of any ongoing execution.
+      _loadMonitorTaskRunner.compareAndSetState(LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.LOADING,
+                                                LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.RUNNING);
     }
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlState.java
@@ -22,12 +22,11 @@ import com.google.gson.Gson;
 import java.util.Set;
 import java.util.StringJoiner;
 
+import static com.linkedin.kafka.cruisecontrol.executor.ExecutorState.IN_PROGRESS_STATES;
 import static com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils.JSON_VERSION;
 import static com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils.VERSION;
 import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTask.TaskType;
 import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTask.State;
-import static com.linkedin.kafka.cruisecontrol.executor.ExecutorState.State.NO_TASK_IN_PROGRESS;
-import static com.linkedin.kafka.cruisecontrol.executor.ExecutorState.State.STARTING_EXECUTION;
 
 @JsonResponseClass
 public class CruiseControlState extends AbstractCruiseControlResponse {
@@ -129,8 +128,8 @@ public class CruiseControlState extends AbstractCruiseControlResponse {
 
   protected void writeVerboseExecutorState(StringBuilder sb) {
     if (_executorState != null) {
-      // There is no execution task summary if executor is in idle state.
-      if (_executorState.state() == NO_TASK_IN_PROGRESS || _executorState.state() == STARTING_EXECUTION) {
+      // There is no execution task summary if no execution is in progress.
+      if (!IN_PROGRESS_STATES.contains(_executorState.state())) {
         return;
       }
       Map<TaskType, Map<State, Set<ExecutionTask>>> taskSnapshot = _executorState.executionTasksSummary().filteredTasksByState();

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -235,7 +235,6 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
     Executor executor = new Executor(configs, time, new MetricRegistry(), mockMetadataClient, DEMOTION_HISTORY_RETENTION_TIME_MS,
                                      REMOVAL_HISTORY_RETENTION_TIME_MS, null, mockUserTaskManager,
                                      mockAnomalyDetector);
-    executor.setExecutionMode(false);
     executor.executeProposals(proposalsToExecute,
                               Collections.emptySet(),
                               null,
@@ -248,7 +247,8 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
                               null,
                               true,
                               RANDOM_UUID,
-                              ExecutorTest.class::getSimpleName);
+                              ExecutorTest.class::getSimpleName,
+                              false);
     waitUntilTrue(() -> (executor.state().state() == ExecutorState.State.LEADER_MOVEMENT_TASK_IN_PROGRESS && !executor.inExecutionTasks().isEmpty()),
                   "Leader movement task did not start within the time limit",
                   EXECUTION_DEADLINE_MS, EXECUTION_SHORT_CHECK_MS);
@@ -277,7 +277,8 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
                               null,
                               true,
                               RANDOM_UUID,
-                              ExecutorTest.class::getSimpleName);
+                              ExecutorTest.class::getSimpleName,
+                              false);
     waitUntilTrue(() -> (executor.state().state() == ExecutorState.State.INTER_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS),
                   "Inter-broker replica movement task did not start within the time limit",
                   EXECUTION_DEADLINE_MS, EXECUTION_SHORT_CHECK_MS);
@@ -473,7 +474,6 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
     Executor executor = new Executor(configs, new SystemTime(), new MetricRegistry(), null, DEMOTION_HISTORY_RETENTION_TIME_MS,
                                      REMOVAL_HISTORY_RETENTION_TIME_MS, mockExecutorNotifier, mockUserTaskManager,
                                      mockAnomalyDetector);
-    executor.setExecutionMode(false);
     Map<TopicPartition, Integer> replicationFactors = new HashMap<>(proposalsToCheck.size());
     for (ExecutionProposal proposal : proposalsToCheck) {
       TopicPartition tp = new TopicPartition(proposal.topic(), proposal.partitionId());
@@ -481,8 +481,8 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
     }
 
     executor.executeProposals(proposalsToExecute, Collections.emptySet(), null, mockLoadMonitor, null,
-                              null, null, null,
-                              null, replicationThrottle, isTriggeredByUserRequest, RANDOM_UUID, ExecutorTest.class::getSimpleName);
+                              null, null, null, null,
+                              replicationThrottle, isTriggeredByUserRequest, RANDOM_UUID, ExecutorTest.class::getSimpleName, false);
 
     if (verifyProgress) {
       waitUntilTrue(() -> ExecutorUtils.partitionsBeingReassigned(kafkaZkClient).contains(TP0),

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -111,7 +111,7 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
       List<ExecutionProposal> proposalsToExecute = new ArrayList<>();
       List<ExecutionProposal> proposalsToCheck = new ArrayList<>();
       populateProposals(proposalsToExecute, proposalsToCheck, 0);
-      executeAndVerifyProposals(kafkaZkClient, proposalsToExecute, proposalsToCheck, false, null, false);
+      executeAndVerifyProposals(kafkaZkClient, proposalsToExecute, proposalsToCheck, false, null, false, true);
     } finally {
       KafkaCruiseControlUtils.closeKafkaZkClientWithTimeout(kafkaZkClient);
     }
@@ -128,7 +128,7 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
       List<ExecutionProposal> proposalsToCheck = new ArrayList<>();
       populateProposals(proposalsToExecute, proposalsToCheck, PRODUCE_SIZE_IN_BYTES);
       // Throttle rate is set to the half of the produce size.
-      executeAndVerifyProposals(kafkaZkClient, proposalsToExecute, proposalsToCheck, false, PRODUCE_SIZE_IN_BYTES / 2, true);
+      executeAndVerifyProposals(kafkaZkClient, proposalsToExecute, proposalsToCheck, false, PRODUCE_SIZE_IN_BYTES / 2, true, true);
     } finally {
       KafkaCruiseControlUtils.closeKafkaZkClientWithTimeout(kafkaZkClient);
     }
@@ -159,7 +159,7 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
                                               new ReplicaPlacementInfo(initialLeader1)));
 
       Collection<ExecutionProposal> proposalsToExecute = Arrays.asList(proposal0, proposal1);
-      executeAndVerifyProposals(kafkaZkClient, proposalsToExecute, Collections.emptyList(), true, null, false);
+      executeAndVerifyProposals(kafkaZkClient, proposalsToExecute, Collections.emptyList(), true, null, false, false);
 
       // We are not doing the rollback.
       assertEquals(Collections.singletonList(initialLeader0 == 0 ? 1 : 0),
@@ -176,8 +176,11 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
   @Test
   public void testExecutionKnobs() {
     KafkaCruiseControlConfig config = new KafkaCruiseControlConfig(getExecutorProperties());
+    assertThrows(IllegalStateException.class,
+                 () -> new Executor(config, null, new MetricRegistry(), EasyMock.mock(MetadataClient.class), DEMOTION_HISTORY_RETENTION_TIME_MS,
+                                    REMOVAL_HISTORY_RETENTION_TIME_MS, null, null, null));
     Executor executor = new Executor(config, null, new MetricRegistry(), EasyMock.mock(MetadataClient.class), DEMOTION_HISTORY_RETENTION_TIME_MS,
-                                     REMOVAL_HISTORY_RETENTION_TIME_MS, null, null, null);
+                                     REMOVAL_HISTORY_RETENTION_TIME_MS, null, null, EasyMock.mock(AnomalyDetector.class));
 
     // Verify correctness of set/get requested execution progress check interval.
     long defaultExecutionProgressCheckIntervalMs = config.getLong(ExecutorConfig.EXECUTION_PROGRESS_CHECK_INTERVAL_MS_CONFIG);
@@ -443,12 +446,14 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
                                          Collection<ExecutionProposal> proposalsToCheck,
                                          boolean completeWithError,
                                          Long replicationThrottle,
-                                         boolean verifyProgress)
+                                         boolean verifyProgress,
+                                         boolean isTriggeredByUserRequest)
       throws OngoingExecutionException {
     KafkaCruiseControlConfig configs = new KafkaCruiseControlConfig(getExecutorProperties());
     UserTaskManager.UserTaskInfo mockUserTaskInfo = getMockUserTaskInfo();
-    UserTaskManager mockUserTaskManager = getMockUserTaskManager(RANDOM_UUID, mockUserTaskInfo,
-                                                                 Collections.singletonList(completeWithError));
+    UserTaskManager mockUserTaskManager = isTriggeredByUserRequest ? getMockUserTaskManager(RANDOM_UUID, mockUserTaskInfo,
+                                                                                            Collections.singletonList(completeWithError))
+                                                                   : null;
     ExecutorNotifier mockExecutorNotifier = EasyMock.mock(ExecutorNotifier.class);
     LoadMonitor mockLoadMonitor = getMockLoadMonitor();
     Capture<String> captureMessage = Capture.newInstance(CaptureType.FIRST);
@@ -460,7 +465,11 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
       mockExecutorNotifier.sendNotification(EasyMock.capture(captureMessage));
     }
 
-    EasyMock.replay(mockUserTaskInfo, mockUserTaskManager, mockExecutorNotifier, mockLoadMonitor, mockAnomalyDetector);
+    if (isTriggeredByUserRequest) {
+      EasyMock.replay(mockUserTaskInfo, mockUserTaskManager, mockExecutorNotifier, mockLoadMonitor, mockAnomalyDetector);
+    } else {
+      EasyMock.replay(mockUserTaskInfo, mockExecutorNotifier, mockLoadMonitor, mockAnomalyDetector);
+    }
     Executor executor = new Executor(configs, new SystemTime(), new MetricRegistry(), null, DEMOTION_HISTORY_RETENTION_TIME_MS,
                                      REMOVAL_HISTORY_RETENTION_TIME_MS, mockExecutorNotifier, mockUserTaskManager,
                                      mockAnomalyDetector);
@@ -473,7 +482,7 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
 
     executor.executeProposals(proposalsToExecute, Collections.emptySet(), null, mockLoadMonitor, null,
                               null, null, null,
-                              null, replicationThrottle, true, RANDOM_UUID, ExecutorTest.class::getSimpleName);
+                              null, replicationThrottle, isTriggeredByUserRequest, RANDOM_UUID, ExecutorTest.class::getSimpleName);
 
     if (verifyProgress) {
       waitUntilTrue(() -> ExecutorUtils.partitionsBeingReassigned(kafkaZkClient).contains(TP0),
@@ -505,7 +514,11 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
                    proposal.newLeader().brokerId(), kafkaZkClient.getLeaderForPartition(tp).get());
 
     }
-    EasyMock.verify(mockUserTaskInfo, mockUserTaskManager, mockExecutorNotifier, mockLoadMonitor, mockAnomalyDetector);
+    if (isTriggeredByUserRequest) {
+      EasyMock.verify(mockUserTaskInfo, mockUserTaskManager, mockExecutorNotifier, mockLoadMonitor, mockAnomalyDetector);
+    } else {
+      EasyMock.verify(mockUserTaskInfo, mockExecutorNotifier, mockLoadMonitor, mockAnomalyDetector);
+    }
   }
 
   private Properties getExecutorProperties() {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
@@ -17,7 +17,6 @@ import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.ExecutorConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
 import com.linkedin.kafka.cruisecontrol.exception.BrokerCapacityResolutionException;
-import com.linkedin.kafka.cruisecontrol.executor.Executor;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import com.linkedin.kafka.cruisecontrol.model.ModelParameters;
 import com.linkedin.kafka.cruisecontrol.monitor.metricdefinition.KafkaMetricDef;
@@ -50,7 +49,6 @@ import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUnitTestUtils.w
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC0;
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC1;
 import static com.linkedin.kafka.cruisecontrol.monitor.MonitorUnitTestUtils.getMetadata;
-import static com.linkedin.kafka.cruisecontrol.executor.ExecutorState.noTaskInProgress;
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.DEFAULT_START_TIME_FOR_CLUSTER_MODEL;
 import static org.apache.kafka.common.KafkaFuture.completedFuture;
 import static org.easymock.EasyMock.*;
@@ -540,13 +538,6 @@ public class LoadMonitorTest {
             .anyTimes();
     EasyMock.replay(mockAdminClient);
 
-    // Create mock executor.
-    Executor mockExecutor = EasyMock.mock(Executor.class);
-    EasyMock.expect(mockExecutor.state())
-            .andReturn(noTaskInProgress(null, null))
-            .anyTimes();
-    EasyMock.replay(mockExecutor);
-
     // Create load monitor.
     Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
     props.put(MonitorConfig.NUM_PARTITION_METRICS_WINDOWS_CONFIG, Integer.toString(numWindowToPreserve));
@@ -564,7 +555,7 @@ public class LoadMonitorTest {
     }
     KafkaCruiseControlConfig config = new KafkaCruiseControlConfig(props);
     _time = new MockTime(0, START_TIME_MS, TimeUnit.NANOSECONDS.convert(START_TIME_MS, TimeUnit.MILLISECONDS));
-    LoadMonitor loadMonitor = new LoadMonitor(config, mockMetadataClient, mockAdminClient, _time, mockExecutor, new MetricRegistry(), METRIC_DEF);
+    LoadMonitor loadMonitor = new LoadMonitor(config, mockMetadataClient, mockAdminClient, _time, new MetricRegistry(), METRIC_DEF);
 
     KafkaPartitionMetricSampleAggregator aggregator = loadMonitor.partitionSampleAggregator();
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/task/LoadMonitorTaskRunnerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/task/LoadMonitorTaskRunnerTest.java
@@ -110,7 +110,7 @@ public class LoadMonitorTaskRunnerTest extends CCKafkaIntegrationTestHarness {
                                  metadataClient, METRIC_DEF, TIME, dropwizardMetricRegistry, null, sampler);
     LoadMonitorTaskRunner loadMonitorTaskRunner =
         new LoadMonitorTaskRunner(config, fetcherManager, mockPartitionMetricSampleAggregator,
-                                  mockBrokerMetricSampleAggregator, metadataClient, null, TIME);
+                                  mockBrokerMetricSampleAggregator, metadataClient, TIME);
     while (metadata.fetch().topics().size() < NUM_TOPICS) {
       Thread.sleep(10);
       metadataClient.refreshMetadata();
@@ -159,7 +159,7 @@ public class LoadMonitorTaskRunnerTest extends CCKafkaIntegrationTestHarness {
                                  METRIC_DEF, TIME, dropwizardMetricRegistry, null, sampler);
     LoadMonitorTaskRunner loadMonitorTaskRunner =
         new LoadMonitorTaskRunner(config, fetcherManager, mockMetricSampleAggregator, mockBrokerMetricSampleAggregator,
-                                  metadataClient, null, TIME);
+                                  metadataClient, TIME);
     while (metadata.fetch().topics().size() < 100) {
       metadataClient.refreshMetadata();
     }
@@ -194,7 +194,7 @@ public class LoadMonitorTaskRunnerTest extends CCKafkaIntegrationTestHarness {
   }
 
   // A simple metric sampler that increment the mock time by 1
-  private class MockSampler implements MetricSampler {
+  private static class MockSampler implements MetricSampler {
     private int _exceptionsLeft;
 
     MockSampler(int numExceptions) {
@@ -276,7 +276,7 @@ public class LoadMonitorTaskRunnerTest extends CCKafkaIntegrationTestHarness {
     }
 
     @Override
-    public void waitObject(Object obj, Supplier<Boolean> condition, long timeoutMs) throws InterruptedException {
+    public void waitObject(Object obj, Supplier<Boolean> condition, long timeoutMs) {
       // Noop
     }
   }

--- a/cruise-control/src/yaml/responses/executorState.yaml
+++ b/cruise-control/src/yaml/responses/executorState.yaml
@@ -18,6 +18,7 @@ ExecutorState:
         - INTRA_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS
         - LEADER_MOVEMENT_TASK_IN_PROGRESS
         - STOPPING_EXECUTION
+        - INITIALIZING_PROPOSAL_EXECUTION
     recentlyDemotedBrokers:
       type: array
       items:

--- a/docs/wiki/User Guide/REST-APIs.md
+++ b/docs/wiki/User Guide/REST-APIs.md
@@ -72,7 +72,8 @@ The returned state contains the following information:
 	   `INTER_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS` /
 	   `INTRA_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS` /
 	   `LEADER_MOVEMENT_TASK_IN_PROGRESS` /
-	   `STOPPING_EXECUTION`
+	   `STOPPING_EXECUTION` /
+	   `INITIALIZING_PROPOSAL_EXECUTION`
   * Inter-broker replica movement progress (if state is `INTER_BROKER_REPLICA_MOVEMENT_IN_PROGRESS`)
   * Intra-broker replica movement progress (if state is `INTRA_BROKER_REPLICA_MOVEMENT_IN_PROGRESS`)
   * Leadership movement progress (if state is `LEADERSHIP_MOVEMENT`)

--- a/docs/wiki/User Guide/REST-APIs.md
+++ b/docs/wiki/User Guide/REST-APIs.md
@@ -68,10 +68,11 @@ The returned state contains the following information:
   * Time and reason of recently sampling task pause/resume
 * **Executor State**:
   * State: `NO_TASK_IN_PROGRESS` /
-	   `EXECUTION_STARTED` /
-	   `INTER_BROKER_REPLICA_MOVEMENT_IN_PROGRESS` /
-           `INTRA_BROKER_REPLICA_MOVEMENT_IN_PROGRESS` /
-	   `LEADER_MOVEMENT_IN_PROGRESS`
+	   `STARTING_EXECUTION` /
+	   `INTER_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS` /
+	   `INTRA_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS` /
+	   `LEADER_MOVEMENT_TASK_IN_PROGRESS` /
+	   `STOPPING_EXECUTION`
   * Inter-broker replica movement progress (if state is `INTER_BROKER_REPLICA_MOVEMENT_IN_PROGRESS`)
   * Intra-broker replica movement progress (if state is `INTRA_BROKER_REPLICA_MOVEMENT_IN_PROGRESS`)
   * Leadership movement progress (if state is `LEADERSHIP_MOVEMENT`)


### PR DESCRIPTION
This PR resolves #969 and #1259.

* Removes pause sampling after loading regardless of ongoing execution
* Ensures that executor state is consistent within ProposalExecutionRunnable in preparation for #909.
* Adds `INITIALIZING_PROPOSAL_EXECUTION` executor state for #909.
* Extracts execution util functions to a utility class.