### PR TITLE
Make MetricSampler more extensible.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/AbstractMetricSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/AbstractMetricSampler.java
@@ -17,10 +17,17 @@ import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.CruiseControlMetr
 
 import static com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricFetcherManager.BROKER_CAPACITY_CONFIG_RESOLVER_OBJECT_CONFIG;
 
+/**
+ * This is a base implementation of a MetricSampler that can be overriden by concrete Metric Sampler
+ * implementations. It takes care of the common logic of initializing a {@link CruiseControlMetricsProcessor},
+ * and then using it to record every individual {@link CruiseControlMetric}, and finally convert all
+ * of these into {@link com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricSampler.Samples}.
+ */
 abstract public class AbstractMetricSampler implements MetricSampler {
     private CruiseControlMetricsProcessor _metricsProcessor;
 
-    @Override public void configure(Map<String, ?> configs) {
+    @Override
+    public void configure(Map<String, ?> configs) {
         BrokerCapacityConfigResolver capacityResolver =
             (BrokerCapacityConfigResolver) configs.get(BROKER_CAPACITY_CONFIG_RESOLVER_OBJECT_CONFIG);
         if (capacityResolver == null) {
@@ -56,8 +63,24 @@ abstract public class AbstractMetricSampler implements MetricSampler {
         }
     }
 
+    /**
+     * This method will be called to add all the {@link CruiseControlMetric}s
+     * for a cluster in one sampling period.
+     *
+     * Concrete metric sampler implementations can implement this method according to
+     * their corresponding business logic of fetching metrics for the cluster.
+     *
+     * @param metricSamplerOptions Object that encapsulates all the options to be used for sampling metrics.
+     * @return Total number of metrics sampled.
+     */
     abstract protected int addMetrics(MetricSamplerOptions metricSamplerOptions) throws SamplingException;
-
+    /**
+     * This method records a single individual metric obtained from the cluster during a sampling period.
+     * The {@link #addMetrics(MetricSamplerOptions)} method implemented in the conrete metric sampler
+     * class will call this method for every metric it obtains for a single sampling period for the cluster.
+     *
+     * @param metric Individual CruiseControlMetric being recorded by the Metric Sampler.
+     */
     protected void addMetric(CruiseControlMetric metric) {
         this._metricsProcessor.addMetric(metric);
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/AbstractMetricSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/AbstractMetricSampler.java
@@ -18,7 +18,7 @@ import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.CruiseControlMetr
 import static com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricFetcherManager.BROKER_CAPACITY_CONFIG_RESOLVER_OBJECT_CONFIG;
 
 /**
- * This is a base implementation of a MetricSampler that can be overriden by concrete Metric Sampler
+ * This is a base implementation of a MetricSampler that can be overridden by concrete Metric Sampler
  * implementations. It takes care of the common logic of initializing a {@link CruiseControlMetricsProcessor},
  * and then using it to record every individual {@link CruiseControlMetric}, and finally convert all
  * of these into {@link com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricSampler.Samples}.
@@ -41,15 +41,15 @@ abstract public class AbstractMetricSampler implements MetricSampler {
 
     @Override
     public Samples getSamples(Cluster cluster, Set<TopicPartition> assignedPartitions, long startTimeMs,
-        long endTimeMs, SamplingMode mode, MetricDef metricDef, long timeout) throws SamplingException {
+        long endTimeMs, SamplingMode mode, MetricDef metricDef, long timeoutMs) throws SamplingException {
         MetricSamplerOptions metricSamplerOptions = new MetricSamplerOptions(
-            cluster, assignedPartitions, startTimeMs, endTimeMs, mode, metricDef, timeout);
+            cluster, assignedPartitions, startTimeMs, endTimeMs, mode, metricDef, timeoutMs);
         return getSamples(metricSamplerOptions);
     }
 
     @Override
     public Samples getSamples(MetricSamplerOptions metricSamplerOptions) throws SamplingException {
-        int totalMetricsAdded = addMetrics(metricSamplerOptions);
+        int totalMetricsAdded = retrieveMetricsForProcessing(metricSamplerOptions);
 
         try {
             if (totalMetricsAdded > 0) {
@@ -64,24 +64,26 @@ abstract public class AbstractMetricSampler implements MetricSampler {
     }
 
     /**
-     * This method will be called to add all the {@link CruiseControlMetric}s
-     * for a cluster in one sampling period.
+     * This method will be called to retrieve all the {@link CruiseControlMetric}s
+     * for a cluster in one sampling period for processing by the {@link CruiseControlMetricsProcessor}.
      *
      * Concrete metric sampler implementations can implement this method according to
      * their corresponding business logic of fetching metrics for the cluster.
      *
      * @param metricSamplerOptions Object that encapsulates all the options to be used for sampling metrics.
-     * @return Total number of metrics sampled.
+     * @return Total number of metrics retrieved.
      */
-    abstract protected int addMetrics(MetricSamplerOptions metricSamplerOptions) throws SamplingException;
+    abstract protected int retrieveMetricsForProcessing(MetricSamplerOptions metricSamplerOptions)
+        throws SamplingException;
     /**
-     * This method records a single individual metric obtained from the cluster during a sampling period.
-     * The {@link #addMetrics(MetricSamplerOptions)} method implemented in the conrete metric sampler
-     * class will call this method for every metric it obtains for a single sampling period for the cluster.
+     * This method adds a metric obtained from the cluster to the list of metrics being
+     * retrieved for processing during a single sampling period.
+     * The {@link #retrieveMetricsForProcessing(MetricSamplerOptions)} method implemented in the concrete metric
+     * sampler class will call this method for every metric it obtains for a single sampling period for the cluster.
      *
-     * @param metric Individual CruiseControlMetric being recorded by the Metric Sampler.
+     * @param metric Individual {@link CruiseControlMetric} being recorded by the Metric Sampler.
      */
-    protected void addMetric(CruiseControlMetric metric) {
+    protected void addMetricForProcessing(CruiseControlMetric metric) {
         this._metricsProcessor.addMetric(metric);
     }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/AbstractMetricSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/AbstractMetricSampler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.monitor.sampling;
+
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.TopicPartition;
+
+import com.linkedin.cruisecontrol.metricdef.MetricDef;
+import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityConfigResolver;
+import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
+import com.linkedin.kafka.cruisecontrol.exception.SamplingException;
+import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.CruiseControlMetric;
+
+import static com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricFetcherManager.BROKER_CAPACITY_CONFIG_RESOLVER_OBJECT_CONFIG;
+
+abstract public class AbstractMetricSampler implements MetricSampler {
+    private CruiseControlMetricsProcessor _metricsProcessor;
+
+    @Override public void configure(Map<String, ?> configs) {
+        BrokerCapacityConfigResolver capacityResolver =
+            (BrokerCapacityConfigResolver) configs.get(BROKER_CAPACITY_CONFIG_RESOLVER_OBJECT_CONFIG);
+        if (capacityResolver == null) {
+            throw new IllegalArgumentException(
+                "Metrics reporter sampler configuration is missing broker capacity config resolver object.");
+        }
+        boolean allowCpuCapacityEstimation = (Boolean) configs.get(
+            MonitorConfig.SAMPLING_ALLOW_CPU_CAPACITY_ESTIMATION_CONFIG);
+        _metricsProcessor = new CruiseControlMetricsProcessor(capacityResolver, allowCpuCapacityEstimation);
+    }
+
+    @Override
+    public Samples getSamples(Cluster cluster, Set<TopicPartition> assignedPartitions, long startTimeMs,
+        long endTimeMs, SamplingMode mode, MetricDef metricDef, long timeout) throws SamplingException {
+        MetricSamplerOptions metricSamplerOptions = new MetricSamplerOptions(
+            cluster, assignedPartitions, startTimeMs, endTimeMs, mode, metricDef, timeout);
+        return getSamples(metricSamplerOptions);
+    }
+
+    @Override
+    public Samples getSamples(MetricSamplerOptions metricSamplerOptions) throws SamplingException {
+        int totalMetricsAdded = addMetrics(metricSamplerOptions);
+
+        try {
+            if (totalMetricsAdded > 0) {
+                return _metricsProcessor.process(metricSamplerOptions.cluster(),
+                    metricSamplerOptions.assignedPartitions(), metricSamplerOptions.mode());
+            } else {
+                return MetricSampler.EMPTY_SAMPLES;
+            }
+        } finally {
+            _metricsProcessor.clear();
+        }
+    }
+
+    abstract protected int addMetrics(MetricSamplerOptions metricSamplerOptions) throws SamplingException;
+
+    protected void addMetric(CruiseControlMetric metric) {
+        this._metricsProcessor.addMetric(metric);
+    }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsReporterSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsReporterSampler.java
@@ -109,7 +109,7 @@ public class CruiseControlMetricsReporterSampler extends AbstractMetricSampler {
         partitionsToPause.clear();
       }
     } while (!consumptionDone(_metricConsumer, endOffsets) &&
-        System.currentTimeMillis() < metricSamplerOptions.timeout());
+        System.currentTimeMillis() < metricSamplerOptions.timeoutMs());
     LOG.info("Finished sampling for topic partitions {} in time range [{},{}]. Collected {} metrics.",
         _currentPartitionAssignment, metricSamplerOptions.startTimeMs(),
         metricSamplerOptions.endTimeMs(), totalMetricsAdded);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsReporterSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsReporterSampler.java
@@ -4,8 +4,6 @@
 
 package com.linkedin.kafka.cruisecontrol.monitor.sampling;
 
-import com.linkedin.cruisecontrol.metricdef.MetricDef;
-import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityConfigResolver;
 import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
 import com.linkedin.kafka.cruisecontrol.exception.SamplingException;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporterConfig;
@@ -21,7 +19,6 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
-import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
@@ -30,11 +27,10 @@ import org.slf4j.LoggerFactory;
 
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.consumptionDone;
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.sanityCheckOffsetFetch;
-import static com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricFetcherManager.BROKER_CAPACITY_CONFIG_RESOLVER_OBJECT_CONFIG;
 import static com.linkedin.kafka.cruisecontrol.monitor.sampling.SamplingUtils.createMetricConsumer;
 
 
-public class CruiseControlMetricsReporterSampler implements MetricSampler {
+public class CruiseControlMetricsReporterSampler extends AbstractMetricSampler {
   private static final Logger LOG = LoggerFactory.getLogger(CruiseControlMetricsReporterSampler.class);
   // Configurations
   public static final String METRIC_REPORTER_SAMPLER_BOOTSTRAP_SERVERS = "metric.reporter.sampler.bootstrap.servers";
@@ -45,7 +41,6 @@ public class CruiseControlMetricsReporterSampler implements MetricSampler {
   // Default configs
   public static final String CONSUMER_CLIENT_ID_PREFIX = "CruiseControlMetricsReporterSampler";
   public static final long ACCEPTABLE_NETWORK_DELAY_MS = 100L;
-  protected CruiseControlMetricsProcessor _metricsProcessor;
 
   protected Consumer<String, CruiseControlMetric> _metricConsumer;
   protected String _metricReporterTopic;
@@ -58,20 +53,15 @@ public class CruiseControlMetricsReporterSampler implements MetricSampler {
   protected long _acceptableMetricRecordProduceDelayMs;
 
   @Override
-  public Samples getSamples(Cluster cluster,
-                            Set<TopicPartition> assignedPartitions,
-                            long startTimeMs,
-                            long endTimeMs,
-                            SamplingMode mode,
-                            MetricDef metricDef,
-                            long timeout) throws SamplingException {
+
+  protected int addMetrics(MetricSamplerOptions metricSamplerOptions) throws SamplingException {
     if (refreshPartitionAssignment()) {
-      return MetricSampler.EMPTY_SAMPLES;
+      return 0;
     }
     // Now seek to the startTimeMs.
     Map<TopicPartition, Long> timestampToSeek = new HashMap<>(_currentPartitionAssignment.size());
     for (TopicPartition tp : _currentPartitionAssignment) {
-      timestampToSeek.put(tp, startTimeMs);
+      timestampToSeek.put(tp, metricSamplerOptions.startTimeMs());
     }
     Set<TopicPartition> assignment = new HashSet<>(_currentPartitionAssignment);
     Map<TopicPartition, Long> endOffsets = _metricConsumer.endOffsets(assignment);
@@ -101,16 +91,16 @@ public class CruiseControlMetricsReporterSampler implements MetricSampler {
           continue;
         }
         long recordTime = record.value().time();
-        if (recordTime + _acceptableMetricRecordProduceDelayMs < startTimeMs) {
+        if (recordTime + _acceptableMetricRecordProduceDelayMs < metricSamplerOptions.startTimeMs()) {
           LOG.debug("Discarding metric {} because its timestamp is more than {} ms earlier than the start time of sampling period {}.",
-                    record.value(), _acceptableMetricRecordProduceDelayMs, startTimeMs);
-        } else if (recordTime >= endTimeMs) {
+              record.value(), _acceptableMetricRecordProduceDelayMs, metricSamplerOptions.startTimeMs());
+        } else if (recordTime >= metricSamplerOptions.endTimeMs()) {
           TopicPartition tp = new TopicPartition(record.topic(), record.partition());
           LOG.debug("Saw metric {} whose timestamp is larger than the end time of sampling period {}. Pausing "
-                    + "partition {} at offset {}.", record.value(), endTimeMs, tp, record.offset());
+              + "partition {} at offset {}.", record.value(), metricSamplerOptions.endTimeMs(), tp, record.offset());
           partitionsToPause.add(tp);
         } else {
-          _metricsProcessor.addMetric(record.value());
+          addMetric(record.value());
           totalMetricsAdded++;
         }
       }
@@ -118,19 +108,13 @@ public class CruiseControlMetricsReporterSampler implements MetricSampler {
         _metricConsumer.pause(partitionsToPause);
         partitionsToPause.clear();
       }
-    } while (!consumptionDone(_metricConsumer, endOffsets) && System.currentTimeMillis() < timeout);
+    } while (!consumptionDone(_metricConsumer, endOffsets) &&
+        System.currentTimeMillis() < metricSamplerOptions.timeout());
     LOG.info("Finished sampling for topic partitions {} in time range [{},{}]. Collected {} metrics.",
-             _currentPartitionAssignment, startTimeMs, endTimeMs, totalMetricsAdded);
+        _currentPartitionAssignment, metricSamplerOptions.startTimeMs(),
+        metricSamplerOptions.endTimeMs(), totalMetricsAdded);
 
-    try {
-      if (totalMetricsAdded > 0) {
-        return _metricsProcessor.process(cluster, assignedPartitions, mode);
-      } else {
-        return new Samples(Collections.emptySet(), Collections.emptySet());
-      }
-    } finally {
-      _metricsProcessor.clear();
-    }
+    return totalMetricsAdded;
   }
 
   /**
@@ -167,18 +151,13 @@ public class CruiseControlMetricsReporterSampler implements MetricSampler {
 
   @Override
   public void configure(Map<String, ?> configs) {
+    super.configure(configs);
     int numSamplers = (Integer) configs.get(MonitorConfig.NUM_METRIC_FETCHERS_CONFIG);
     if (numSamplers != 1) {
       throw new ConfigException("CruiseControlMetricsReporterSampler is not thread safe. Please change " +
                                 MonitorConfig.NUM_METRIC_FETCHERS_CONFIG + " to 1");
     }
 
-    BrokerCapacityConfigResolver capacityResolver = (BrokerCapacityConfigResolver) configs.get(BROKER_CAPACITY_CONFIG_RESOLVER_OBJECT_CONFIG);
-    if (capacityResolver == null) {
-      throw new IllegalArgumentException("Metrics reporter sampler configuration is missing broker capacity config resolver object.");
-    }
-    boolean allowCpuCapacityEstimation = (Boolean) configs.get(MonitorConfig.SAMPLING_ALLOW_CPU_CAPACITY_ESTIMATION_CONFIG);
-    _metricsProcessor = new CruiseControlMetricsProcessor(capacityResolver, allowCpuCapacityEstimation);
     _metricReporterTopic = (String) configs.get(METRIC_REPORTER_TOPIC);
     if (_metricReporterTopic == null) {
       _metricReporterTopic = CruiseControlMetricsReporterConfig.DEFAULT_CRUISE_CONTROL_METRICS_TOPIC;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricFetcher.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricFetcher.java
@@ -114,8 +114,9 @@ abstract class MetricFetcher implements Callable<Boolean> {
    * @return The accepted partition and broker metric samples.
    */
   protected MetricSampler.Samples fetchSamples() throws SamplingException {
-    MetricSampler.Samples samples = _metricSampler.getSamples(_cluster, _assignedPartitions, _startTimeMs, _endTimeMs,
-                                                              _samplingMode, _metricDef, _timeout);
+    MetricSampler.MetricSamplerOptions metricSamplerOptions = new MetricSampler.MetricSamplerOptions(
+        _cluster, _assignedPartitions, _startTimeMs, _endTimeMs, _samplingMode, _metricDef, _timeout);
+    MetricSampler.Samples samples = _metricSampler.getSamples(metricSamplerOptions);
     if (samples == null) {
       samples = MetricSampler.EMPTY_SAMPLES;
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricFetcher.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricFetcher.java
@@ -114,7 +114,7 @@ abstract class MetricFetcher implements Callable<Boolean> {
    * @return The accepted partition and broker metric samples.
    */
   protected MetricSampler.Samples fetchSamples() throws SamplingException {
-    MetricSampler.MetricSamplerOptions metricSamplerOptions = new MetricSampler.MetricSamplerOptions(
+    MetricSamplerOptions metricSamplerOptions = new MetricSamplerOptions(
         _cluster, _assignedPartitions, _startTimeMs, _endTimeMs, _samplingMode, _metricDef, _timeout);
     MetricSampler.Samples samples = _metricSampler.getSamples(metricSamplerOptions);
     if (samples == null) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSampler.java
@@ -27,7 +27,7 @@ public interface MetricSampler extends CruiseControlConfigurable, AutoCloseable 
   Samples EMPTY_SAMPLES = new Samples(Collections.emptySet(), Collections.emptySet());
 
   /**
-   * Get the metric samples from the Kafka cluster with the options passed in {@link MetricSamplerOptions}.
+   * Get the metric samples from the Kafka cluster with the options passed as arguments.
    * The samples include PartitionMetricSamples and BrokerMetricSamples.
    *
    * Due to the lack of direct metrics at partition level, Kafka Cruise Control needs to estimate the CPU
@@ -48,7 +48,7 @@ public interface MetricSampler extends CruiseControlConfigurable, AutoCloseable 
    * @param endTimeMs the end time of the sampling period.
    * @param mode The sampling mode.
    * @param metricDef the metric definitions.
-   * @param timeout The sampling timeout in milliseconds to stop sampling even if there is more data to get.
+   * @param timeoutMs The sampling timeout in milliseconds to stop sampling even if there is more data to get.
    * @return Samples collected from the Kafka cluster.
    */
   @Deprecated
@@ -58,7 +58,7 @@ public interface MetricSampler extends CruiseControlConfigurable, AutoCloseable 
                      long endTimeMs,
                      SamplingMode mode,
                      MetricDef metricDef,
-                     long timeout)
+                     long timeoutMs)
       throws SamplingException;
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSampler.java
@@ -17,9 +17,9 @@ import org.apache.kafka.common.TopicPartition;
 /**
  * The interface to get metric samples of given topic partitions.
  * <p>
- * Kafka Cruise Control periodically collects the metrics of all the partitions in the cluster, including the leader and follower
- * replicas. The {@link #getSamples(MetricSamplerOptions)}
- * will be called for all the replicas of partitions in the cluster in one sampling period.
+ * Kafka Cruise Control periodically collects the metrics of topics, brokers and partitions in the cluster.
+ * The {@link #getSamples(MetricSamplerOptions)} is called periodically to collect metrics
+ * of all these types from a cluster in one sampling period.
  * The MetricSampler may be used by multiple threads at the same time, so the implementation need to be thread safe.
  *
  */
@@ -27,10 +27,7 @@ public interface MetricSampler extends CruiseControlConfigurable, AutoCloseable 
   Samples EMPTY_SAMPLES = new Samples(Collections.emptySet(), Collections.emptySet());
 
   /**
-   * @deprecated Please use {@link #getSamples(MetricSamplerOptions)}
-   *
-   * Get the metric sample of the given topic partition and replica from the Kafka cluster.
-   *
+   * Get the metric samples from the Kafka cluster with the options passed in {@link MetricSamplerOptions}.
    * The samples include PartitionMetricSamples and BrokerMetricSamples.
    *
    * Due to the lack of direct metrics at partition level, Kafka Cruise Control needs to estimate the CPU
@@ -51,9 +48,10 @@ public interface MetricSampler extends CruiseControlConfigurable, AutoCloseable 
    * @param endTimeMs the end time of the sampling period.
    * @param mode The sampling mode.
    * @param metricDef the metric definitions.
-   * @param timeout The sampling timeout to stop sampling even if there is more data to get.
-   * @return The PartitionMetricSample of the topic partition and replica id
+   * @param timeout The sampling timeout in milliseconds to stop sampling even if there is more data to get.
+   * @return Samples collected from the Kafka cluster.
    */
+  @Deprecated
   Samples getSamples(Cluster cluster,
                      Set<TopicPartition> assignedPartitions,
                      long startTimeMs,
@@ -64,8 +62,7 @@ public interface MetricSampler extends CruiseControlConfigurable, AutoCloseable 
       throws SamplingException;
 
   /**
-   * Get the metric sample of the given topic partition and replica from the Kafka cluster.
-   *
+   * Get the metric samples from the Kafka cluster with the options passed in {@link MetricSamplerOptions}.
    * The samples include PartitionMetricSamples and BrokerMetricSamples.
    *
    * Due to the lack of direct metrics at partition level, Kafka Cruise Control needs to estimate the CPU
@@ -81,76 +78,9 @@ public interface MetricSampler extends CruiseControlConfigurable, AutoCloseable 
    * partition movement.
    *
    * @param metricSamplerOptions This class encapsulates all the arguments needed by MetricSampler to get samples.
-   * @return The PartitionMetricSample of the topic partition and replica id
+   * @return Samples collected from the Kafka cluster.
    */
   Samples getSamples(MetricSamplerOptions metricSamplerOptions) throws SamplingException;
-
-  /**
-   * This class encapsulates the options that need to be passed to the {@link #getSamples(MetricSamplerOptions)}
-   * method. Future use-cases may choose to extend this class and add more options.
-   */
-  public class MetricSamplerOptions {
-    /**
-     * @param cluster the metadata of the cluster.
-     * @param assignedPartitions the topic partition
-     * @param startTimeMs the start time of the sampling period.
-     * @param endTimeMs the end time of the sampling period.
-     * @param mode The sampling mode.
-     * @param metricDef the metric definitions.
-     * @param timeout The sampling timeout to stop sampling even if there is more data to get.
-     */
-    public MetricSamplerOptions(Cluster cluster,
-                                Set<TopicPartition> assignedPartitions,
-                                long startTimeMs,
-                                long endTimeMs,
-                                SamplingMode mode,
-                                MetricDef metricDef,
-                                long timeout) {
-      this._cluster = cluster;
-      this._assignedPartitions = assignedPartitions;
-      this._startTimeMs = startTimeMs;
-      this._endTimeMs = endTimeMs;
-      this._mode = mode;
-      this._metricDef = metricDef;
-      this._timeout = timeout;
-    }
-
-    private final Cluster _cluster;
-    private final Set<TopicPartition> _assignedPartitions;
-    private final long _startTimeMs;
-    private final long _endTimeMs;
-    private final SamplingMode _mode;
-    private final MetricDef _metricDef;
-    private final long _timeout;
-
-    public Cluster cluster() {
-      return _cluster;
-    }
-
-    public Set<TopicPartition> assignedPartitions() {
-      return _assignedPartitions;
-    }
-
-    public long startTimeMs() {
-      return _startTimeMs;
-    }
-
-    public long endTimeMs() {
-      return _endTimeMs;
-    }
-
-    public SamplingMode mode() {
-      return _mode;
-    }
-
-    public MetricDef metricDef() {
-      return _metricDef;
-    }
-
-    public long timeout() {
-      return _timeout;
-    }
-  }
 
   /**
    * The sampling mode to indicate which type of samples is interested.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSampler.java
@@ -18,7 +18,7 @@ import org.apache.kafka.common.TopicPartition;
  * The interface to get metric samples of given topic partitions.
  * <p>
  * Kafka Cruise Control periodically collects the metrics of all the partitions in the cluster, including the leader and follower
- * replicas. The {@link #getSamples(Cluster, Set, long, long, SamplingMode, MetricDef, long)}
+ * replicas. The {@link #getSamples(MetricSamplerOptions)}
  * will be called for all the replicas of partitions in the cluster in one sampling period.
  * The MetricSampler may be used by multiple threads at the same time, so the implementation need to be thread safe.
  *
@@ -27,6 +27,8 @@ public interface MetricSampler extends CruiseControlConfigurable, AutoCloseable 
   Samples EMPTY_SAMPLES = new Samples(Collections.emptySet(), Collections.emptySet());
 
   /**
+   * @deprecated Please use {@link #getSamples(MetricSamplerOptions)}
+   *
    * Get the metric sample of the given topic partition and replica from the Kafka cluster.
    *
    * The samples include PartitionMetricSamples and BrokerMetricSamples.
@@ -60,6 +62,95 @@ public interface MetricSampler extends CruiseControlConfigurable, AutoCloseable 
                      MetricDef metricDef,
                      long timeout)
       throws SamplingException;
+
+  /**
+   * Get the metric sample of the given topic partition and replica from the Kafka cluster.
+   *
+   * The samples include PartitionMetricSamples and BrokerMetricSamples.
+   *
+   * Due to the lack of direct metrics at partition level, Kafka Cruise Control needs to estimate the CPU
+   * utilization for each partition by using the following formula:
+   *
+   *  BROKER_CPU_UTIL = a * ALL_TOPIC_BYTES_IN_RATE + b * ALL_TOPIC_BYTES_OUT_RATE + c * ALL_FOLLOWER_BYTES_IN_RATE
+   *
+   *  LEADER_PARTITION_CPU_UTIL = a * LEADER_PARTITION_BYTES_IN + b * LEADER_PARTITION_BYTES_OUT
+   *
+   *  FOLLOWER_PARTITION_CPU_UTIL = c * LEADER_PARTITION_BYTES_IN
+   *
+   * Kafka Cruise Control needs to know the parameters of a, b and c for cost evaluation of leader and
+   * partition movement.
+   *
+   * @param metricSamplerOptions This class encapsulates all the arguments needed by MetricSampler to get samples.
+   * @return The PartitionMetricSample of the topic partition and replica id
+   */
+  Samples getSamples(MetricSamplerOptions metricSamplerOptions) throws SamplingException;
+
+  /**
+   * This class encapsulates the options that need to be passed to the {@link #getSamples(MetricSamplerOptions)}
+   * method. Future use-cases may choose to extend this class and add more options.
+   */
+  public class MetricSamplerOptions {
+    /**
+     * @param cluster the metadata of the cluster.
+     * @param assignedPartitions the topic partition
+     * @param startTimeMs the start time of the sampling period.
+     * @param endTimeMs the end time of the sampling period.
+     * @param mode The sampling mode.
+     * @param metricDef the metric definitions.
+     * @param timeout The sampling timeout to stop sampling even if there is more data to get.
+     */
+    public MetricSamplerOptions(Cluster cluster,
+                                Set<TopicPartition> assignedPartitions,
+                                long startTimeMs,
+                                long endTimeMs,
+                                SamplingMode mode,
+                                MetricDef metricDef,
+                                long timeout) {
+      this._cluster = cluster;
+      this._assignedPartitions = assignedPartitions;
+      this._startTimeMs = startTimeMs;
+      this._endTimeMs = endTimeMs;
+      this._mode = mode;
+      this._metricDef = metricDef;
+      this._timeout = timeout;
+    }
+
+    private final Cluster _cluster;
+    private final Set<TopicPartition> _assignedPartitions;
+    private final long _startTimeMs;
+    private final long _endTimeMs;
+    private final SamplingMode _mode;
+    private final MetricDef _metricDef;
+    private final long _timeout;
+
+    public Cluster cluster() {
+      return _cluster;
+    }
+
+    public Set<TopicPartition> assignedPartitions() {
+      return _assignedPartitions;
+    }
+
+    public long startTimeMs() {
+      return _startTimeMs;
+    }
+
+    public long endTimeMs() {
+      return _endTimeMs;
+    }
+
+    public SamplingMode mode() {
+      return _mode;
+    }
+
+    public MetricDef metricDef() {
+      return _metricDef;
+    }
+
+    public long timeout() {
+      return _timeout;
+    }
+  }
 
   /**
    * The sampling mode to indicate which type of samples is interested.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSamplerOptions.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSamplerOptions.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
 package com.linkedin.kafka.cruisecontrol.monitor.sampling;
 
 import java.util.Set;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSamplerOptions.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSamplerOptions.java
@@ -1,0 +1,75 @@
+package com.linkedin.kafka.cruisecontrol.monitor.sampling;
+
+import java.util.Set;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.TopicPartition;
+
+import com.linkedin.cruisecontrol.metricdef.MetricDef;
+
+/**
+ * This class encapsulates the options that need to be passed to the
+ * {@link MetricSampler#getSamples(MetricSamplerOptions)} method.
+ * Future use-cases may choose to extend this class and add more options.
+ */
+public class MetricSamplerOptions {
+  /**
+   * @param cluster the metadata of the cluster.
+   * @param assignedPartitions the topic partition
+   * @param startTimeMs the start time of the sampling period.
+   * @param endTimeMs the end time of the sampling period.
+   * @param mode The sampling mode.
+   * @param metricDef the metric definitions.
+   * @param timeoutMs The sampling timeout in milliseconds to stop sampling even if there is more data to get.
+   */
+  public MetricSamplerOptions(Cluster cluster,
+                              Set<TopicPartition> assignedPartitions,
+                              long startTimeMs,
+                              long endTimeMs,
+                              MetricSampler.SamplingMode mode,
+                              MetricDef metricDef,
+                              long timeoutMs) {
+    _cluster = cluster;
+    _assignedPartitions = assignedPartitions;
+    _startTimeMs = startTimeMs;
+    _endTimeMs = endTimeMs;
+    _mode = mode;
+    _metricDef = metricDef;
+    _timeoutMs = timeoutMs;
+  }
+
+  private final Cluster _cluster;
+  private final Set<TopicPartition> _assignedPartitions;
+  private final long _startTimeMs;
+  private final long _endTimeMs;
+  private final MetricSampler.SamplingMode _mode;
+  private final MetricDef _metricDef;
+  private final long _timeoutMs;
+
+  public Cluster cluster() {
+    return _cluster;
+  }
+
+  public Set<TopicPartition> assignedPartitions() {
+    return _assignedPartitions;
+  }
+
+  public long startTimeMs() {
+    return _startTimeMs;
+  }
+
+  public long endTimeMs() {
+    return _endTimeMs;
+  }
+
+  public MetricSampler.SamplingMode mode() {
+    return _mode;
+  }
+
+  public MetricDef metricDef() {
+    return _metricDef;
+  }
+
+  public long timeoutMs() {
+    return _timeoutMs;
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/NoopSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/NoopSampler.java
@@ -16,7 +16,7 @@ public class NoopSampler implements MetricSampler {
 
   @Override
   public Samples getSamples(Cluster cluster, Set<TopicPartition> assignedPartitions, long startTimeMs, long endTimeMs,
-                            SamplingMode mode, MetricDef metricDef, long timeout) throws SamplingException {
+                            SamplingMode mode, MetricDef metricDef, long timeoutMs) throws SamplingException {
     return null;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/NoopSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/NoopSampler.java
@@ -20,6 +20,10 @@ public class NoopSampler implements MetricSampler {
     return null;
   }
 
+  @Override public Samples getSamples(MetricSamplerOptions metricSamplerOptions) throws SamplingException {
+    return null;
+  }
+
   @Override
   public void configure(Map<String, ?> configs) {
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/task/LoadMonitorTaskRunnerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/task/LoadMonitorTaskRunnerTest.java
@@ -18,6 +18,7 @@ import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaIntegration
 import com.linkedin.kafka.cruisecontrol.monitor.metricdefinition.KafkaMetricDef;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricFetcherManager;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricSampler;
+import com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricSamplerOptions;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.NoopSampleStore;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.holder.PartitionMetricSample;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.aggregator.KafkaBrokerMetricSampleAggregator;

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/task/LoadMonitorTaskRunnerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/task/LoadMonitorTaskRunnerTest.java
@@ -212,9 +212,9 @@ public class LoadMonitorTaskRunnerTest extends CCKafkaIntegrationTestHarness {
                               long endTime,
                               SamplingMode mode,
                               MetricDef metricDef,
-                              long timeout) throws SamplingException {
+                              long timeoutMs) throws SamplingException {
       return getSamples(
-          new MetricSamplerOptions(cluster, assignedPartitions, startTime, endTime, mode, metricDef, timeout));
+          new MetricSamplerOptions(cluster, assignedPartitions, startTime, endTime, mode, metricDef, timeoutMs));
     }
 
     @Override

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/task/LoadMonitorTaskRunnerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/task/LoadMonitorTaskRunnerTest.java
@@ -212,14 +212,21 @@ public class LoadMonitorTaskRunnerTest extends CCKafkaIntegrationTestHarness {
                               SamplingMode mode,
                               MetricDef metricDef,
                               long timeout) throws SamplingException {
+      return getSamples(
+          new MetricSamplerOptions(cluster, assignedPartitions, startTime, endTime, mode, metricDef, timeout));
+    }
 
+    @Override
+    public Samples getSamples(MetricSamplerOptions metricSamplerOptions) throws SamplingException {
       if (_exceptionsLeft > 0) {
         _exceptionsLeft--;
         throw new SamplingException("Error");
       }
-      Set<PartitionMetricSample> partitionMetricSamples = new HashSet<>(assignedPartitions.size());
-      for (TopicPartition tp : assignedPartitions) {
-        PartitionMetricSample sample = new PartitionMetricSample(cluster.partition(tp).leader().id(), tp);
+      Set<PartitionMetricSample> partitionMetricSamples =
+          new HashSet<>(metricSamplerOptions.assignedPartitions().size());
+      for (TopicPartition tp : metricSamplerOptions.assignedPartitions()) {
+        PartitionMetricSample sample = new PartitionMetricSample(
+            metricSamplerOptions.cluster().partition(tp).leader().id(), tp);
         long now = TIME.milliseconds();
         for (Resource resource : Resource.cachedValues()) {
           for (MetricInfo metricInfo : KafkaMetricDef.resourceToMetricInfo(resource)) {


### PR DESCRIPTION
This PR extracts the code from `CruiseControlMetricsReporterSampler` that initiates the MetricProcessor and uses it to convert `CruiseControlMetric` objects into `Sample` objects into an `AbstractMetricSampler` class. This code is reusable, and can be utilized by other implementations of `MetricSampler`.

We also encapsulate the options passed to `getSamples` method of `MetricSampler` into an `MetricSamplerOptions` class, so that it is extensible in the future by adding more fields to it, without breaking API compatibility. We are deprecating the older signature of `getSamples` that uses individual arguments.