### PR TITLE
Prevent concurrent execution request from corrupting ongoing execution state.

### DIFF
--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -285,6 +285,7 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
                                                  true,
                                                  RANDOM_UUID,
                                                  false));
+    executor.failGeneratingProposalsForExecution(UNKNOWN_UUID);
 
     // Now successfully start the execution..
     executor.setGeneratingProposalsForExecution(RANDOM_UUID, ExecutorTest.class::getSimpleName, true);


### PR DESCRIPTION
This PR resolves #1286.
