### PR TITLE
Skip parsing scopes that have keys without a matching value.

### DIFF
--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/metric/MetricsUtils.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/metric/MetricsUtils.java
@@ -204,11 +204,15 @@ public class MetricsUtils {
 
   /**
    * Convert a yammer metrics scope to a tags map.
+   * Skip parsing scopes that (1) are {@code null} or (2) have keys without a matching value
+   * (see https://github.com/linkedin/cruise-control/issues/1296).
    */
   private static Map<String, String> yammerMetricScopeToTags(String scope) {
     if (scope != null) {
       String[] kv = scope.split("\\.");
-      assert kv.length % 2 == 0;
+      if (kv.length % 2 != 0) {
+        return Collections.emptyMap();
+      }
       Map<String, String> tags = new HashMap<>();
       for (int i = 0; i < kv.length; i += 2) {
         tags.put(kv[i], kv[i + 1]);


### PR DESCRIPTION
This PR resolves #1296.
-- also note that `assert` statement is removed as (1) it is typically not enabled anyway (i.e. unless users explicitly use the `-ea` switch, it is disabled) and (2) this makes metrics reporter more defensive against Yammer metrics with an unexpected scope.