### PR TITLE
Let executor substate show information on process before starting an execution

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -572,7 +572,6 @@ public class KafkaCruiseControl {
    *                            when executing proposals (if null, no throttling is applied).
    * @param isTriggeredByUserRequest Whether the execution is triggered by a user request.
    * @param uuid UUID of the execution.
-   * @param reasonSupplier Reason supplier for the execution.
    */
   public void executeProposals(Set<ExecutionProposal> proposals,
                                Set<Integer> unthrottledBrokers,
@@ -584,13 +583,12 @@ public class KafkaCruiseControl {
                                ReplicaMovementStrategy replicaMovementStrategy,
                                Long replicationThrottle,
                                boolean isTriggeredByUserRequest,
-                               String uuid,
-                               Supplier<String> reasonSupplier) throws OngoingExecutionException {
+                               String uuid) throws OngoingExecutionException {
     if (hasProposalsToExecute(proposals, uuid)) {
       _executor.executeProposals(proposals, unthrottledBrokers, null, _loadMonitor,
                                  concurrentInterBrokerPartitionMovements, concurrentIntraBrokerPartitionMovements,
                                  concurrentLeaderMovements, executionProgressCheckIntervalMs, replicaMovementStrategy,
-                                 replicationThrottle, isTriggeredByUserRequest, uuid, reasonSupplier, isKafkaAssignerMode);
+                                 replicationThrottle, isTriggeredByUserRequest, uuid, isKafkaAssignerMode);
     }
   }
 
@@ -612,7 +610,6 @@ public class KafkaCruiseControl {
    *                            when executing remove operations (if null, no throttling is applied).
    * @param isTriggeredByUserRequest Whether the execution is triggered by a user request.
    * @param uuid UUID of the execution.
-   * @param reasonSupplier Reason supplier for the execution.
    */
   public void executeRemoval(Set<ExecutionProposal> proposals,
                              boolean throttleDecommissionedBroker,
@@ -624,13 +621,12 @@ public class KafkaCruiseControl {
                              ReplicaMovementStrategy replicaMovementStrategy,
                              Long replicationThrottle,
                              boolean isTriggeredByUserRequest,
-                             String uuid,
-                             Supplier<String> reasonSupplier) throws OngoingExecutionException {
+                             String uuid) throws OngoingExecutionException {
     if (hasProposalsToExecute(proposals, uuid)) {
       _executor.executeProposals(proposals, throttleDecommissionedBroker ? Collections.emptySet() : removedBrokers,
                                  removedBrokers, _loadMonitor, concurrentInterBrokerPartitionMovements, 0,
                                  concurrentLeaderMovements, executionProgressCheckIntervalMs, replicaMovementStrategy,
-                                 replicationThrottle, isTriggeredByUserRequest, uuid, reasonSupplier, isKafkaAssignerMode);
+                                 replicationThrottle, isTriggeredByUserRequest, uuid, isKafkaAssignerMode);
     }
   }
 
@@ -649,7 +645,6 @@ public class KafkaCruiseControl {
    *                            when executing demote operations (if null, no throttling is applied).
    * @param isTriggeredByUserRequest Whether the execution is triggered by a user request.
    * @param uuid UUID of the execution.
-   * @param reasonSupplier Reason supplier for the execution.
    */
   public void executeDemotion(Set<ExecutionProposal> proposals,
                               Set<Integer> demotedBrokers,
@@ -659,8 +654,7 @@ public class KafkaCruiseControl {
                               ReplicaMovementStrategy replicaMovementStrategy,
                               Long replicationThrottle,
                               boolean isTriggeredByUserRequest,
-                              String uuid,
-                              Supplier<String> reasonSupplier) throws OngoingExecutionException {
+                              String uuid) throws OngoingExecutionException {
     if (hasProposalsToExecute(proposals, uuid)) {
       // (1) Kafka Assigner mode is irrelevant for demoting.
       // (2) Ensure that replica swaps within partitions, which are prerequisites for broker demotion and does not trigger data move,
@@ -672,7 +666,7 @@ public class KafkaCruiseControl {
 
       _executor.executeDemoteProposals(proposals, demotedBrokers, _loadMonitor, concurrentSwaps, concurrentLeaderMovements,
                                        executionProgressCheckIntervalMs, replicaMovementStrategy, replicationThrottle,
-                                       isTriggeredByUserRequest, uuid, reasonSupplier);
+                                       isTriggeredByUserRequest, uuid);
     }
   }
 
@@ -683,6 +677,25 @@ public class KafkaCruiseControl {
    */
   public void userTriggeredStopExecution(boolean forceExecutionStop) {
     _executor.userTriggeredStopExecution(forceExecutionStop);
+  }
+
+  /**
+   * See {@link Executor#setGeneratingProposalsForExecution(String, Supplier, boolean)}.
+   * @param uuid UUID of the current execution.
+   * @param reasonSupplier Reason supplier for the execution.
+   * @param isTriggeredByUserRequest Whether the execution is triggered by a user request.
+   */
+  public void setGeneratingProposalsForExecution(String uuid, Supplier<String> reasonSupplier, boolean isTriggeredByUserRequest)
+      throws OngoingExecutionException {
+    _executor.setGeneratingProposalsForExecution(uuid, reasonSupplier, isTriggeredByUserRequest);
+  }
+
+  /**
+   * See {@link Executor#failGeneratingProposalsForExecution(String)}.
+   * @param uuid UUID of the failed proposal generation for execution.
+   */
+  public synchronized void failGeneratingProposalsForExecution(String uuid) {
+    _executor.failGeneratingProposalsForExecution(uuid);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -381,7 +381,6 @@ public class Executor {
    *                            when executing a proposal (if null, no throttling is applied).
    * @param isTriggeredByUserRequest Whether the execution is triggered by a user request.
    * @param uuid UUID of the execution.
-   * @param reasonSupplier Reason supplier for the execution.
    * @param isKafkaAssignerMode {@code true} if kafka assigner mode, {@code false} otherwise.
    */
   public synchronized void executeProposals(Collection<ExecutionProposal> proposals,
@@ -396,14 +395,12 @@ public class Executor {
                                             Long replicationThrottle,
                                             boolean isTriggeredByUserRequest,
                                             String uuid,
-                                            Supplier<String> reasonSupplier,
                                             boolean isKafkaAssignerMode) throws OngoingExecutionException {
     try {
       setExecutionMode(isKafkaAssignerMode);
       initProposalExecution(proposals, unthrottledBrokers, loadMonitor, requestedInterBrokerPartitionMovementConcurrency,
                             requestedIntraBrokerPartitionMovementConcurrency, requestedLeadershipMovementConcurrency,
-                            requestedExecutionProgressCheckIntervalMs, replicaMovementStrategy, uuid, reasonSupplier,
-                            isTriggeredByUserRequest);
+                            requestedExecutionProgressCheckIntervalMs, replicaMovementStrategy, uuid, isTriggeredByUserRequest);
       startExecution(loadMonitor, null, removedBrokers, replicationThrottle, isTriggeredByUserRequest);
     } catch (Exception e) {
       processExecuteProposalsFailure();
@@ -420,7 +417,6 @@ public class Executor {
                                                   Long requestedExecutionProgressCheckIntervalMs,
                                                   ReplicaMovementStrategy replicaMovementStrategy,
                                                   String uuid,
-                                                  Supplier<String> reasonSupplier,
                                                   boolean isTriggeredByUserRequest) throws OngoingExecutionException {
     if (_hasOngoingExecution) {
       throw new OngoingExecutionException("Cannot execute new proposals while there is an ongoing execution.");
@@ -429,13 +425,15 @@ public class Executor {
     if (loadMonitor == null) {
       throw new IllegalArgumentException("Load monitor cannot be null.");
     }
-    if (uuid == null) {
-      throw new IllegalStateException("UUID of the execution cannot be null.");
+    if (_executorState.state() != GENERATING_PROPOSALS_FOR_EXECUTION) {
+      throw new IllegalStateException(String.format("Unexpected executor state %s. Initializing proposal execution requires"
+                                                    + " generating proposals for execution.", _executorState.state()));
     }
-    if (reasonSupplier == null) {
-      throw new IllegalArgumentException("Reason supplier cannot be null.");
+    if (uuid == null || !uuid.equals(_uuid)) {
+      throw new IllegalStateException(String.format("Attempt to initialize proposal execution with a UUID %s that differs from"
+                                                    + " the UUID used for generating proposals for execution %s.", uuid, _uuid));
     }
-    _executorState = ExecutorState.initializeProposalExecution(uuid, reasonSupplier.get(), recentlyDemotedBrokers(),
+    _executorState = ExecutorState.initializeProposalExecution(_uuid, _reasonSupplier.get(), recentlyDemotedBrokers(),
                                                                recentlyRemovedBrokers(), isTriggeredByUserRequest);
     _executionTaskManager.setExecutionModeForTaskTracker(_isKafkaAssignerMode);
     _executionTaskManager.addExecutionProposals(proposals, brokersToSkipConcurrencyCheck, _metadataClient.refreshMetadata().cluster(),
@@ -444,8 +442,6 @@ public class Executor {
     setRequestedIntraBrokerPartitionMovementConcurrency(requestedIntraBrokerPartitionMovementConcurrency);
     setRequestedLeadershipMovementConcurrency(requestedLeadershipMovementConcurrency);
     setRequestedExecutionProgressCheckIntervalMs(requestedExecutionProgressCheckIntervalMs);
-    _uuid = uuid;
-    _reasonSupplier = reasonSupplier;
   }
 
   /**
@@ -464,7 +460,6 @@ public class Executor {
    * @param replicaMovementStrategy The strategy used to determine the execution order of generated replica movement tasks.
    * @param isTriggeredByUserRequest Whether the execution is triggered by a user request.
    * @param uuid UUID of the execution.
-   * @param reasonSupplier Reason supplier for the execution.
    */
   public synchronized void executeDemoteProposals(Collection<ExecutionProposal> proposals,
                                                   Collection<Integer> demotedBrokers,
@@ -475,13 +470,11 @@ public class Executor {
                                                   ReplicaMovementStrategy replicaMovementStrategy,
                                                   Long replicationThrottle,
                                                   boolean isTriggeredByUserRequest,
-                                                  String uuid,
-                                                  Supplier<String> reasonSupplier) throws OngoingExecutionException {
+                                                  String uuid) throws OngoingExecutionException {
     try {
       setExecutionMode(false);
       initProposalExecution(proposals, demotedBrokers, loadMonitor, concurrentSwaps, 0, requestedLeadershipMovementConcurrency,
-                            requestedExecutionProgressCheckIntervalMs, replicaMovementStrategy, uuid, reasonSupplier,
-                            isTriggeredByUserRequest);
+                            requestedExecutionProgressCheckIntervalMs, replicaMovementStrategy, uuid, isTriggeredByUserRequest);
       startExecution(loadMonitor, demotedBrokers, null, replicationThrottle, isTriggeredByUserRequest);
     } catch (Exception e) {
       processExecuteProposalsFailure();
@@ -612,6 +605,60 @@ public class Executor {
     _uuid = null;
     _reasonSupplier = null;
     _executorState = ExecutorState.noTaskInProgress(recentlyDemotedBrokers(), recentlyRemovedBrokers());
+  }
+
+  /**
+   * Notify the executor on starting to generate proposals for execution with the given uuid and reason supplier.
+   * The executor must be in {@link ExecutorState.State#NO_TASK_IN_PROGRESS} state for this operation to succeed.
+   *
+   * @param uuid UUID of the current execution.
+   * @param reasonSupplier Reason supplier for the execution.
+   * @param isTriggeredByUserRequest Whether the execution is triggered by a user request.
+   */
+  public synchronized void setGeneratingProposalsForExecution(String uuid, Supplier<String> reasonSupplier, boolean isTriggeredByUserRequest)
+      throws OngoingExecutionException {
+    ExecutorState.State currentExecutorState = _executorState.state();
+    if (currentExecutorState != NO_TASK_IN_PROGRESS) {
+      throw new OngoingExecutionException(String.format("Cannot generate proposals while the executor is in %s state.", currentExecutorState));
+    }
+    if (uuid == null) {
+      throw new IllegalArgumentException("UUID of the execution cannot be null.");
+    }
+    if (reasonSupplier == null) {
+      throw new IllegalArgumentException("Reason supplier cannot be null.");
+    }
+
+    _uuid = uuid;
+    _reasonSupplier = reasonSupplier;
+    _executorState = ExecutorState.generatingProposalsForExecution(_uuid, _reasonSupplier.get(), recentlyDemotedBrokers(),
+                                                                   recentlyRemovedBrokers(), isTriggeredByUserRequest);
+  }
+
+  /**
+   * Notify the executor on the failure to generate proposals for execution with the given uuid.
+   * The executor may stuck in {@link ExecutorState.State#GENERATING_PROPOSALS_FOR_EXECUTION} state if this call is omitted.
+   *
+   * This is a no-op if called when
+   * <ul>
+   *   <li>Not generating proposals for execution: This is because all other execution failures after generating proposals
+   *   for execution are already handled by the executor.</li>
+   *   <li>Generating proposals with a different UUID: This indicates an error in the caller-side logic, and is not
+   *   supposed to happen because at any given time proposals shall be generated for only one request -- for detecting
+   *   such presumably benign misuse (if any), this case is logged as a warning.</li>
+   * </ul>
+   * @param uuid UUID of the failed proposal generation for execution.
+   */
+  public synchronized void failGeneratingProposalsForExecution(String uuid) {
+    if (_executorState.state() == GENERATING_PROPOSALS_FOR_EXECUTION) {
+      if (uuid != null && uuid.equals(_uuid)) {
+        LOG.info("Failed to generate proposals for execution (UUID: {} reason: {}).", uuid, _reasonSupplier.get());
+        _uuid = null;
+        _reasonSupplier = null;
+        _executorState = ExecutorState.noTaskInProgress(recentlyDemotedBrokers(), recentlyRemovedBrokers());
+      } else {
+        LOG.warn("UUID mismatch in attempt to report failure to generate proposals (received: {} expected: {})", uuid, _uuid);
+      }
+    }
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorState.java
@@ -126,7 +126,8 @@ public class ExecutorState {
     INTRA_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS,
     LEADER_MOVEMENT_TASK_IN_PROGRESS,
     STOPPING_EXECUTION,
-    INITIALIZING_PROPOSAL_EXECUTION
+    INITIALIZING_PROPOSAL_EXECUTION,
+    GENERATING_PROPOSALS_FOR_EXECUTION
   }
 
   public static final Set<State> IN_PROGRESS_STATES;
@@ -231,6 +232,31 @@ public class ExecutorState {
                                                           Set<Integer> recentlyRemovedBrokers,
                                                           boolean isTriggeredByUserRequest) {
     return new ExecutorState(State.INITIALIZING_PROPOSAL_EXECUTION,
+                             null,
+                             0,
+                             0,
+                             0,
+                             uuid,
+                             reason,
+                             recentlyDemotedBrokers,
+                             recentlyRemovedBrokers,
+                             isTriggeredByUserRequest);
+  }
+
+  /**
+   * @param uuid UUID of the current execution.
+   * @param reason Reason of the current execution.
+   * @param recentlyDemotedBrokers Recently demoted broker IDs.
+   * @param recentlyRemovedBrokers Recently removed broker IDs.
+   * @param isTriggeredByUserRequest Whether the execution is triggered by a user request.
+   * @return Executor state when generating proposals for execution.
+   */
+  public static ExecutorState generatingProposalsForExecution(String uuid,
+                                                              String reason,
+                                                              Set<Integer> recentlyDemotedBrokers,
+                                                              Set<Integer> recentlyRemovedBrokers,
+                                                              boolean isTriggeredByUserRequest) {
+    return new ExecutorState(State.GENERATING_PROPOSALS_FOR_EXECUTION,
                              null,
                              0,
                              0,
@@ -372,6 +398,7 @@ public class ExecutorState {
         break;
       case STARTING_EXECUTION:
       case INITIALIZING_PROPOSAL_EXECUTION:
+      case GENERATING_PROPOSALS_FOR_EXECUTION:
         populateUuidFieldInJsonStructure(execState, _uuid);
         execState.put(TRIGGERED_TASK_REASON, _reason);
         break;
@@ -476,6 +503,7 @@ public class ExecutorState {
         return String.format("{%s: %s%s%s}", STATE, _state, recentlyDemotedBrokers, recentlyRemovedBrokers);
       case STARTING_EXECUTION:
       case INITIALIZING_PROPOSAL_EXECUTION:
+      case GENERATING_PROPOSALS_FOR_EXECUTION:
         return String.format("{%s: %s, %s: %s, %s: %s%s%s}", STATE, _state,
                              _isTriggeredByUserRequest ? TRIGGERED_USER_TASK_ID : TRIGGERED_SELF_HEALING_TASK_ID,
                              _uuid, TRIGGERED_TASK_REASON, _reason, recentlyDemotedBrokers, recentlyRemovedBrokers);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/AddBrokersRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/AddBrokersRunnable.java
@@ -32,16 +32,17 @@ public class AddBrokersRunnable extends GoalBasedOperationRunnable {
   protected final Integer _concurrentInterBrokerPartitionMovements;
   protected final Integer _concurrentLeaderMovements;
   protected final Long _executionProgressCheckIntervalMs;
-  protected final String _uuid;
-  protected final String _reason;
   protected final ReplicaMovementStrategy _replicaMovementStrategy;
   protected final Long _replicationThrottle;
+  // Currently no self-healing action triggers broker addition -- i.e. all are triggered by user requests.
+  protected static final boolean ADD_BROKERS_IS_TRIGGERED_BY_USER_REQUEST = true;
 
   public AddBrokersRunnable(KafkaCruiseControl kafkaCruiseControl,
                             OperationFuture future,
                             AddBrokerParameters parameters,
                             String uuid) {
-    super(kafkaCruiseControl, future, parameters, parameters.dryRun(), parameters.stopOngoingExecution(), parameters.skipHardGoalCheck());
+    super(kafkaCruiseControl, future, parameters, parameters.dryRun(), parameters.stopOngoingExecution(), parameters.skipHardGoalCheck(),
+          uuid, parameters::reason, ADD_BROKERS_IS_TRIGGERED_BY_USER_REQUEST);
     _brokerIds = parameters.brokerIds();
     _throttleAddedBrokers = parameters.throttleAddedBrokers();
     _concurrentInterBrokerPartitionMovements = parameters.concurrentInterBrokerPartitionMovements();
@@ -49,8 +50,6 @@ public class AddBrokersRunnable extends GoalBasedOperationRunnable {
     _executionProgressCheckIntervalMs = parameters.executionProgressCheckIntervalMs();
     _replicaMovementStrategy = parameters.replicaMovementStrategy();
     _replicationThrottle = parameters.replicationThrottle();
-    _uuid = uuid;
-    _reason = parameters.reason();
   }
 
   @Override
@@ -92,8 +91,7 @@ public class AddBrokersRunnable extends GoalBasedOperationRunnable {
                                            _replicaMovementStrategy,
                                            _replicationThrottle,
                                            true,
-                                           _uuid,
-                                           () -> _reason);
+                                           _uuid);
     }
     return result;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/ProposalsRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/ProposalsRunnable.java
@@ -16,6 +16,7 @@ import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import static com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.RunnableUtils.computeOptimizationOptions;
@@ -31,12 +32,15 @@ public class ProposalsRunnable extends GoalBasedOperationRunnable {
   protected final Set<Integer> _destinationBrokerIds;
   protected final boolean _isRebalanceDiskMode;
   protected final boolean _isTriggeredByGoalViolation;
-  // This runnable does not start or modify executions, skips hard goal check to evaluate any combination of goals, and
-  // is not triggered by goal violation unless specified otherwise.
+  // This runnable does not start or modify executions. Hence, it ignores execution-related parameters, including hard
+  // goal check (i.e. to evaluate any combination of goals). Unless specified otherwise, it is not triggered by goal violation.
   protected static final boolean PROPOSALS_DRYRUN = true;
   protected static final boolean PROPOSALS_STOP_ONGOING_EXECUTION = false;
   protected static final boolean PROPOSALS_SKIP_HARD_GOAL_CHECK = true;
   protected static final boolean PROPOSALS_IS_TRIGGERED_BY_GOAL_VIOLATION = false;
+  protected static final String PROPOSALS_UUID = null;
+  protected static final Supplier<String> PROPOSALS_REASON_SUPPLIER = null;
+  protected static final boolean PROPOSALS_IS_TRIGGERED_BY_USER_REQUEST = true;
 
   /**
    * Constructor to be used for creating a runnable for rebalance.
@@ -56,7 +60,8 @@ public class ProposalsRunnable extends GoalBasedOperationRunnable {
                            boolean isTriggeredByGoalViolation) {
     super(kafkaCruiseControl, future, PROPOSALS_DRYRUN, goals, PROPOSALS_STOP_ONGOING_EXECUTION,
           modelCompletenessRequirements, skipHardGoalCheck, excludedTopics, allowCapacityEstimation,
-          excludeRecentlyDemotedBrokers, excludeRecentlyRemovedBrokers);
+          excludeRecentlyDemotedBrokers, excludeRecentlyRemovedBrokers, PROPOSALS_UUID, PROPOSALS_REASON_SUPPLIER,
+          PROPOSALS_IS_TRIGGERED_BY_USER_REQUEST);
     _ignoreProposalCache = ignoreProposalCache;
     _destinationBrokerIds = destinationBrokerIds;
     _isRebalanceDiskMode = isRebalanceDiskMode;
@@ -64,7 +69,8 @@ public class ProposalsRunnable extends GoalBasedOperationRunnable {
   }
 
   public ProposalsRunnable(KafkaCruiseControl kafkaCruiseControl, OperationFuture future, ProposalsParameters parameters) {
-    super(kafkaCruiseControl, future, parameters, PROPOSALS_DRYRUN, PROPOSALS_STOP_ONGOING_EXECUTION, PROPOSALS_SKIP_HARD_GOAL_CHECK);
+    super(kafkaCruiseControl, future, parameters, PROPOSALS_DRYRUN, PROPOSALS_STOP_ONGOING_EXECUTION, PROPOSALS_SKIP_HARD_GOAL_CHECK,
+          PROPOSALS_UUID, PROPOSALS_REASON_SUPPLIER, PROPOSALS_IS_TRIGGERED_BY_USER_REQUEST);
     _ignoreProposalCache = parameters.ignoreProposalCache();
     _destinationBrokerIds = parameters.destinationBrokerIds();
     _isRebalanceDiskMode = parameters.isRebalanceDiskMode();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RunnableUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RunnableUtils.java
@@ -56,6 +56,7 @@ public class RunnableUtils {
   public static final boolean SELF_HEALING_SKIP_URP_DEMOTION = true;
   public static final boolean SELF_HEALING_EXCLUDE_FOLLOWER_DEMOTION = true;
   public static final boolean SELF_HEALING_SKIP_RACK_AWARENESS_CHECK = false;
+  public static final boolean SELF_HEALING_IS_TRIGGERED_BY_USER_REQUEST = false;
   private static final Set<String> KAFKA_ASSIGNER_GOALS =
       Collections.unmodifiableSet(new HashSet<>(Arrays.asList(KafkaAssignerEvenRackAwareGoal.class.getSimpleName(),
                                                               KafkaAssignerDiskUsageDistributionGoal.class.getSimpleName())));

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorTest.java
@@ -315,8 +315,7 @@ public class AnomalyDetectorTest {
                                               EasyMock.eq(SELF_HEALING_REPLICA_MOVEMENT_STRATEGY),
                                               EasyMock.eq(null),
                                               EasyMock.eq(false),
-                                              EasyMock.anyString(),
-                                              EasyMock.anyObject());
+                                              EasyMock.anyString());
 
       EasyMock.expect(mockAnomalyNotifier.onGoalViolation(EasyMock.isA(GoalViolations.class))).andReturn(AnomalyNotificationResult.fix());
     } else if (anomalyType == KafkaAnomalyType.DISK_FAILURE) {
@@ -350,8 +349,7 @@ public class AnomalyDetectorTest {
                                               EasyMock.eq(SELF_HEALING_REPLICA_MOVEMENT_STRATEGY),
                                               EasyMock.eq(null),
                                               EasyMock.eq(false),
-                                              EasyMock.anyString(),
-                                              EasyMock.anyObject());
+                                              EasyMock.anyString());
 
       EasyMock.expect(mockKafkaCruiseControl.acquireForModelGeneration(EasyMock.anyObject())).andReturn(null);
       EasyMock.expect(mockAnomalyNotifier.onDiskFailure(EasyMock.isA(DiskFailures.class))).andReturn(AnomalyNotificationResult.fix());
@@ -385,8 +383,7 @@ public class AnomalyDetectorTest {
                                              EasyMock.eq(SELF_HEALING_REPLICA_MOVEMENT_STRATEGY),
                                              EasyMock.eq(null),
                                              EasyMock.eq(false),
-                                             EasyMock.anyString(),
-                                             EasyMock.anyObject());
+                                             EasyMock.anyString());
       EasyMock.expect(mockAnomalyNotifier.onMetricAnomaly(EasyMock.isA(SlowBrokers.class))).andReturn(AnomalyNotificationResult.fix());
     } else if (anomalyType == KafkaAnomalyType.TOPIC_ANOMALY) {
       ClusterModel clusterModel = unbalanced();
@@ -420,8 +417,7 @@ public class AnomalyDetectorTest {
                                               EasyMock.eq(SELF_HEALING_REPLICA_MOVEMENT_STRATEGY),
                                               EasyMock.eq(null),
                                               EasyMock.eq(false),
-                                              EasyMock.anyString(),
-                                              EasyMock.anyObject());
+                                              EasyMock.anyString());
       EasyMock.expect(mockAnomalyNotifier.onTopicAnomaly(EasyMock.isA(TopicAnomaly.class))).andReturn(AnomalyNotificationResult.fix());
     }
     EasyMock.expect(mockKafkaCruiseControl.meetCompletenessRequirements(Collections.emptyList())).andReturn(true);
@@ -429,6 +425,10 @@ public class AnomalyDetectorTest {
                                                    EasyMock.eq(0L),
                                                    EasyMock.eq(TimeUnit.MILLISECONDS)))
             .andReturn(null);
+
+    // Set generating proposals for execution.
+    mockKafkaCruiseControl.setGeneratingProposalsForExecution(EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.eq(false));
+
     replayCommonMocks(mockAnomalyNotifier, mockBrokerFailureDetector, mockGoalViolationDetector, mockMetricAnomalyDetector,
                       mockDetectorScheduler, mockKafkaCruiseControl);
     expectAndReplayFixMocks(mockOptimizerResult, mockBrokerStats);

--- a/cruise-control/src/yaml/responses/executorState.yaml
+++ b/cruise-control/src/yaml/responses/executorState.yaml
@@ -19,6 +19,7 @@ ExecutorState:
         - LEADER_MOVEMENT_TASK_IN_PROGRESS
         - STOPPING_EXECUTION
         - INITIALIZING_PROPOSAL_EXECUTION
+        - GENERATING_PROPOSALS_FOR_EXECUTION
     recentlyDemotedBrokers:
       type: array
       items:

--- a/docs/wiki/User Guide/REST-APIs.md
+++ b/docs/wiki/User Guide/REST-APIs.md
@@ -73,7 +73,8 @@ The returned state contains the following information:
 	   `INTRA_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS` /
 	   `LEADER_MOVEMENT_TASK_IN_PROGRESS` /
 	   `STOPPING_EXECUTION` /
-	   `INITIALIZING_PROPOSAL_EXECUTION`
+	   `INITIALIZING_PROPOSAL_EXECUTION` /
+	   `GENERATING_PROPOSALS_FOR_EXECUTION`
   * Inter-broker replica movement progress (if state is `INTER_BROKER_REPLICA_MOVEMENT_IN_PROGRESS`)
   * Intra-broker replica movement progress (if state is `INTRA_BROKER_REPLICA_MOVEMENT_IN_PROGRESS`)
   * Leadership movement progress (if state is `LEADERSHIP_MOVEMENT`)


### PR DESCRIPTION
This PR resolves #909.
* Adds `GENERATING_PROPOSALS_FOR_EXECUTION` executor substate to reflect the state after receiving a non-dryrun execution request and before `INITIALIZING_PROPOSAL_EXECUTION`.