### PR TITLE
Add summary response to kafka_cluster_state

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionState.java
@@ -20,17 +20,17 @@ import org.apache.kafka.common.PartitionInfo;
 @JsonResponseClass
 public class ClusterPartitionState {
   @JsonResponseField
-  protected static final String OFFLINE = "offline";
+  public static final String OFFLINE = "offline";
   @JsonResponseField
-  protected static final String WITH_OFFLINE_REPLICAS = "with-offline-replicas";
+  public static final String WITH_OFFLINE_REPLICAS = "with-offline-replicas";
   @JsonResponseField
-  protected static final String URP = "urp";
+  public static final String URP = "urp";
   @JsonResponseField
-  protected static final String UNDER_MIN_ISR = "under-min-isr";
+  public static final String UNDER_MIN_ISR = "under-min-isr";
   @JsonResponseField(required = false)
-  protected static final String OTHER = "other";
-  protected static final String MIN_INSYNC_REPLICAS = "min.insync.replicas";
-  protected static final int DEFAULT_MIN_INSYNC_REPLICAS = 1;
+  public static final String OTHER = "other";
+  public static final String MIN_INSYNC_REPLICAS = "min.insync.replicas";
+  public static final int DEFAULT_MIN_INSYNC_REPLICAS = 1;
 
   protected final Set<PartitionInfo> _underReplicatedPartitions;
   protected final Set<PartitionInfo> _offlinePartitions;
@@ -54,10 +54,13 @@ public class ClusterPartitionState {
     _underMinIsrPartitions = new TreeSet<>(comparator);
     // Gather the partition state.
     populateKafkaPartitionState(_underReplicatedPartitions, _offlinePartitions, _otherPartitions,
-        _partitionsWithOfflineReplicas, _underMinIsrPartitions, verbose, topicPattern);
+                                _partitionsWithOfflineReplicas, _underMinIsrPartitions, verbose, topicPattern);
   }
 
-  protected Map<String, Object> getJsonStructure() {
+  /**
+   * @return response with JSON structure.
+   */
+  public Map<String, Object> getJsonStructure() {
     // Write the partition state.
     Map<String, Object> jsonMap = new HashMap<>();
     jsonMap.put(OFFLINE, getJsonPartitions(_offlinePartitions));
@@ -83,12 +86,12 @@ public class ClusterPartitionState {
    * @param topicPattern regex of topic to filter partition states by, is null if no filter is to be applied
    */
   protected void populateKafkaPartitionState(Set<PartitionInfo> underReplicatedPartitions,
-      Set<PartitionInfo> offlinePartitions,
-      Set<PartitionInfo> otherPartitions,
-      Set<PartitionInfo> partitionsWithOfflineReplicas,
-      Set<PartitionInfo> underMinIsrPartitions,
-      boolean verbose,
-      Pattern topicPattern) {
+                                             Set<PartitionInfo> offlinePartitions,
+                                             Set<PartitionInfo> otherPartitions,
+                                             Set<PartitionInfo> partitionsWithOfflineReplicas,
+                                             Set<PartitionInfo> underMinIsrPartitions,
+                                             boolean verbose,
+                                             Pattern topicPattern) {
     for (String topic : _kafkaCluster.topics()) {
       if (topicPattern == null || topicPattern.matcher(topic).matches()) {
         int minInsyncReplicas = minInsyncReplicas(topic);
@@ -144,13 +147,19 @@ public class ClusterPartitionState {
     return partitionList;
   }
 
-  protected void writePartitionSummary(StringBuilder sb, boolean verbose) {
+
+  /**
+   * Write broker summary
+   * @param sb String builder to write the response to.
+   * @param verbose True if verbose, false otherwise.
+   */
+  public void writePartitionSummary(StringBuilder sb, boolean verbose) {
     int topicNameLength = _kafkaCluster.topics().stream().mapToInt(String::length).max().orElse(20) + 5;
 
     String initMessage = verbose ? "All Partitions in the Cluster (verbose):"
-        : "Under Replicated, Offline, and Under MinIsr Partitions:";
+                                 : "Under Replicated, Offline, and Under MinIsr Partitions:";
     sb.append(String.format("%n%s%n%" + topicNameLength + "s%10s%10s%30s%30s%25s%25s%n", initMessage, "TOPIC",
-        "PARTITION", "LEADER", "REPLICAS", "IN-SYNC", "OUT-OF-SYNC", "OFFLINE"));
+                            "PARTITION", "LEADER", "REPLICAS", "IN-SYNC", "OUT-OF-SYNC", "OFFLINE"));
 
     // Write the cluster state.
     sb.append(String.format("Offline Partitions:%n"));

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterStats.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterStats.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.response;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * A class to keep selected stats concerning brokers, topics, replicas, and leaders -- per broker topic stats are
+ * omitted for simplicity.
+ */
+@JsonResponseClass
+public class ClusterStats {
+  @JsonResponseField
+  public static final String BROKERS = "Brokers";
+  @JsonResponseField
+  public static final String TOPICS = "Topics";
+  @JsonResponseField
+  public static final String REPLICAS = "Replicas";
+  @JsonResponseField
+  public static final String LEADERS = "Leaders";
+  @JsonResponseField
+  public static final String AVG_REPLICATION_FACTOR = "AvgReplicationFactor";
+  @JsonResponseField
+  public static final String AVG_REPLICAS_PER_BROKER = "AvgReplicasPerBroker";
+  @JsonResponseField
+  public static final String AVG_LEADERS_PER_BROKER = "AvgLeadersPerBroker";
+  @JsonResponseField
+  public static final String MAX_REPLICAS_PER_BROKER = "MaxReplicasPerBroker";
+  @JsonResponseField
+  public static final String MAX_LEADERS_PER_BROKER = "MaxLeadersPerBroker";
+  @JsonResponseField
+  public static final String STD_REPLICAS_PER_BROKER = "StdReplicasPerBroker";
+  @JsonResponseField
+  public static final String STD_LEADERS_PER_BROKER = "StdLeadersPerBroker";
+  protected final int _numBrokers;
+  protected final int _numTopics;
+  protected final int _numReplicas;
+  protected final int _numLeaders;
+  protected final double _avgReplicationFactor;
+  protected final double _avgReplicasPerBroker;
+  protected final double _avgLeadersPerBroker;
+  protected final int _maxReplicasPerBroker;
+  protected final int _maxLeadersPerBroker;
+  protected final double _stdReplicasPerBroker;
+  protected final double _stdLeadersPerBroker;
+
+  public ClusterStats(int numTopics, Map<Integer, Integer> replicaCountByBrokerId, Map<Integer, Integer> leaderCountByBrokerId) {
+    _numBrokers = replicaCountByBrokerId.keySet().size();
+    _numTopics = numTopics;
+    _numReplicas = replicaCountByBrokerId.values().stream().mapToInt(i -> i).sum();
+    _numLeaders = leaderCountByBrokerId.values().stream().mapToInt(i -> i).sum();
+    _avgReplicationFactor = _numLeaders == 0 ? 0 : _numReplicas / (double) _numLeaders;
+
+    // Replicas per broker
+    _avgReplicasPerBroker = _numReplicas / (double) _numBrokers;
+    int maxReplicasPerBroker = 0;
+    double replicaVariance = 0.0;
+    for (int replicasInBroker : replicaCountByBrokerId.values()) {
+      maxReplicasPerBroker = Math.max(maxReplicasPerBroker, replicasInBroker);
+      replicaVariance += Math.pow((double) replicasInBroker - _avgReplicasPerBroker, 2) / _numBrokers;
+    }
+    _maxReplicasPerBroker = maxReplicasPerBroker;
+    _stdReplicasPerBroker = Math.sqrt(replicaVariance);
+
+    // Leaders per broker
+    _avgLeadersPerBroker = _numLeaders / (double) _numBrokers;
+    int maxLeadersPerBroker = 0;
+    double leaderVariance = 0.0;
+    for (int leadersInBroker : leaderCountByBrokerId.values()) {
+      maxLeadersPerBroker = Math.max(maxLeadersPerBroker, leadersInBroker);
+      leaderVariance += Math.pow((double) leadersInBroker - _avgLeadersPerBroker, 2) / _numBrokers;
+    }
+    _maxLeadersPerBroker = maxLeadersPerBroker;
+    _stdLeadersPerBroker = Math.sqrt(leaderVariance);
+  }
+
+  /**
+   * @return response with JSON structure.
+   */
+  public Map<String, Object> getJsonStructure() {
+    // Write the cluster summary.
+    Map<String, Object> jsonMap = new HashMap<>(11);
+    jsonMap.put(BROKERS, _numBrokers);
+    jsonMap.put(TOPICS, _numTopics);
+    jsonMap.put(REPLICAS, _numReplicas);
+    jsonMap.put(LEADERS, _numLeaders);
+    jsonMap.put(AVG_REPLICATION_FACTOR, _avgReplicationFactor);
+    jsonMap.put(AVG_REPLICAS_PER_BROKER, _avgReplicasPerBroker);
+    jsonMap.put(AVG_LEADERS_PER_BROKER, _avgLeadersPerBroker);
+    jsonMap.put(MAX_REPLICAS_PER_BROKER, _maxReplicasPerBroker);
+    jsonMap.put(MAX_LEADERS_PER_BROKER, _maxLeadersPerBroker);
+    jsonMap.put(STD_REPLICAS_PER_BROKER, _stdReplicasPerBroker);
+    jsonMap.put(STD_LEADERS_PER_BROKER, _stdLeadersPerBroker);
+    return jsonMap;
+  }
+
+  /**
+   * Write broker summary
+   * @param sb String builder to write the response to.
+   */
+  public void writeClusterStats(StringBuilder sb) {
+    sb.append(String.format("Summary: The cluster has %d brokers, %d replicas, %d leaders, and %d topics with avg replication factor: %.2f."
+                            + " [Leaders/Replicas per broker] avg: %.2f/%.2f max: %d/%d std: %.2f/%.2f%n%n",
+                            _numBrokers, _numReplicas, _numLeaders, _numTopics, _avgReplicationFactor, _avgLeadersPerBroker,
+                            _avgReplicasPerBroker, _maxLeadersPerBroker, _maxReplicasPerBroker, _stdLeadersPerBroker, _stdReplicasPerBroker));
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/KafkaClusterState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/KafkaClusterState.java
@@ -22,9 +22,9 @@ import static com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils.VE
 @JsonResponseClass
 public class KafkaClusterState extends AbstractCruiseControlResponse {
   @JsonResponseField
-  protected static final String KAFKA_BROKER_STATE = "KafkaBrokerState";
+  public static final String KAFKA_BROKER_STATE = "KafkaBrokerState";
   @JsonResponseField
-  protected static final String KAFKA_PARTITION_STATE = "KafkaPartitionState";
+  public static final String KAFKA_PARTITION_STATE = "KafkaPartitionState";
   protected final Map<String, Properties> _allTopicConfigs;
   protected final Properties _clusterConfigs;
   protected final Map<String, Object> _adminClientConfigs;

--- a/cruise-control/src/yaml/responses/kafkaClusterState.yaml
+++ b/cruise-control/src/yaml/responses/kafkaClusterState.yaml
@@ -23,6 +23,7 @@ ClusterBrokerState:
     - IsController
     - OnlineLogDirsByBrokerId
     - OfflineLogDirsByBrokerId
+    - Summary
   properties:
     LeaderCountByBrokerId:
       type: object
@@ -60,6 +61,57 @@ ClusterBrokerState:
         type: array
         items:
           type: string
+    Summary:
+      $ref: '#/ClusterStats'
+
+ClusterStats:
+  type: object
+  required:
+    - Brokers
+    - Topics
+    - Replicas
+    - Leaders
+    - AvgReplicationFactor
+    - AvgReplicasPerBroker
+    - AvgLeadersPerBroker
+    - MaxReplicasPerBroker
+    - MaxLeadersPerBroker
+    - StdReplicasPerBroker
+    - StdLeadersPerBroker
+  properties:
+    Brokers:
+      type: integer
+      format: int32
+    Topics:
+      type: integer
+      format: int32
+    Replicas:
+      type: integer
+      format: int32
+    Leaders:
+      type: integer
+      format: int32
+    AvgReplicationFactor:
+      type: number
+      format: double
+    AvgReplicasPerBroker:
+      type: number
+      format: double
+    AvgLeadersPerBroker:
+      type: number
+      format: double
+    MaxReplicasPerBroker:
+      type: integer
+      format: int32
+    MaxLeadersPerBroker:
+      type: integer
+      format: int32
+    StdReplicasPerBroker:
+      type: integer
+      format: int32
+    StdLeadersPerBroker:
+      type: integer
+      format: int32
 
 ClusterPartitionState:
   type: object


### PR DESCRIPTION
This PR resolves #1247 and #1092.

Expected response format has been verified via a deployment:
1. Plaintext response --
```
Summary: The cluster has 9 brokers, 2331 replicas, 777 leaders, and 42 topics with avg replication factor: 3.00. [Leaders/Replicas per broker] avg: 86.33/259.00 max: 146/320 std: 36.51/93.82

<The existing kafka_cluster_state plaintext response>
```
2. JSON response --
Adds the `Summary` under `KafkaBrokerState`.

```
"Summary":{"StdLeadersPerBroker":36.50875085358151,"Leaders":777,"MaxLeadersPerBroker":146,"Topics":42,"MaxReplicasPerBroker":320,"StdReplicasPerBroker":93.82015893304713,"Brokers":9,"AvgReplicationFactor":3.0,"AvgLeadersPerBroker":86.33333333333333,"Replicas":2331,"AvgReplicasPerBroker":259.0}
```

Note: Changes of constants and selected response functions from `protected` to `public` were performed to let inheriting classes and tests access them from outside these classes.