### PR TITLE
Add check to validate that time range start time is smaller than end time

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/BootstrapParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/BootstrapParameters.java
@@ -59,6 +59,9 @@ public class BootstrapParameters extends AbstractParameters {
     if (_startMs == null && _endMs != null) {
       throw new UserRequestException("The start time cannot be empty when end time is specified.");
     }
+    if (_startMs != null && _endMs != null) {
+      ParameterUtils.validateTimeRange(_startMs, _endMs);
+    }
   }
 
   public Long startMs() {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/BootstrapParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/BootstrapParameters.java
@@ -53,8 +53,8 @@ public class BootstrapParameters extends AbstractParameters {
   @Override
   protected void initParameters() throws UnsupportedEncodingException {
     super.initParameters();
-    _startMs = ParameterUtils.startMs(_request);
-    _endMs = ParameterUtils.endMs(_request);
+    _startMs = ParameterUtils.startMsOrDefault(_request, null);
+    _endMs = ParameterUtils.endMsOrDefault(_request, null);
     _clearMetrics = ParameterUtils.clearMetrics(_request);
     if (_startMs == null && _endMs != null) {
       throw new UserRequestException("The start time cannot be empty when end time is specified.");

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ClusterLoadParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ClusterLoadParameters.java
@@ -61,8 +61,9 @@ public class ClusterLoadParameters extends AbstractParameters {
   protected void initParameters() throws UnsupportedEncodingException {
     super.initParameters();
     Long time = ParameterUtils.time(_request);
-    _endMs = time == null ? ParameterUtils.endMs(_request) : time;
-    _startMs = ParameterUtils.startMs(_request);
+    _endMs = time == null ? ParameterUtils.endMsOrDefault(_request, System.currentTimeMillis()) : time;
+    _startMs = ParameterUtils.startMsOrDefault(_request, ParameterUtils.DEFAULT_START_TIME_FOR_CLUSTER_MODEL);
+    ParameterUtils.validateTimeRange(_startMs, _endMs);
     _requirements = new ModelCompletenessRequirements(1, 0.0, true);
     _allowCapacityEstimation = ParameterUtils.allowCapacityEstimation(_request);
     _populateDiskInfo = ParameterUtils.populateDiskInfo(_request);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
@@ -394,13 +394,7 @@ public class ParameterUtils {
   }
 
   static Long replicationThrottle(HttpServletRequest request, KafkaCruiseControlConfig config) {
-    String parameterString = caseSensitiveParameterName(request.getParameterMap(), REPLICATION_THROTTLE_PARAM);
-    Long value;
-    if (parameterString == null) {
-      value = config.getLong(ExecutorConfig.DEFAULT_REPLICATION_THROTTLE_CONFIG);
-    } else {
-      value = Long.parseLong(request.getParameter(parameterString));
-    }
+    Long value = getLongParam(request, REPLICATION_THROTTLE_PARAM, config.getLong(ExecutorConfig.DEFAULT_REPLICATION_THROTTLE_CONFIG));
     if (value != null && value < 0) {
       throw new UserRequestException(String.format("Requested rebalance throttle must be non-negative (Requested: %s).", value));
     }
@@ -826,8 +820,7 @@ public class ParameterUtils {
    * @return Execution progress check interval in milliseconds.
    */
   static Long executionProgressCheckIntervalMs(HttpServletRequest request) {
-    String parameterString = caseSensitiveParameterName(request.getParameterMap(), EXECUTION_PROGRESS_CHECK_INTERVAL_MS_PARAM);
-    return parameterString == null ? null : Long.parseLong(request.getParameter(parameterString));
+    return getLongParam(request, EXECUTION_PROGRESS_CHECK_INTERVAL_MS_PARAM, null);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
@@ -248,6 +248,23 @@ public class ParameterUtils {
   }
 
   /**
+   * Get the long parameter parameter.
+   *
+   * @param request HTTP request received by Cruise Control.
+   * @param parameter Parameter to parse from the request.
+   * @param defaultIfMissing Default value to set if the request does not contain the parameter.
+   * @return The specified value for the parameter, or defaultIfMissing if the parameter is missing.
+   */
+  public static Long getLongParam(HttpServletRequest request, String parameter, @Nullable Long defaultIfMissing) {
+    String parameterString = caseSensitiveParameterName(request.getParameterMap(), parameter);
+
+    if (parameterString == null) {
+      return defaultIfMissing;
+    }
+    return Long.parseLong(request.getParameter(parameterString));
+  }
+
+  /**
    * Get the {@link List} parameter.
    *
    * @param request HTTP request received by Cruise Control.
@@ -409,24 +426,12 @@ public class ParameterUtils {
     return timeString.toUpperCase().equals("NOW") ? System.currentTimeMillis() : Long.parseLong(timeString);
   }
 
-  @Nullable
-  static Long startMs(HttpServletRequest request) {
-    return parseParamAsLong(request, START_MS_PARAM);
+  static Long startMsOrDefault(HttpServletRequest request, @Nullable Long defaultIfMissing) {
+    return getLongParam(request, START_MS_PARAM, defaultIfMissing);
   }
 
-  @Nullable
-  static Long endMs(HttpServletRequest request) {
-    return parseParamAsLong(request, END_MS_PARAM);
-  }
-
-  static long startMsOrDefault(HttpServletRequest request, long defaultStartMs) {
-    Long startMs = parseParamAsLong(request, START_MS_PARAM);
-    return startMs == null ? defaultStartMs : startMs;
-  }
-
-  static long endMsOrDefault(HttpServletRequest request, long defaultEndMs) {
-    Long endMs = parseParamAsLong(request, END_MS_PARAM);
-    return endMs == null ? defaultEndMs : endMs;
+  static Long endMsOrDefault(HttpServletRequest request, @Nullable Long defaultIfMissing) {
+    return getLongParam(request, END_MS_PARAM, defaultIfMissing);
   }
 
   static void validateTimeRange(long startMs, long endMs) {
@@ -1072,12 +1077,6 @@ public class ParameterUtils {
 
   static boolean fetchCompletedTask(HttpServletRequest request) {
     return getBooleanParam(request, FETCH_COMPLETED_TASK_PARAM, false);
-  }
-
-  @Nullable
-  private static Long parseParamAsLong(HttpServletRequest request, String paramName) {
-    String parameterString = caseSensitiveParameterName(request.getParameterMap(), paramName);
-    return parameterString == null ? null : Long.parseLong(request.getParameter(parameterString));
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
@@ -257,11 +257,7 @@ public class ParameterUtils {
    */
   public static Long getLongParam(HttpServletRequest request, String parameter, @Nullable Long defaultIfMissing) {
     String parameterString = caseSensitiveParameterName(request.getParameterMap(), parameter);
-
-    if (parameterString == null) {
-      return defaultIfMissing;
-    }
-    return Long.parseLong(request.getParameter(parameterString));
+    return parameterString == null ? defaultIfMissing : Long.valueOf(request.getParameter(parameterString));
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/PartitionLoadParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/PartitionLoadParameters.java
@@ -93,14 +93,15 @@ public class PartitionLoadParameters extends AbstractParameters {
       throw new UserRequestException("Parameters to ask for max and avg load are mutually exclusive to each other.");
     }
     _topic = ParameterUtils.topic(_request);
-    _startMs = ParameterUtils.startMs(_request);
-    _endMs = ParameterUtils.endMs(_request);
     _partitionLowerBoundary = ParameterUtils.partitionBoundary(_request, false);
     _partitionUpperBoundary = ParameterUtils.partitionBoundary(_request, true);
     _entries = ParameterUtils.entries(_request);
     _minValidPartitionRatio = ParameterUtils.minValidPartitionRatio(_request);
     _allowCapacityEstimation = ParameterUtils.allowCapacityEstimation(_request);
     _brokerIds = ParameterUtils.brokerIds(_request, true);
+    _startMs = ParameterUtils.startMsOrDefault(_request, ParameterUtils.DEFAULT_START_TIME_FOR_CLUSTER_MODEL);
+    _endMs = ParameterUtils.endMsOrDefault(_request, System.currentTimeMillis());
+    ParameterUtils.validateTimeRange(_startMs, _endMs);
   }
 
   public Resource resource() {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/TrainParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/TrainParameters.java
@@ -51,6 +51,7 @@ public class TrainParameters extends AbstractParameters {
     if (_startMs == null || _endMs == null) {
       throw new UserRequestException("Missing start or end parameter.");
     }
+    ParameterUtils.validateTimeRange(_startMs, _endMs);
   }
 
   public Long startMs() {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/TrainParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/TrainParameters.java
@@ -46,8 +46,8 @@ public class TrainParameters extends AbstractParameters {
   @Override
   protected void initParameters() throws UnsupportedEncodingException {
     super.initParameters();
-    _startMs = ParameterUtils.startMs(_request);
-    _endMs = ParameterUtils.endMs(_request);
+    _startMs = ParameterUtils.startMsOrDefault(_request, null);
+    _endMs = ParameterUtils.endMsOrDefault(_request, null);
     if (_startMs == null || _endMs == null) {
       throw new UserRequestException("Missing start or end parameter.");
     }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtilsTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtilsTest.java
@@ -78,8 +78,9 @@ public class ParameterUtilsTest {
     HttpServletRequest mockRequest = EasyMock.mock(HttpServletRequest.class);
     KafkaCruiseControlConfig controlConfig = EasyMock.mock(KafkaCruiseControlConfig.class);
 
-    Map<String, String[]> paramMap = new HashMap<>();
-    paramMap.put(ParameterUtils.REPLICATION_THROTTLE_PARAM, new String[]{ParameterUtils.REPLICATION_THROTTLE_PARAM});
+    Map<String, String[]> paramMap = Collections.singletonMap(
+        ParameterUtils.REPLICATION_THROTTLE_PARAM,
+        new String[]{ParameterUtils.REPLICATION_THROTTLE_PARAM});
 
     EasyMock.expect(mockRequest.getParameterMap()).andReturn(paramMap).times(1);
     EasyMock.expect(mockRequest.getParameter(ParameterUtils.REPLICATION_THROTTLE_PARAM)).andReturn(REPLICATION_THROTTLE_STRING).times(1);
@@ -97,7 +98,7 @@ public class ParameterUtilsTest {
     HttpServletRequest mockRequest = EasyMock.mock(HttpServletRequest.class);
     KafkaCruiseControlConfig controlConfig = EasyMock.mock(KafkaCruiseControlConfig.class);
     // No parameter string value in the parameter map
-    EasyMock.expect(mockRequest.getParameterMap()).andReturn(Collections.emptyMap()).times(1);
+    EasyMock.expect(mockRequest.getParameterMap()).andReturn(Collections.emptyMap()).once();
     EasyMock.expect(controlConfig.getLong(ExecutorConfig.DEFAULT_REPLICATION_THROTTLE_CONFIG))
             .andReturn(Long.valueOf(DEFAULT_REPLICATION_THROTTLE_STRING));
 
@@ -110,7 +111,7 @@ public class ParameterUtilsTest {
   @Test
   public void testParseExecutionProgressCheckIntervalMsNoValue() {
     HttpServletRequest mockRequest = EasyMock.mock(HttpServletRequest.class);
-    EasyMock.expect(mockRequest.getParameterMap()).andReturn(Collections.emptyMap()).times(1);
+    EasyMock.expect(mockRequest.getParameterMap()).andReturn(Collections.emptyMap()).once();
     EasyMock.replay(mockRequest);
     Assert.assertNull(ParameterUtils.executionProgressCheckIntervalMs(mockRequest));
     EasyMock.verify(mockRequest);
@@ -120,8 +121,7 @@ public class ParameterUtilsTest {
   public void testParseExecutionProgressCheckIntervalMsWithValue() {
     HttpServletRequest mockRequest = EasyMock.mock(HttpServletRequest.class);
 
-    Map<String, String[]> paramMap = new HashMap<>();
-    paramMap.put(
+    Map<String, String[]> paramMap = Collections.singletonMap(
         ParameterUtils.EXECUTION_PROGRESS_CHECK_INTERVAL_MS_PARAM,
         new String[]{ParameterUtils.EXECUTION_PROGRESS_CHECK_INTERVAL_MS_PARAM});
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtilsTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtilsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.parameters;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class ParameterUtilsTest {
+
+  private static final Long DEFAULT_START_TIME_MS = -1L;
+  private static final Long DEFAULT_END_TIME_MS = -2L;
+
+  @Test
+  public void testParseTimeRangeSet() {
+    HttpServletRequest mockRequest = EasyMock.mock(HttpServletRequest.class);
+    String startTimeString = "12345";
+    String endTimeString = "23456";
+    Map<String, String[]> paramMap = new HashMap<>();
+    paramMap.put(ParameterUtils.START_MS_PARAM, new String[]{ParameterUtils.START_MS_PARAM});
+    paramMap.put(ParameterUtils.END_MS_PARAM, new String[]{ParameterUtils.END_MS_PARAM});
+
+    EasyMock.expect(mockRequest.getParameterMap()).andReturn(paramMap).anyTimes();
+    EasyMock.expect(mockRequest.getParameter(ParameterUtils.START_MS_PARAM)).andReturn(startTimeString).anyTimes();
+    EasyMock.expect(mockRequest.getParameter(ParameterUtils.END_MS_PARAM)).andReturn(endTimeString).anyTimes();
+    EasyMock.replay(mockRequest);
+
+    Long startMs = ParameterUtils.startMs(mockRequest);
+    Long endMs = ParameterUtils.endMs(mockRequest);
+    Assert.assertNotNull(startMs);
+    Assert.assertNotNull(endMs);
+    Assert.assertEquals((Long) Long.parseLong(startTimeString), startMs);
+    Assert.assertEquals((Long) Long.parseLong(endTimeString), endMs);
+    ParameterUtils.validateTimeRange(startMs, endMs);
+
+    startMs = ParameterUtils.startMsOrDefault(mockRequest, DEFAULT_START_TIME_MS);
+    endMs = ParameterUtils.endMsOrDefault(mockRequest, DEFAULT_END_TIME_MS);
+
+    Assert.assertEquals((Long) Long.parseLong(startTimeString), startMs);
+    Assert.assertEquals((Long) Long.parseLong(endTimeString), endMs);
+  }
+
+  @Test
+  public void testParseTimeRangeNotSet() {
+    HttpServletRequest mockRequest = EasyMock.mock(HttpServletRequest.class);
+    // Mock the request so that it does not contain start/end time
+    EasyMock.expect(mockRequest.getParameterMap()).andReturn(Collections.emptyMap()).anyTimes();
+    EasyMock.replay(mockRequest);
+
+    Long startMs = ParameterUtils.startMs(mockRequest);
+    Long endMs = ParameterUtils.endMs(mockRequest);
+    Assert.assertNull(startMs);
+    Assert.assertNull(endMs);
+
+    startMs = ParameterUtils.startMsOrDefault(mockRequest, DEFAULT_START_TIME_MS);
+    endMs = ParameterUtils.endMsOrDefault(mockRequest, DEFAULT_END_TIME_MS);
+
+    Assert.assertEquals(DEFAULT_START_TIME_MS, startMs);
+    Assert.assertEquals(DEFAULT_END_TIME_MS, endMs);
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtilsTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtilsTest.java
@@ -50,6 +50,7 @@ public class ParameterUtilsTest {
 
     Assert.assertEquals(Long.valueOf(START_TIME_STRING), startMs);
     Assert.assertEquals(Long.valueOf(END_TIME_STRING), endMs);
+    EasyMock.verify(mockRequest);
   }
 
   @Test
@@ -69,6 +70,7 @@ public class ParameterUtilsTest {
 
     Assert.assertEquals(DEFAULT_START_TIME_MS, startMs);
     Assert.assertEquals(DEFAULT_END_TIME_MS, endMs);
+    EasyMock.verify(mockRequest);
   }
 
   @Test
@@ -83,11 +85,11 @@ public class ParameterUtilsTest {
     EasyMock.expect(mockRequest.getParameter(ParameterUtils.REPLICATION_THROTTLE_PARAM)).andReturn(REPLICATION_THROTTLE_STRING).times(1);
     EasyMock.expect(controlConfig.getLong(ExecutorConfig.DEFAULT_REPLICATION_THROTTLE_CONFIG)).andReturn(null); // No default
 
-    EasyMock.replay(mockRequest);
-    EasyMock.replay(controlConfig);
+    EasyMock.replay(mockRequest, controlConfig);
 
     Long replicationThrottle = ParameterUtils.replicationThrottle(mockRequest, controlConfig);
     Assert.assertEquals(Long.valueOf(REPLICATION_THROTTLE_STRING), replicationThrottle);
+    EasyMock.verify(mockRequest);
   }
 
   @Test
@@ -99,8 +101,7 @@ public class ParameterUtilsTest {
     EasyMock.expect(controlConfig.getLong(ExecutorConfig.DEFAULT_REPLICATION_THROTTLE_CONFIG))
             .andReturn(Long.valueOf(DEFAULT_REPLICATION_THROTTLE_STRING));
 
-    EasyMock.replay(mockRequest);
-    EasyMock.replay(controlConfig);
+    EasyMock.replay(mockRequest, controlConfig);
 
     Long replicationThrottle = ParameterUtils.replicationThrottle(mockRequest, controlConfig);
     Assert.assertEquals(Long.valueOf(DEFAULT_REPLICATION_THROTTLE_STRING), replicationThrottle);
@@ -112,6 +113,7 @@ public class ParameterUtilsTest {
     EasyMock.expect(mockRequest.getParameterMap()).andReturn(Collections.emptyMap()).times(1);
     EasyMock.replay(mockRequest);
     Assert.assertNull(ParameterUtils.executionProgressCheckIntervalMs(mockRequest));
+    EasyMock.verify(mockRequest);
   }
 
   @Test
@@ -130,6 +132,8 @@ public class ParameterUtilsTest {
     EasyMock.replay(mockRequest);
 
     Long executionProgressCheckIntervalMs = ParameterUtils.executionProgressCheckIntervalMs(mockRequest);
+
+    EasyMock.verify(mockRequest);
     Assert.assertEquals(Long.valueOf(EXECUTION_PROGRESS_CHECK_INTERVAL_STRING), executionProgressCheckIntervalMs);
   }
 }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtilsTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtilsTest.java
@@ -82,8 +82,8 @@ public class ParameterUtilsTest {
         ParameterUtils.REPLICATION_THROTTLE_PARAM,
         new String[]{ParameterUtils.REPLICATION_THROTTLE_PARAM});
 
-    EasyMock.expect(mockRequest.getParameterMap()).andReturn(paramMap).times(1);
-    EasyMock.expect(mockRequest.getParameter(ParameterUtils.REPLICATION_THROTTLE_PARAM)).andReturn(REPLICATION_THROTTLE_STRING).times(1);
+    EasyMock.expect(mockRequest.getParameterMap()).andReturn(paramMap).once();
+    EasyMock.expect(mockRequest.getParameter(ParameterUtils.REPLICATION_THROTTLE_PARAM)).andReturn(REPLICATION_THROTTLE_STRING).once();
     EasyMock.expect(controlConfig.getLong(ExecutorConfig.DEFAULT_REPLICATION_THROTTLE_CONFIG)).andReturn(null); // No default
 
     EasyMock.replay(mockRequest, controlConfig);
@@ -125,9 +125,9 @@ public class ParameterUtilsTest {
         ParameterUtils.EXECUTION_PROGRESS_CHECK_INTERVAL_MS_PARAM,
         new String[]{ParameterUtils.EXECUTION_PROGRESS_CHECK_INTERVAL_MS_PARAM});
 
-    EasyMock.expect(mockRequest.getParameterMap()).andReturn(paramMap).times(1);
+    EasyMock.expect(mockRequest.getParameterMap()).andReturn(paramMap).once();
     EasyMock.expect(mockRequest.getParameter(ParameterUtils.EXECUTION_PROGRESS_CHECK_INTERVAL_MS_PARAM))
-            .andReturn(EXECUTION_PROGRESS_CHECK_INTERVAL_STRING).times(1);
+            .andReturn(EXECUTION_PROGRESS_CHECK_INTERVAL_STRING).once();
 
     EasyMock.replay(mockRequest);
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtilsTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtilsTest.java
@@ -4,6 +4,8 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
+import com.linkedin.kafka.cruisecontrol.config.constants.ExecutorConfig;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -19,6 +21,9 @@ public class ParameterUtilsTest {
   private static final Long DEFAULT_END_TIME_MS = -2L;
   private static final String START_TIME_STRING = "12345";
   private static final String END_TIME_STRING = "23456";
+  private static final String REPLICATION_THROTTLE_STRING = "1000";
+  private static final String DEFAULT_REPLICATION_THROTTLE_STRING = "2000";
+  private static final String EXECUTION_PROGRESS_CHECK_INTERVAL_STRING = "1500";
 
   @Test
   public void testParseTimeRangeSet() {
@@ -36,15 +41,15 @@ public class ParameterUtilsTest {
     Long endMs = ParameterUtils.endMsOrDefault(mockRequest, null);
     Assert.assertNotNull(startMs);
     Assert.assertNotNull(endMs);
-    Assert.assertEquals((Long) Long.parseLong(START_TIME_STRING), startMs);
-    Assert.assertEquals((Long) Long.parseLong(END_TIME_STRING), endMs);
+    Assert.assertEquals(Long.valueOf(START_TIME_STRING), startMs);
+    Assert.assertEquals(Long.valueOf(END_TIME_STRING), endMs);
     ParameterUtils.validateTimeRange(startMs, endMs);
 
     startMs = ParameterUtils.startMsOrDefault(mockRequest, DEFAULT_START_TIME_MS);
     endMs = ParameterUtils.endMsOrDefault(mockRequest, DEFAULT_END_TIME_MS);
 
-    Assert.assertEquals(Long.parseLong(START_TIME_STRING), startMs.longValue());
-    Assert.assertEquals(Long.parseLong(END_TIME_STRING), endMs.longValue());
+    Assert.assertEquals(Long.valueOf(START_TIME_STRING), startMs);
+    Assert.assertEquals(Long.valueOf(END_TIME_STRING), endMs);
   }
 
   @Test
@@ -64,5 +69,67 @@ public class ParameterUtilsTest {
 
     Assert.assertEquals(DEFAULT_START_TIME_MS, startMs);
     Assert.assertEquals(DEFAULT_END_TIME_MS, endMs);
+  }
+
+  @Test
+  public void testParseReplicationThrottleWithNoDefault() {
+    HttpServletRequest mockRequest = EasyMock.mock(HttpServletRequest.class);
+    KafkaCruiseControlConfig controlConfig = EasyMock.mock(KafkaCruiseControlConfig.class);
+
+    Map<String, String[]> paramMap = new HashMap<>();
+    paramMap.put(ParameterUtils.REPLICATION_THROTTLE_PARAM, new String[]{ParameterUtils.REPLICATION_THROTTLE_PARAM});
+
+    EasyMock.expect(mockRequest.getParameterMap()).andReturn(paramMap).times(1);
+    EasyMock.expect(mockRequest.getParameter(ParameterUtils.REPLICATION_THROTTLE_PARAM)).andReturn(REPLICATION_THROTTLE_STRING).times(1);
+    EasyMock.expect(controlConfig.getLong(ExecutorConfig.DEFAULT_REPLICATION_THROTTLE_CONFIG)).andReturn(null); // No default
+
+    EasyMock.replay(mockRequest);
+    EasyMock.replay(controlConfig);
+
+    Long replicationThrottle = ParameterUtils.replicationThrottle(mockRequest, controlConfig);
+    Assert.assertEquals(Long.valueOf(REPLICATION_THROTTLE_STRING), replicationThrottle);
+  }
+
+  @Test
+  public void testParseReplicationThrottleWithDefault() {
+    HttpServletRequest mockRequest = EasyMock.mock(HttpServletRequest.class);
+    KafkaCruiseControlConfig controlConfig = EasyMock.mock(KafkaCruiseControlConfig.class);
+    // No parameter string value in the parameter map
+    EasyMock.expect(mockRequest.getParameterMap()).andReturn(Collections.emptyMap()).times(1);
+    EasyMock.expect(controlConfig.getLong(ExecutorConfig.DEFAULT_REPLICATION_THROTTLE_CONFIG))
+            .andReturn(Long.valueOf(DEFAULT_REPLICATION_THROTTLE_STRING));
+
+    EasyMock.replay(mockRequest);
+    EasyMock.replay(controlConfig);
+
+    Long replicationThrottle = ParameterUtils.replicationThrottle(mockRequest, controlConfig);
+    Assert.assertEquals(Long.valueOf(DEFAULT_REPLICATION_THROTTLE_STRING), replicationThrottle);
+  }
+
+  @Test
+  public void testParseExecutionProgressCheckIntervalMsNoValue() {
+    HttpServletRequest mockRequest = EasyMock.mock(HttpServletRequest.class);
+    EasyMock.expect(mockRequest.getParameterMap()).andReturn(Collections.emptyMap()).times(1);
+    EasyMock.replay(mockRequest);
+    Assert.assertNull(ParameterUtils.executionProgressCheckIntervalMs(mockRequest));
+  }
+
+  @Test
+  public void testParseExecutionProgressCheckIntervalMsWithValue() {
+    HttpServletRequest mockRequest = EasyMock.mock(HttpServletRequest.class);
+
+    Map<String, String[]> paramMap = new HashMap<>();
+    paramMap.put(
+        ParameterUtils.EXECUTION_PROGRESS_CHECK_INTERVAL_MS_PARAM,
+        new String[]{ParameterUtils.EXECUTION_PROGRESS_CHECK_INTERVAL_MS_PARAM});
+
+    EasyMock.expect(mockRequest.getParameterMap()).andReturn(paramMap).times(1);
+    EasyMock.expect(mockRequest.getParameter(ParameterUtils.EXECUTION_PROGRESS_CHECK_INTERVAL_MS_PARAM))
+            .andReturn(EXECUTION_PROGRESS_CHECK_INTERVAL_STRING).times(1);
+
+    EasyMock.replay(mockRequest);
+
+    Long executionProgressCheckIntervalMs = ParameterUtils.executionProgressCheckIntervalMs(mockRequest);
+    Assert.assertEquals(Long.valueOf(EXECUTION_PROGRESS_CHECK_INTERVAL_STRING), executionProgressCheckIntervalMs);
   }
 }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtilsTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
  */
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
@@ -17,45 +17,45 @@ public class ParameterUtilsTest {
 
   private static final Long DEFAULT_START_TIME_MS = -1L;
   private static final Long DEFAULT_END_TIME_MS = -2L;
+  private static final String START_TIME_STRING = "12345";
+  private static final String END_TIME_STRING = "23456";
 
   @Test
   public void testParseTimeRangeSet() {
     HttpServletRequest mockRequest = EasyMock.mock(HttpServletRequest.class);
-    String startTimeString = "12345";
-    String endTimeString = "23456";
     Map<String, String[]> paramMap = new HashMap<>();
     paramMap.put(ParameterUtils.START_MS_PARAM, new String[]{ParameterUtils.START_MS_PARAM});
     paramMap.put(ParameterUtils.END_MS_PARAM, new String[]{ParameterUtils.END_MS_PARAM});
 
-    EasyMock.expect(mockRequest.getParameterMap()).andReturn(paramMap).anyTimes();
-    EasyMock.expect(mockRequest.getParameter(ParameterUtils.START_MS_PARAM)).andReturn(startTimeString).anyTimes();
-    EasyMock.expect(mockRequest.getParameter(ParameterUtils.END_MS_PARAM)).andReturn(endTimeString).anyTimes();
+    EasyMock.expect(mockRequest.getParameterMap()).andReturn(paramMap).times(4);
+    EasyMock.expect(mockRequest.getParameter(ParameterUtils.START_MS_PARAM)).andReturn(START_TIME_STRING).times(2);
+    EasyMock.expect(mockRequest.getParameter(ParameterUtils.END_MS_PARAM)).andReturn(END_TIME_STRING).times(2);
     EasyMock.replay(mockRequest);
 
-    Long startMs = ParameterUtils.startMs(mockRequest);
-    Long endMs = ParameterUtils.endMs(mockRequest);
+    Long startMs = ParameterUtils.startMsOrDefault(mockRequest, null);
+    Long endMs = ParameterUtils.endMsOrDefault(mockRequest, null);
     Assert.assertNotNull(startMs);
     Assert.assertNotNull(endMs);
-    Assert.assertEquals((Long) Long.parseLong(startTimeString), startMs);
-    Assert.assertEquals((Long) Long.parseLong(endTimeString), endMs);
+    Assert.assertEquals((Long) Long.parseLong(START_TIME_STRING), startMs);
+    Assert.assertEquals((Long) Long.parseLong(END_TIME_STRING), endMs);
     ParameterUtils.validateTimeRange(startMs, endMs);
 
     startMs = ParameterUtils.startMsOrDefault(mockRequest, DEFAULT_START_TIME_MS);
     endMs = ParameterUtils.endMsOrDefault(mockRequest, DEFAULT_END_TIME_MS);
 
-    Assert.assertEquals((Long) Long.parseLong(startTimeString), startMs);
-    Assert.assertEquals((Long) Long.parseLong(endTimeString), endMs);
+    Assert.assertEquals(Long.parseLong(START_TIME_STRING), startMs.longValue());
+    Assert.assertEquals(Long.parseLong(END_TIME_STRING), endMs.longValue());
   }
 
   @Test
   public void testParseTimeRangeNotSet() {
     HttpServletRequest mockRequest = EasyMock.mock(HttpServletRequest.class);
     // Mock the request so that it does not contain start/end time
-    EasyMock.expect(mockRequest.getParameterMap()).andReturn(Collections.emptyMap()).anyTimes();
+    EasyMock.expect(mockRequest.getParameterMap()).andReturn(Collections.emptyMap()).times(4);
     EasyMock.replay(mockRequest);
 
-    Long startMs = ParameterUtils.startMs(mockRequest);
-    Long endMs = ParameterUtils.endMs(mockRequest);
+    Long startMs = ParameterUtils.startMsOrDefault(mockRequest, null);
+    Long endMs = ParameterUtils.endMsOrDefault(mockRequest, null);
     Assert.assertNull(startMs);
     Assert.assertNull(endMs);
 


### PR DESCRIPTION
This PR resolves #1355.

Notes for code reviewer:

This PR adds the below methods `ParameterUtils.endMsOrDefault` and `ParameterUtils.startMsOrDefault`. The reason is that it should be up to the caller to decide the default values for start time and end time. Depending on which `AbstractParameters` class parses the request, they might have different default values for start time and/or end time.

The original `startMs` and `endMs` returns null if no start/end time is set in the request. 