### PR TITLE
Add support for Kafka 2.6 brokers

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTask.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTask.java
@@ -11,7 +11,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import com.linkedin.kafka.cruisecontrol.servlet.response.JsonResponseField;
 import com.linkedin.kafka.cruisecontrol.servlet.response.JsonResponseClass;
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskManager.java
@@ -22,7 +22,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTask.TaskType;
-import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTask.State;
 import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTaskTracker.ExecutionTasksSummary;
 /**
  * The class that helps track the execution status for the balancing.
@@ -261,7 +260,7 @@ public class ExecutionTaskManager {
    */
   public synchronized void markTasksInProgress(List<ExecutionTask> tasks) {
     for (ExecutionTask task : tasks) {
-      _executionTaskTracker.markTaskState(task, State.IN_PROGRESS);
+      _executionTaskTracker.markTaskState(task, ExecutionTaskState.IN_PROGRESS);
       switch (task.type()) {
         case INTER_BROKER_REPLICA_ACTION:
           _inProgressPartitionsForInterBrokerMovement.add(task.proposal().topicPartition());
@@ -287,11 +286,11 @@ public class ExecutionTaskManager {
    * Aborting execution will yield Aborted completion.
    */
   public synchronized void markTaskDone(ExecutionTask task) {
-    if (task.state() == State.IN_PROGRESS) {
-      _executionTaskTracker.markTaskState(task, State.COMPLETED);
+    if (task.state() == ExecutionTaskState.IN_PROGRESS) {
+      _executionTaskTracker.markTaskState(task, ExecutionTaskState.COMPLETED);
       completeTask(task);
-    } else if (task.state() == State.ABORTING) {
-      _executionTaskTracker.markTaskState(task, State.ABORTED);
+    } else if (task.state() == ExecutionTaskState.ABORTING) {
+      _executionTaskTracker.markTaskState(task, ExecutionTaskState.ABORTED);
       completeTask(task);
     }
   }
@@ -300,8 +299,8 @@ public class ExecutionTaskManager {
    * Mark an in-progress task as aborting (1) if an error is encountered and (2) the rollback is possible.
    */
   public synchronized void markTaskAborting(ExecutionTask task) {
-    if (task.state() == State.IN_PROGRESS) {
-      _executionTaskTracker.markTaskState(task, State.ABORTING);
+    if (task.state() == ExecutionTaskState.IN_PROGRESS) {
+      _executionTaskTracker.markTaskState(task, ExecutionTaskState.ABORTING);
     }
   }
 
@@ -309,8 +308,8 @@ public class ExecutionTaskManager {
    * Mark an in-progress task as aborting (1) if an error is encountered and (2) the rollback is not possible.
    */
   public synchronized void markTaskDead(ExecutionTask task) {
-    if (task.state() != State.DEAD) {
-      _executionTaskTracker.markTaskState(task, State.DEAD);
+    if (task.state() != ExecutionTaskState.DEAD) {
+      _executionTaskTracker.markTaskState(task, ExecutionTaskState.DEAD);
       completeTask(task);
     }
   }
@@ -369,7 +368,7 @@ public class ExecutionTaskManager {
   }
 
   /**
-   * @return The tasks that are {@link State#IN_PROGRESS} or {@link State#ABORTING} for all task types.
+   * @return The tasks that are {@link ExecutionTaskState#IN_PROGRESS} or {@link ExecutionTaskState#ABORTING} for all task types.
    */
   public synchronized Set<ExecutionTask> inExecutionTasks() {
     return inExecutionTasks(TaskType.cachedValues());
@@ -377,7 +376,7 @@ public class ExecutionTaskManager {
 
   /**
    * @param types Task type.
-   * @return The tasks that are {@link State#IN_PROGRESS} or {@link State#ABORTING} for the given task type.
+   * @return The tasks that are {@link ExecutionTaskState#IN_PROGRESS} or {@link ExecutionTaskState#ABORTING} for the given task type.
    */
   public synchronized Set<ExecutionTask> inExecutionTasks(Collection<TaskType> types) {
     return _executionTaskTracker.inExecutionTasks(types);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskState.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+package com.linkedin.kafka.cruisecontrol.executor;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public enum ExecutionTaskState {
+    PENDING, IN_PROGRESS, ABORTING, ABORTED, DEAD, COMPLETED;
+
+    private static final List<ExecutionTaskState> CACHED_VALUES = Collections.unmodifiableList(Arrays.asList(values()));
+
+    /**
+     * Use this instead of values() because values() creates a new array each time.
+     * @return enumerated values in the same order as values()
+     */
+    public static List<ExecutionTaskState> cachedValues() {
+        return CACHED_VALUES;
+    }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
  */
 package com.linkedin.kafka.cruisecontrol.executor;
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorState.java
@@ -13,7 +13,6 @@ import java.util.Set;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTask.State.*;
 import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTask.TaskType.*;
 import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTaskTracker.ExecutionTasksSummary;
 import com.linkedin.kafka.cruisecontrol.servlet.response.JsonResponseField;
@@ -322,9 +321,9 @@ public class ExecutorState {
    * @return Number of finished movements, which is the sum of dead, completed, and aborted tasks.
    */
   public int numFinishedMovements(ExecutionTask.TaskType type) {
-    return _executionTasksSummary.taskStat().get(type).get(DEAD) +
-           _executionTasksSummary.taskStat().get(type).get(COMPLETED) +
-           _executionTasksSummary.taskStat().get(type).get(ABORTED);
+    return _executionTasksSummary.taskStat().get(type).get(ExecutionTaskState.DEAD) +
+           _executionTasksSummary.taskStat().get(type).get(ExecutionTaskState.COMPLETED) +
+           _executionTasksSummary.taskStat().get(type).get(ExecutionTaskState.ABORTED);
   }
 
   /**
@@ -361,7 +360,7 @@ public class ExecutorState {
     return _executionTasksSummary;
   }
 
-  private List<Object> getTaskDetails(ExecutionTask.TaskType type, ExecutionTask.State state) {
+  private List<Object> getTaskDetails(ExecutionTask.TaskType type, ExecutionTaskState state) {
     List<Object> taskList = new ArrayList<>();
     for (ExecutionTask task : _executionTasksSummary.filteredTasksByState().get(type).get(state)) {
       taskList.add(task.getJsonStructure());
@@ -391,8 +390,8 @@ public class ExecutorState {
     if (_recentlyRemovedBrokers != null && !_recentlyRemovedBrokers.isEmpty()) {
       execState.put(RECENTLY_REMOVED_BROKERS, _recentlyRemovedBrokers);
     }
-    Map<ExecutionTask.State, Integer> interBrokerPartitionMovementStats;
-    Map<ExecutionTask.State, Integer> intraBrokerPartitionMovementStats;
+    Map<ExecutionTaskState, Integer> interBrokerPartitionMovementStats;
+    Map<ExecutionTaskState, Integer> intraBrokerPartitionMovementStats;
     switch (_state) {
       case NO_TASK_IN_PROGRESS:
         break;
@@ -406,11 +405,11 @@ public class ExecutorState {
         populateUuidFieldInJsonStructure(execState, _uuid);
         execState.put(TRIGGERED_TASK_REASON, _reason);
         execState.put(MAXIMUM_CONCURRENT_LEADER_MOVEMENTS, _maximumConcurrentLeaderMovements);
-        execState.put(NUM_PENDING_LEADERSHIP_MOVEMENTS, _executionTasksSummary.taskStat().get(LEADER_ACTION).get(PENDING));
+        execState.put(NUM_PENDING_LEADERSHIP_MOVEMENTS, _executionTasksSummary.taskStat().get(LEADER_ACTION).get(ExecutionTaskState.PENDING));
         execState.put(NUM_FINISHED_LEADERSHIP_MOVEMENTS, numFinishedMovements(LEADER_ACTION));
         execState.put(NUM_TOTAL_LEADERSHIP_MOVEMENTS, numTotalMovements(LEADER_ACTION));
         if (verbose) {
-          execState.put(PENDING_LEADERSHIP_MOVEMENT, getTaskDetails(LEADER_ACTION, PENDING));
+          execState.put(PENDING_LEADERSHIP_MOVEMENT, getTaskDetails(LEADER_ACTION, ExecutionTaskState.PENDING));
         }
         break;
       case INTER_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS:
@@ -418,20 +417,20 @@ public class ExecutorState {
         populateUuidFieldInJsonStructure(execState, _uuid);
         execState.put(TRIGGERED_TASK_REASON, _reason);
         execState.put(MAXIMUM_CONCURRENT_INTER_BROKER_PARTITION_MOVEMENTS_PER_BROKER, _maximumConcurrentInterBrokerPartitionMovementsPerBroker);
-        execState.put(NUM_IN_PROGRESS_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(IN_PROGRESS));
-        execState.put(NUM_ABORTING_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(ABORTING));
-        execState.put(NUM_PENDING_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(PENDING));
+        execState.put(NUM_IN_PROGRESS_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(ExecutionTaskState.IN_PROGRESS));
+        execState.put(NUM_ABORTING_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(ExecutionTaskState.ABORTING));
+        execState.put(NUM_PENDING_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(ExecutionTaskState.PENDING));
         execState.put(NUM_FINISHED_INTER_BROKER_PARTITION_MOVEMENTS, numFinishedMovements(INTER_BROKER_REPLICA_ACTION));
         execState.put(NUM_TOTAL_INTER_BROKER_PARTITION_MOVEMENTS, numTotalMovements(INTER_BROKER_REPLICA_ACTION));
         execState.put(FINISHED_INTER_BROKER_DATA_MOVEMENT, _executionTasksSummary.finishedInterBrokerDataMovementInMB());
         execState.put(TOTAL_INTER_BROKER_DATA_TO_MOVE, numTotalInterBrokerDataToMove());
         if (verbose) {
-          execState.put(IN_PROGRESS_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, IN_PROGRESS));
-          execState.put(PENDING_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, PENDING));
-          execState.put(ABORTING_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, ABORTING));
-          execState.put(ABORTED_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, ABORTED));
-          execState.put(DEAD_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, DEAD));
-          execState.put(COMPLETED_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, COMPLETED));
+          execState.put(IN_PROGRESS_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, ExecutionTaskState.IN_PROGRESS));
+          execState.put(PENDING_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, ExecutionTaskState.PENDING));
+          execState.put(ABORTING_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, ExecutionTaskState.ABORTING));
+          execState.put(ABORTED_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, ExecutionTaskState.ABORTED));
+          execState.put(DEAD_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, ExecutionTaskState.DEAD));
+          execState.put(COMPLETED_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, ExecutionTaskState.COMPLETED));
         }
         break;
       case INTRA_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS:
@@ -439,20 +438,20 @@ public class ExecutorState {
         populateUuidFieldInJsonStructure(execState, _uuid);
         execState.put(TRIGGERED_TASK_REASON, _reason);
         execState.put(MAXIMUM_CONCURRENT_INTRA_BROKER_PARTITION_MOVEMENTS_PER_BROKER, _maximumConcurrentIntraBrokerPartitionMovementsPerBroker);
-        execState.put(NUM_IN_PROGRESS_INTRA_BROKER_PARTITION_MOVEMENTS, intraBrokerPartitionMovementStats.get(IN_PROGRESS));
-        execState.put(NUM_ABORTING_INTRA_BROKER_PARTITION_MOVEMENTS, intraBrokerPartitionMovementStats.get(ABORTING));
-        execState.put(NUM_PENDING_INTRA_BROKER_PARTITION_MOVEMENTS, intraBrokerPartitionMovementStats.get(PENDING));
+        execState.put(NUM_IN_PROGRESS_INTRA_BROKER_PARTITION_MOVEMENTS, intraBrokerPartitionMovementStats.get(ExecutionTaskState.IN_PROGRESS));
+        execState.put(NUM_ABORTING_INTRA_BROKER_PARTITION_MOVEMENTS, intraBrokerPartitionMovementStats.get(ExecutionTaskState.ABORTING));
+        execState.put(NUM_PENDING_INTRA_BROKER_PARTITION_MOVEMENTS, intraBrokerPartitionMovementStats.get(ExecutionTaskState.PENDING));
         execState.put(NUM_FINISHED_INTRA_BROKER_PARTITION_MOVEMENTS, numFinishedMovements(INTRA_BROKER_REPLICA_ACTION));
         execState.put(NUM_TOTAL_INTRA_BROKER_PARTITION_MOVEMENTS, numTotalMovements(INTRA_BROKER_REPLICA_ACTION));
         execState.put(FINISHED_INTRA_BROKER_DATA_MOVEMENT, _executionTasksSummary.finishedIntraBrokerDataMovementInMB());
         execState.put(TOTAL_INTRA_BROKER_DATA_TO_MOVE, numTotalIntraBrokerDataToMove());
         if (verbose) {
-          execState.put(IN_PROGRESS_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, IN_PROGRESS));
-          execState.put(PENDING_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, PENDING));
-          execState.put(ABORTING_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, ABORTING));
-          execState.put(ABORTED_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, ABORTED));
-          execState.put(DEAD_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, DEAD));
-          execState.put(COMPLETED_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, COMPLETED));
+          execState.put(IN_PROGRESS_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, ExecutionTaskState.IN_PROGRESS));
+          execState.put(PENDING_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, ExecutionTaskState.PENDING));
+          execState.put(ABORTING_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, ExecutionTaskState.ABORTING));
+          execState.put(ABORTED_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, ExecutionTaskState.ABORTED));
+          execState.put(DEAD_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, ExecutionTaskState.DEAD));
+          execState.put(COMPLETED_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, ExecutionTaskState.COMPLETED));
         }
         break;
       case STOPPING_EXECUTION:
@@ -463,21 +462,21 @@ public class ExecutorState {
         execState.put(MAXIMUM_CONCURRENT_INTER_BROKER_PARTITION_MOVEMENTS_PER_BROKER, _maximumConcurrentInterBrokerPartitionMovementsPerBroker);
         execState.put(MAXIMUM_CONCURRENT_INTRA_BROKER_PARTITION_MOVEMENTS_PER_BROKER, _maximumConcurrentIntraBrokerPartitionMovementsPerBroker);
         execState.put(MAXIMUM_CONCURRENT_LEADER_MOVEMENTS, _maximumConcurrentLeaderMovements);
-        execState.put(NUM_CANCELLED_LEADERSHIP_MOVEMENTS, _executionTasksSummary.taskStat().get(LEADER_ACTION).get(PENDING));
-        execState.put(NUM_IN_PROGRESS_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(IN_PROGRESS));
-        execState.put(NUM_ABORTING_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(ABORTING));
-        execState.put(NUM_CANCELLED_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(PENDING));
-        execState.put(NUM_IN_PROGRESS_INTRA_BROKER_PARTITION_MOVEMENTS, intraBrokerPartitionMovementStats.get(IN_PROGRESS));
-        execState.put(NUM_ABORTING_INTRA_BROKER_PARTITION_MOVEMENTS, intraBrokerPartitionMovementStats.get(ABORTING));
-        execState.put(NUM_CANCELLED_INTRA_BROKER_PARTITION_MOVEMENTS, intraBrokerPartitionMovementStats.get(PENDING));
+        execState.put(NUM_CANCELLED_LEADERSHIP_MOVEMENTS, _executionTasksSummary.taskStat().get(LEADER_ACTION).get(ExecutionTaskState.PENDING));
+        execState.put(NUM_IN_PROGRESS_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(ExecutionTaskState.IN_PROGRESS));
+        execState.put(NUM_ABORTING_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(ExecutionTaskState.ABORTING));
+        execState.put(NUM_CANCELLED_INTER_BROKER_PARTITION_MOVEMENTS, interBrokerPartitionMovementStats.get(ExecutionTaskState.PENDING));
+        execState.put(NUM_IN_PROGRESS_INTRA_BROKER_PARTITION_MOVEMENTS, intraBrokerPartitionMovementStats.get(ExecutionTaskState.IN_PROGRESS));
+        execState.put(NUM_ABORTING_INTRA_BROKER_PARTITION_MOVEMENTS, intraBrokerPartitionMovementStats.get(ExecutionTaskState.ABORTING));
+        execState.put(NUM_CANCELLED_INTRA_BROKER_PARTITION_MOVEMENTS, intraBrokerPartitionMovementStats.get(ExecutionTaskState.PENDING));
         if (verbose) {
-          execState.put(CANCELLED_LEADERSHIP_MOVEMENT, getTaskDetails(LEADER_ACTION, ExecutionTask.State.PENDING));
-          execState.put(CANCELLED_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, PENDING));
-          execState.put(IN_PROGRESS_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, IN_PROGRESS));
-          execState.put(ABORTING_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, ABORTING));
-          execState.put(CANCELLED_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, PENDING));
-          execState.put(IN_PROGRESS_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, IN_PROGRESS));
-          execState.put(ABORTING_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, ABORTING));
+          execState.put(CANCELLED_LEADERSHIP_MOVEMENT, getTaskDetails(LEADER_ACTION, ExecutionTaskState.PENDING));
+          execState.put(CANCELLED_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, ExecutionTaskState.PENDING));
+          execState.put(IN_PROGRESS_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, ExecutionTaskState.IN_PROGRESS));
+          execState.put(ABORTING_INTER_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTER_BROKER_REPLICA_ACTION, ExecutionTaskState.ABORTING));
+          execState.put(CANCELLED_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, ExecutionTaskState.PENDING));
+          execState.put(IN_PROGRESS_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, ExecutionTaskState.IN_PROGRESS));
+          execState.put(ABORTING_INTRA_BROKER_PARTITION_MOVEMENT, getTaskDetails(INTRA_BROKER_REPLICA_ACTION, ExecutionTaskState.ABORTING));
         }
         break;
       default:
@@ -496,8 +495,8 @@ public class ExecutorState {
                                     ? String.format(", %s: %s", RECENTLY_DEMOTED_BROKERS, _recentlyDemotedBrokers) : "";
     String recentlyRemovedBrokers = (_recentlyRemovedBrokers != null && !_recentlyRemovedBrokers.isEmpty())
                                     ? String.format(", %s: %s", RECENTLY_REMOVED_BROKERS, _recentlyRemovedBrokers) : "";
-    Map<ExecutionTask.State, Integer> interBrokerPartitionMovementStats;
-    Map<ExecutionTask.State, Integer> intraBrokerPartitionMovementStats;
+    Map<ExecutionTaskState, Integer> interBrokerPartitionMovementStats;
+    Map<ExecutionTaskState, Integer> intraBrokerPartitionMovementStats;
     switch (_state) {
       case NO_TASK_IN_PROGRESS:
         return String.format("{%s: %s%s%s}", STATE, _state, recentlyDemotedBrokers, recentlyRemovedBrokers);
@@ -518,9 +517,9 @@ public class ExecutorState {
                              + " completed/total bytes(MB): %d/%d, maximum concurrent inter-broker partition movements per-broker:"
                              + " %d, %s: %s, %s: %s%s%s}",
                              STATE, _state,
-                             interBrokerPartitionMovementStats.get(PENDING),
-                             interBrokerPartitionMovementStats.get(IN_PROGRESS),
-                             interBrokerPartitionMovementStats.get(ABORTING),
+                             interBrokerPartitionMovementStats.get(ExecutionTaskState.PENDING),
+                             interBrokerPartitionMovementStats.get(ExecutionTaskState.IN_PROGRESS),
+                             interBrokerPartitionMovementStats.get(ExecutionTaskState.ABORTING),
                              numFinishedMovements(INTER_BROKER_REPLICA_ACTION),
                              numTotalMovements(INTER_BROKER_REPLICA_ACTION),
                              _executionTasksSummary.finishedInterBrokerDataMovementInMB(),
@@ -532,9 +531,9 @@ public class ExecutorState {
         return String.format("{%s: %s, pending/in-progress/aborting/finished/total intra-broker partition movement %d/%d/%d/%d/%d, completed/total"
                              + " bytes(MB): %d/%d, maximum concurrent intra-broker partition movements per-broker: %d, %s: %s, %s: %s%s%s}",
                              STATE, _state,
-                             intraBrokerPartitionMovementStats.get(PENDING),
-                             intraBrokerPartitionMovementStats.get(IN_PROGRESS),
-                             intraBrokerPartitionMovementStats.get(ABORTING),
+                             intraBrokerPartitionMovementStats.get(ExecutionTaskState.PENDING),
+                             intraBrokerPartitionMovementStats.get(ExecutionTaskState.IN_PROGRESS),
+                             intraBrokerPartitionMovementStats.get(ExecutionTaskState.ABORTING),
                              numFinishedMovements(INTRA_BROKER_REPLICA_ACTION),
                              numTotalMovements(INTRA_BROKER_REPLICA_ACTION),
                              _executionTasksSummary.finishedIntraBrokerDataMovementInMB(),
@@ -550,15 +549,15 @@ public class ExecutorState {
                              + "maximum concurrent inter-broker partition movements per-broker: %d, maximum concurrent leadership movements: %d, "
                              + "%s: %s, %s: %s%s%s}",
                              STATE, _state,
-                             intraBrokerPartitionMovementStats.get(PENDING),
-                             intraBrokerPartitionMovementStats.get(IN_PROGRESS),
-                             intraBrokerPartitionMovementStats.get(ABORTING),
+                             intraBrokerPartitionMovementStats.get(ExecutionTaskState.PENDING),
+                             intraBrokerPartitionMovementStats.get(ExecutionTaskState.IN_PROGRESS),
+                             intraBrokerPartitionMovementStats.get(ExecutionTaskState.ABORTING),
                              numTotalMovements(INTRA_BROKER_REPLICA_ACTION),
-                             interBrokerPartitionMovementStats.get(PENDING),
-                             interBrokerPartitionMovementStats.get(IN_PROGRESS),
-                             interBrokerPartitionMovementStats.get(ABORTING),
+                             interBrokerPartitionMovementStats.get(ExecutionTaskState.PENDING),
+                             interBrokerPartitionMovementStats.get(ExecutionTaskState.IN_PROGRESS),
+                             interBrokerPartitionMovementStats.get(ExecutionTaskState.ABORTING),
                              numTotalMovements(INTER_BROKER_REPLICA_ACTION),
-                             _executionTasksSummary.taskStat().get(LEADER_ACTION).get(ExecutionTask.State.PENDING),
+                             _executionTasksSummary.taskStat().get(LEADER_ACTION).get(ExecutionTaskState.PENDING),
                              numTotalMovements(LEADER_ACTION),
                              _maximumConcurrentIntraBrokerPartitionMovementsPerBroker,
                              _maximumConcurrentInterBrokerPartitionMovementsPerBroker,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
@@ -60,9 +60,9 @@ class ReplicationThrottleHelper {
   boolean shouldRemoveThrottleForTask(ExecutionTask task) {
     return
       // the task should not be in progress
-      task.state() != ExecutionTask.State.IN_PROGRESS &&
+      task.state() != ExecutionTaskState.IN_PROGRESS &&
         // the task should not be pending
-        task.state() != ExecutionTask.State.PENDING &&
+        task.state() != ExecutionTaskState.PENDING &&
         // replica throttles only apply to inter-broker replica movement
         task.type() == ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION;
   }
@@ -71,7 +71,7 @@ class ReplicationThrottleHelper {
   // replica movement.
   boolean taskIsInProgress(ExecutionTask task) {
     return
-      task.state() == ExecutionTask.State.IN_PROGRESS &&
+      task.state() == ExecutionTaskState.IN_PROGRESS &&
         task.type() == ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlState.java
@@ -9,6 +9,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorState;
 import com.linkedin.kafka.cruisecontrol.executor.ExecutionTask;
+import com.linkedin.kafka.cruisecontrol.executor.ExecutionTaskState;
 import com.linkedin.kafka.cruisecontrol.executor.ExecutorState;
 import com.linkedin.kafka.cruisecontrol.monitor.LoadMonitorState;
 import com.linkedin.cruisecontrol.servlet.parameters.CruiseControlParameters;
@@ -26,7 +27,6 @@ import static com.linkedin.kafka.cruisecontrol.executor.ExecutorState.IN_PROGRES
 import static com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils.JSON_VERSION;
 import static com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils.VERSION;
 import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTask.TaskType;
-import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTask.State;
 
 @JsonResponseClass
 public class CruiseControlState extends AbstractCruiseControlResponse {
@@ -132,7 +132,7 @@ public class CruiseControlState extends AbstractCruiseControlResponse {
       if (!IN_PROGRESS_STATES.contains(_executorState.state())) {
         return;
       }
-      Map<TaskType, Map<State, Set<ExecutionTask>>> taskSnapshot = _executorState.executionTasksSummary().filteredTasksByState();
+      Map<TaskType, Map<ExecutionTaskState, Set<ExecutionTask>>> taskSnapshot = _executorState.executionTasksSummary().filteredTasksByState();
       taskSnapshot.forEach((type, taskMap) -> {
         String taskTypeString = type == TaskType.INTER_BROKER_REPLICA_ACTION ? INTER_BROKER_PARTITION_MOVEMENTS :
                                 type == TaskType.INTRA_BROKER_REPLICA_ACTION ? INTRA_BROKER_PARTITION_MOVEMENTS :
@@ -140,23 +140,23 @@ public class CruiseControlState extends AbstractCruiseControlResponse {
         sb.append(String.format("%n%n%s %s:%n",
                                 _executorState.state() == ExecutorState.State.STOPPING_EXECUTION ? "Cancelled" : "Pending",
                                 taskTypeString));
-        for (ExecutionTask task :  taskMap.get(State.PENDING)) {
+        for (ExecutionTask task :  taskMap.get(ExecutionTaskState.PENDING)) {
           sb.append(String.format("%s%n", task));
         }
         sb.append(String.format("%n%nIn progress %s:%n", taskTypeString));
-        for (ExecutionTask task : taskMap.get(State.IN_PROGRESS)) {
+        for (ExecutionTask task : taskMap.get(ExecutionTaskState.IN_PROGRESS)) {
           sb.append(String.format("%s%n", task));
         }
         sb.append(String.format("%n%nAborting %s:%n", taskTypeString));
-        for (ExecutionTask task :  taskMap.get(State.ABORTING)) {
+        for (ExecutionTask task :  taskMap.get(ExecutionTaskState.ABORTING)) {
           sb.append(String.format("%s%n", task));
         }
         sb.append(String.format("%n%nAborted %s:%n", taskTypeString));
-        for (ExecutionTask task :  taskMap.get(State.ABORTED)) {
+        for (ExecutionTask task :  taskMap.get(ExecutionTaskState.ABORTED)) {
           sb.append(String.format("%s%n", task));
         }
         sb.append(String.format("%n%nDead %s:%n", taskTypeString));
-        for (ExecutionTask task :  taskMap.get(State.DEAD)) {
+        for (ExecutionTask task :  taskMap.get(ExecutionTaskState.DEAD)) {
           sb.append(String.format("%s%n", task));
         }
       });

--- a/cruise-control/src/main/scala/com/linkedin/kafka/cruisecontrol/executor/ExecutorUtils.scala
+++ b/cruise-control/src/main/scala/com/linkedin/kafka/cruisecontrol/executor/ExecutorUtils.scala
@@ -45,14 +45,14 @@ object ExecutorUtils {
         var addTask = true
         val replicasToWrite = inProgressReplicasOpt match {
           case Some(inProgressReplicas) =>
-            if (task.state() == ExecutionTask.State.ABORTING) {
+            if (task.state() == ExecutionTaskState.ABORTING) {
               oldReplicas
-            } else if (task.state() == ExecutionTask.State.DEAD
-              || task.state() == ExecutionTask.State.ABORTED
-              || task.state() == ExecutionTask.State.COMPLETED) {
+            } else if (task.state() == ExecutionTaskState.DEAD
+              || task.state() == ExecutionTaskState.ABORTED
+              || task.state() == ExecutionTaskState.COMPLETED) {
               addTask = false
               Seq.empty
-            } else if (task.state() == ExecutionTask.State.IN_PROGRESS) {
+            } else if (task.state() == ExecutionTaskState.IN_PROGRESS) {
               if (!newReplicas.equals(inProgressReplicas)) {
                 throw new RuntimeException(s"The provided new replica list $newReplicas" +
                   s"is different from the in progress replica list $inProgressReplicas for $tp")
@@ -62,10 +62,10 @@ object ExecutorUtils {
               throw new IllegalStateException(s"Should never be here, the state is ${task.state()}")
             }
           case None =>
-            if (task.state() == ExecutionTask.State.ABORTED
-              || task.state() == ExecutionTask.State.DEAD
-              || task.state() == ExecutionTask.State.ABORTING
-              || task.state() == ExecutionTask.State.COMPLETED) {
+            if (task.state() == ExecutionTaskState.ABORTED
+              || task.state() == ExecutionTaskState.DEAD
+              || task.state() == ExecutionTaskState.ABORTING
+              || task.state() == ExecutionTaskState.COMPLETED) {
               LOG.warn(s"No need to abort tasks $task because the partition is not in reassignment")
               addTask = false
               Seq.empty
@@ -96,7 +96,6 @@ object ExecutorUtils {
   def executePreferredLeaderElection(kafkaZkClient: KafkaZkClient, tasks: java.util.List[ExecutionTask]) {
     val partitionsToExecute = tasks.asScala.map(task =>
       new TopicPartition(task.proposal.topic, task.proposal.partitionId)).toSet
-
     val preferredReplicaElectionCommand = new PreferredReplicaLeaderElectionCommand(kafkaZkClient, partitionsToExecute)
     preferredReplicaElectionCommand.moveLeaderToPreferredReplica()
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.daemon=false
 org.gradle.parallel=false
 org.gradle.jvmargs=-Xms512m -Xmx512m
-kafkaVersion=2.5.0
-zookeeperVersion=3.5.7
+kafkaVersion=2.6.0
+zookeeperVersion=3.5.8


### PR DESCRIPTION
This PR resolves #1309 and allows the Cruise Control Metrics reporter to work with Kafka 2.6 brokers.

This PR also refactors the `ExecutionTask.State` enum into its own separate class. This is needed as switching to the Kafka 2.6 libraries causes the gradle scala compiler to throw cyclical reference errors for this class.
