### PR TITLE
Check whether a cluster is using JBOD when populate_disk_info is true

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
@@ -202,8 +202,11 @@ public class Broker implements Serializable, Comparable<Broker> {
     return _state != State.DEAD;
   }
 
+  /**
+   * @return True if the broker is using JBOD, false otherwise
+   */
   public boolean isUsingJBOD() {
-    return _diskByLogdir.size() > 1;
+    return !_diskByLogdir.isEmpty();
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
@@ -202,6 +202,10 @@ public class Broker implements Serializable, Comparable<Broker> {
     return _state != State.DEAD;
   }
 
+  public boolean isUsingJBOD() {
+    return _diskByLogdir.size() > 1;
+  }
+
   /**
    * @return True if the broker is a new broker, false otherwise.
    */

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/LoadRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/LoadRunnable.java
@@ -9,7 +9,6 @@ import com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress;
 import com.linkedin.kafka.cruisecontrol.exception.KafkaCruiseControlException;
 import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
-import com.linkedin.kafka.cruisecontrol.monitor.LoadMonitor;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 import com.linkedin.kafka.cruisecontrol.servlet.UserRequestException;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.ClusterLoadParameters;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/LoadRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/LoadRunnable.java
@@ -12,12 +12,12 @@ import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 import com.linkedin.kafka.cruisecontrol.servlet.UserRequestException;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.ClusterLoadParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.PartitionLoadParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.response.stats.BrokerStats;
 
 import static com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig.MIN_VALID_PARTITION_RATIO_CONFIG;
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.DEFAULT_START_TIME_FOR_CLUSTER_MODEL;
+import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.POPULATE_DISK_INFO_PARAM;
 
 
 /**
@@ -67,7 +67,7 @@ public class LoadRunnable extends OperationRunnable {
         return cachedBrokerStats;
       }
     } else if (isClusterUsingJBOD()) {
-      throw new UserRequestException(String.format("Cannot set %s=true for non-JBOD Kafka clusters.", ParameterUtils.POPULATE_DISK_INFO_PARAM));
+      throw new UserRequestException(String.format("Cannot set %s=true for non-JBOD Kafka clusters.", POPULATE_DISK_INFO_PARAM));
     }
 
     if (_start != DEFAULT_START_TIME_FOR_CLUSTER_MODEL) {


### PR DESCRIPTION
This PR resolves #1353 

Notes for reviewers:

The implementation is based on the assumption that if a `Broker` has multiple `Disk`s, it must be using JBOD. Please correct me if this assumption is incorrect. Thanks!