### PR TITLE
Enable Cruise Control to collect metrics from low traffic clusters by default

### DIFF
--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterConfig.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterConfig.java
@@ -67,7 +67,7 @@ public class CruiseControlMetricsReporterConfig extends AbstractConfig {
   public static final Short DEFAULT_CRUISE_CONTROL_MIN_INSYNC_REPLICAS = -1;
   public static final long DEFAULT_CRUISE_CONTROL_METRICS_REPORTER_INTERVAL_MS = 60000;
   public static final String PRODUCER_ID = "CruiseControlMetricsReporter";
-  public static final int DEFAULT_CRUISE_CONTROL_METRICS_REPORTER_LINGER_MS = 30 * 1000;
+  public static final int DEFAULT_CRUISE_CONTROL_METRICS_REPORTER_LINGER_MS = 5000;
   public static final int DEFAULT_CRUISE_CONTROL_METRICS_REPORTER_MAX_BLOCK_MS = 60 * 1000;
   public static final int DEFAULT_CRUISE_CONTROL_METRICS_BATCH_SIZE = 800 * 1000;
   public static final boolean DEFAULT_CRUISE_CONTROL_METRICS_REPORTER_KUBERNETES_MODE = false;

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterConfig.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterConfig.java
@@ -12,13 +12,10 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class CruiseControlMetricsReporterConfig extends AbstractConfig {
   private static final ConfigDef CONFIG;
   private static final Set<String> CONFIGS = new HashSet<>();
-  private static final Logger LOG = LoggerFactory.getLogger(CruiseControlMetricsReporterConfig.class);
   public static final String PREFIX = "cruise.control.metrics.reporter.";
   // Configurations
   public static final String CRUISE_CONTROL_METRICS_TOPIC_CONFIG = "cruise.control.metrics.topic";

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterConfig.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterConfig.java
@@ -67,7 +67,7 @@ public class CruiseControlMetricsReporterConfig extends AbstractConfig {
   public static final Short DEFAULT_CRUISE_CONTROL_MIN_INSYNC_REPLICAS = -1;
   public static final long DEFAULT_CRUISE_CONTROL_METRICS_REPORTER_INTERVAL_MS = 60000;
   public static final String PRODUCER_ID = "CruiseControlMetricsReporter";
-  public static final int DEFAULT_CRUISE_CONTROL_METRICS_REPORTER_LINGER_MS = 5000;
+  public static final int DEFAULT_CRUISE_CONTROL_METRICS_REPORTER_LINGER_MS = 5 * 1000;
   public static final int DEFAULT_CRUISE_CONTROL_METRICS_REPORTER_MAX_BLOCK_MS = 60 * 1000;
   public static final int DEFAULT_CRUISE_CONTROL_METRICS_BATCH_SIZE = 800 * 1000;
   public static final boolean DEFAULT_CRUISE_CONTROL_METRICS_REPORTER_KUBERNETES_MODE = false;


### PR DESCRIPTION
Cruise Control (CC) can fail to collect sufficient metrics from low traffic Kafka clusters for an extended period of time, which would make CC unable to handle model-based (e.g. get cluster `load`) or goal-based (`rebalance` the cluster using the default goals) operations – e.g.
```
Error processing GET request '/partition_load' due to: 'com.linkedin.kafka.cruisecontrol.exception.KafkaCruiseControlException: com.linkedin.cruisecontrol.exception.NotEnoughValidWindowsException: There are only 0 valid windows when aggregating in range [-1, 1603951915056] for aggregation options (minValidEntityRatio=0.98, minValidEntityGroupRatio=0.00, minValidWindows=1, numEntitiesToInclude=55498, granularity=ENTITY)'.
```

We have already exposed the relevant config to fix similar observed issues in https://github.com/linkedin/cruise-control/pull/730. However, the default config value has not been updated, which requires users to manually change the config. This patch updates the default value of the relevant config to a value that enable collection of metrics from low traffic clusters by default.