### PR TITLE
Support handling planned maintenance events submitted via a topic

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -341,6 +341,13 @@ public class KafkaCruiseControlUtils {
    * transient network failures (e.g. Error sending fetch request XXX to node XXX: org.apache.kafka.common.errors.DisconnectException.)
    * that prevents the consumer from getting offset from some brokers for as long as reconnect.backoff.ms.
    *
+   * Note the following assumptions for the given parameters:
+   * <ul>
+   *   <li>if a partition has never been written to, its end offset is expected to be {@code 0}.</li>
+   *   <li>if the earliest offset, whose timestamp is greater than or equal to the given timestamp in the corresponding
+   *   partition does not exist, {@code null} is expected for the offset for the time of the partition.</li>
+   * </ul>
+   *
    * @param endOffsets End offsets retrieved by consumer.
    * @param offsetsForTimes Offsets for times retrieved by consumer.
    */

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -10,26 +10,48 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.PreferredLeaderElectionGo
 import com.linkedin.kafka.cruisecontrol.config.EnvConfigProvider;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig;
+import com.linkedin.kafka.cruisecontrol.exception.SamplingException;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 import com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunner;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import kafka.zk.KafkaZkClient;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.AlterConfigsResult;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.CreatePartitionsResult;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.admin.DescribeLogDirsResult;
+import org.apache.kafka.clients.admin.NewPartitions;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.errors.ReassignmentInProgressException;
+import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.SystemTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import scala.Option;
 
 import java.io.FileInputStream;
@@ -49,12 +71,15 @@ import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.SKIP_HARD_GOAL_CHECK_PARAM;
+import static kafka.log.LogConfig.CleanupPolicyProp;
+import static kafka.log.LogConfig.RetentionMsProp;
 
 
 /**
  * Util class for convenience.
  */
 public class KafkaCruiseControlUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaCruiseControlUtils.class);
   public static final double MAX_BALANCEDNESS_SCORE = 100.0;
   public static final int ZK_SESSION_TIMEOUT = 120000;
   public static final int ZK_CONNECTION_TIMEOUT = 120000;
@@ -72,6 +97,8 @@ public class KafkaCruiseControlUtils {
   public static final int REQUEST_VERSION_UPDATE = -1;
   public static final String ENV_CONFIG_PROVIDER_NAME = "env";
   public static final String ENV_CONFIG_PROVIDER_CLASS_CONFIG = ".env.class";
+  public static final long CLIENT_REQUEST_TIMEOUT_MS = 30000L;
+  public static final String DEFAULT_CLEANUP_POLICY = "delete";
 
   private KafkaCruiseControlUtils() {
 
@@ -166,6 +193,194 @@ public class KafkaCruiseControlUtils {
       throw new ConfigException(String.format("Configuration %s must be provided.", configName));
     }
     return value;
+  }
+
+  /**
+   * Creates the given topic if it does not exist.
+   *
+   * @param adminClient The adminClient to send createTopics request.
+   * @param topicToBeCreated A wrapper around the topic to be created.
+   * @return {@code false} if the topic to be created already exists, {@code true} otherwise.
+   */
+  public static boolean createTopic(AdminClient adminClient, NewTopic topicToBeCreated) {
+    try {
+      CreateTopicsResult createTopicsResult = adminClient.createTopics(Collections.singletonList(topicToBeCreated));
+      createTopicsResult.values().get(topicToBeCreated.name()).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      LOG.info("Topic {} has been created.", topicToBeCreated.name());
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      if (e.getCause() instanceof TopicExistsException) {
+        return false;
+      }
+      throw new IllegalStateException(String.format("Unable to create topic %s.", topicToBeCreated.name()), e);
+    }
+    return true;
+  }
+
+  /**
+   * Build a wrapper around the topic with the given desired properties and {@link #DEFAULT_CLEANUP_POLICY}.
+   *
+   * @param topic The name of the topic.
+   * @param partitionCount Desired partition count.
+   * @param replicationFactor Desired replication factor.
+   * @param retentionMs Desired retention in milliseconds.
+   * @return A wrapper around the topic with the given desired properties.
+   */
+  public static NewTopic wrapTopic(String topic, int partitionCount, short replicationFactor, long retentionMs) {
+    if (partitionCount <= 0 || replicationFactor <= 0 || retentionMs <= 0) {
+      throw new IllegalArgumentException(String.format("Partition count (%d), replication factor (%d), and retention ms (%d)"
+                                                       + " must be positive for the topic (%s).", partitionCount,
+                                                       replicationFactor, retentionMs, topic));
+    }
+
+    NewTopic newTopic = new NewTopic(topic, partitionCount, replicationFactor);
+    Map<String, String> config = new HashMap<>(2);
+    config.put(RetentionMsProp(), Long.toString(retentionMs));
+    config.put(CleanupPolicyProp(), DEFAULT_CLEANUP_POLICY);
+    newTopic.configs(config);
+
+    return newTopic;
+  }
+
+  /**
+   * Add config altering operations to the given configs to alter for configs that differ between current and desired.
+   *
+   * @param configsToAlter A set of config altering operations to be populated.
+   * @param desiredConfig Desired config value by name.
+   * @param currentConfig Current config.
+   */
+  private static void maybeUpdateConfig(Set<AlterConfigOp> configsToAlter, Map<String, String> desiredConfig, Config currentConfig) {
+    for (Map.Entry<String, String> entry : desiredConfig.entrySet()) {
+      String configName = entry.getKey();
+      String targetConfigValue = entry.getValue();
+      ConfigEntry currentConfigEntry = currentConfig.get(configName);
+      if (currentConfigEntry == null || !currentConfigEntry.value().equals(targetConfigValue)) {
+        configsToAlter.add(new AlterConfigOp(new ConfigEntry(configName, targetConfigValue), AlterConfigOp.OpType.SET));
+      }
+    }
+  }
+
+  /**
+   * Update topic configurations with the desired configs specified in the given topicToUpdateConfigs.
+   *
+   * @param adminClient The adminClient to send describeConfigs and incrementalAlterConfigs requests.
+   * @param topicToUpdateConfigs Existing topic to update selected configs if needed -- cannot be {@code null}.
+   * @return {@code true} if the request is completed successfully, {@code false} if there are any exceptions.
+   */
+  public static boolean maybeUpdateTopicConfig(AdminClient adminClient, NewTopic topicToUpdateConfigs) {
+    String topicName = topicToUpdateConfigs.name();
+    // Retrieve topic config to check if it needs an update.
+    ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
+    DescribeConfigsResult describeConfigsResult = adminClient.describeConfigs(Collections.singleton(topicResource));
+    Config topicConfig;
+    try {
+      topicConfig = describeConfigsResult.values().get(topicResource).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      LOG.warn("Config check for topic {} failed due to failure to describe its configs.", topicName, e);
+      return false;
+    }
+
+    // Update configs if needed.
+    Map<String, String> desiredConfig = topicToUpdateConfigs.configs();
+    if (desiredConfig != null) {
+      Set<AlterConfigOp> alterConfigOps = new HashSet<>(desiredConfig.size());
+      maybeUpdateConfig(alterConfigOps, desiredConfig, topicConfig);
+      if (!alterConfigOps.isEmpty()) {
+        AlterConfigsResult alterConfigsResult
+            = adminClient.incrementalAlterConfigs(Collections.singletonMap(topicResource, alterConfigOps));
+        try {
+          alterConfigsResult.values().get(topicResource).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+          LOG.warn("Config change for topic {} failed.", topicName, e);
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Increase the partition count of the given existing topic to the desired partition count (if needed).
+   *
+   * @param adminClient The adminClient to send describeTopics and createPartitions requests.
+   * @param topicToAddPartitions Existing topic to add more partitions if needed -- cannot be {@code null}.
+   * @return {@code true} if the request is completed successfully, {@code false} if there are any exceptions.
+   */
+  public static boolean maybeIncreasePartitionCount(AdminClient adminClient, NewTopic topicToAddPartitions) {
+    String topicName = topicToAddPartitions.name();
+
+    // Retrieve partition count of topic to check if it needs a partition count update.
+    TopicDescription topicDescription;
+    try {
+      topicDescription = adminClient.describeTopics(Collections.singletonList(topicName)).values()
+                                    .get(topicName).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      LOG.warn("Partition count increase check for topic {} failed due to failure to describe cluster.", topicName, e);
+      return false;
+    }
+
+    // Update partition count of topic if needed.
+    if (topicDescription.partitions().size() < topicToAddPartitions.numPartitions()) {
+      CreatePartitionsResult createPartitionsResult = adminClient.createPartitions(
+          Collections.singletonMap(topicName, NewPartitions.increaseTo(topicToAddPartitions.numPartitions())));
+
+      try {
+        createPartitionsResult.values().get(topicName).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      } catch (InterruptedException | ExecutionException | TimeoutException e) {
+        LOG.warn("Partition count increase to {} for topic {} failed{}.", topicToAddPartitions.numPartitions(), topicName,
+                 (e.getCause() instanceof ReassignmentInProgressException) ? " due to ongoing reassignment" : "", e);
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Sanity check whether there are failures in partition offsets fetched by a consumer. This typically happens due to
+   * transient network failures (e.g. Error sending fetch request XXX to node XXX: org.apache.kafka.common.errors.DisconnectException.)
+   * that prevents the consumer from getting offset from some brokers for as long as reconnect.backoff.ms.
+   *
+   * @param endOffsets End offsets retrieved by consumer.
+   * @param offsetsForTimes Offsets for times retrieved by consumer.
+   */
+  public static void sanityCheckOffsetFetch(Map<TopicPartition, Long> endOffsets,
+                                            Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes)
+      throws SamplingException {
+    Set<TopicPartition> failedToFetchOffsets = new HashSet<>();
+    for (Map.Entry<TopicPartition, OffsetAndTimestamp> entry : offsetsForTimes.entrySet()) {
+      if (entry.getValue() == null && endOffsets.get(entry.getKey()) == null) {
+        failedToFetchOffsets.add(entry.getKey());
+      }
+    }
+
+    if (!failedToFetchOffsets.isEmpty()) {
+      throw new SamplingException(String.format("Consumer failed to fetch offsets for %s. Consider decreasing "
+                                                + "reconnect.backoff.ms to mitigate consumption failures"
+                                                + " due to transient network issues.", failedToFetchOffsets));
+    }
+  }
+
+  /**
+   * Check whether the given consumer is done with the consumption of each partition with the given offsets.
+   * A consumption is considered as done if either of the following is satisfied:
+   * <ul>
+   *   <li>The consumer has caught up with the provided offsets</li>
+   *   <li>All partitions are paused</li>
+   * </ul>
+   *
+   * @param offsets Offsets for each partition consumption to catch up.
+   * @return True if the consumption is done, false otherwise.
+   */
+  public static <K, V> boolean consumptionDone(Consumer<K, V> consumer, Map<TopicPartition, Long> offsets) {
+    Set<TopicPartition> partitionsNotPaused = new HashSet<>(consumer.assignment());
+    partitionsNotPaused.removeAll(consumer.paused());
+    for (TopicPartition tp : partitionsNotPaused) {
+      if (consumer.position(tp) < offsets.get(tp)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**
@@ -366,9 +581,9 @@ public class KafkaCruiseControlUtils {
     // Add bootstrap server.
     List<String> bootstrapServers = configs.getList(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG);
     String bootstrapServersString = bootstrapServers.toString()
-        .replace(" ", "")
-        .replace("[", "")
-        .replace("]", "");
+                                                    .replace(" ", "")
+                                                    .replace("[", "")
+                                                    .replace("]", "");
     adminClientConfigs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServersString);
 
     // Add security protocol (if specified).

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AddBrokerPlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AddBrokerPlan.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.detector;
+
+import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.Set;
+
+
+public class AddBrokerPlan extends MaintenancePlan {
+  public static final byte PLAN_VERSION = 0;
+  private final Set<Integer> _brokers;
+
+  public AddBrokerPlan(long timeMs, int brokerId, Set<Integer> brokers) {
+    super(MaintenanceEventType.ADD_BROKER, timeMs, brokerId);
+    if (brokers == null || brokers.isEmpty()) {
+      throw new IllegalArgumentException("Missing brokers for the plan.");
+    }
+    if (brokers.size() > Short.MAX_VALUE) {
+      throw new IllegalArgumentException(String.format("Cannot add more than %d brokers (attempt: %d).",
+                                                       Short.MAX_VALUE, brokers.size()));
+    }
+    _brokers = brokers;
+  }
+
+  @Override
+  public byte planVersion() {
+    return PLAN_VERSION;
+  }
+
+  public Set<Integer> brokers() {
+    return _brokers;
+  }
+
+  @Override
+  public ByteBuffer toBuffer(int headerSize) {
+    short numBrokersToAdd = (short) _brokers.size();
+    ByteBuffer buffer = ByteBuffer.allocate(headerSize
+                                            + Byte.BYTES /* plan version */
+                                            + Long.BYTES /* timeMs */
+                                            + Integer.BYTES /* broker id */
+                                            + Short.BYTES /* number of brokers to add */
+                                            + (Integer.BYTES * numBrokersToAdd) /* brokers to add */);
+    buffer.position(headerSize);
+    buffer.put(planVersion());
+    buffer.putLong(timeMs());
+    buffer.putInt(brokerId());
+    buffer.putShort(numBrokersToAdd);
+    for (Integer brokerToAdd : _brokers) {
+      buffer.putInt(brokerToAdd);
+    }
+    return buffer;
+  }
+
+  /**
+   * Deserialize given byte buffer to an {@link AddBrokerPlan}.
+   *
+   * @param buffer buffer to deserialize.
+   * @return The {@link AddBrokerPlan} corresponding to the deserialized buffer.
+   */
+  public static AddBrokerPlan fromBuffer(ByteBuffer buffer) throws UnknownVersionException {
+    byte version = buffer.get();
+    if (version > PLAN_VERSION) {
+      throw new UnknownVersionException("Cannot deserialize the plan for version " + version + ". Current version: " + PLAN_VERSION);
+    }
+
+    long timeMs = buffer.getLong();
+    int brokerId = buffer.getInt();
+    short numBrokersToAdd = buffer.getShort();
+    Set<Integer> brokers = new HashSet<>(numBrokersToAdd);
+    for (short i = 0; i < numBrokersToAdd; i++) {
+      brokers.add(buffer.getInt());
+    }
+
+    return new AddBrokerPlan(timeMs, brokerId, brokers);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[%s] Brokers: %s, Source [timeMs: %d, broker: %d]", _maintenanceEventType, _brokers, _timeMs, _brokerId);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AddBrokerPlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AddBrokerPlan.java
@@ -7,6 +7,11 @@ package com.linkedin.kafka.cruisecontrol.detector;
 import java.util.Set;
 
 
+/**
+ * A plan to add brokers.
+ *
+ * The desired brokers to add are indicated using a set of broker ids.
+ */
 public class AddBrokerPlan extends MaintenancePlanWithBrokers {
   public static final byte LATEST_SUPPORTED_VERSION = 0;
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AddBrokerPlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AddBrokerPlan.java
@@ -4,85 +4,13 @@
 
 package com.linkedin.kafka.cruisecontrol.detector;
 
-import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
-import java.nio.ByteBuffer;
-import java.util.HashSet;
 import java.util.Set;
 
 
-public class AddBrokerPlan extends MaintenancePlan {
-  public static final byte PLAN_VERSION = 0;
-  private final Set<Integer> _brokers;
+public class AddBrokerPlan extends MaintenancePlanWithBrokers {
+  public static final byte LATEST_SUPPORTED_VERSION = 0;
 
   public AddBrokerPlan(long timeMs, int brokerId, Set<Integer> brokers) {
-    super(MaintenanceEventType.ADD_BROKER, timeMs, brokerId);
-    if (brokers == null || brokers.isEmpty()) {
-      throw new IllegalArgumentException("Missing brokers for the plan.");
-    }
-    if (brokers.size() > Short.MAX_VALUE) {
-      throw new IllegalArgumentException(String.format("Cannot add more than %d brokers (attempt: %d).",
-                                                       Short.MAX_VALUE, brokers.size()));
-    }
-    _brokers = brokers;
-  }
-
-  @Override
-  public byte planVersion() {
-    return PLAN_VERSION;
-  }
-
-  public Set<Integer> brokers() {
-    return _brokers;
-  }
-
-  @Override
-  public ByteBuffer toBuffer(int headerSize) {
-    short numBrokersToAdd = (short) _brokers.size();
-    int contentSize = (Byte.BYTES /* plan version */
-                       + Long.BYTES /* timeMs */
-                       + Integer.BYTES /* broker id */
-                       + Short.BYTES /* number of brokers to add */
-                       + (Integer.BYTES * numBrokersToAdd) /* brokers to add */);
-    ByteBuffer buffer = ByteBuffer.allocate(headerSize + Long.BYTES /* crc */ + contentSize);
-    buffer.position(headerSize + Long.BYTES);
-    buffer.put(planVersion());
-    buffer.putLong(timeMs());
-    buffer.putInt(brokerId());
-    buffer.putShort(numBrokersToAdd);
-    for (Integer brokerToAdd : _brokers) {
-      buffer.putInt(brokerToAdd);
-    }
-    putCrc(headerSize, buffer, contentSize);
-    return buffer;
-  }
-
-  /**
-   * Deserialize given byte buffer to an {@link AddBrokerPlan}.
-   *
-   * @param headerSize The header size of the buffer.
-   * @param buffer buffer to deserialize.
-   * @return The {@link AddBrokerPlan} corresponding to the deserialized buffer.
-   */
-  public static AddBrokerPlan fromBuffer(int headerSize, ByteBuffer buffer) throws UnknownVersionException {
-    verifyCrc(headerSize, buffer);
-    byte version = buffer.get();
-    if (version > PLAN_VERSION) {
-      throw new UnknownVersionException("Cannot deserialize the plan for version " + version + ". Current version: " + PLAN_VERSION);
-    }
-
-    long timeMs = buffer.getLong();
-    int brokerId = buffer.getInt();
-    short numBrokersToAdd = buffer.getShort();
-    Set<Integer> brokers = new HashSet<>(numBrokersToAdd);
-    for (short i = 0; i < numBrokersToAdd; i++) {
-      brokers.add(buffer.getInt());
-    }
-
-    return new AddBrokerPlan(timeMs, brokerId, brokers);
-  }
-
-  @Override
-  public String toString() {
-    return String.format("[%s] Brokers: %s, Source [timeMs: %d, broker: %d]", _maintenanceEventType, _brokers, _timeMs, _brokerId);
+    super(MaintenanceEventType.ADD_BROKER, timeMs, brokerId, LATEST_SUPPORTED_VERSION, brokers);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorUtils.java
@@ -47,10 +47,14 @@ public class AnomalyDetectorUtils {
    * Create a Kafka consumer for retrieving reported Maintenance plans.
    * The consumer uses {@link String} for keys and {@link MaintenancePlan} for values.
    *
+   * This consumer is not intended to use (1) the group management functionality by using subscribe(topic) or (2) the Kafka-based
+   * offset management strategy. Hence, the {@link ConsumerConfig#GROUP_ID_CONFIG} config is irrelevant to it.
+   *
    * @param configs The configurations for Cruise Control.
+   * @param clientIdPrefix Client id prefix.
    * @return A new Kafka consumer
    */
-  public static Consumer<String, MaintenancePlan> createMaintenanceEventConsumer(Map<String, ?> configs, String groupIdPrefix) {
+  public static Consumer<String, MaintenancePlan> createMaintenanceEventConsumer(Map<String, ?> configs, String clientIdPrefix) {
     // Get bootstrap servers
     String bootstrapServers = configs.get(MonitorConfig.BOOTSTRAP_SERVERS_CONFIG).toString();
     // Trim the brackets in List's String representation.
@@ -63,8 +67,7 @@ public class AnomalyDetectorUtils {
     Properties consumerProps = new Properties();
     consumerProps.putAll(configs);
     consumerProps.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-    consumerProps.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupIdPrefix + randomToken);
-    consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, groupIdPrefix + "-consumer-" + randomToken);
+    consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, clientIdPrefix + "-consumer-" + randomToken);
     consumerProps.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
     consumerProps.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
     consumerProps.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, Integer.toString(Integer.MAX_VALUE));

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorUtils.java
@@ -54,13 +54,10 @@ public class AnomalyDetectorUtils {
    * @param clientIdPrefix Client id prefix.
    * @return A new Kafka consumer
    */
+  @SuppressWarnings("unchecked")
   public static Consumer<String, MaintenancePlan> createMaintenanceEventConsumer(Map<String, ?> configs, String clientIdPrefix) {
     // Get bootstrap servers
-    String bootstrapServers = configs.get(MonitorConfig.BOOTSTRAP_SERVERS_CONFIG).toString();
-    // Trim the brackets in List's String representation.
-    if (bootstrapServers.length() > 2) {
-      bootstrapServers = bootstrapServers.substring(1, bootstrapServers.length() - 1);
-    }
+    String bootstrapServers = String.join(",", (List<String>) configs.get(MonitorConfig.BOOTSTRAP_SERVERS_CONFIG));
 
     // Create consumer
     long randomToken = RANDOM.nextLong();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DemoteBrokerPlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DemoteBrokerPlan.java
@@ -38,13 +38,13 @@ public class DemoteBrokerPlan extends MaintenancePlan {
   @Override
   public ByteBuffer toBuffer(int headerSize) {
     short numBrokersToDemote = (short) _brokers.size();
-    ByteBuffer buffer = ByteBuffer.allocate(headerSize
-                                            + Byte.BYTES /* plan version */
-                                            + Long.BYTES /* timeMs */
-                                            + Integer.BYTES /* broker id */
-                                            + Short.BYTES /* number of brokers to demote */
-                                            + (Integer.BYTES * numBrokersToDemote) /* brokers to demote */);
-    buffer.position(headerSize);
+    int contentSize = (Byte.BYTES /* plan version */
+                       + Long.BYTES /* timeMs */
+                       + Integer.BYTES /* broker id */
+                       + Short.BYTES /* number of brokers to demote */
+                       + (Integer.BYTES * numBrokersToDemote) /* brokers to demote */);
+    ByteBuffer buffer = ByteBuffer.allocate(headerSize + Long.BYTES /* crc */ + contentSize);
+    buffer.position(headerSize + Long.BYTES);
     buffer.put(planVersion());
     buffer.putLong(timeMs());
     buffer.putInt(brokerId());
@@ -52,16 +52,19 @@ public class DemoteBrokerPlan extends MaintenancePlan {
     for (Integer brokerToDemote : _brokers) {
       buffer.putInt(brokerToDemote);
     }
+    putCrc(headerSize, buffer, contentSize);
     return buffer;
   }
 
   /**
    * Deserialize given byte buffer to an {@link DemoteBrokerPlan}.
    *
+   * @param headerSize The header size of the buffer.
    * @param buffer buffer to deserialize.
    * @return The {@link DemoteBrokerPlan} corresponding to the deserialized buffer.
    */
-  public static DemoteBrokerPlan fromBuffer(ByteBuffer buffer) throws UnknownVersionException {
+  public static DemoteBrokerPlan fromBuffer(int headerSize, ByteBuffer buffer) throws UnknownVersionException {
+    verifyCrc(headerSize, buffer);
     byte version = buffer.get();
     if (version > PLAN_VERSION) {
       throw new UnknownVersionException("Cannot deserialize the plan for version " + version + ". Current version: " + PLAN_VERSION);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DemoteBrokerPlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DemoteBrokerPlan.java
@@ -7,6 +7,11 @@ package com.linkedin.kafka.cruisecontrol.detector;
 import java.util.Set;
 
 
+/**
+ * A plan to demote brokers.
+ *
+ * The desired brokers to demote are indicated using a set of broker ids.
+ */
 public class DemoteBrokerPlan extends MaintenancePlanWithBrokers {
   public static final byte LATEST_SUPPORTED_VERSION = 0;
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DemoteBrokerPlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DemoteBrokerPlan.java
@@ -4,85 +4,13 @@
 
 package com.linkedin.kafka.cruisecontrol.detector;
 
-import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
-import java.nio.ByteBuffer;
-import java.util.HashSet;
 import java.util.Set;
 
 
-public class DemoteBrokerPlan extends MaintenancePlan {
-  public static final byte PLAN_VERSION = 0;
-  private final Set<Integer> _brokers;
+public class DemoteBrokerPlan extends MaintenancePlanWithBrokers {
+  public static final byte LATEST_SUPPORTED_VERSION = 0;
 
   public DemoteBrokerPlan(long timeMs, int brokerId, Set<Integer> brokers) {
-    super(MaintenanceEventType.DEMOTE_BROKER, timeMs, brokerId);
-    if (brokers == null || brokers.isEmpty()) {
-      throw new IllegalArgumentException("Missing brokers for the plan.");
-    }
-    if (brokers.size() > Short.MAX_VALUE) {
-      throw new IllegalArgumentException(String.format("Cannot demote more than %d brokers (attempt: %d).",
-                                                       Short.MAX_VALUE, brokers.size()));
-    }
-    _brokers = brokers;
-  }
-
-  @Override
-  public byte planVersion() {
-    return PLAN_VERSION;
-  }
-
-  public Set<Integer> brokers() {
-    return _brokers;
-  }
-
-  @Override
-  public ByteBuffer toBuffer(int headerSize) {
-    short numBrokersToDemote = (short) _brokers.size();
-    int contentSize = (Byte.BYTES /* plan version */
-                       + Long.BYTES /* timeMs */
-                       + Integer.BYTES /* broker id */
-                       + Short.BYTES /* number of brokers to demote */
-                       + (Integer.BYTES * numBrokersToDemote) /* brokers to demote */);
-    ByteBuffer buffer = ByteBuffer.allocate(headerSize + Long.BYTES /* crc */ + contentSize);
-    buffer.position(headerSize + Long.BYTES);
-    buffer.put(planVersion());
-    buffer.putLong(timeMs());
-    buffer.putInt(brokerId());
-    buffer.putShort(numBrokersToDemote);
-    for (Integer brokerToDemote : _brokers) {
-      buffer.putInt(brokerToDemote);
-    }
-    putCrc(headerSize, buffer, contentSize);
-    return buffer;
-  }
-
-  /**
-   * Deserialize given byte buffer to an {@link DemoteBrokerPlan}.
-   *
-   * @param headerSize The header size of the buffer.
-   * @param buffer buffer to deserialize.
-   * @return The {@link DemoteBrokerPlan} corresponding to the deserialized buffer.
-   */
-  public static DemoteBrokerPlan fromBuffer(int headerSize, ByteBuffer buffer) throws UnknownVersionException {
-    verifyCrc(headerSize, buffer);
-    byte version = buffer.get();
-    if (version > PLAN_VERSION) {
-      throw new UnknownVersionException("Cannot deserialize the plan for version " + version + ". Current version: " + PLAN_VERSION);
-    }
-
-    long timeMs = buffer.getLong();
-    int brokerId = buffer.getInt();
-    short numBrokersToDemote = buffer.getShort();
-    Set<Integer> brokers = new HashSet<>(numBrokersToDemote);
-    for (short i = 0; i < numBrokersToDemote; i++) {
-      brokers.add(buffer.getInt());
-    }
-
-    return new DemoteBrokerPlan(timeMs, brokerId, brokers);
-  }
-
-  @Override
-  public String toString() {
-    return String.format("[%s] Brokers: %s, Source [timeMs: %d, broker: %d]", _maintenanceEventType, _brokers, _timeMs, _brokerId);
+    super(MaintenanceEventType.DEMOTE_BROKER, timeMs, brokerId, LATEST_SUPPORTED_VERSION, brokers);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DemoteBrokerPlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DemoteBrokerPlan.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.detector;
+
+import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.Set;
+
+
+public class DemoteBrokerPlan extends MaintenancePlan {
+  public static final byte PLAN_VERSION = 0;
+  private final Set<Integer> _brokers;
+
+  public DemoteBrokerPlan(long timeMs, int brokerId, Set<Integer> brokers) {
+    super(MaintenanceEventType.DEMOTE_BROKER, timeMs, brokerId);
+    if (brokers == null || brokers.isEmpty()) {
+      throw new IllegalArgumentException("Missing brokers for the plan.");
+    }
+    if (brokers.size() > Short.MAX_VALUE) {
+      throw new IllegalArgumentException(String.format("Cannot demote more than %d brokers (attempt: %d).",
+                                                       Short.MAX_VALUE, brokers.size()));
+    }
+    _brokers = brokers;
+  }
+
+  @Override
+  public byte planVersion() {
+    return PLAN_VERSION;
+  }
+
+  public Set<Integer> brokers() {
+    return _brokers;
+  }
+
+  @Override
+  public ByteBuffer toBuffer(int headerSize) {
+    short numBrokersToDemote = (short) _brokers.size();
+    ByteBuffer buffer = ByteBuffer.allocate(headerSize
+                                            + Byte.BYTES /* plan version */
+                                            + Long.BYTES /* timeMs */
+                                            + Integer.BYTES /* broker id */
+                                            + Short.BYTES /* number of brokers to demote */
+                                            + (Integer.BYTES * numBrokersToDemote) /* brokers to demote */);
+    buffer.position(headerSize);
+    buffer.put(planVersion());
+    buffer.putLong(timeMs());
+    buffer.putInt(brokerId());
+    buffer.putShort(numBrokersToDemote);
+    for (Integer brokerToDemote : _brokers) {
+      buffer.putInt(brokerToDemote);
+    }
+    return buffer;
+  }
+
+  /**
+   * Deserialize given byte buffer to an {@link DemoteBrokerPlan}.
+   *
+   * @param buffer buffer to deserialize.
+   * @return The {@link DemoteBrokerPlan} corresponding to the deserialized buffer.
+   */
+  public static DemoteBrokerPlan fromBuffer(ByteBuffer buffer) throws UnknownVersionException {
+    byte version = buffer.get();
+    if (version > PLAN_VERSION) {
+      throw new UnknownVersionException("Cannot deserialize the plan for version " + version + ". Current version: " + PLAN_VERSION);
+    }
+
+    long timeMs = buffer.getLong();
+    int brokerId = buffer.getInt();
+    short numBrokersToDemote = buffer.getShort();
+    Set<Integer> brokers = new HashSet<>(numBrokersToDemote);
+    for (short i = 0; i < numBrokersToDemote; i++) {
+      brokers.add(buffer.getInt());
+    }
+
+    return new DemoteBrokerPlan(timeMs, brokerId, brokers);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[%s] Brokers: %s, Source [timeMs: %d, broker: %d]", _maintenanceEventType, _brokers, _timeMs, _brokerId);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/FixOfflineReplicasPlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/FixOfflineReplicasPlan.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.detector;
+
+import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
+import java.nio.ByteBuffer;
+
+
+public class FixOfflineReplicasPlan extends MaintenancePlan {
+  public static final byte PLAN_VERSION = 0;
+
+  public FixOfflineReplicasPlan(long timeMs, int brokerId) {
+    super(MaintenanceEventType.FIX_OFFLINE_REPLICAS, timeMs, brokerId);
+  }
+
+  @Override
+  public byte planVersion() {
+    return PLAN_VERSION;
+  }
+
+  /**
+   * Deserialize given byte buffer to an {@link FixOfflineReplicasPlan}.
+   *
+   * @param buffer buffer to deserialize.
+   * @return The {@link FixOfflineReplicasPlan} corresponding to the deserialized buffer.
+   */
+  public static FixOfflineReplicasPlan fromBuffer(ByteBuffer buffer) throws UnknownVersionException {
+    byte version = buffer.get();
+    if (version > PLAN_VERSION) {
+      throw new UnknownVersionException("Cannot deserialize the plan for version " + version + ". Current version: " + PLAN_VERSION);
+    }
+
+    long timeMs = buffer.getLong();
+    int brokerId = buffer.getInt();
+
+    return new FixOfflineReplicasPlan(timeMs, brokerId);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[%s] Source [timeMs: %d, broker: %d]", _maintenanceEventType, _timeMs, _brokerId);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/FixOfflineReplicasPlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/FixOfflineReplicasPlan.java
@@ -4,44 +4,11 @@
 
 package com.linkedin.kafka.cruisecontrol.detector;
 
-import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
-import java.nio.ByteBuffer;
-
 
 public class FixOfflineReplicasPlan extends MaintenancePlan {
-  public static final byte PLAN_VERSION = 0;
+  public static final byte LATEST_SUPPORTED_VERSION = 0;
 
   public FixOfflineReplicasPlan(long timeMs, int brokerId) {
-    super(MaintenanceEventType.FIX_OFFLINE_REPLICAS, timeMs, brokerId);
-  }
-
-  @Override
-  public byte planVersion() {
-    return PLAN_VERSION;
-  }
-
-  /**
-   * Deserialize given byte buffer to an {@link FixOfflineReplicasPlan}.
-   *
-   * @param headerSize The header size of the buffer.
-   * @param buffer buffer to deserialize.
-   * @return The {@link FixOfflineReplicasPlan} corresponding to the deserialized buffer.
-   */
-  public static FixOfflineReplicasPlan fromBuffer(int headerSize, ByteBuffer buffer) throws UnknownVersionException {
-    verifyCrc(headerSize, buffer);
-    byte version = buffer.get();
-    if (version > PLAN_VERSION) {
-      throw new UnknownVersionException("Cannot deserialize the plan for version " + version + ". Current version: " + PLAN_VERSION);
-    }
-
-    long timeMs = buffer.getLong();
-    int brokerId = buffer.getInt();
-
-    return new FixOfflineReplicasPlan(timeMs, brokerId);
-  }
-
-  @Override
-  public String toString() {
-    return String.format("[%s] Source [timeMs: %d, broker: %d]", _maintenanceEventType, _timeMs, _brokerId);
+    super(MaintenanceEventType.FIX_OFFLINE_REPLICAS, timeMs, brokerId, LATEST_SUPPORTED_VERSION);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/FixOfflineReplicasPlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/FixOfflineReplicasPlan.java
@@ -5,6 +5,9 @@
 package com.linkedin.kafka.cruisecontrol.detector;
 
 
+/**
+ * A plan to fix offline replicas in the cluster.
+ */
 public class FixOfflineReplicasPlan extends MaintenancePlan {
   public static final byte LATEST_SUPPORTED_VERSION = 0;
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/FixOfflineReplicasPlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/FixOfflineReplicasPlan.java
@@ -23,10 +23,12 @@ public class FixOfflineReplicasPlan extends MaintenancePlan {
   /**
    * Deserialize given byte buffer to an {@link FixOfflineReplicasPlan}.
    *
+   * @param headerSize The header size of the buffer.
    * @param buffer buffer to deserialize.
    * @return The {@link FixOfflineReplicasPlan} corresponding to the deserialized buffer.
    */
-  public static FixOfflineReplicasPlan fromBuffer(ByteBuffer buffer) throws UnknownVersionException {
+  public static FixOfflineReplicasPlan fromBuffer(int headerSize, ByteBuffer buffer) throws UnknownVersionException {
+    verifyCrc(headerSize, buffer);
     byte version = buffer.get();
     if (version > PLAN_VERSION) {
       throw new UnknownVersionException("Cannot deserialize the plan for version " + version + ". Current version: " + PLAN_VERSION);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventDetector.java
@@ -58,6 +58,11 @@ public class MaintenanceEventDetector extends AbstractAnomalyDetector implements
         LOG.warn("Maintenance event detector encountered an exception.", e);
       }
     }
+    try {
+      _maintenanceEventReader.close();
+    } catch (Exception e) {
+      LOG.error("Received exception while closing maintenance event reader", e);
+    }
 
     LOG.debug("Maintenance event detector is shutdown.");
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventReader.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventReader.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.detector;
 
 import com.linkedin.cruisecontrol.common.CruiseControlConfigurable;
+import com.linkedin.kafka.cruisecontrol.exception.SamplingException;
 import java.time.Duration;
 import java.util.Set;
 import org.apache.kafka.common.annotation.InterfaceStability;
@@ -29,5 +30,5 @@ public interface MaintenanceEventReader extends CruiseControlConfigurable, AutoC
    * @param timeout The maximum time to block (must not be greater than {@link Long#MAX_VALUE} milliseconds)
    * @return Set of maintenance events, or empty set if none is available after the given timeout expires.
    */
-  Set<MaintenanceEvent> readEvents(Duration timeout);
+  Set<MaintenanceEvent> readEvents(Duration timeout) throws SamplingException;
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventTopicReader.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventTopicReader.java
@@ -177,9 +177,9 @@ public class MaintenanceEventTopicReader implements MaintenanceEventReader {
         ConsumerRecords<String, MaintenancePlan> records = _consumer.poll(timeout);
         for (ConsumerRecord<String, MaintenancePlan> record : records) {
           if (record == null) {
-            // This means that the record cannot be parsed because the maintenance event type is not recognized.
-            // It might happen when newer type of maintenance events have been added and the current code is still old.
-            // We simply ignore that metric in this case (see MaintenancePlanSerde#fromBytes).
+            // This means that the record cannot be parsed because the maintenance plan version is not supported. It might
+            // happen when existing maintenance plans have been updated and the current code is still old. We simply ignore
+            // that plan in this case (see MaintenancePlanSerde.MaintenancePlanTypeAdapter#verifyTypeAndVersion(String, byte).
             LOG.warn("Cannot parse record, please update your Cruise Control version.");
             continue;
           }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventTopicReader.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventTopicReader.java
@@ -83,11 +83,11 @@ public class MaintenanceEventTopicReader implements MaintenanceEventReader {
   public static final String MAINTENANCE_EVENT_TOPIC_REPLICATION_FACTOR_CONFIG = "maintenance.event.topic.replication.factor";
   public static final short DEFAULT_MAINTENANCE_EVENT_TOPIC_REPLICATION_FACTOR = 2;
   public static final String MAINTENANCE_EVENT_TOPIC_PARTITION_COUNT_CONFIG = "maintenance.event.topic.partition.count";
-  public static final int DEFAULT_MAINTENANCE_EVENT_TOPIC_PARTITION_COUNT = 32;
+  public static final int DEFAULT_MAINTENANCE_EVENT_TOPIC_PARTITION_COUNT = 8;
   public static final String MAINTENANCE_EVENT_TOPIC_RETENTION_MS_CONFIG = "maintenance.event.topic.retention.ms";
   public static final long DEFAULT_MAINTENANCE_EVENT_TOPIC_RETENTION_TIME_MS = Duration.ofHours(6).toMillis();
   public static final Duration CONSUMER_CLOSE_TIMEOUT = Duration.ofSeconds(2);
-  public static final String CONSUMER_GROUP_ID_PREFIX = MaintenanceEventTopicReader.class.getSimpleName();
+  public static final String CONSUMER_CLIENT_ID_PREFIX = MaintenanceEventTopicReader.class.getSimpleName();
   // How far should topic reader initially (i.e. upon startup) look back in the history for maintenance events.
   public static final long INIT_MAINTENANCE_HISTORY_MS = 60000L;
 
@@ -258,7 +258,7 @@ public class MaintenanceEventTopicReader implements MaintenanceEventReader {
     _maintenancePlanExpirationMs = maintenancePlanExpirationMs == null || maintenancePlanExpirationMs.isEmpty()
                                    ? DEFAULT_MAINTENANCE_PLAN_EXPIRATION_MS : Long.parseLong(maintenancePlanExpirationMs);
 
-    _consumer = createMaintenanceEventConsumer(configs, CONSUMER_GROUP_ID_PREFIX);
+    _consumer = createMaintenanceEventConsumer(configs, CONSUMER_CLIENT_ID_PREFIX);
 
     ensureTopicCreated(configs);
     _currentPartitionAssignment = Collections.emptySet();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventTopicReader.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventTopicReader.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.detector;
+
+import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
+import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils;
+import com.linkedin.kafka.cruisecontrol.config.constants.AnomalyDetectorConfig;
+import com.linkedin.kafka.cruisecontrol.exception.SamplingException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.CLIENT_REQUEST_TIMEOUT_MS;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.consumptionDone;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.createTopic;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.maybeIncreasePartitionCount;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.maybeUpdateTopicConfig;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.sanityCheckOffsetFetch;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.wrapTopic;
+import static com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorUtils.ANOMALY_DETECTION_TIME_MS_OBJECT_CONFIG;
+import static com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorUtils.KAFKA_CRUISE_CONTROL_OBJECT_CONFIG;
+import static com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorUtils.createMaintenanceEventConsumer;
+import static com.linkedin.kafka.cruisecontrol.detector.AnomalyUtils.extractKafkaCruiseControlObjectFromConfig;
+import static com.linkedin.kafka.cruisecontrol.detector.MaintenanceEvent.BROKERS_OBJECT_CONFIG;
+import static com.linkedin.kafka.cruisecontrol.detector.MaintenanceEvent.MAINTENANCE_EVENT_TYPE_CONFIG;
+import static com.linkedin.kafka.cruisecontrol.detector.MaintenanceEvent.TOPICS_WITH_RF_UPDATE_CONFIG;
+import static com.linkedin.kafka.cruisecontrol.detector.notifier.KafkaAnomalyType.MAINTENANCE_EVENT;
+
+
+/**
+ * A maintenance event reader that retrieves events from the configured Kafka topic.
+ *
+ * Required configurations for this class.
+ * <ul>
+ *   <li>{@link #MAINTENANCE_EVENT_TOPIC_CONFIG}: The config for the name of the Kafka topic to consume maintenance events
+ *   from (default: {@link #DEFAULT_MAINTENANCE_EVENT_TOPIC}).</li>
+ *   <li>{@link #MAINTENANCE_EVENT_TOPIC_REPLICATION_FACTOR_CONFIG}: The config for the replication factor of the maintenance
+ *   event topic (default: min({@link #DEFAULT_MAINTENANCE_EVENT_TOPIC_REPLICATION_FACTOR}, broker-count-in-the-cluster)).</li>
+ *   <li>{@link #MAINTENANCE_EVENT_TOPIC_PARTITION_COUNT_CONFIG}: The config for the partition count of the maintenance
+ *   event topic (default: {@link #DEFAULT_MAINTENANCE_EVENT_TOPIC_PARTITION_COUNT}).</li>
+ *   <li>{@link #MAINTENANCE_EVENT_TOPIC_RETENTION_MS_CONFIG}: The config for the retention of the maintenance event topic
+ *   (default: {@link #DEFAULT_MAINTENANCE_EVENT_TOPIC_RETENTION_TIME_MS}).</li>
+ *   <li>{@link #MAINTENANCE_PLAN_EXPIRATION_MS_CONFIG}: The config for the validity period of a maintenance plan
+ *   (default: {@link #DEFAULT_MAINTENANCE_PLAN_EXPIRATION_MS}).</li>
+ * </ul>
+ */
+public class MaintenanceEventTopicReader implements MaintenanceEventReader {
+  private static final Logger LOG = LoggerFactory.getLogger(MaintenanceEventTopicReader.class);
+  protected String _maintenanceEventTopic;
+  protected Consumer<String, MaintenancePlan> _consumer;
+  protected Set<TopicPartition> _currentPartitionAssignment;
+  protected volatile boolean _shutdown = false;
+  protected long _lastEventReadPeriodEndTimeMs;
+  protected KafkaCruiseControl _kafkaCruiseControl;
+  // A maintenance event has a certain validity period after which it expires and becomes invalid. A delay in handling
+  // could be introduced by the Kafka producer that generates the plan, the consumer that retrieves the plan, or the
+  // network that connects these clients to the Kafka cluster. Maintenance event topic reader discards the expired events.
+  protected long _maintenancePlanExpirationMs;
+
+  public static final String MAINTENANCE_PLAN_EXPIRATION_MS_CONFIG = "maintenance.plan.expiration.ms";
+  public static final long DEFAULT_MAINTENANCE_PLAN_EXPIRATION_MS = Duration.ofMinutes(15).toMillis();
+  public static final String MAINTENANCE_EVENT_TOPIC_CONFIG = "maintenance.event.topic";
+  public static final String DEFAULT_MAINTENANCE_EVENT_TOPIC = "__MaintenanceEvent";
+  public static final String MAINTENANCE_EVENT_TOPIC_REPLICATION_FACTOR_CONFIG = "maintenance.event.topic.replication.factor";
+  public static final short DEFAULT_MAINTENANCE_EVENT_TOPIC_REPLICATION_FACTOR = 2;
+  public static final String MAINTENANCE_EVENT_TOPIC_PARTITION_COUNT_CONFIG = "maintenance.event.topic.partition.count";
+  public static final int DEFAULT_MAINTENANCE_EVENT_TOPIC_PARTITION_COUNT = 32;
+  public static final String MAINTENANCE_EVENT_TOPIC_RETENTION_MS_CONFIG = "maintenance.event.topic.retention.ms";
+  public static final long DEFAULT_MAINTENANCE_EVENT_TOPIC_RETENTION_TIME_MS = Duration.ofHours(6).toMillis();
+  public static final Duration CONSUMER_CLOSE_TIMEOUT = Duration.ofSeconds(2);
+  public static final String CONSUMER_GROUP_ID_PREFIX = MaintenanceEventTopicReader.class.getSimpleName();
+  // How far should topic reader initially (i.e. upon startup) look back in the history for maintenance events.
+  public static final long INIT_MAINTENANCE_HISTORY_MS = 60000L;
+
+  /**
+   * Seek to the relevant offsets (i.e. either (1) end time of the last event read period or (2) end offset) that the
+   * consumer will use on the next poll from each partition.
+   *
+   * @return End offsets by the partitions to be consumed.
+   */
+  protected Map<TopicPartition, Long> seekToRelevantOffsets() throws SamplingException {
+    Map<TopicPartition, Long> timestampToSeek = new HashMap<>(_currentPartitionAssignment.size());
+    for (TopicPartition tp : _currentPartitionAssignment) {
+      timestampToSeek.put(tp, _lastEventReadPeriodEndTimeMs);
+    }
+    Set<TopicPartition> assignment = new HashSet<>(_currentPartitionAssignment);
+    Map<TopicPartition, Long> endOffsets = _consumer.endOffsets(assignment);
+    Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes = _consumer.offsetsForTimes(timestampToSeek);
+    sanityCheckOffsetFetch(endOffsets, offsetsForTimes);
+
+    // If offsets for times are provided for a partition, seek to the returned offset. Otherwise, i.e. for partitions
+    // without a record timestamp greater than or equal to the target timestamp, seek to the end offset.
+    for (Map.Entry<TopicPartition, OffsetAndTimestamp> entry : offsetsForTimes.entrySet()) {
+      TopicPartition tp = entry.getKey();
+      OffsetAndTimestamp offsetAndTimestamp = entry.getValue();
+      _consumer.seek(tp, offsetAndTimestamp != null ? offsetAndTimestamp.offset() : endOffsets.get(tp));
+    }
+
+    return endOffsets;
+  }
+
+  protected void addMaintenancePlan(MaintenancePlan maintenancePlan, Set<MaintenanceEvent> maintenanceEvents) {
+    LOG.debug("Retrieved maintenance plan {}.", maintenancePlan);
+    Map<String, Object> parameterConfigOverrides = new HashMap<>(4);
+    parameterConfigOverrides.put(KAFKA_CRUISE_CONTROL_OBJECT_CONFIG, _kafkaCruiseControl);
+    parameterConfigOverrides.put(ANOMALY_DETECTION_TIME_MS_OBJECT_CONFIG, _kafkaCruiseControl.timeMs());
+    parameterConfigOverrides.put(MAINTENANCE_EVENT_TYPE_CONFIG, maintenancePlan.maintenanceEventType());
+    switch (maintenancePlan.maintenanceEventType()) {
+      case ADD_BROKER:
+        parameterConfigOverrides.put(BROKERS_OBJECT_CONFIG, ((AddBrokerPlan) maintenancePlan).brokers());
+        break;
+      case REMOVE_BROKER:
+        parameterConfigOverrides.put(BROKERS_OBJECT_CONFIG, ((RemoveBrokerPlan) maintenancePlan).brokers());
+        break;
+      case FIX_OFFLINE_REPLICAS:
+      case REBALANCE:
+        break;
+      case DEMOTE_BROKER:
+        parameterConfigOverrides.put(BROKERS_OBJECT_CONFIG, ((DemoteBrokerPlan) maintenancePlan).brokers());
+        break;
+      case TOPIC_REPLICATION_FACTOR:
+        parameterConfigOverrides.put(TOPICS_WITH_RF_UPDATE_CONFIG, ((TopicReplicationFactorPlan) maintenancePlan).topicRegexWithRFUpdate());
+        break;
+      default:
+        throw new IllegalStateException(String.format("Unrecognized event type %s", maintenancePlan.maintenanceEventType()));
+    }
+    maintenanceEvents.add(_kafkaCruiseControl.config().getConfiguredInstance(AnomalyDetectorConfig.MAINTENANCE_EVENT_CLASS_CONFIG,
+                                                                             MaintenanceEvent.class,
+                                                                             parameterConfigOverrides));
+  }
+
+  /**
+   * See {@link MaintenanceEventReader#readEvents(Duration)}
+   * This method may block beyond the timeout in order to execute additional logic to create maintenance events from the
+   * maintenance plans retrieved from the relevant topic.
+   *
+   * @param timeout The maximum time to block for retrieving records from the relevant topic.
+   * @return Set of maintenance events, or empty set if none is available after the given timeout expires.
+   */
+  @Override
+  public Set<MaintenanceEvent> readEvents(Duration timeout) throws SamplingException {
+    LOG.debug("Reading maintenance events.");
+    long eventReadPeriodEndMs = _kafkaCruiseControl.timeMs();
+    if (refreshPartitionAssignment()) {
+      _lastEventReadPeriodEndTimeMs = eventReadPeriodEndMs;
+      return Collections.emptySet();
+    }
+
+    long timeoutEndMs = eventReadPeriodEndMs + timeout.toMillis();
+    Set<MaintenanceEvent> maintenanceEvents = new HashSet<>();
+    try {
+      Map<TopicPartition, Long> endOffsets = seekToRelevantOffsets();
+      LOG.debug("Started to consume from maintenance event topic partitions {}.", _currentPartitionAssignment);
+      _consumer.resume(_consumer.paused());
+      Set<TopicPartition> partitionsToPause = new HashSet<>();
+
+      do {
+        ConsumerRecords<String, MaintenancePlan> records = _consumer.poll(timeout);
+        for (ConsumerRecord<String, MaintenancePlan> record : records) {
+          if (record == null) {
+            // This means that the record cannot be parsed because the maintenance event type is not recognized.
+            // It might happen when newer type of maintenance events have been added and the current code is still old.
+            // We simply ignore that metric in this case (see MaintenancePlanSerde#fromBytes).
+            LOG.warn("Cannot parse record, please update your Cruise Control version.");
+            continue;
+          }
+
+          long planGenerationTimeMs = record.value().timeMs();
+          if (planGenerationTimeMs + _maintenancePlanExpirationMs < eventReadPeriodEndMs) {
+            LOG.warn("Discarding the expired plan {}. (Expired: {} Evaluated: {}).", record.value(),
+                     planGenerationTimeMs + _maintenancePlanExpirationMs, eventReadPeriodEndMs);
+          } else if (planGenerationTimeMs >= eventReadPeriodEndMs) {
+            TopicPartition tp = new TopicPartition(record.topic(), record.partition());
+            LOG.debug("Saw plan {} generated after the end time of event read period {}. Pausing {} at offset {}.",
+                      record.value(), eventReadPeriodEndMs, tp, record.offset());
+            partitionsToPause.add(tp);
+          } else {
+            addMaintenancePlan(record.value(), maintenanceEvents);
+          }
+        }
+
+        if (!partitionsToPause.isEmpty()) {
+          _consumer.pause(partitionsToPause);
+          partitionsToPause.clear();
+        }
+      } while (!consumptionDone(_consumer, endOffsets) && _kafkaCruiseControl.timeMs() < timeoutEndMs);
+
+      if (maintenanceEvents.size() > 0) {
+        LOG.info("Retrieved {} maintenance plans from partitions {} (range [{},{}]).", maintenanceEvents.size(),
+                 _currentPartitionAssignment, _lastEventReadPeriodEndTimeMs, eventReadPeriodEndMs);
+      }
+    } finally {
+      _lastEventReadPeriodEndTimeMs = eventReadPeriodEndMs;
+    }
+
+    return maintenanceEvents;
+  }
+
+  /**
+   * Ensure that the {@link #_consumer} is assigned to the latest partitions of the {@link #_maintenanceEventTopic}.
+   * This enables metrics reporter sampler to handle dynamic partition size increases in {@link #_maintenanceEventTopic}.
+   *
+   * @return True if the set of partitions currently assigned to this consumer is empty, false otherwise.
+   */
+  protected boolean refreshPartitionAssignment() {
+    List<PartitionInfo> remotePartitionInfo = _consumer.partitionsFor(_maintenanceEventTopic);
+    if (remotePartitionInfo == null) {
+      LOG.error("Consumer returned null for maintenance event topic {}.", _maintenanceEventTopic);
+      return true;
+    }
+    if (remotePartitionInfo.isEmpty()) {
+      _currentPartitionAssignment = Collections.emptySet();
+      LOG.error("The set of partitions currently assigned to the maintenance event consumer is empty.");
+      return true;
+    }
+
+    // Ensure that reassignment overhead is avoided if partition set of the topic has not changed.
+    if (remotePartitionInfo.size() == _currentPartitionAssignment.size()) {
+      return false;
+    }
+
+    _currentPartitionAssignment = new HashSet<>(remotePartitionInfo.size());
+    for (PartitionInfo partitionInfo : remotePartitionInfo) {
+      _currentPartitionAssignment.add(new TopicPartition(partitionInfo.topic(), partitionInfo.partition()));
+    }
+
+    _consumer.assign(_currentPartitionAssignment);
+    return false;
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    _kafkaCruiseControl = extractKafkaCruiseControlObjectFromConfig(configs, MAINTENANCE_EVENT);
+    String maintenanceEventTopic = (String) configs.get(MAINTENANCE_EVENT_TOPIC_CONFIG);
+    _maintenanceEventTopic = maintenanceEventTopic == null || maintenanceEventTopic.isEmpty()
+                             ? DEFAULT_MAINTENANCE_EVENT_TOPIC : maintenanceEventTopic;
+
+    String maintenancePlanExpirationMs = (String) configs.get(MAINTENANCE_PLAN_EXPIRATION_MS_CONFIG);
+    _maintenancePlanExpirationMs = maintenancePlanExpirationMs == null || maintenancePlanExpirationMs.isEmpty()
+                                   ? DEFAULT_MAINTENANCE_PLAN_EXPIRATION_MS : Long.parseLong(maintenancePlanExpirationMs);
+
+    _consumer = createMaintenanceEventConsumer(configs, CONSUMER_GROUP_ID_PREFIX);
+
+    ensureTopicCreated(configs);
+    _currentPartitionAssignment = Collections.emptySet();
+    if (refreshPartitionAssignment()) {
+      throw new IllegalStateException("Cannot find the maintenance event topic " + _maintenanceEventTopic + " in the cluster.");
+    }
+
+    _lastEventReadPeriodEndTimeMs = _kafkaCruiseControl.timeMs() - INIT_MAINTENANCE_HISTORY_MS;
+  }
+
+  /**
+   * Retrieve the replication factor of the maintenance event topic.
+   * If user did not set a value for {@link #MAINTENANCE_EVENT_TOPIC_REPLICATION_FACTOR_CONFIG}, it uses the
+   * min({@link #DEFAULT_MAINTENANCE_EVENT_TOPIC_REPLICATION_FACTOR}, {@code broker-count-in-the-cluster}).
+   *
+   * @param config The configurations for Cruise Control.
+   * @param adminClient The adminClient to send describeCluster request.
+   * @return The replication factor of the maintenance event topic.
+   */
+  protected static short maintenanceEventTopicReplicationFactor(Map<String, ?> config, AdminClient adminClient) {
+    String maintenanceEventTopicRF = (String) config.get(MAINTENANCE_EVENT_TOPIC_REPLICATION_FACTOR_CONFIG);
+    if (maintenanceEventTopicRF == null || maintenanceEventTopicRF.isEmpty()) {
+      short numberOfBrokersInCluster;
+      try {
+        numberOfBrokersInCluster = (short) adminClient.describeCluster().nodes().get(CLIENT_REQUEST_TIMEOUT_MS,
+                                                                                     TimeUnit.MILLISECONDS).size();
+      } catch (InterruptedException | ExecutionException | TimeoutException e) {
+        throw new IllegalStateException("Auto creation of maintenance event topic failed due to failure to describe cluster.", e);
+      }
+
+      return (short) Math.min(DEFAULT_MAINTENANCE_EVENT_TOPIC_REPLICATION_FACTOR, numberOfBrokersInCluster);
+    }
+
+    return Short.parseShort(maintenanceEventTopicRF);
+  }
+
+  protected static long maintenanceEventTopicRetentionMs(Map<String, ?> config) {
+    String maintenanceEventTopicRetentionMs = (String) config.get(MAINTENANCE_EVENT_TOPIC_RETENTION_MS_CONFIG);
+    return maintenanceEventTopicRetentionMs == null || maintenanceEventTopicRetentionMs.isEmpty()
+           ? DEFAULT_MAINTENANCE_EVENT_TOPIC_RETENTION_TIME_MS : Long.parseLong(maintenanceEventTopicRetentionMs);
+  }
+
+  protected static int maintenanceEventTopicPartitionCount(Map<String, ?> config) {
+    String maintenanceEventTopicPartitionCount = (String) config.get(MAINTENANCE_EVENT_TOPIC_PARTITION_COUNT_CONFIG);
+    return maintenanceEventTopicPartitionCount == null || maintenanceEventTopicPartitionCount.isEmpty()
+           ? DEFAULT_MAINTENANCE_EVENT_TOPIC_PARTITION_COUNT
+           : Integer.parseInt(maintenanceEventTopicPartitionCount);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected void ensureTopicCreated(Map<String, ?> config) {
+    AdminClient adminClient = KafkaCruiseControlUtils.createAdminClient((Map<String, Object>) config);
+    try {
+      short replicationFactor = maintenanceEventTopicReplicationFactor(config, adminClient);
+      long retentionMs = maintenanceEventTopicRetentionMs(config);
+      int partitionCount = maintenanceEventTopicPartitionCount(config);
+
+      NewTopic maintenanceEventTopic = wrapTopic(_maintenanceEventTopic, partitionCount, replicationFactor, retentionMs);
+      maybeCreateOrUpdateTopic(adminClient, maintenanceEventTopic);
+    } finally {
+      KafkaCruiseControlUtils.closeAdminClientWithTimeout(adminClient);
+    }
+  }
+
+  /**
+   * If the topic does not exist, create it with the requested partition count, replication factor, retention, and cleanup
+   * policy. Otherwise, if the existing topic has
+   * <ul>
+   *   <li>fewer than the requested number of partitions, increase the count to the requested value</li>
+   *   <li>a different retention, then update the retention to the requested value</li>
+   *   <li>a different cleanup policy, update the cleanup policy to the requested value</li>
+   * </ul>
+   *
+   * Note that the replication factor is not adjusted if an existing maintenance event topic has a different replication
+   * factor. Automated handling of replication factor inconsistencies is the responsibility of {@link TopicAnomalyDetector}.
+   *
+   * @param adminClient Admin client to use in topic creation, config checks, and required updates (if any).
+   * @param maintenanceEventTopic Maintenance event topic.
+   */
+  protected void maybeCreateOrUpdateTopic(AdminClient adminClient, NewTopic maintenanceEventTopic) {
+    if (!createTopic(adminClient, maintenanceEventTopic)) {
+      // Update topic config and partition count to ensure desired properties.
+      maybeUpdateTopicConfig(adminClient, maintenanceEventTopic);
+      maybeIncreasePartitionCount(adminClient, maintenanceEventTopic);
+    }
+  }
+
+  @Override
+  public void close() {
+    _shutdown = true;
+    // Close consumer.
+    _consumer.close(CONSUMER_CLOSE_TIMEOUT);
+    _currentPartitionAssignment.clear();
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventType.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventType.java
@@ -24,24 +24,12 @@ import java.util.List;
  */
 public enum MaintenanceEventType {
   // Do not change the order of enums. Append new ones to the end.
-  ADD_BROKER((byte) 0),
-  REMOVE_BROKER((byte) 1),
-  FIX_OFFLINE_REPLICAS((byte) 2),
-  REBALANCE((byte) 3),
-  DEMOTE_BROKER((byte) 4),
-  TOPIC_REPLICATION_FACTOR((byte) 5);
+  ADD_BROKER, REMOVE_BROKER, FIX_OFFLINE_REPLICAS, REBALANCE, DEMOTE_BROKER, TOPIC_REPLICATION_FACTOR;
 
   // This id helps with serialization and deserialization of event types
-  private final byte _id;
-
-  MaintenanceEventType(byte id) {
-    _id = id;
-  }
-
   byte id() {
-    return _id;
+    return (byte) ordinal();
   }
-
   /**
    * Retrieve the {@link MaintenanceEvent} that corresponds to the given id.
    *

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventType.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventType.java
@@ -23,7 +23,38 @@ import java.util.List;
  * </ul>
  */
 public enum MaintenanceEventType {
-  ADD_BROKER, REMOVE_BROKER, FIX_OFFLINE_REPLICAS, REBALANCE, DEMOTE_BROKER, TOPIC_REPLICATION_FACTOR;
+  // Do not change the order of enums. Append new ones to the end.
+  ADD_BROKER((byte) 0),
+  REMOVE_BROKER((byte) 1),
+  FIX_OFFLINE_REPLICAS((byte) 2),
+  REBALANCE((byte) 3),
+  DEMOTE_BROKER((byte) 4),
+  TOPIC_REPLICATION_FACTOR((byte) 5);
+
+  // This id helps with serialization and deserialization of event types
+  private final byte _id;
+
+  MaintenanceEventType(byte id) {
+    _id = id;
+  }
+
+  byte id() {
+    return _id;
+  }
+
+  /**
+   * Retrieve the {@link MaintenanceEvent} that corresponds to the given id.
+   *
+   * @param id ID that corresponds to the maintenance event type.
+   * @return Maintenance Event type with the given id.
+   */
+  public static MaintenanceEventType forId(byte id) {
+    if (id < cachedValues().size()) {
+      return cachedValues().get(id);
+    }
+
+    throw new IllegalArgumentException("MaintenanceEventType " + id + " does not exist.");
+  }
 
   private static final List<MaintenanceEventType> CACHED_VALUES = Collections.unmodifiableList(Arrays.asList(values()));
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenancePlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenancePlan.java
@@ -15,11 +15,13 @@ public abstract class MaintenancePlan {
   protected final MaintenanceEventType _maintenanceEventType;
   protected final long _timeMs;
   protected final int _brokerId;
+  protected final byte _planVersion;
 
-  public MaintenancePlan(MaintenanceEventType maintenanceEventType, long timeMs, int brokerId) {
+  public MaintenancePlan(MaintenanceEventType maintenanceEventType, long timeMs, int brokerId, byte planVersion) {
     _maintenanceEventType = maintenanceEventType;
     _timeMs = timeMs;
     _brokerId = brokerId;
+    _planVersion = planVersion;
   }
 
   /**
@@ -47,56 +49,24 @@ public abstract class MaintenancePlan {
   }
 
   /**
-   * @return The plan version for serialization/deserialization.
+   * @return The plan version.
    */
-  public abstract byte planVersion();
-
-  /**
-   * Verifies the crc of the given buffer with the crc computed with the rest of the buffer.
-   *
-   * @param headerSize The header size of the buffer.
-   * @param buffer The buffer, whose next eight bytes at its current position has the crc value to be verified.
-   */
-  protected static void verifyCrc(int headerSize, ByteBuffer buffer) {
-    long crc = buffer.getLong();
-    long computedCrc = Crc32C.compute(buffer, 0, buffer.limit() - (headerSize + Long.BYTES /* crc */));
-    if (crc != computedCrc) {
-      throw new IllegalArgumentException(String.format("The plan is corrupt. CRC (stored: %d, computed: %d)", crc, computedCrc));
-    }
+  public byte planVersion() {
+    return _planVersion;
   }
 
-  /**
-   * Puts the crc to the current position of the given buffer.
-   * The CRC covers all content to the end of the buffer -- i.e. all the bytes that follow the CRC.
-   *
-   * @param headerSize The header size of the buffer.
-   * @param buffer The buffer that has all bytes that follow the CRC written to it.
-   * @param contentSize The size of the content -- i.e. the size of all the bytes that follow the CRC.
-   */
-  protected void putCrc(int headerSize, ByteBuffer buffer, int contentSize) {
-    // The CRC covers all data to the end of the buffer -- i.e. all the bytes that follow the CRC.
-    long crc = Crc32C.compute(buffer, headerSize + Long.BYTES /* crc */ - buffer.position(), contentSize);
-    buffer.putLong(buffer.position() - contentSize - Long.BYTES /* crc */, crc);
-  }
-
-  /**
-   * Serialize the maintenance plan to a byte buffer with the header size reserved.
-   *
-   * @param headerSize the header size to reserve.
-   * @return A {@link ByteBuffer} with header size reserved at the beginning.
-   */
-  public ByteBuffer toBuffer(int headerSize) {
-    int contentSize = (Byte.BYTES /* plan version */
+  protected long getCrc() {
+    int contentSize = (Byte.BYTES /* maintenance event type id */
+                       + Byte.BYTES /* plan version */
                        + Long.BYTES /* timeMs */
                        + Integer.BYTES /* broker id */);
-    ByteBuffer buffer = ByteBuffer.allocate(headerSize + Long.BYTES /* crc */ + contentSize);
-
-    buffer.position(headerSize + Long.BYTES);
+    ByteBuffer buffer = ByteBuffer.allocate(contentSize);
+    buffer.put(maintenanceEventType().id());
     buffer.put(planVersion());
     buffer.putLong(timeMs());
     buffer.putInt(brokerId());
-    putCrc(headerSize, buffer, contentSize);
-    return buffer;
+    // The CRC covers all data to the end of the buffer.
+    return Crc32C.compute(buffer, -buffer.position(), contentSize);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenancePlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenancePlan.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.detector;
 
 import java.nio.ByteBuffer;
+import org.apache.kafka.common.utils.Crc32C;
 
 
 /**
@@ -51,20 +52,50 @@ public abstract class MaintenancePlan {
   public abstract byte planVersion();
 
   /**
+   * Verifies the crc of the given buffer with the crc computed with the rest of the buffer.
+   *
+   * @param headerSize The header size of the buffer.
+   * @param buffer The buffer, whose next eight bytes at its current position has the crc value to be verified.
+   */
+  protected static void verifyCrc(int headerSize, ByteBuffer buffer) {
+    long crc = buffer.getLong();
+    long computedCrc = Crc32C.compute(buffer, 0, buffer.limit() - (headerSize + Long.BYTES /* crc */));
+    if (crc != computedCrc) {
+      throw new IllegalArgumentException(String.format("The plan is corrupt. CRC (stored: %d, computed: %d)", crc, computedCrc));
+    }
+  }
+
+  /**
+   * Puts the crc to the current position of the given buffer.
+   * The CRC covers all content to the end of the buffer -- i.e. all the bytes that follow the CRC.
+   *
+   * @param headerSize The header size of the buffer.
+   * @param buffer The buffer that has all bytes that follow the CRC written to it.
+   * @param contentSize The size of the content -- i.e. the size of all the bytes that follow the CRC.
+   */
+  protected void putCrc(int headerSize, ByteBuffer buffer, int contentSize) {
+    // The CRC covers all data to the end of the buffer -- i.e. all the bytes that follow the CRC.
+    long crc = Crc32C.compute(buffer, headerSize + Long.BYTES /* crc */ - buffer.position(), contentSize);
+    buffer.putLong(buffer.position() - contentSize - Long.BYTES /* crc */, crc);
+  }
+
+  /**
    * Serialize the maintenance plan to a byte buffer with the header size reserved.
    *
    * @param headerSize the header size to reserve.
    * @return A {@link ByteBuffer} with header size reserved at the beginning.
    */
   public ByteBuffer toBuffer(int headerSize) {
-    ByteBuffer buffer = ByteBuffer.allocate(headerSize
-                                            + Byte.BYTES /* plan version */
-                                            + Long.BYTES /* timeMs */
-                                            + Integer.BYTES /* broker id */);
-    buffer.position(headerSize);
+    int contentSize = (Byte.BYTES /* plan version */
+                       + Long.BYTES /* timeMs */
+                       + Integer.BYTES /* broker id */);
+    ByteBuffer buffer = ByteBuffer.allocate(headerSize + Long.BYTES /* crc */ + contentSize);
+
+    buffer.position(headerSize + Long.BYTES);
     buffer.put(planVersion());
     buffer.putLong(timeMs());
     buffer.putInt(brokerId());
+    putCrc(headerSize, buffer, contentSize);
     return buffer;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenancePlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenancePlan.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.detector;
+
+import java.nio.ByteBuffer;
+
+
+/**
+ * An abstract class for all maintenance plans.
+ */
+public abstract class MaintenancePlan {
+  protected final MaintenanceEventType _maintenanceEventType;
+  protected final long _timeMs;
+  protected final int _brokerId;
+
+  public MaintenancePlan(MaintenanceEventType maintenanceEventType, long timeMs, int brokerId) {
+    _maintenanceEventType = maintenanceEventType;
+    _timeMs = timeMs;
+    _brokerId = brokerId;
+  }
+
+  /**
+   * Retrieve the maintenance event type of this maintenance plan.
+   *
+   * @return the maintenance event type of this maintenance plan, which is stored in the serialized metrics so
+   * that the deserializer will know which class should be used to deserialize the data.
+   */
+  public MaintenanceEventType maintenanceEventType() {
+    return _maintenanceEventType;
+  }
+
+  /**
+   * @return The timestamp in ms that corresponds to the generation of this plan.
+   */
+  public long timeMs() {
+    return _timeMs;
+  }
+
+  /**
+   * @return The id of the broker that reported this maintenance event.
+   */
+  public int brokerId() {
+    return _brokerId;
+  }
+
+  /**
+   * @return The plan version for serialization/deserialization.
+   */
+  public abstract byte planVersion();
+
+  /**
+   * Serialize the maintenance plan to a byte buffer with the header size reserved.
+   *
+   * @param headerSize the header size to reserve.
+   * @return A {@link ByteBuffer} with header size reserved at the beginning.
+   */
+  public ByteBuffer toBuffer(int headerSize) {
+    ByteBuffer buffer = ByteBuffer.allocate(headerSize
+                                            + Byte.BYTES /* plan version */
+                                            + Long.BYTES /* timeMs */
+                                            + Integer.BYTES /* broker id */);
+    buffer.position(headerSize);
+    buffer.put(planVersion());
+    buffer.putLong(timeMs());
+    buffer.putInt(brokerId());
+    return buffer;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[%s] Source [timeMs: %d, broker: %d]", _maintenanceEventType, _timeMs, _brokerId);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenancePlanSerde.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenancePlanSerde.java
@@ -4,8 +4,19 @@
 
 package com.linkedin.kafka.cruisecontrol.detector;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.reflect.TypeToken;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
-import java.nio.ByteBuffer;
+import java.lang.reflect.Type;
 import java.util.Map;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
@@ -15,53 +26,13 @@ import org.apache.kafka.common.serialization.Serializer;
  * A serializer / deserializer of {@link MaintenancePlan}.
  */
 public class MaintenancePlanSerde implements Serializer<MaintenancePlan>, Deserializer<MaintenancePlan> {
-  // The overhead of the type bytes
-  private static final int EVENT_TYPE_OFFSET = 0;
-  private static final int HEADER_LENGTH = Byte.BYTES;
-
-  /**
-   * Serialize the Maintenance plan to a byte array.
-   *
-   * @param recordValue Maintenance plan to be serialized.
-   * @return Serialized Maintenance plan as a byte array.
-   */
-  public static byte[] toBytes(MaintenancePlan recordValue) {
-    ByteBuffer byteBuffer = recordValue.toBuffer(HEADER_LENGTH);
-    byteBuffer.put(EVENT_TYPE_OFFSET, recordValue.maintenanceEventType().id());
-    return byteBuffer.array();
-  }
-
-  /**
-   * Deserialize from byte array to Maintenance plan.
-   *
-   * @param bytes Bytes array corresponding to Maintenance plan.
-   * @return Deserialized byte array as Maintenance plan, or {@code null} if the maintenance event type is not recognized.
-   */
-  public static MaintenancePlan fromBytes(byte[] bytes) throws UnknownVersionException {
-    ByteBuffer buffer = ByteBuffer.wrap(bytes);
-    switch (MaintenanceEventType.forId(buffer.get())) {
-      case ADD_BROKER:
-        return AddBrokerPlan.fromBuffer(HEADER_LENGTH, buffer);
-      case REMOVE_BROKER:
-        return RemoveBrokerPlan.fromBuffer(HEADER_LENGTH, buffer);
-      case FIX_OFFLINE_REPLICAS:
-        return FixOfflineReplicasPlan.fromBuffer(HEADER_LENGTH, buffer);
-      case REBALANCE:
-        return RebalancePlan.fromBuffer(HEADER_LENGTH, buffer);
-      case DEMOTE_BROKER:
-        return DemoteBrokerPlan.fromBuffer(HEADER_LENGTH, buffer);
-      case TOPIC_REPLICATION_FACTOR:
-        return TopicReplicationFactorPlan.fromBuffer(HEADER_LENGTH, buffer);
-      default:
-        // This could happen when a new type of maintenance event is added but we are still running the old code.
-        return null;
-    }
-  }
+  private final Gson
+      _gson = new GsonBuilder().registerTypeAdapter(MaintenancePlan.class, new MaintenancePlanTypeAdapter()).create();
 
   @Override
   public MaintenancePlan deserialize(String topic, byte[] bytes) {
     try {
-      return fromBytes(bytes);
+      return _gson.fromJson(new String(bytes), MaintenancePlan.class);
     } catch (Exception e) {
       throw new RuntimeException("Error occurred while deserializing Maintenance plan.", e);
     }
@@ -74,11 +45,100 @@ public class MaintenancePlanSerde implements Serializer<MaintenancePlan>, Deseri
 
   @Override
   public byte[] serialize(String topic, MaintenancePlan recordValue) {
-    return toBytes(recordValue);
+    return _gson.toJson(recordValue, new TypeToken<MaintenancePlan>() { }.getType()).getBytes();
   }
 
   @Override
   public void close() {
 
+  }
+
+  /**
+   * An adapter to support runtime type inference of maintenance plan.
+   */
+  public static class MaintenancePlanTypeAdapter implements JsonSerializer<MaintenancePlan>, JsonDeserializer<MaintenancePlan> {
+    public static final String PLAN_TYPE = "planType";
+    public static final String VERSION = "version";
+    public static final String CRC = "crc"; /* crc of the content */
+    public static final String CONTENT = "content";
+
+    /**
+     * Verifies the crc of the given plan with the crc computed with the given plan.
+     *
+     * @param maintenancePlan Maintenance plan
+     * @param storedCrc Expected crc of the maintenance plan retrieved via deserialization.
+     */
+    private static void verifyCrc(MaintenancePlan maintenancePlan, long storedCrc) {
+      long computedCrc = maintenancePlan.getCrc();
+      if (storedCrc != computedCrc) {
+        throw new IllegalArgumentException(String.format("Plan is corrupt. CRC (stored: %d, computed: %d)", storedCrc, computedCrc));
+      }
+    }
+
+    /**
+     * Check whether the maintenance plan with the given type exists and supports the given version
+     *
+     * @param type Plan type to verify
+     * @param version Version to verify
+     */
+    private static void verifyTypeAndVersion(String type, byte version) throws UnknownVersionException {
+      byte latestSupportedVersion;
+      if (AddBrokerPlan.class.getSimpleName().equals(type)) {
+        latestSupportedVersion = AddBrokerPlan.LATEST_SUPPORTED_VERSION;
+      } else if (RemoveBrokerPlan.class.getSimpleName().equals(type)) {
+        latestSupportedVersion = RemoveBrokerPlan.LATEST_SUPPORTED_VERSION;
+      } else if (FixOfflineReplicasPlan.class.getSimpleName().equals(type)) {
+        latestSupportedVersion = FixOfflineReplicasPlan.LATEST_SUPPORTED_VERSION;
+      } else if (RebalancePlan.class.getSimpleName().equals(type)) {
+        latestSupportedVersion = RebalancePlan.LATEST_SUPPORTED_VERSION;
+      } else if (DemoteBrokerPlan.class.getSimpleName().equals(type)) {
+        latestSupportedVersion = DemoteBrokerPlan.LATEST_SUPPORTED_VERSION;
+      } else if (TopicReplicationFactorPlan.class.getSimpleName().equals(type)) {
+        latestSupportedVersion = TopicReplicationFactorPlan.LATEST_SUPPORTED_VERSION;
+      } else { // This could happen when a new type of maintenance event is added but we are still running the old code.
+        throw new IllegalArgumentException(String.format("Unsupported plan type: %s", type));
+      }
+
+      if (version > latestSupportedVersion) {
+        throw new UnknownVersionException(String.format("Cannot deserialize the plan with type %s and version %d. Latest"
+                                                        + " supported version: %d.", type, version, latestSupportedVersion));
+      }
+    }
+
+    @Override
+    public JsonElement serialize(MaintenancePlan maintenancePlan, Type typeOfSrc, JsonSerializationContext context) {
+      JsonObject result = new JsonObject();
+      result.add(PLAN_TYPE, new JsonPrimitive(maintenancePlan.getClass().getSimpleName()));
+      result.add(VERSION, new JsonPrimitive(maintenancePlan.planVersion()));
+      result.add(CRC, new JsonPrimitive(maintenancePlan.getCrc()));
+      result.add(CONTENT, context.serialize(maintenancePlan, maintenancePlan.getClass()));
+      return result;
+    }
+
+    @Override
+    public MaintenancePlan deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+        throws JsonParseException {
+      JsonObject jsonObject = json.getAsJsonObject();
+      String type = jsonObject.get(PLAN_TYPE).getAsString();
+      byte version = jsonObject.get(VERSION).getAsByte();
+      try {
+        verifyTypeAndVersion(type, version);
+      } catch (UnknownVersionException e) {
+        return null;
+      }
+      long storedCrc = jsonObject.get(CRC).getAsLong();
+      JsonElement element = jsonObject.get(CONTENT);
+
+      try {
+        String fullName = typeOfT.getTypeName();
+        String packageText = fullName.substring(0, fullName.lastIndexOf(".") + 1);
+
+        MaintenancePlan maintenancePlan = context.deserialize(element, Class.forName(packageText + type));
+        verifyCrc(maintenancePlan, storedCrc);
+        return maintenancePlan;
+      } catch (ClassNotFoundException cnfe) {
+        throw new JsonParseException("Unknown element type: " + type, cnfe);
+      }
+    }
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenancePlanSerde.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenancePlanSerde.java
@@ -17,6 +17,7 @@ import com.google.gson.JsonSerializer;
 import com.google.gson.reflect.TypeToken;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
@@ -32,7 +33,7 @@ public class MaintenancePlanSerde implements Serializer<MaintenancePlan>, Deseri
   @Override
   public MaintenancePlan deserialize(String topic, byte[] bytes) {
     try {
-      return _gson.fromJson(new String(bytes), MaintenancePlan.class);
+      return _gson.fromJson(new String(bytes, StandardCharsets.UTF_8), MaintenancePlan.class);
     } catch (Exception e) {
       throw new RuntimeException("Error occurred while deserializing Maintenance plan.", e);
     }
@@ -45,7 +46,7 @@ public class MaintenancePlanSerde implements Serializer<MaintenancePlan>, Deseri
 
   @Override
   public byte[] serialize(String topic, MaintenancePlan recordValue) {
-    return _gson.toJson(recordValue, new TypeToken<MaintenancePlan>() { }.getType()).getBytes();
+    return _gson.toJson(recordValue, new TypeToken<MaintenancePlan>() { }.getType()).getBytes(StandardCharsets.UTF_8);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenancePlanSerde.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenancePlanSerde.java
@@ -17,7 +17,7 @@ import org.apache.kafka.common.serialization.Serializer;
 public class MaintenancePlanSerde implements Serializer<MaintenancePlan>, Deserializer<MaintenancePlan> {
   // The overhead of the type bytes
   private static final int EVENT_TYPE_OFFSET = 0;
-  private static final int HEADER_LENGTH = 1;
+  private static final int HEADER_LENGTH = Byte.BYTES;
 
   /**
    * Serialize the Maintenance plan to a byte array.
@@ -41,17 +41,17 @@ public class MaintenancePlanSerde implements Serializer<MaintenancePlan>, Deseri
     ByteBuffer buffer = ByteBuffer.wrap(bytes);
     switch (MaintenanceEventType.forId(buffer.get())) {
       case ADD_BROKER:
-        return AddBrokerPlan.fromBuffer(buffer);
+        return AddBrokerPlan.fromBuffer(HEADER_LENGTH, buffer);
       case REMOVE_BROKER:
-        return RemoveBrokerPlan.fromBuffer(buffer);
+        return RemoveBrokerPlan.fromBuffer(HEADER_LENGTH, buffer);
       case FIX_OFFLINE_REPLICAS:
-        return FixOfflineReplicasPlan.fromBuffer(buffer);
+        return FixOfflineReplicasPlan.fromBuffer(HEADER_LENGTH, buffer);
       case REBALANCE:
-        return RebalancePlan.fromBuffer(buffer);
+        return RebalancePlan.fromBuffer(HEADER_LENGTH, buffer);
       case DEMOTE_BROKER:
-        return DemoteBrokerPlan.fromBuffer(buffer);
+        return DemoteBrokerPlan.fromBuffer(HEADER_LENGTH, buffer);
       case TOPIC_REPLICATION_FACTOR:
-        return TopicReplicationFactorPlan.fromBuffer(buffer);
+        return TopicReplicationFactorPlan.fromBuffer(HEADER_LENGTH, buffer);
       default:
         // This could happen when a new type of maintenance event is added but we are still running the old code.
         return null;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenancePlanSerde.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenancePlanSerde.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.detector;
+
+import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+
+
+/**
+ * A serializer / deserializer of {@link MaintenancePlan}.
+ */
+public class MaintenancePlanSerde implements Serializer<MaintenancePlan>, Deserializer<MaintenancePlan> {
+  // The overhead of the type bytes
+  private static final int EVENT_TYPE_OFFSET = 0;
+  private static final int HEADER_LENGTH = 1;
+
+  /**
+   * Serialize the Maintenance plan to a byte array.
+   *
+   * @param recordValue Maintenance plan to be serialized.
+   * @return Serialized Maintenance plan as a byte array.
+   */
+  public static byte[] toBytes(MaintenancePlan recordValue) {
+    ByteBuffer byteBuffer = recordValue.toBuffer(HEADER_LENGTH);
+    byteBuffer.put(EVENT_TYPE_OFFSET, recordValue.maintenanceEventType().id());
+    return byteBuffer.array();
+  }
+
+  /**
+   * Deserialize from byte array to Maintenance plan.
+   *
+   * @param bytes Bytes array corresponding to Maintenance plan.
+   * @return Deserialized byte array as Maintenance plan, or {@code null} if the maintenance event type is not recognized.
+   */
+  public static MaintenancePlan fromBytes(byte[] bytes) throws UnknownVersionException {
+    ByteBuffer buffer = ByteBuffer.wrap(bytes);
+    switch (MaintenanceEventType.forId(buffer.get())) {
+      case ADD_BROKER:
+        return AddBrokerPlan.fromBuffer(buffer);
+      case REMOVE_BROKER:
+        return RemoveBrokerPlan.fromBuffer(buffer);
+      case FIX_OFFLINE_REPLICAS:
+        return FixOfflineReplicasPlan.fromBuffer(buffer);
+      case REBALANCE:
+        return RebalancePlan.fromBuffer(buffer);
+      case DEMOTE_BROKER:
+        return DemoteBrokerPlan.fromBuffer(buffer);
+      case TOPIC_REPLICATION_FACTOR:
+        return TopicReplicationFactorPlan.fromBuffer(buffer);
+      default:
+        // This could happen when a new type of maintenance event is added but we are still running the old code.
+        return null;
+    }
+  }
+
+  @Override
+  public MaintenancePlan deserialize(String topic, byte[] bytes) {
+    try {
+      return fromBytes(bytes);
+    } catch (Exception e) {
+      throw new RuntimeException("Error occurred while deserializing Maintenance plan.", e);
+    }
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+
+  }
+
+  @Override
+  public byte[] serialize(String topic, MaintenancePlan recordValue) {
+    return toBytes(recordValue);
+  }
+
+  @Override
+  public void close() {
+
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenancePlanWithBrokers.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenancePlanWithBrokers.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.detector;
+
+import java.nio.ByteBuffer;
+import java.util.Set;
+import org.apache.kafka.common.utils.Crc32C;
+
+
+public abstract class MaintenancePlanWithBrokers extends MaintenancePlan {
+  protected final Set<Integer> _brokers;
+
+  public MaintenancePlanWithBrokers(MaintenanceEventType maintenanceEventType, long timeMs, int brokerId, byte planVersion,  Set<Integer> brokers) {
+    super(maintenanceEventType, timeMs, brokerId, planVersion);
+
+    if (brokers == null || brokers.isEmpty()) {
+      throw new IllegalArgumentException("Missing brokers for the plan.");
+    }
+    _brokers = brokers;
+  }
+
+  protected long getCrc() {
+    short numBrokers = (short) _brokers.size();
+    int contentSize = (Byte.BYTES /* maintenance event type id */
+                       + Byte.BYTES /* plan version */
+                       + Long.BYTES /* timeMs */
+                       + Integer.BYTES /* broker id */
+                       + Short.BYTES /* number of brokers */
+                       + (Integer.BYTES * numBrokers) /* brokers */);
+    ByteBuffer buffer = ByteBuffer.allocate(contentSize);
+    buffer.put(maintenanceEventType().id());
+    buffer.put(planVersion());
+    buffer.putLong(timeMs());
+    buffer.putInt(brokerId());
+    buffer.putShort(numBrokers);
+    for (Integer broker : _brokers) {
+      buffer.putInt(broker);
+    }
+    // The CRC covers all data to the end of the buffer.
+    return Crc32C.compute(buffer, -buffer.position(), contentSize);
+  }
+
+  public Set<Integer> brokers() {
+    return _brokers;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[%s] Brokers: %s, Source [timeMs: %d, broker: %d]", _maintenanceEventType, _brokers, _timeMs, _brokerId);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/RebalancePlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/RebalancePlan.java
@@ -4,44 +4,11 @@
 
 package com.linkedin.kafka.cruisecontrol.detector;
 
-import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
-import java.nio.ByteBuffer;
-
 
 public class RebalancePlan extends MaintenancePlan {
-  public static final byte PLAN_VERSION = 0;
+  public static final byte LATEST_SUPPORTED_VERSION = 0;
 
   public RebalancePlan(long timeMs, int brokerId) {
-    super(MaintenanceEventType.REBALANCE, timeMs, brokerId);
-  }
-
-  @Override
-  public byte planVersion() {
-    return PLAN_VERSION;
-  }
-
-  /**
-   * Deserialize given byte buffer to a {@link RebalancePlan}.
-   *
-   * @param headerSize The header size of the buffer.
-   * @param buffer buffer to deserialize.
-   * @return The {@link RebalancePlan} corresponding to the deserialized buffer.
-   */
-  public static RebalancePlan fromBuffer(int headerSize, ByteBuffer buffer) throws UnknownVersionException {
-    verifyCrc(headerSize, buffer);
-    byte version = buffer.get();
-    if (version > PLAN_VERSION) {
-      throw new UnknownVersionException("Cannot deserialize the plan for version " + version + ". Current version: " + PLAN_VERSION);
-    }
-
-    long timeMs = buffer.getLong();
-    int brokerId = buffer.getInt();
-
-    return new RebalancePlan(timeMs, brokerId);
-  }
-
-  @Override
-  public String toString() {
-    return String.format("[%s] Source [timeMs: %d, broker: %d]", _maintenanceEventType, _timeMs, _brokerId);
+    super(MaintenanceEventType.REBALANCE, timeMs, brokerId, LATEST_SUPPORTED_VERSION);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/RebalancePlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/RebalancePlan.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.detector;
+
+import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
+import java.nio.ByteBuffer;
+
+
+public class RebalancePlan extends MaintenancePlan {
+  public static final byte PLAN_VERSION = 0;
+
+  public RebalancePlan(long timeMs, int brokerId) {
+    super(MaintenanceEventType.REBALANCE, timeMs, brokerId);
+  }
+
+  @Override
+  public byte planVersion() {
+    return PLAN_VERSION;
+  }
+
+  /**
+   * Deserialize given byte buffer to a {@link RebalancePlan}.
+   *
+   * @param buffer buffer to deserialize.
+   * @return The {@link RebalancePlan} corresponding to the deserialized buffer.
+   */
+  public static RebalancePlan fromBuffer(ByteBuffer buffer) throws UnknownVersionException {
+    byte version = buffer.get();
+    if (version > PLAN_VERSION) {
+      throw new UnknownVersionException("Cannot deserialize the plan for version " + version + ". Current version: " + PLAN_VERSION);
+    }
+
+    long timeMs = buffer.getLong();
+    int brokerId = buffer.getInt();
+
+    return new RebalancePlan(timeMs, brokerId);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[%s] Source [timeMs: %d, broker: %d]", _maintenanceEventType, _timeMs, _brokerId);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/RebalancePlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/RebalancePlan.java
@@ -23,10 +23,12 @@ public class RebalancePlan extends MaintenancePlan {
   /**
    * Deserialize given byte buffer to a {@link RebalancePlan}.
    *
+   * @param headerSize The header size of the buffer.
    * @param buffer buffer to deserialize.
    * @return The {@link RebalancePlan} corresponding to the deserialized buffer.
    */
-  public static RebalancePlan fromBuffer(ByteBuffer buffer) throws UnknownVersionException {
+  public static RebalancePlan fromBuffer(int headerSize, ByteBuffer buffer) throws UnknownVersionException {
+    verifyCrc(headerSize, buffer);
     byte version = buffer.get();
     if (version > PLAN_VERSION) {
       throw new UnknownVersionException("Cannot deserialize the plan for version " + version + ". Current version: " + PLAN_VERSION);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/RebalancePlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/RebalancePlan.java
@@ -5,6 +5,9 @@
 package com.linkedin.kafka.cruisecontrol.detector;
 
 
+/**
+ * A plan to rebalance the cluster.
+ */
 public class RebalancePlan extends MaintenancePlan {
   public static final byte LATEST_SUPPORTED_VERSION = 0;
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/RemoveBrokerPlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/RemoveBrokerPlan.java
@@ -38,13 +38,13 @@ public class RemoveBrokerPlan extends MaintenancePlan {
   @Override
   public ByteBuffer toBuffer(int headerSize) {
     short numBrokersToRemove = (short) _brokers.size();
-    ByteBuffer buffer = ByteBuffer.allocate(headerSize
-                                            + Byte.BYTES /* plan version */
-                                            + Long.BYTES /* timeMs */
-                                            + Integer.BYTES /* broker id */
-                                            + Short.BYTES /* number of brokers to remove */
-                                            + (Integer.BYTES * numBrokersToRemove) /* brokers to remove */);
-    buffer.position(headerSize);
+    int contentSize = (Byte.BYTES /* plan version */
+                       + Long.BYTES /* timeMs */
+                       + Integer.BYTES /* broker id */
+                       + Short.BYTES /* number of brokers to remove */
+                       + (Integer.BYTES * numBrokersToRemove) /* brokers to remove */);
+    ByteBuffer buffer = ByteBuffer.allocate(headerSize + Long.BYTES /* crc */ + contentSize);
+    buffer.position(headerSize + Long.BYTES);
     buffer.put(planVersion());
     buffer.putLong(timeMs());
     buffer.putInt(brokerId());
@@ -52,16 +52,19 @@ public class RemoveBrokerPlan extends MaintenancePlan {
     for (Integer brokerToRemove : _brokers) {
       buffer.putInt(brokerToRemove);
     }
+    putCrc(headerSize, buffer, contentSize);
     return buffer;
   }
 
   /**
    * Deserialize given byte buffer to an {@link RemoveBrokerPlan}.
    *
+   * @param headerSize The header size of the buffer.
    * @param buffer buffer to deserialize.
    * @return The {@link RemoveBrokerPlan} corresponding to the deserialized buffer.
    */
-  public static RemoveBrokerPlan fromBuffer(ByteBuffer buffer) throws UnknownVersionException {
+  public static RemoveBrokerPlan fromBuffer(int headerSize, ByteBuffer buffer) throws UnknownVersionException {
+    verifyCrc(headerSize, buffer);
     byte version = buffer.get();
     if (version > PLAN_VERSION) {
       throw new UnknownVersionException("Cannot deserialize the plan for version " + version + ". Current version: " + PLAN_VERSION);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/RemoveBrokerPlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/RemoveBrokerPlan.java
@@ -4,85 +4,13 @@
 
 package com.linkedin.kafka.cruisecontrol.detector;
 
-import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
-import java.nio.ByteBuffer;
-import java.util.HashSet;
 import java.util.Set;
 
 
-public class RemoveBrokerPlan extends MaintenancePlan {
-  public static final byte PLAN_VERSION = 0;
-  private final Set<Integer> _brokers;
+public class RemoveBrokerPlan extends MaintenancePlanWithBrokers {
+  public static final byte LATEST_SUPPORTED_VERSION = 0;
 
   public RemoveBrokerPlan(long timeMs, int brokerId, Set<Integer> brokers) {
-    super(MaintenanceEventType.REMOVE_BROKER, timeMs, brokerId);
-    if (brokers == null || brokers.isEmpty()) {
-      throw new IllegalArgumentException("Missing brokers for the plan.");
-    }
-    if (brokers.size() > Short.MAX_VALUE) {
-      throw new IllegalArgumentException(String.format("Cannot remove more than %d brokers (attempt: %d).",
-                                                       Short.MAX_VALUE, brokers.size()));
-    }
-    _brokers = brokers;
-  }
-
-  @Override
-  public byte planVersion() {
-    return PLAN_VERSION;
-  }
-
-  public Set<Integer> brokers() {
-    return _brokers;
-  }
-
-  @Override
-  public ByteBuffer toBuffer(int headerSize) {
-    short numBrokersToRemove = (short) _brokers.size();
-    int contentSize = (Byte.BYTES /* plan version */
-                       + Long.BYTES /* timeMs */
-                       + Integer.BYTES /* broker id */
-                       + Short.BYTES /* number of brokers to remove */
-                       + (Integer.BYTES * numBrokersToRemove) /* brokers to remove */);
-    ByteBuffer buffer = ByteBuffer.allocate(headerSize + Long.BYTES /* crc */ + contentSize);
-    buffer.position(headerSize + Long.BYTES);
-    buffer.put(planVersion());
-    buffer.putLong(timeMs());
-    buffer.putInt(brokerId());
-    buffer.putShort(numBrokersToRemove);
-    for (Integer brokerToRemove : _brokers) {
-      buffer.putInt(brokerToRemove);
-    }
-    putCrc(headerSize, buffer, contentSize);
-    return buffer;
-  }
-
-  /**
-   * Deserialize given byte buffer to an {@link RemoveBrokerPlan}.
-   *
-   * @param headerSize The header size of the buffer.
-   * @param buffer buffer to deserialize.
-   * @return The {@link RemoveBrokerPlan} corresponding to the deserialized buffer.
-   */
-  public static RemoveBrokerPlan fromBuffer(int headerSize, ByteBuffer buffer) throws UnknownVersionException {
-    verifyCrc(headerSize, buffer);
-    byte version = buffer.get();
-    if (version > PLAN_VERSION) {
-      throw new UnknownVersionException("Cannot deserialize the plan for version " + version + ". Current version: " + PLAN_VERSION);
-    }
-
-    long timeMs = buffer.getLong();
-    int brokerId = buffer.getInt();
-    short numBrokersToRemove = buffer.getShort();
-    Set<Integer> brokers = new HashSet<>(numBrokersToRemove);
-    for (short i = 0; i < numBrokersToRemove; i++) {
-      brokers.add(buffer.getInt());
-    }
-
-    return new RemoveBrokerPlan(timeMs, brokerId, brokers);
-  }
-
-  @Override
-  public String toString() {
-    return String.format("[%s] Brokers: %s, Source [timeMs: %d, broker: %d]", _maintenanceEventType, _brokers, _timeMs, _brokerId);
+    super(MaintenanceEventType.REMOVE_BROKER, timeMs, brokerId, LATEST_SUPPORTED_VERSION, brokers);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/RemoveBrokerPlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/RemoveBrokerPlan.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.detector;
+
+import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.Set;
+
+
+public class RemoveBrokerPlan extends MaintenancePlan {
+  public static final byte PLAN_VERSION = 0;
+  private final Set<Integer> _brokers;
+
+  public RemoveBrokerPlan(long timeMs, int brokerId, Set<Integer> brokers) {
+    super(MaintenanceEventType.REMOVE_BROKER, timeMs, brokerId);
+    if (brokers == null || brokers.isEmpty()) {
+      throw new IllegalArgumentException("Missing brokers for the plan.");
+    }
+    if (brokers.size() > Short.MAX_VALUE) {
+      throw new IllegalArgumentException(String.format("Cannot remove more than %d brokers (attempt: %d).",
+                                                       Short.MAX_VALUE, brokers.size()));
+    }
+    _brokers = brokers;
+  }
+
+  @Override
+  public byte planVersion() {
+    return PLAN_VERSION;
+  }
+
+  public Set<Integer> brokers() {
+    return _brokers;
+  }
+
+  @Override
+  public ByteBuffer toBuffer(int headerSize) {
+    short numBrokersToRemove = (short) _brokers.size();
+    ByteBuffer buffer = ByteBuffer.allocate(headerSize
+                                            + Byte.BYTES /* plan version */
+                                            + Long.BYTES /* timeMs */
+                                            + Integer.BYTES /* broker id */
+                                            + Short.BYTES /* number of brokers to remove */
+                                            + (Integer.BYTES * numBrokersToRemove) /* brokers to remove */);
+    buffer.position(headerSize);
+    buffer.put(planVersion());
+    buffer.putLong(timeMs());
+    buffer.putInt(brokerId());
+    buffer.putShort(numBrokersToRemove);
+    for (Integer brokerToRemove : _brokers) {
+      buffer.putInt(brokerToRemove);
+    }
+    return buffer;
+  }
+
+  /**
+   * Deserialize given byte buffer to an {@link RemoveBrokerPlan}.
+   *
+   * @param buffer buffer to deserialize.
+   * @return The {@link RemoveBrokerPlan} corresponding to the deserialized buffer.
+   */
+  public static RemoveBrokerPlan fromBuffer(ByteBuffer buffer) throws UnknownVersionException {
+    byte version = buffer.get();
+    if (version > PLAN_VERSION) {
+      throw new UnknownVersionException("Cannot deserialize the plan for version " + version + ". Current version: " + PLAN_VERSION);
+    }
+
+    long timeMs = buffer.getLong();
+    int brokerId = buffer.getInt();
+    short numBrokersToRemove = buffer.getShort();
+    Set<Integer> brokers = new HashSet<>(numBrokersToRemove);
+    for (short i = 0; i < numBrokersToRemove; i++) {
+      brokers.add(buffer.getInt());
+    }
+
+    return new RemoveBrokerPlan(timeMs, brokerId, brokers);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[%s] Brokers: %s, Source [timeMs: %d, broker: %d]", _maintenanceEventType, _brokers, _timeMs, _brokerId);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/RemoveBrokerPlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/RemoveBrokerPlan.java
@@ -7,6 +7,11 @@ package com.linkedin.kafka.cruisecontrol.detector;
 import java.util.Set;
 
 
+/**
+ * A plan to remove brokers.
+ *
+ * The desired brokers to remove are indicated using a set of broker ids.
+ */
 public class RemoveBrokerPlan extends MaintenancePlanWithBrokers {
   public static final byte LATEST_SUPPORTED_VERSION = 0;
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/TopicReplicationFactorPlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/TopicReplicationFactorPlan.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.detector;
+
+import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class TopicReplicationFactorPlan extends MaintenancePlan {
+  public static final byte PLAN_VERSION = 0;
+  // A map containing the regex of topics by the corresponding desired replication factor
+  private final Map<Short, String> _topicRegexWithRFUpdate;
+
+  public TopicReplicationFactorPlan(long timeMs, int brokerId, Map<Short, String> topicRegexWithRFUpdate) {
+    super(MaintenanceEventType.TOPIC_REPLICATION_FACTOR, timeMs, brokerId);
+    if (topicRegexWithRFUpdate == null || topicRegexWithRFUpdate.isEmpty()) {
+      throw new IllegalArgumentException("Missing replication factor updates for the plan.");
+    }
+    // Sanity check: the number of bulk updates for replication factor of topics.
+    if (topicRegexWithRFUpdate.size() > Byte.MAX_VALUE) {
+      throw new IllegalArgumentException(String.format("Cannot update more than %d different replication factor (attempt: %d).",
+                                                       Byte.MAX_VALUE, topicRegexWithRFUpdate.size()));
+    }
+    // Sanity check: Each regex must have some value.
+    for (String regex : topicRegexWithRFUpdate.values()) {
+      if (regex == null || regex.isEmpty()) {
+        throw new IllegalArgumentException("Missing topics of the replication factor update for the plan.");
+      }
+    }
+    _topicRegexWithRFUpdate = topicRegexWithRFUpdate;
+  }
+
+  @Override
+  public byte planVersion() {
+    return PLAN_VERSION;
+  }
+
+  public Map<Short, String> topicRegexWithRFUpdate() {
+    return _topicRegexWithRFUpdate;
+  }
+
+  @Override
+  public ByteBuffer toBuffer(int headerSize) {
+    byte numRFUpdateEntries = (byte) _topicRegexWithRFUpdate.size();
+    int requiredCapacityForRFEntries = 0;
+    for (Map.Entry<Short, String> entry : _topicRegexWithRFUpdate.entrySet()) {
+      requiredCapacityForRFEntries += (Short.BYTES /* replication factor */ + Integer.BYTES /* regex length */
+                                       + entry.getValue().getBytes(StandardCharsets.UTF_8).length /* regex */);
+    }
+
+    ByteBuffer buffer = ByteBuffer.allocate(headerSize
+                                            + Byte.BYTES /* plan version */
+                                            + Long.BYTES /* timeMs */
+                                            + Integer.BYTES /* broker id */
+                                            + Byte.BYTES /* number of replication factor update entries */
+                                            + requiredCapacityForRFEntries /* total capacity for all entries */);
+    buffer.position(headerSize);
+    buffer.put(planVersion());
+    buffer.putLong(timeMs());
+    buffer.putInt(brokerId());
+    buffer.put(numRFUpdateEntries);
+    for (Map.Entry<Short, String> entry : _topicRegexWithRFUpdate.entrySet()) {
+      buffer.putShort(entry.getKey());
+      byte[] regex = entry.getValue().getBytes(StandardCharsets.UTF_8);
+      buffer.putInt(regex.length);
+      buffer.put(regex);
+    }
+    return buffer;
+  }
+
+  /**
+   * Deserialize given byte buffer to an {@link TopicReplicationFactorPlan}.
+   *
+   * @param buffer buffer to deserialize.
+   * @return The {@link TopicReplicationFactorPlan} corresponding to the deserialized buffer.
+   */
+  public static TopicReplicationFactorPlan fromBuffer(ByteBuffer buffer) throws UnknownVersionException {
+    byte version = buffer.get();
+    if (version > PLAN_VERSION) {
+      throw new UnknownVersionException("Cannot deserialize the plan for version " + version + ". Current version: " + PLAN_VERSION);
+    }
+
+    long timeMs = buffer.getLong();
+    int brokerId = buffer.getInt();
+    byte numRFUpdateEntries = buffer.get();
+    Map<Short, String> topicRegexWithRFUpdate = new HashMap<>(numRFUpdateEntries);
+
+    for (int i = 0; i < numRFUpdateEntries; i++) {
+      short replicationFactor = buffer.getShort();
+      int regexLength = buffer.getInt();
+      String regex = new String(buffer.array(), buffer.arrayOffset() + buffer.position(), regexLength, StandardCharsets.UTF_8);
+      buffer.position(buffer.position() + regexLength);
+      topicRegexWithRFUpdate.put(replicationFactor, regex);
+    }
+
+    return new TopicReplicationFactorPlan(timeMs, brokerId, topicRegexWithRFUpdate);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[%s] TopicRegexWithRFUpdate: %s, Source [timeMs: %d, broker: %d]", _maintenanceEventType,
+                         _topicRegexWithRFUpdate, _timeMs, _brokerId);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/TopicReplicationFactorPlan.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/TopicReplicationFactorPlan.java
@@ -10,6 +10,11 @@ import java.util.Map;
 import org.apache.kafka.common.utils.Crc32C;
 
 
+/**
+ * A plan to update the replication factor of specified topics.
+ *
+ * The desired replication factor for topics are indicated using topic regex per desired replication factor.
+ */
 public class TopicReplicationFactorPlan extends MaintenancePlan {
   public static final byte LATEST_SUPPORTED_VERSION = 0;
   // A map containing the regex of topics by the corresponding desired replication factor

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/exception/SamplingException.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/exception/SamplingException.java
@@ -5,11 +5,11 @@
 package com.linkedin.kafka.cruisecontrol.exception;
 
 /**
- * The exception indicating something went wrong during the metrics sampling.
+ * The exception indicating something went wrong while sampling data from a requested source.
  */
-public class MetricSamplingException extends KafkaCruiseControlException {
+public class SamplingException extends KafkaCruiseControlException {
 
-  public MetricSamplingException(String message) {
+  public SamplingException(String message) {
     super(message);
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsReporterSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsReporterSampler.java
@@ -39,10 +39,11 @@ public class CruiseControlMetricsReporterSampler implements MetricSampler {
   // Configurations
   public static final String METRIC_REPORTER_SAMPLER_BOOTSTRAP_SERVERS = "metric.reporter.sampler.bootstrap.servers";
   public static final String METRIC_REPORTER_TOPIC = "metric.reporter.topic";
+  @Deprecated
   public static final String METRIC_REPORTER_SAMPLER_GROUP_ID = "metric.reporter.sampler.group.id";
   public static final Duration METRIC_REPORTER_CONSUMER_POLL_TIMEOUT = Duration.ofMillis(5000L);
   // Default configs
-  public static final String DEFAULT_METRIC_REPORTER_SAMPLER_GROUP_ID = "CruiseControlMetricsReporterSampler";
+  public static final String CONSUMER_CLIENT_ID_PREFIX = "CruiseControlMetricsReporterSampler";
   public static final long ACCEPTABLE_NETWORK_DELAY_MS = 100L;
   protected CruiseControlMetricsProcessor _metricsProcessor;
 
@@ -186,7 +187,7 @@ public class CruiseControlMetricsReporterSampler implements MetricSampler {
     _acceptableMetricRecordProduceDelayMs = ACCEPTABLE_NETWORK_DELAY_MS +
         Math.max(reporterConfig.getLong(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_REPORTER_MAX_BLOCK_MS_CONFIG),
                  reporterConfig.getLong(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_REPORTER_LINGER_MS_CONFIG));
-    _metricConsumer = createMetricConsumer(configs);
+    _metricConsumer = createMetricConsumer(configs, CONSUMER_CLIENT_ID_PREFIX);
     _currentPartitionAssignment = Collections.emptySet();
     if (refreshPartitionAssignment()) {
       throw new IllegalStateException("Cruise Control cannot find partitions for the metrics reporter that topic matches "

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsReporterSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsReporterSampler.java
@@ -7,35 +7,31 @@ package com.linkedin.kafka.cruisecontrol.monitor.sampling;
 import com.linkedin.cruisecontrol.metricdef.MetricDef;
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityConfigResolver;
 import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
-import com.linkedin.kafka.cruisecontrol.exception.MetricSamplingException;
+import com.linkedin.kafka.cruisecontrol.exception.SamplingException;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporterConfig;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.CruiseControlMetric;
-import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.MetricSerde;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-import java.util.Random;
 import java.util.Set;
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.serialization.StringDeserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.consumptionDone;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.sanityCheckOffsetFetch;
 import static com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricFetcherManager.BROKER_CAPACITY_CONFIG_RESOLVER_OBJECT_CONFIG;
-import static com.linkedin.kafka.cruisecontrol.monitor.sampling.SamplingUtils.sanityCheckOffsetFetch;
+import static com.linkedin.kafka.cruisecontrol.monitor.sampling.SamplingUtils.createMetricConsumer;
 
 
 public class CruiseControlMetricsReporterSampler implements MetricSampler {
@@ -49,8 +45,6 @@ public class CruiseControlMetricsReporterSampler implements MetricSampler {
   public static final String DEFAULT_METRIC_REPORTER_SAMPLER_GROUP_ID = "CruiseControlMetricsReporterSampler";
   public static final long ACCEPTABLE_NETWORK_DELAY_MS = 100L;
   protected CruiseControlMetricsProcessor _metricsProcessor;
-  // static random token to avoid group conflict.
-  protected static final Random RANDOM = new Random();
 
   protected Consumer<String, CruiseControlMetric> _metricConsumer;
   protected String _metricReporterTopic;
@@ -69,7 +63,7 @@ public class CruiseControlMetricsReporterSampler implements MetricSampler {
                             long endTimeMs,
                             SamplingMode mode,
                             MetricDef metricDef,
-                            long timeout) throws MetricSamplingException {
+                            long timeout) throws SamplingException {
     if (refreshPartitionAssignment()) {
       return MetricSampler.EMPTY_SAMPLES;
     }
@@ -123,7 +117,7 @@ public class CruiseControlMetricsReporterSampler implements MetricSampler {
         _metricConsumer.pause(partitionsToPause);
         partitionsToPause.clear();
       }
-    } while (!consumptionDone(endOffsets) && System.currentTimeMillis() < timeout);
+    } while (!consumptionDone(_metricConsumer, endOffsets) && System.currentTimeMillis() < timeout);
     LOG.info("Finished sampling for topic partitions {} in time range [{},{}]. Collected {} metrics.",
              _currentPartitionAssignment, startTimeMs, endTimeMs, totalMetricsAdded);
 
@@ -136,23 +130,6 @@ public class CruiseControlMetricsReporterSampler implements MetricSampler {
     } finally {
       _metricsProcessor.clear();
     }
-  }
-
-  /**
-   * The check if the consumption is done or not. The consumption is done if the consumer has caught up with the
-   * log end or all the partitions are paused.
-   * @param endOffsets the log end for each partition.
-   * @return True if the consumption is done, false otherwise.
-   */
-  protected boolean consumptionDone(Map<TopicPartition, Long> endOffsets) {
-    Set<TopicPartition> partitionsNotPaused = new HashSet<>(_metricConsumer.assignment());
-    partitionsNotPaused.removeAll(_metricConsumer.paused());
-    for (TopicPartition tp : partitionsNotPaused) {
-      if (_metricConsumer.position(tp) < endOffsets.get(tp)) {
-        return false;
-      }
-    }
-    return true;
   }
 
   /**
@@ -201,43 +178,15 @@ public class CruiseControlMetricsReporterSampler implements MetricSampler {
     }
     boolean allowCpuCapacityEstimation = (Boolean) configs.get(MonitorConfig.SAMPLING_ALLOW_CPU_CAPACITY_ESTIMATION_CONFIG);
     _metricsProcessor = new CruiseControlMetricsProcessor(capacityResolver, allowCpuCapacityEstimation);
-
-    String bootstrapServers = (String) configs.get(METRIC_REPORTER_SAMPLER_BOOTSTRAP_SERVERS);
-    if (bootstrapServers == null) {
-      bootstrapServers = configs.get(MonitorConfig.BOOTSTRAP_SERVERS_CONFIG).toString();
-      // Trim the brackets in List's String representation.
-      if (bootstrapServers.length() > 2) {
-        bootstrapServers = bootstrapServers.substring(1, bootstrapServers.length() - 1);
-      }
-    }
     _metricReporterTopic = (String) configs.get(METRIC_REPORTER_TOPIC);
     if (_metricReporterTopic == null) {
       _metricReporterTopic = CruiseControlMetricsReporterConfig.DEFAULT_CRUISE_CONTROL_METRICS_TOPIC;
     }
-    String groupId = (String) configs.get(METRIC_REPORTER_SAMPLER_GROUP_ID);
-    if (groupId == null) {
-      groupId = DEFAULT_METRIC_REPORTER_SAMPLER_GROUP_ID + "-" + RANDOM.nextLong();
-    }
-    String reconnectBackoffMs = configs.get(MonitorConfig.RECONNECT_BACKOFF_MS_CONFIG).toString();
-
     CruiseControlMetricsReporterConfig reporterConfig = new CruiseControlMetricsReporterConfig(configs, false);
     _acceptableMetricRecordProduceDelayMs = ACCEPTABLE_NETWORK_DELAY_MS +
         Math.max(reporterConfig.getLong(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_REPORTER_MAX_BLOCK_MS_CONFIG),
                  reporterConfig.getLong(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_REPORTER_LINGER_MS_CONFIG));
-
-    Properties consumerProps = new Properties();
-    consumerProps.putAll(configs);
-    Random random = new Random();
-    consumerProps.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-    consumerProps.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-    consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, groupId + "-consumer-" + random.nextInt());
-    consumerProps.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
-    consumerProps.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
-    consumerProps.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, Integer.toString(Integer.MAX_VALUE));
-    consumerProps.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-    consumerProps.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, MetricSerde.class.getName());
-    consumerProps.setProperty(ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG, reconnectBackoffMs);
-    _metricConsumer = new KafkaConsumer<>(consumerProps);
+    _metricConsumer = createMetricConsumer(configs);
     _currentPartitionAssignment = Collections.emptySet();
     if (refreshPartitionAssignment()) {
       throw new IllegalStateException("Cruise Control cannot find partitions for the metrics reporter that topic matches "

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
@@ -47,6 +47,7 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.linkedin.kafka.cruisecontrol.monitor.sampling.SamplingUtils.bootstrapServers;
 import static com.linkedin.kafka.cruisecontrol.monitor.sampling.SamplingUtils.createSampleStoreConsumer;
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.createTopic;
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.CLIENT_REQUEST_TIMEOUT_MS;
@@ -194,12 +195,7 @@ public class KafkaSampleStore implements SampleStore {
   protected KafkaProducer<byte[], byte[]> createProducer(Map<String, ?> config) {
     Properties producerProps = new Properties();
     producerProps.putAll(config);
-    String bootstrapServers = config.get(MonitorConfig.BOOTSTRAP_SERVERS_CONFIG).toString();
-    // Trim the brackets in List's String representation.
-    if (bootstrapServers.length() > 2) {
-      bootstrapServers = bootstrapServers.substring(1, bootstrapServers.length() - 1);
-    }
-    producerProps.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    producerProps.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers(config));
     producerProps.setProperty(ProducerConfig.CLIENT_ID_CONFIG, PRODUCER_CLIENT_ID);
     // Set batch.size and linger.ms to a big number to have better batching.
     producerProps.setProperty(ProducerConfig.LINGER_MS_CONFIG, "30000");

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
@@ -94,7 +94,7 @@ public class KafkaSampleStore implements SampleStore {
   protected static final long DEFAULT_MIN_PARTITION_SAMPLE_STORE_TOPIC_RETENTION_TIME_MS = 3600000L;
   protected static final long DEFAULT_MIN_BROKER_SAMPLE_STORE_TOPIC_RETENTION_TIME_MS = 3600000L;
   protected static final String PRODUCER_CLIENT_ID = "KafkaCruiseControlSampleStoreProducer";
-  protected static final String CONSUMER_GROUP_ID_PREFIX = "KafkaCruiseControlSampleStore";
+  protected static final String CONSUMER_CLIENT_ID_PREFIX = "KafkaCruiseControlSampleStore";
 
   protected List<KafkaConsumer<byte[], byte[]>> _consumers;
   protected ExecutorService _metricProcessorExecutor;
@@ -155,7 +155,7 @@ public class KafkaSampleStore implements SampleStore {
     _metricProcessorExecutor = Executors.newFixedThreadPool(numProcessingThreads);
     _consumers = new ArrayList<>(numProcessingThreads);
     for (int i = 0; i < numProcessingThreads; i++) {
-      _consumers.add(createSampleStoreConsumer(config, CONSUMER_GROUP_ID_PREFIX));
+      _consumers.add(createSampleStoreConsumer(config, CONSUMER_CLIENT_ID_PREFIX));
     }
 
     _producer = createProducer(config);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
@@ -7,7 +7,6 @@ package com.linkedin.kafka.cruisecontrol.monitor.sampling;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils;
 import com.linkedin.kafka.cruisecontrol.config.constants.ExecutorConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
-import com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsUtils;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.holder.BrokerMetricSample;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.holder.PartitionMetricSample;
@@ -20,7 +19,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -30,10 +28,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -47,16 +43,16 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.TopicExistsException;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.linkedin.kafka.cruisecontrol.monitor.sampling.SamplingUtils.CLIENT_REQUEST_TIMEOUT_MS;
-import static com.linkedin.kafka.cruisecontrol.monitor.sampling.SamplingUtils.maybeUpdateTopicConfig;
-import static com.linkedin.kafka.cruisecontrol.monitor.sampling.SamplingUtils.maybeIncreasePartitionCount;
-import static com.linkedin.kafka.cruisecontrol.monitor.sampling.SamplingUtils.wrapTopic;
+import static com.linkedin.kafka.cruisecontrol.monitor.sampling.SamplingUtils.createSampleStoreConsumer;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.createTopic;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.CLIENT_REQUEST_TIMEOUT_MS;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.maybeUpdateTopicConfig;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.maybeIncreasePartitionCount;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.wrapTopic;
 
 /**
  * The sample store that implements the {@link SampleStore}. It stores the partition metric samples and broker metric
@@ -98,8 +94,7 @@ public class KafkaSampleStore implements SampleStore {
   protected static final long DEFAULT_MIN_PARTITION_SAMPLE_STORE_TOPIC_RETENTION_TIME_MS = 3600000L;
   protected static final long DEFAULT_MIN_BROKER_SAMPLE_STORE_TOPIC_RETENTION_TIME_MS = 3600000L;
   protected static final String PRODUCER_CLIENT_ID = "KafkaCruiseControlSampleStoreProducer";
-  protected static final String CONSUMER_CLIENT_ID = "KafkaCruiseControlSampleStoreConsumer";
-  protected static final Random RANDOM = new Random();
+  protected static final String CONSUMER_GROUP_ID_PREFIX = "KafkaCruiseControlSampleStore";
 
   protected List<KafkaConsumer<byte[], byte[]>> _consumers;
   protected ExecutorService _metricProcessorExecutor;
@@ -160,7 +155,7 @@ public class KafkaSampleStore implements SampleStore {
     _metricProcessorExecutor = Executors.newFixedThreadPool(numProcessingThreads);
     _consumers = new ArrayList<>(numProcessingThreads);
     for (int i = 0; i < numProcessingThreads; i++) {
-      _consumers.add(createConsumer(config));
+      _consumers.add(createSampleStoreConsumer(config, CONSUMER_GROUP_ID_PREFIX));
     }
 
     _producer = createProducer(config);
@@ -196,28 +191,6 @@ public class KafkaSampleStore implements SampleStore {
     return _sampleStoreTopicReplicationFactor;
   }
 
-  /**
-   * Creates the given topic if it does not exist.
-   *
-   * @param adminClient The adminClient to send createTopics request.
-   * @param topicToBeCreated A wrapper around the topic to be created.
-   * @return {@code false} if the topic to be created already exists, {@code true} otherwise.
-   */
-  protected static boolean createTopic(AdminClient adminClient, NewTopic topicToBeCreated) {
-    try {
-      CreateTopicsResult createTopicsResult = adminClient.createTopics(Collections.singletonList(topicToBeCreated));
-      createTopicsResult.values().get(topicToBeCreated.name()).get(CruiseControlMetricsUtils.CLIENT_REQUEST_TIMEOUT_MS,
-                                                                   TimeUnit.MILLISECONDS);
-      LOG.info("Topic {} has been created.", topicToBeCreated.name());
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      if (e.getCause() instanceof TopicExistsException) {
-        return false;
-      }
-      throw new IllegalStateException(String.format("Unable to create topic %s.", topicToBeCreated.name()), e);
-    }
-    return true;
-  }
-
   protected KafkaProducer<byte[], byte[]> createProducer(Map<String, ?> config) {
     Properties producerProps = new Properties();
     producerProps.putAll(config);
@@ -239,28 +212,6 @@ public class KafkaSampleStore implements SampleStore {
     producerProps.setProperty(ProducerConfig.RECONNECT_BACKOFF_MS_CONFIG,
                               config.get(MonitorConfig.RECONNECT_BACKOFF_MS_CONFIG).toString());
     return new KafkaProducer<>(producerProps);
-  }
-
-  protected KafkaConsumer<byte[], byte[]> createConsumer(Map<String, ?> config) {
-    Properties consumerProps = new Properties();
-    consumerProps.putAll(config);
-    long randomToken = RANDOM.nextLong();
-    String bootstrapServers = config.get(MonitorConfig.BOOTSTRAP_SERVERS_CONFIG).toString();
-    // Trim the brackets in List's String representation.
-    if (bootstrapServers.length() > 2) {
-      bootstrapServers = bootstrapServers.substring(1, bootstrapServers.length() - 1);
-    }
-    consumerProps.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-    consumerProps.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "KafkaCruiseControlSampleStore" + randomToken);
-    consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, CONSUMER_CLIENT_ID + randomToken);
-    consumerProps.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-    consumerProps.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
-    consumerProps.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, Integer.toString(Integer.MAX_VALUE));
-    consumerProps.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
-    consumerProps.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
-    consumerProps.setProperty(ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG,
-                                             config.get(MonitorConfig.RECONNECT_BACKOFF_MS_CONFIG).toString());
-    return new KafkaConsumer<>(consumerProps);
   }
 
   @SuppressWarnings("unchecked")

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricFetcher.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricFetcher.java
@@ -7,7 +7,7 @@ package com.linkedin.kafka.cruisecontrol.monitor.sampling;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import com.linkedin.cruisecontrol.metricdef.MetricDef;
-import com.linkedin.kafka.cruisecontrol.exception.MetricSamplingException;
+import com.linkedin.kafka.cruisecontrol.exception.SamplingException;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.holder.BrokerMetricSample;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.holder.PartitionMetricSample;
 import java.util.Set;
@@ -76,7 +76,7 @@ abstract class MetricFetcher implements Callable<Boolean> {
 
     try {
       fetchMetricsForAssignedPartitions();
-    } catch (MetricSamplingException mse) {
+    } catch (SamplingException mse) {
       LOG.warn("Received sampling error.", mse);
       hasSamplingError = true;
     } catch (Throwable t) {
@@ -90,7 +90,7 @@ abstract class MetricFetcher implements Callable<Boolean> {
   /**
    * Execute one iteration of metric sampling for all the assigned partitions.
    */
-  protected void fetchMetricsForAssignedPartitions() throws MetricSamplingException {
+  protected void fetchMetricsForAssignedPartitions() throws SamplingException {
     final Timer.Context ctx = _fetchTimer.time();
 
     try {
@@ -113,7 +113,7 @@ abstract class MetricFetcher implements Callable<Boolean> {
    * Fetch the metric samples indicated by {@link #_samplingMode}.
    * @return The accepted partition and broker metric samples.
    */
-  protected MetricSampler.Samples fetchSamples() throws MetricSamplingException {
+  protected MetricSampler.Samples fetchSamples() throws SamplingException {
     MetricSampler.Samples samples = _metricSampler.getSamples(_cluster, _assignedPartitions, _startTimeMs, _endTimeMs,
                                                               _samplingMode, _metricDef, _timeout);
     if (samples == null) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSampler.java
@@ -6,7 +6,7 @@ package com.linkedin.kafka.cruisecontrol.monitor.sampling;
 
 import com.linkedin.cruisecontrol.common.CruiseControlConfigurable;
 import com.linkedin.cruisecontrol.metricdef.MetricDef;
-import com.linkedin.kafka.cruisecontrol.exception.MetricSamplingException;
+import com.linkedin.kafka.cruisecontrol.exception.SamplingException;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.holder.BrokerMetricSample;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.holder.PartitionMetricSample;
 import java.util.Collections;
@@ -59,7 +59,7 @@ public interface MetricSampler extends CruiseControlConfigurable, AutoCloseable 
                      SamplingMode mode,
                      MetricDef metricDef,
                      long timeout)
-      throws MetricSamplingException;
+      throws SamplingException;
 
   /**
    * The sampling mode to indicate which type of samples is interested.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/NoopSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/NoopSampler.java
@@ -5,7 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.monitor.sampling;
 
 import com.linkedin.cruisecontrol.metricdef.MetricDef;
-import com.linkedin.kafka.cruisecontrol.exception.MetricSamplingException;
+import com.linkedin.kafka.cruisecontrol.exception.SamplingException;
 import java.util.Map;
 import java.util.Set;
 import org.apache.kafka.common.Cluster;
@@ -16,7 +16,7 @@ public class NoopSampler implements MetricSampler {
 
   @Override
   public Samples getSamples(Cluster cluster, Set<TopicPartition> assignedPartitions, long startTimeMs, long endTimeMs,
-                            SamplingMode mode, MetricDef metricDef, long timeout) throws MetricSamplingException {
+                            SamplingMode mode, MetricDef metricDef, long timeout) throws SamplingException {
     return null;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/ReadOnlyKafkaSampleStore.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/ReadOnlyKafkaSampleStore.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.Executors;
 
+import static com.linkedin.kafka.cruisecontrol.monitor.sampling.SamplingUtils.createSampleStoreConsumer;
+
 
 /**
  * This samples store only reads the partition metric samples and broker metric samples from the Kafka topic.
@@ -32,7 +34,7 @@ public class ReadOnlyKafkaSampleStore extends KafkaSampleStore {
     _metricProcessorExecutor = Executors.newFixedThreadPool(numProcessingThreads);
     _consumers = new ArrayList<>(numProcessingThreads);
     for (int i = 0; i < numProcessingThreads; i++) {
-      _consumers.add(createConsumer(config));
+      _consumers.add(createSampleStoreConsumer(config, CONSUMER_GROUP_ID_PREFIX));
     }
     _loadingProgress = -1.0;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/ReadOnlyKafkaSampleStore.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/ReadOnlyKafkaSampleStore.java
@@ -34,7 +34,7 @@ public class ReadOnlyKafkaSampleStore extends KafkaSampleStore {
     _metricProcessorExecutor = Executors.newFixedThreadPool(numProcessingThreads);
     _consumers = new ArrayList<>(numProcessingThreads);
     for (int i = 0; i < numProcessingThreads; i++) {
-      _consumers.add(createSampleStoreConsumer(config, CONSUMER_GROUP_ID_PREFIX));
+      _consumers.add(createSampleStoreConsumer(config, CONSUMER_CLIENT_ID_PREFIX));
     }
     _loadingProgress = -1.0;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/SamplingUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/SamplingUtils.java
@@ -345,13 +345,16 @@ public class SamplingUtils {
     return new KafkaConsumer<>(consumerProps);
   }
 
-  private static String bootstrapServers(Map<String, ?> configs) {
-    String bootstrapServers = configs.get(MonitorConfig.BOOTSTRAP_SERVERS_CONFIG).toString();
-    // Trim the brackets in List's String representation.
-    if (bootstrapServers.length() > 2) {
-      bootstrapServers = bootstrapServers.substring(1, bootstrapServers.length() - 1);
-    }
-    return bootstrapServers;
+  /**
+   * Retrieve comma separated bootstrap servers from the configurations for Cruise Control for configuring
+   * {@link org.apache.kafka.clients.CommonClientConfigs#BOOTSTRAP_SERVERS_CONFIG}.
+   *
+   * @param config The configurations for Cruise Control.
+   * @return Comma separated bootstrap servers.
+   */
+  @SuppressWarnings("unchecked")
+  public static String bootstrapServers(Map<String, ?> config) {
+    return String.join(",", (List<String>) config.get(MonitorConfig.BOOTSTRAP_SERVERS_CONFIG));
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/SamplingUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/SamplingUtils.java
@@ -7,8 +7,10 @@ package com.linkedin.kafka.cruisecontrol.monitor.sampling;
 import com.linkedin.cruisecontrol.metricdef.MetricDef;
 import com.linkedin.cruisecontrol.metricdef.MetricInfo;
 import com.linkedin.kafka.cruisecontrol.common.Resource;
-import com.linkedin.kafka.cruisecontrol.exception.MetricSamplingException;
+import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.UnknownVersionException;
+import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.CruiseControlMetric;
+import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.MetricSerde;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.RawMetricType;
 import com.linkedin.kafka.cruisecontrol.model.ModelUtils;
 import com.linkedin.kafka.cruisecontrol.monitor.metricdefinition.KafkaMetricDef;
@@ -16,46 +18,36 @@ import com.linkedin.kafka.cruisecontrol.monitor.sampling.holder.BrokerLoad;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.holder.BrokerMetricSample;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.holder.PartitionMetricSample;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.AlterConfigOp;
-import org.apache.kafka.clients.admin.AlterConfigsResult;
-import org.apache.kafka.clients.admin.Config;
-import org.apache.kafka.clients.admin.ConfigEntry;
-import org.apache.kafka.clients.admin.CreatePartitionsResult;
-import org.apache.kafka.clients.admin.DescribeConfigsResult;
-import org.apache.kafka.clients.admin.NewPartitions;
-import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.admin.TopicDescription;
-import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.config.ConfigResource;
-import org.apache.kafka.common.errors.ReassignmentInProgressException;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static kafka.log.LogConfig.CleanupPolicyProp;
-import static kafka.log.LogConfig.RetentionMsProp;
+import static com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig.RECONNECT_BACKOFF_MS_CONFIG;
 import static com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig.SAMPLING_ALLOW_CPU_CAPACITY_ESTIMATION_CONFIG;
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.metric.RawMetricType.*;
+import static com.linkedin.kafka.cruisecontrol.monitor.sampling.CruiseControlMetricsReporterSampler.METRIC_REPORTER_SAMPLER_BOOTSTRAP_SERVERS;
+import static com.linkedin.kafka.cruisecontrol.monitor.sampling.CruiseControlMetricsReporterSampler.METRIC_REPORTER_SAMPLER_GROUP_ID;
+import static com.linkedin.kafka.cruisecontrol.monitor.sampling.CruiseControlMetricsReporterSampler.DEFAULT_METRIC_REPORTER_SAMPLER_GROUP_ID;
 
 
 public class SamplingUtils {
   private static final Logger LOG = LoggerFactory.getLogger(SamplingUtils.class);
   private static final String SKIP_BUILDING_SAMPLE_PREFIX = "Skip generating metric sample for ";
-  public static final long CLIENT_REQUEST_TIMEOUT_MS = 10000L;
-  public static final String DEFAULT_CLEANUP_POLICY = "delete";
   public static final int UNRECOGNIZED_BROKER_ID = -1;
+  public static final Random RANDOM = new Random();
 
   private SamplingUtils() {
   }
@@ -135,29 +127,6 @@ public class SamplingUtils {
       result += metricSample.metricValue(id);
     }
     return result;
-  }
-
-  /**
-   * Check whether there are failures in fetching offsets during sampling.
-   *
-   * @param endOffsets End offsets retrieved by consumer.
-   * @param offsetsForTimes Offsets for times retrieved by consumer.
-   */
-  static void sanityCheckOffsetFetch(Map<TopicPartition, Long> endOffsets,
-                                     Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes)
-      throws MetricSamplingException {
-    Set<TopicPartition> failedToFetchOffsets = new HashSet<>();
-    for (Map.Entry<TopicPartition, OffsetAndTimestamp> entry : offsetsForTimes.entrySet()) {
-      if (entry.getValue() == null && endOffsets.get(entry.getKey()) == null) {
-        failedToFetchOffsets.add(entry.getKey());
-      }
-    }
-
-    if (!failedToFetchOffsets.isEmpty()) {
-      throw new MetricSamplingException(String.format("Metric consumer failed to fetch offsets for %s. Consider "
-                                                      + "decreasing reconnect.backoff.ms to mitigate consumption failures"
-                                                      + " due to transient network issues.", failedToFetchOffsets));
-    }
   }
 
   /**
@@ -346,124 +315,70 @@ public class SamplingUtils {
   }
 
   /**
-   * Build a wrapper around the topic with the given desired properties and {@link #DEFAULT_CLEANUP_POLICY}.
+   * Create a Kafka consumer for retrieving reported Cruise Control metrics.
+   * The consumer uses {@link String} for keys and {@link CruiseControlMetric} for values.
    *
-   * @param topic The name of the topic.
-   * @param partitionCount Desired partition count.
-   * @param replicationFactor Desired replication factor.
-   * @param retentionMs Desired retention in milliseconds.
-   * @return A wrapper around the topic with the given desired properties.
+   * @param configs The configurations for Cruise Control.
+   * @return A new Kafka consumer
    */
-  public static NewTopic wrapTopic(String topic, int partitionCount, short replicationFactor, long retentionMs) {
-    if (partitionCount <= 0 || replicationFactor <= 0 || retentionMs <= 0) {
-      throw new IllegalArgumentException(String.format("Partition count (%d), replication factor (%d), and retention ms (%d)"
-                                                       + " must be positive for the topic (%s).", partitionCount,
-                                                       replicationFactor, retentionMs, topic));
+  public static Consumer<String, CruiseControlMetric> createMetricConsumer(Map<String, ?> configs) {
+    // Get bootstrap servers
+    String bootstrapServers = (String) configs.get(METRIC_REPORTER_SAMPLER_BOOTSTRAP_SERVERS);
+    if (bootstrapServers == null) {
+      bootstrapServers = bootstrapServers(configs);
+    }
+    // Get group id
+    long randomToken = RANDOM.nextLong();
+    String groupId = (String) configs.get(METRIC_REPORTER_SAMPLER_GROUP_ID);
+    if (groupId == null) {
+      groupId = DEFAULT_METRIC_REPORTER_SAMPLER_GROUP_ID + "-" + randomToken;
     }
 
-    NewTopic newTopic = new NewTopic(topic, partitionCount, replicationFactor);
-    Map<String, String> config = new HashMap<>(2);
-    config.put(RetentionMsProp(), Long.toString(retentionMs));
-    config.put(CleanupPolicyProp(), DEFAULT_CLEANUP_POLICY);
-    newTopic.configs(config);
+    // Create consumer
+    Properties consumerProps = new Properties();
+    consumerProps.putAll(configs);
+    consumerProps.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    consumerProps.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+    consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, groupId + "-consumer-" + randomToken);
+    consumerProps.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+    consumerProps.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+    consumerProps.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, Integer.toString(Integer.MAX_VALUE));
+    consumerProps.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+    consumerProps.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, MetricSerde.class.getName());
+    consumerProps.setProperty(ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG, configs.get(RECONNECT_BACKOFF_MS_CONFIG).toString());
+    return new KafkaConsumer<>(consumerProps);
+  }
 
-    return newTopic;
+  private static String bootstrapServers(Map<String, ?> configs) {
+    String bootstrapServers = configs.get(MonitorConfig.BOOTSTRAP_SERVERS_CONFIG).toString();
+    // Trim the brackets in List's String representation.
+    if (bootstrapServers.length() > 2) {
+      bootstrapServers = bootstrapServers.substring(1, bootstrapServers.length() - 1);
+    }
+    return bootstrapServers;
   }
 
   /**
-   * Add config altering operations to the given configs to alter for configs that differ between current and desired.
+   * Create a Kafka consumer for retrieving samples from the Sample Store.
+   * The consumer uses {@link ByteArrayDeserializer} for both key and values.
    *
-   * @param configsToAlter A set of config altering operations to be populated.
-   * @param desiredConfig Desired config value by name.
-   * @param currentConfig Current config.
+   * @param configs The configurations for Cruise Control.
+   * @param groupIdPrefix Group id prefix of the consumer.
+   * @return A new Kafka consumer
    */
-  private static void maybeUpdateConfig(Set<AlterConfigOp> configsToAlter, Map<String, String> desiredConfig, Config currentConfig) {
-    for (Map.Entry<String, String> entry : desiredConfig.entrySet()) {
-      String configName = entry.getKey();
-      String targetConfigValue = entry.getValue();
-      ConfigEntry currentConfigEntry = currentConfig.get(configName);
-      if (currentConfigEntry == null || !currentConfigEntry.value().equals(targetConfigValue)) {
-        configsToAlter.add(new AlterConfigOp(new ConfigEntry(configName, targetConfigValue), AlterConfigOp.OpType.SET));
-      }
-    }
-  }
-
-  /**
-   * Update topic configurations with the desired configs specified in the given topicToUpdateConfigs.
-   *
-   * @param adminClient The adminClient to send describeConfigs and incrementalAlterConfigs requests.
-   * @param topicToUpdateConfigs Existing topic to update selected configs if needed -- cannot be {@code null}.
-   * @return {@code true} if the request is completed successfully, {@code false} if there are any exceptions.
-   */
-  public static boolean maybeUpdateTopicConfig(AdminClient adminClient, NewTopic topicToUpdateConfigs) {
-    String topicName = topicToUpdateConfigs.name();
-    // Retrieve topic config to check if it needs an update.
-    ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
-    DescribeConfigsResult describeConfigsResult = adminClient.describeConfigs(Collections.singleton(topicResource));
-    Config topicConfig;
-    try {
-      topicConfig = describeConfigsResult.values().get(topicResource).get(CLIENT_REQUEST_TIMEOUT_MS,
-                                                                          TimeUnit.MILLISECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      LOG.warn("Config check for topic {} failed due to failure to describe its configs.", topicName, e);
-      return false;
-    }
-
-    // Update configs if needed.
-    Map<String, String> desiredConfig = topicToUpdateConfigs.configs();
-    if (desiredConfig != null) {
-      Set<AlterConfigOp> alterConfigOps = new HashSet<>(desiredConfig.size());
-      maybeUpdateConfig(alterConfigOps, desiredConfig, topicConfig);
-      if (!alterConfigOps.isEmpty()) {
-        AlterConfigsResult alterConfigsResult
-            = adminClient.incrementalAlterConfigs(Collections.singletonMap(topicResource, alterConfigOps));
-        try {
-          alterConfigsResult.values().get(topicResource).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-          LOG.warn("Config change for topic {} failed.", topicName, e);
-          return false;
-        }
-      }
-    }
-
-    return true;
-  }
-
-  /**
-   * Increase the partition count of the given existing topic to the desired partition count (if needed).
-   *
-   * @param adminClient The adminClient to send describeTopics and createPartitions requests.
-   * @param topicToAddPartitions Existing topic to add more partitions if needed -- cannot be {@code null}.
-   * @return {@code true} if the request is completed successfully, {@code false} if there are any exceptions.
-   */
-  public static boolean maybeIncreasePartitionCount(AdminClient adminClient, NewTopic topicToAddPartitions) {
-    String topicName = topicToAddPartitions.name();
-
-    // Retrieve partition count of topic to check if it needs a partition count update.
-    TopicDescription topicDescription;
-    try {
-      topicDescription = adminClient.describeTopics(Collections.singletonList(topicName)).values()
-                                    .get(topicName).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      LOG.warn("Partition count increase check for topic {} failed due to failure to describe cluster.", topicName, e);
-      return false;
-    }
-
-    // Update partition count of topic if needed.
-    if (topicDescription.partitions().size() < topicToAddPartitions.numPartitions()) {
-      CreatePartitionsResult createPartitionsResult = adminClient.createPartitions(
-          Collections.singletonMap(topicName, NewPartitions.increaseTo(topicToAddPartitions.numPartitions())));
-
-      try {
-        createPartitionsResult.values().get(topicName).get(CLIENT_REQUEST_TIMEOUT_MS,
-                                                           TimeUnit.MILLISECONDS);
-      } catch (InterruptedException | ExecutionException | TimeoutException e) {
-        LOG.warn("Partition count increase to {} for topic {} failed{}.", topicToAddPartitions.numPartitions(), topicName,
-                 (e.getCause() instanceof ReassignmentInProgressException) ? " due to ongoing reassignment" : "", e);
-        return false;
-      }
-    }
-
-    return true;
+  public static KafkaConsumer<byte[], byte[]> createSampleStoreConsumer(Map<String, ?> configs, String groupIdPrefix) {
+    long randomToken = RANDOM.nextLong();
+    Properties consumerProps = new Properties();
+    consumerProps.putAll(configs);
+    consumerProps.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers(configs));
+    consumerProps.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupIdPrefix + randomToken);
+    consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, groupIdPrefix + "-consumer-" + randomToken);
+    consumerProps.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    consumerProps.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+    consumerProps.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, Integer.toString(Integer.MAX_VALUE));
+    consumerProps.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+    consumerProps.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+    consumerProps.setProperty(ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG, configs.get(RECONNECT_BACKOFF_MS_CONFIG).toString());
+    return new KafkaConsumer<>(consumerProps);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/SessionManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/SessionManager.java
@@ -106,7 +106,6 @@ public class SessionManager {
    *
    * @return The {@link OperationFuture} for the provided async operation.
    */
-  @SuppressWarnings("unchecked")
   synchronized OperationFuture getAndCreateSessionIfNotExist(HttpServletRequest request,
                                                              Supplier<OperationFuture> operation,
                                                              int step) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/CruiseControlIntegrationTestHarness.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/CruiseControlIntegrationTestHarness.java
@@ -16,7 +16,7 @@ import java.util.Properties;
 
 public abstract class CruiseControlIntegrationTestHarness extends CCKafkaIntegrationTestHarness {
 
-  private KafkaCruiseControlConfig _config;
+  protected KafkaCruiseControlConfig _config;
   protected KafkaCruiseControlApp _app;
 
   protected static final String LOCALHOST = "localhost";
@@ -36,7 +36,6 @@ public abstract class CruiseControlIntegrationTestHarness extends CCKafkaIntegra
 
   /**
    * Starts up an embedded Cruise Control environment with Zookeeper, Kafka brokers and a Cruise Control instance.
-   * @throws Exception
    */
   public void start() throws Exception {
     super.setUp();
@@ -47,8 +46,7 @@ public abstract class CruiseControlIntegrationTestHarness extends CCKafkaIntegra
   }
 
   /**
-   * Shuts down the CruiseControl instance, Kafka brokers and the Zookeeper instance.
-   * @throws Exception
+   * Shuts down the Cruise Control instance, Kafka brokers and the Zookeeper instance.
    */
   public void stop() {
     if (_app != null) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventTest.java
@@ -66,7 +66,7 @@ public class MaintenanceEventTest {
     MOCK_BROKERS_OBJECT = Collections.unmodifiableSet(mockBrokersObject);
   }
   // Note that the use of MOCK_TOPICS_WITH_RF_UPDATE assumes the use of a cluster model, which contains T1.
-  private static final Map<Short, Set<String>> MOCK_TOPICS_WITH_RF_UPDATE = Collections.singletonMap((short) 2, Collections.singleton(T1));
+  private static final Map<Short, String> MOCK_TOPICS_WITH_RF_UPDATE = Collections.singletonMap((short) 2, T1);
   private static final String SELF_HEALING_REASON_PREFIX = String.format("Self healing for %s: ", MAINTENANCE_EVENT);
   private static final String WITH_BROKERS_REASON_SUFFIX = String.format(" for brokers: [%s]}", MOCK_BROKERS_OBJECT);
   private static final String WITH_RF_UPDATE_SUFFIX = String.format(" by desired RF: [%s]}", MOCK_TOPICS_WITH_RF_UPDATE);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventTopicReaderTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventTopicReaderTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.detector;
+
+import com.linkedin.kafka.cruisecontrol.CruiseControlIntegrationTestHarness;
+import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
+import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils;
+import com.linkedin.kafka.cruisecontrol.config.constants.AnomalyDetectorConfig;
+import com.linkedin.kafka.cruisecontrol.exception.SamplingException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorUtils.KAFKA_CRUISE_CONTROL_OBJECT_CONFIG;
+import static com.linkedin.kafka.cruisecontrol.detector.MaintenanceEventTopicReader.DEFAULT_MAINTENANCE_PLAN_EXPIRATION_MS;
+import static com.linkedin.kafka.cruisecontrol.detector.MaintenanceEventTopicReader.MAINTENANCE_EVENT_TOPIC_CONFIG;
+import static com.linkedin.kafka.cruisecontrol.detector.MaintenanceEventTopicReader.MAINTENANCE_EVENT_TOPIC_REPLICATION_FACTOR_CONFIG;
+import static com.linkedin.kafka.cruisecontrol.detector.MaintenanceEventTopicReader.MAINTENANCE_EVENT_TOPIC_PARTITION_COUNT_CONFIG;
+import static com.linkedin.kafka.cruisecontrol.detector.MaintenanceEventTopicReader.MAINTENANCE_EVENT_TOPIC_RETENTION_MS_CONFIG;
+import static com.linkedin.kafka.cruisecontrol.detector.MaintenanceEventType.REBALANCE;
+import static com.linkedin.kafka.cruisecontrol.detector.notifier.KafkaAnomalyType.MAINTENANCE_EVENT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+
+public class MaintenanceEventTopicReaderTest extends CruiseControlIntegrationTestHarness {
+  public static final String TEST_TOPIC = "__CloudMaintenanceEvent";
+  public static final String TEST_TOPIC_REPLICATION_FACTOR = "1";
+  public static final String TEST_TOPIC_PARTITION_COUNT = "8";
+  public static final String TEST_TOPIC_RETENTION_TIME_MS = "3600000";
+  public static final String RETENTION_MS_CONFIG = "retention.ms";
+  public static final long TEST_REBALANCE_PLAN_TIME = 1601089200000L;
+  public static final long TEST_EXPIRED_PLAN_TIME = TEST_REBALANCE_PLAN_TIME - 1L;
+  public static final int TEST_BROKER_ID = 42;
+  public static final Duration TEST_TIMEOUT = Duration.ofSeconds(5);
+  public static final Map<Short, String> TEST_TOPIC_REGEX_WITH_RF_UPDATE = Collections.singletonMap((short) 2, "T1");
+  private TopicDescription _topicDescription;
+  private Config _topicConfig;
+
+  /**
+   * Setup the unit test and produce maintenance plans to the maintenance topic.
+   */
+  @Before
+  public void setup() throws Exception {
+    super.start();
+    produceMaintenancePlans();
+  }
+
+  /**
+   * Produces plans to the {@link #TEST_TOPIC}.
+   * All plans except {@link RebalancePlan} are expired.
+   */
+  private void produceMaintenancePlans() {
+    Properties props = new Properties();
+    props.setProperty(ProducerConfig.ACKS_CONFIG, "-1");
+    try (Producer<String, MaintenancePlan> producer = createMaintenancePlanProducer(props)) {
+      sendPlan(producer, new RebalancePlan(TEST_REBALANCE_PLAN_TIME, TEST_BROKER_ID));
+      sendPlan(producer, new FixOfflineReplicasPlan(TEST_EXPIRED_PLAN_TIME, TEST_BROKER_ID));
+      sendPlan(producer, new DemoteBrokerPlan(TEST_EXPIRED_PLAN_TIME, TEST_BROKER_ID, Collections.singleton(TEST_BROKER_ID)));
+      sendPlan(producer, new AddBrokerPlan(TEST_EXPIRED_PLAN_TIME, TEST_BROKER_ID, Collections.singleton(TEST_BROKER_ID)));
+      sendPlan(producer, new RemoveBrokerPlan(TEST_EXPIRED_PLAN_TIME, TEST_BROKER_ID, Collections.singleton(TEST_BROKER_ID)));
+      sendPlan(producer, new TopicReplicationFactorPlan(TEST_EXPIRED_PLAN_TIME, TEST_BROKER_ID, TEST_TOPIC_REGEX_WITH_RF_UPDATE));
+    }
+  }
+
+  @javax.annotation.Nonnull
+  protected Producer<String, MaintenancePlan> createMaintenancePlanProducer(Properties overrides) {
+    Properties props = new Properties();
+    props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
+    props.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getCanonicalName());
+    props.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, MaintenancePlanSerde.class.getCanonicalName());
+    //apply overrides
+    if (overrides != null) {
+      props.putAll(overrides);
+    }
+    return new KafkaProducer<>(props);
+  }
+
+  private void sendPlan(Producer<String, MaintenancePlan> producer, MaintenancePlan maintenancePlan) {
+    producer.send(new ProducerRecord<>(TEST_TOPIC, maintenancePlan), (recordMetadata, e) -> {
+      if (e != null) {
+        fail("Failed to produce maintenance plan");
+      }
+    });
+  }
+
+  @After
+  public void teardown() {
+    super.stop();
+  }
+
+  @Override
+  protected Map<String, Object> withConfigs() {
+    Map<String, Object> configs = new HashMap<>(5);
+    configs.put(MAINTENANCE_EVENT_TOPIC_CONFIG, TEST_TOPIC);
+    configs.put(MAINTENANCE_EVENT_TOPIC_REPLICATION_FACTOR_CONFIG, TEST_TOPIC_REPLICATION_FACTOR);
+    configs.put(MAINTENANCE_EVENT_TOPIC_PARTITION_COUNT_CONFIG, TEST_TOPIC_PARTITION_COUNT);
+    configs.put(MAINTENANCE_EVENT_TOPIC_RETENTION_MS_CONFIG, TEST_TOPIC_RETENTION_TIME_MS);
+    configs.put(AnomalyDetectorConfig.MAINTENANCE_EVENT_READER_CLASS_CONFIG, MaintenanceEventTopicReader.class.getName());
+    return configs;
+  }
+
+  /**
+   * Retrieve the latest metadata for {@link #_topicDescription} and {@link #_topicConfig} topics.
+   * To ensure the latest metadata update, admin clients retrieve the metadata from both brokers and ensure that they
+   * have the same metadata.
+   */
+  private void retrieveLatestMetadata() throws InterruptedException, ExecutionException {
+    TopicDescription description0;
+    TopicDescription description1;
+    Config topicConfig0;
+    Config topicConfig1;
+    ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, TEST_TOPIC);
+    AdminClient adminClient0 = KafkaCruiseControlUtils.createAdminClient(Collections.singletonMap(
+        AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()));
+    AdminClient adminClient1 = KafkaCruiseControlUtils.createAdminClient(Collections.singletonMap(
+        AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(1).plaintextAddr()));
+    try {
+      while (true) {
+        description0 = adminClient0.describeTopics(Collections.singleton(TEST_TOPIC)).values().get(TEST_TOPIC).get();
+        description1 = adminClient1.describeTopics(Collections.singleton(TEST_TOPIC)).values().get(TEST_TOPIC).get();
+        topicConfig0 = adminClient0.describeConfigs(Collections.singleton(topicResource)).values().get(topicResource).get();
+        topicConfig1 = adminClient1.describeConfigs(Collections.singleton(topicResource)).values().get(topicResource).get();
+        if (description0 != null && description1 != null && topicConfig0 != null && topicConfig1 != null
+            && description0.partitions().size() == description1.partitions().size()
+            && description0.partitions().get(0).replicas().size() == description1.partitions().get(0).replicas().size()
+            && topicConfig0.get(RETENTION_MS_CONFIG).value().equals(topicConfig1.get(RETENTION_MS_CONFIG).value())) {
+          _topicDescription = description0;
+          _topicConfig = topicConfig0;
+          break;
+        }
+        Thread.sleep(50);
+      }
+    } finally {
+      KafkaCruiseControlUtils.closeAdminClientWithTimeout(adminClient0);
+      KafkaCruiseControlUtils.closeAdminClientWithTimeout(adminClient1);
+    }
+  }
+
+  private void verify(String partitionCount, String replicationFactor, String retentionMs, boolean testingTopicConfigUpdate)
+      throws ExecutionException, InterruptedException {
+    retrieveLatestMetadata();
+    // Verify that the maintenance event topic has been created with the desired properties.
+    assertEquals(Integer.parseInt(partitionCount), _topicDescription.partitions().size());
+    if (!testingTopicConfigUpdate) {
+      assertEquals(Integer.parseInt(replicationFactor), _topicDescription.partitions().get(0).replicas().size());
+    }
+
+    String currentRetentionMs = _topicConfig.get(RETENTION_MS_CONFIG).value();
+    assertEquals(retentionMs, currentRetentionMs);
+  }
+
+  @Test
+  public void testMaintenanceEventTopicCreationUpdateAndRead()
+      throws ExecutionException, InterruptedException, SamplingException {
+    // Verify that the maintenance event topic has been created with the desired properties.
+    verify(TEST_TOPIC_PARTITION_COUNT, TEST_TOPIC_REPLICATION_FACTOR, TEST_TOPIC_RETENTION_TIME_MS, false);
+
+    // Verify that the maintenance event topic properties can be updated if the topic already exists with different properties.
+    String newPartitionCount = String.valueOf(Integer.parseInt(TEST_TOPIC_PARTITION_COUNT) * 2);
+    String newRF = String.valueOf(Short.parseShort(TEST_TOPIC_REPLICATION_FACTOR) + 1);
+    String newRetentionMs = String.valueOf(Long.MAX_VALUE);
+
+    KafkaCruiseControl mockKafkaCruiseControl = EasyMock.mock(KafkaCruiseControl.class);
+    Map<String, Object> parameterConfigOverrides = new HashMap<>(4);
+    parameterConfigOverrides.put(KAFKA_CRUISE_CONTROL_OBJECT_CONFIG, mockKafkaCruiseControl);
+    parameterConfigOverrides.put(MAINTENANCE_EVENT_TOPIC_REPLICATION_FACTOR_CONFIG, newRF);
+    parameterConfigOverrides.put(MAINTENANCE_EVENT_TOPIC_PARTITION_COUNT_CONFIG, newPartitionCount);
+    parameterConfigOverrides.put(MAINTENANCE_EVENT_TOPIC_RETENTION_MS_CONFIG, newRetentionMs);
+
+    // The current time is expected to cause (1) a valid rebalance plan creation, but (2) an expired demote broker plan.
+    long currentMockTime = TEST_REBALANCE_PLAN_TIME + DEFAULT_MAINTENANCE_PLAN_EXPIRATION_MS;
+    EasyMock.expect(mockKafkaCruiseControl.timeMs()).andReturn(currentMockTime).anyTimes();
+    EasyMock.expect(mockKafkaCruiseControl.config()).andReturn(_config).anyTimes();
+
+    EasyMock.replay(mockKafkaCruiseControl);
+
+    MaintenanceEventReader maintenanceEventReader = _config.getConfiguredInstance(AnomalyDetectorConfig.MAINTENANCE_EVENT_READER_CLASS_CONFIG,
+                                                                                  MaintenanceEventTopicReader.class,
+                                                                                  parameterConfigOverrides);
+
+    assertNotNull(maintenanceEventReader);
+    verify(newPartitionCount, newRF, newRetentionMs, true);
+    Set<MaintenanceEvent> events = maintenanceEventReader.readEvents(TEST_TIMEOUT);
+    EasyMock.verify(mockKafkaCruiseControl);
+    assertEquals(1, events.size());
+    MaintenanceEvent maintenanceEvent = events.iterator().next();
+    assertEquals(MAINTENANCE_EVENT, maintenanceEvent.anomalyType());
+    assertEquals(currentMockTime, maintenanceEvent.detectionTimeMs());
+    assertEquals(REBALANCE, maintenanceEvent.maintenanceEventType());
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/task/LoadMonitorTaskRunnerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/task/LoadMonitorTaskRunnerTest.java
@@ -13,7 +13,7 @@ import com.linkedin.cruisecontrol.metricdef.MetricDef;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.common.MetadataClient;
 import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
-import com.linkedin.kafka.cruisecontrol.exception.MetricSamplingException;
+import com.linkedin.kafka.cruisecontrol.exception.SamplingException;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaIntegrationTestHarness;
 import com.linkedin.kafka.cruisecontrol.monitor.metricdefinition.KafkaMetricDef;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricFetcherManager;
@@ -211,11 +211,11 @@ public class LoadMonitorTaskRunnerTest extends CCKafkaIntegrationTestHarness {
                               long endTime,
                               SamplingMode mode,
                               MetricDef metricDef,
-                              long timeout) throws MetricSamplingException {
+                              long timeout) throws SamplingException {
 
       if (_exceptionsLeft > 0) {
         _exceptionsLeft--;
-        throw new MetricSamplingException("Error");
+        throw new SamplingException("Error");
       }
       Set<PartitionMetricSample> partitionMetricSamples = new HashSet<>(assignedPartitions.size());
       for (TopicPartition tp : assignedPartitions) {

--- a/docs/wiki/User Guide/Configurations.md
+++ b/docs/wiki/User Guide/Configurations.md
@@ -11,6 +11,7 @@
 - [Configurations of pluggable classes](#configurations-of-pluggable-classes)
     - [CruiseControlMetricsReporterSampler configurations](#cruisecontrolmetricsreportersampler-configurations)
     - [KafkaSampleStore configurations](#kafkasamplestore-configurations)
+    - [MaintenanceEventTopicReader configurations](#maintenanceeventtopicreader-configurations)
     - [BrokerCapacityConfigurationFileResolver configurations](#brokercapacityconfigurationfileresolver-configurations)
         - [Populating the Capacity Config File](#populating-the-capacity-config-file)
     - [SelfHealingNotifier configurations](#selfhealingnotifier-configurations)
@@ -244,6 +245,14 @@ We are still trying to improve cruise control. And following are some configurat
 | min.partition.sample.store.topic.retention.time.ms    | Integer | N         | 3600000       | The config for the minimal retention time for Kafka partition sample store topic                                                                                                                        |
 | min.broker.sample.store.topic.retention.time.ms       | Integer | N         | 3600000       | The config for the minimal retention time for Kafka broker sample store topic                                                                                                                           |
 | skip.sample.store.topic.rack.awareness.check          | Boolean | N         | false         | The config to skip rack awareness sanity check for sample store topics                                                                                                                                  |
+
+### MaintenanceEventTopicReader configurations
+| Name                                          | Type    | Required? | Default Value           | Description                                                       |
+|-----------------------------------------------|---------|-----------|-------------------------|-------------------------------------------------------------------|
+| maintenance.event.topic                       | String  | N         | __MaintenanceEvent      | The name of the Kafka topic to consume maintenance events from    |
+| maintenance.event.topic.replication.factor    | Short   | N         | min(2, #alive-brokers)  | The replication factor of the maintenance event topic             |
+| maintenance.event.topic.partition.count       | Integer | N         | 32                      | The partition count of the maintenance event topic                |
+| maintenance.event.topic.retention.ms          | Long    | N         | 21600000                | The retention of the maintenance event topic                      |
 
 ### BrokerCapacityConfigurationFileResolver configurations
 | Name                 | Type   | Required? | Default Value             | Description                                                                        |

--- a/docs/wiki/User Guide/Configurations.md
+++ b/docs/wiki/User Guide/Configurations.md
@@ -251,7 +251,7 @@ We are still trying to improve cruise control. And following are some configurat
 |-----------------------------------------------|---------|-----------|-------------------------|-------------------------------------------------------------------|
 | maintenance.event.topic                       | String  | N         | __MaintenanceEvent      | The name of the Kafka topic to consume maintenance events from    |
 | maintenance.event.topic.replication.factor    | Short   | N         | min(2, #alive-brokers)  | The replication factor of the maintenance event topic             |
-| maintenance.event.topic.partition.count       | Integer | N         | 32                      | The partition count of the maintenance event topic                |
+| maintenance.event.topic.partition.count       | Integer | N         | 8                       | The partition count of the maintenance event topic                |
 | maintenance.event.topic.retention.ms          | Long    | N         | 21600000                | The retention of the maintenance event topic                      |
 
 ### BrokerCapacityConfigurationFileResolver configurations


### PR DESCRIPTION
This PR resolves #1248.

Known issues:
* If a detected maintenance event cannot be handled due to `AnomalyDetectionStatus` being not `READY`, it will be dropped. The support for stronger handling semantics will be added on later PRs.
* Idempotency support (handling duplicate maintenance events) will be added on later PRs.