### PR TITLE
LeaderReplicaDistributionGoal should honor excludedTopics during leadership movement.

### DIFF
--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/ExcludedTopicsTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/ExcludedTopicsTest.java
@@ -211,7 +211,7 @@ public class ExcludedTopicsTest {
     p.add(params(1, LeaderReplicaDistributionGoal.class, excludeT1, null, unbalanced3(), noDeadBroker, true));
     // Test: With all topics excluded, balance not satisfiable, no dead broker (No exception, No proposal
     // for excluded topics, Not expected to look optimized)
-    p.add(params(2, LeaderReplicaDistributionGoal.class, excludeAllTopics, null, unbalanced3(), noDeadBroker, true));
+    p.add(params(2, LeaderReplicaDistributionGoal.class, excludeAllTopics, null, unbalanced3(), noDeadBroker, false));
     // Test: With no topic excluded, satisfiable cluster, one dead broker (No exception, No proposal
     // for excluded topics, Expected to look optimized)
     p.add(params(3, LeaderReplicaDistributionGoal.class, noExclusion, null, unbalanced3(), deadBroker0, true));
@@ -284,7 +284,7 @@ public class ExcludedTopicsTest {
 
       Set<String> excludedTopics = _optimizationOptions.excludedTopics();
       if (_expectedToOptimize) {
-        assertTrue("Excluded Topics Test failed to optimize " + _goal.name() + " with excluded topics.",
+        assertTrue("Excluded Topics Test failed to optimize " + _goal.name() + " with excluded topics " + excludedTopics,
             _goal.optimize(_clusterModel, Collections.emptySet(), _optimizationOptions));
       } else {
         assertFalse("Excluded Topics Test optimized " + _goal.name() + " with excluded topics " + excludedTopics,

--- a/docs/wiki/User Guide/Pluggable-Components.md
+++ b/docs/wiki/User Guide/Pluggable-Components.md
@@ -39,7 +39,7 @@ The goals in Kafka Cruise Control are pluggable with different priorities. The d
 
 * **LeaderBytesInDistributionGoal**: Attempt to make the leader bytes in rate on each host to be balanced.
 
-* **TopicReplicaDistributionGoal**: Attempt to make the replicas of the same topic are evenly distributed across the entire cluster.
+* **TopicReplicaDistributionGoal**: Attempt to make the replicas of the same topic evenly distributed across the entire cluster.
 
 * **LeaderReplicaDistributionGoal**: Attempt to make all the brokers in a cluster to have the similar number of leader replicas.
 


### PR DESCRIPTION
This PR resolves #1266.
