### PR TITLE
Catch and handle exception thrown while linear regression model state gets computed

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/LinearRegressionModelParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/LinearRegressionModelParameters.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
 import org.apache.commons.math3.stat.regression.OLSMultipleLinearRegression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -169,6 +170,7 @@ public class LinearRegressionModelParameters {
   /**
    * @return Linear regression model state.
    */
+  @Nonnull
   public synchronized LinearRegressionModelState modelState() {
     Map<Integer, Double> detailCompleteness = new HashMap<>();
     for (Map.Entry<Integer, AtomicInteger> entry : INDICES.entrySet()) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ModelParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ModelParameters.java
@@ -8,6 +8,7 @@ import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.holder.BrokerMetricSample;
 import java.util.Collection;
+import javax.annotation.Nonnull;
 import org.apache.kafka.common.record.CompressionType;
 
 
@@ -72,6 +73,7 @@ public class ModelParameters {
     LINEAR_REGRESSION_PARAMETERS.addMetricObservation(trainingData);
   }
 
+  @Nonnull
   public static LinearRegressionModelParameters.LinearRegressionModelState linearRegressionModelState() {
     return LINEAR_REGRESSION_PARAMETERS.modelState();
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorState.java
@@ -12,6 +12,7 @@ import com.linkedin.kafka.cruisecontrol.servlet.response.JsonResponseClass;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.HashMap;
+import javax.annotation.Nonnull;
 
 
 @JsonResponseClass
@@ -354,6 +355,7 @@ public class LoadMonitorState {
     return _bootstrapProgress;
   }
 
+  @Nonnull
   public LinearRegressionModelParameters.LinearRegressionModelState detailTrainingProgress() {
     return ModelParameters.linearRegressionModelState();
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlState.java
@@ -11,6 +11,7 @@ import com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorState;
 import com.linkedin.kafka.cruisecontrol.executor.ExecutionTask;
 import com.linkedin.kafka.cruisecontrol.executor.ExecutionTaskState;
 import com.linkedin.kafka.cruisecontrol.executor.ExecutorState;
+import com.linkedin.kafka.cruisecontrol.model.LinearRegressionModelParameters;
 import com.linkedin.kafka.cruisecontrol.monitor.LoadMonitorState;
 import com.linkedin.cruisecontrol.servlet.parameters.CruiseControlParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.CruiseControlStateParameters;
@@ -22,6 +23,7 @@ import java.util.Map;
 import com.google.gson.Gson;
 import java.util.Set;
 import java.util.StringJoiner;
+import org.apache.commons.math3.linear.SingularMatrixException;
 
 import static com.linkedin.kafka.cruisecontrol.executor.ExecutorState.IN_PROGRESS_STATES;
 import static com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils.JSON_VERSION;
@@ -170,8 +172,15 @@ public class CruiseControlState extends AbstractCruiseControlResponse {
    * @param sb String builder to append super verbose response.
    */
   protected void writeSuperVerbose(StringBuilder sb) {
-    if (_monitorState != null && _monitorState.detailTrainingProgress() != null) {
-      sb.append(String.format("%n%nLinear Regression Model State:%n%s", _monitorState.detailTrainingProgress()));
+    if (_monitorState != null) {
+      LinearRegressionModelParameters.LinearRegressionModelState linearRegressionModelState;
+      try {
+        linearRegressionModelState = _monitorState.detailTrainingProgress();
+      } catch (SingularMatrixException e) {
+        sb.append(String.format("%n%nFailed to calculate Linear Regression Model State with error message:%n%s", e.getMessage()));
+        return;
+      }
+      sb.append(String.format("%n%nLinear Regression Model State:%n%s", linearRegressionModelState));
     }
   }
 


### PR DESCRIPTION
This PR resolves #1356.

The current way of handling the `SingularMatrixException` is very non-aggressive. Another more aggressive way to handle it could be throwing 5XX internal server error since it's technically the logic on the CC server cannot figure out the linear regression model.