### PR TITLE
Ensure that topology distribution goals compute balance constraints properly

### DIFF
--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -216,17 +216,11 @@ anomaly.detection.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwar
 # The interested metrics for metric anomaly analyzer.
 metric.anomaly.analyzer.metrics=BROKER_PRODUCE_LOCAL_TIME_MS_50TH,BROKER_PRODUCE_LOCAL_TIME_MS_999TH,BROKER_CONSUMER_FETCH_LOCAL_TIME_MS_50TH,BROKER_CONSUMER_FETCH_LOCAL_TIME_MS_999TH,BROKER_FOLLOWER_FETCH_LOCAL_TIME_MS_50TH,BROKER_FOLLOWER_FETCH_LOCAL_TIME_MS_999TH,BROKER_LOG_FLUSH_TIME_MS_50TH,BROKER_LOG_FLUSH_TIME_MS_999TH
 
-# True if recently demoted brokers are excluded from optimizations during broker failure self healing, false otherwise
-broker.failure.exclude.recently.demoted.brokers=true
+# True if recently demoted brokers are excluded from optimizations during self healing, false otherwise
+self.healing.exclude.recently.demoted.brokers=true
 
-# True if recently removed brokers are excluded from optimizations during broker failure self healing, false otherwise
-broker.failure.exclude.recently.removed.brokers=true
-
-# True if recently demoted brokers are excluded from optimizations during goal violation self healing, false otherwise
-goal.violation.exclude.recently.demoted.brokers=true
-
-# True if recently removed brokers are excluded from optimizations during goal violation self healing, false otherwise
-goal.violation.exclude.recently.removed.brokers=true
+# True if recently removed brokers are excluded from optimizations during self healing, false otherwise
+self.healing.exclude.recently.removed.brokers=true
 
 # The zk path to store failed broker information.
 failed.brokers.zk.path=/CruiseControlBrokerList

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
@@ -441,7 +441,7 @@ public class GoalOptimizer implements Runnable {
       LOG.debug("Optimizing goal {}", goal.name());
       boolean succeeded = goal.optimize(clusterModel, optimizedGoals, optimizationOptions);
       optimizedGoals.add(goal);
-      statsByGoalPriority.put(goal, clusterModel.getClusterStats(_balancingConstraint));
+      statsByGoalPriority.put(goal, clusterModel.getClusterStats(_balancingConstraint, optimizationOptions));
 
       Set<ExecutionProposal> goalProposals = AnalyzerUtils.getDiff(preOptimizedReplicaDistribution,
                                                                    preOptimizedLeaderDistribution,
@@ -479,7 +479,7 @@ public class GoalOptimizer implements Runnable {
                                brokerStatsBeforeOptimization,
                                clusterModel.brokerStats(null),
                                clusterModel.generation(),
-                               clusterModel.getClusterStats(_balancingConstraint),
+                               clusterModel.getClusterStats(_balancingConstraint, optimizationOptions),
                                clusterModel.capacityEstimationInfoByBrokerId(),
                                optimizationOptions,
                                balancednessCostByGoal(goalsByPriority, _priorityWeight, _strictnessWeight));

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -69,7 +69,7 @@ public abstract class AbstractGoal implements Goal {
       _succeeded = true;
       LOG.debug("Starting optimization for {}.", name());
       // Initialize pre-optimized stats.
-      ClusterModelStats statsBeforeOptimization = clusterModel.getClusterStats(_balancingConstraint);
+      ClusterModelStats statsBeforeOptimization = clusterModel.getClusterStats(_balancingConstraint, optimizationOptions);
       LOG.trace("[PRE - {}] {}", name(), statsBeforeOptimization);
       _finished = false;
       long goalStartTime = System.currentTimeMillis();
@@ -82,7 +82,7 @@ public abstract class AbstractGoal implements Goal {
         }
         updateGoalState(clusterModel, optimizationOptions);
       }
-      ClusterModelStats statsAfterOptimization = clusterModel.getClusterStats(_balancingConstraint);
+      ClusterModelStats statsAfterOptimization = clusterModel.getClusterStats(_balancingConstraint, optimizationOptions);
       LOG.trace("[POST - {}] {}", name(), statsAfterOptimization);
       if (LOG.isDebugEnabled()) {
         LOG.debug("Finished optimization for {} in {}ms.", name(), System.currentTimeMillis() - goalStartTime);
@@ -109,6 +109,11 @@ public abstract class AbstractGoal implements Goal {
   @Override
   public abstract String name();
 
+  @Override
+  public void finish() {
+    _finished = true;
+  }
+
   /**
    * Get sorted brokers that the rebalance process will go over to apply balancing actions to replicas they contain.
    *
@@ -116,7 +121,9 @@ public abstract class AbstractGoal implements Goal {
    * @return A collection of brokers that the rebalance process will go over to apply balancing actions to replicas
    * they contain.
    */
-  protected abstract SortedSet<Broker> brokersToBalance(ClusterModel clusterModel);
+  protected SortedSet<Broker> brokersToBalance(ClusterModel clusterModel) {
+    return clusterModel.brokers();
+  }
 
   /**
    * Check if requirements of this goal are not violated if this action is applied to the given cluster state,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractRackAwareGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractRackAwareGoal.java
@@ -41,19 +41,6 @@ public abstract class AbstractRackAwareGoal extends AbstractGoal {
     return new ModelCompletenessRequirements(MIN_NUM_VALID_WINDOWS_FOR_SELF_HEALING, 0.0, true);
   }
 
-  /**
-   * This is a hard goal; hence, the proposals are not limited to dead broker replicas in case of self-healing.
-   * Get brokers that the rebalance process will go over to apply balancing actions to replicas they contain.
-   *
-   * @param clusterModel The state of the cluster.
-   * @return A collection of brokers that the rebalance process will go over to apply balancing actions to replicas
-   * they contain.
-   */
-  @Override
-  protected SortedSet<Broker> brokersToBalance(ClusterModel clusterModel) {
-    return clusterModel.brokers();
-  }
-
   @Override
   public boolean isHardGoal() {
     return true;
@@ -62,11 +49,6 @@ public abstract class AbstractRackAwareGoal extends AbstractGoal {
   @Override
   protected boolean selfSatisfied(ClusterModel clusterModel, BalancingAction action) {
     return true;
-  }
-
-  @Override
-  public void finish() {
-    _finished = true;
   }
 
   /**
@@ -140,7 +122,7 @@ public abstract class AbstractRackAwareGoal extends AbstractGoal {
                                     boolean throwExceptionIfCannotMove)
       throws OptimizationFailureException {
     for (Replica replica : broker.trackedSortedReplicas(replicaSortName(this, false, false)).sortedReplicas(true)) {
-      if (broker.isAlive() && !broker.currentOfflineReplicas().contains(replica) && shouldKeepInTheCurrentRack(replica, clusterModel)) {
+      if (broker.isAlive() && !broker.currentOfflineReplicas().contains(replica) && shouldKeepInTheCurrentBroker(replica, clusterModel)) {
         continue;
       }
       // The relevant rack awareness condition is violated. Move replica to an eligible broker
@@ -156,14 +138,14 @@ public abstract class AbstractRackAwareGoal extends AbstractGoal {
   }
 
   /**
-   * Check whether the given alive replica should stay in the current rack or be moved to another rack to satisfy the
+   * Check whether the given alive replica should stay in the current broker or be moved to another broker to satisfy the
    * specific requirements of the custom rack aware goal in the given cluster state.
    *
-   * @param replica An alive replica to check whether it should stay in the current rack.
+   * @param replica An alive replica to check whether it should stay in the current broker.
    * @param clusterModel The state of the cluster.
-   * @return True if the given alive replica should stay in the current rack, false otherwise.
+   * @return True if the given alive replica should stay in the current broker, false otherwise.
    */
-  protected abstract boolean shouldKeepInTheCurrentRack(Replica replica, ClusterModel clusterModel);
+  protected abstract boolean shouldKeepInTheCurrentBroker(Replica replica, ClusterModel clusterModel);
 
   /**
    * Get a list of eligible brokers for moving the given replica in the given cluster to satisfy the specific

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CapacityGoal.java
@@ -22,7 +22,6 @@ import com.linkedin.kafka.cruisecontrol.model.SortedReplicasHelper;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 import java.util.List;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -136,19 +135,6 @@ public abstract class CapacityGoal extends AbstractGoal {
   }
 
   /**
-   * This is a hard goal; hence, the proposals are not limited to broken broker replicas in case of self-healing.
-   * Get brokers that the rebalance process will go over to apply balancing actions to replicas they contain.
-   *
-   * @param clusterModel The state of the cluster.
-   * @return A collection of brokers that the rebalance process will go over to apply balancing actions to replicas
-   * they contain.
-   */
-  @Override
-  protected SortedSet<Broker> brokersToBalance(ClusterModel clusterModel) {
-    return clusterModel.brokers();
-  }
-
-  /**
    * Sanity checks: Existing total load on cluster is less than the limiting capacity
    * determined by the total capacity of alive cluster multiplied by the capacity threshold.
    *
@@ -210,11 +196,6 @@ public abstract class CapacityGoal extends AbstractGoal {
     // Sanity check: No replica should be moved to a broker, which used to host any replica of the same partition on its broken disk.
     GoalUtils.ensureReplicasMoveOffBrokersWithBadDisks(clusterModel, name());
     finish();
-  }
-
-  @Override
-  public void finish() {
-    _finished = true;
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskCapacityGoal.java
@@ -234,11 +234,6 @@ public class IntraBrokerDiskCapacityGoal extends AbstractGoal {
     return this.getClass().getSimpleName();
   }
 
-  @Override
-  public void finish() {
-    _finished = true;
-  }
-
   /**
    * Check whether the combined replica utilization is above the given disk capacity limits.
    *

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskUsageDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskUsageDistributionGoal.java
@@ -514,9 +514,4 @@ public class IntraBrokerDiskUsageDistributionGoal extends AbstractGoal {
   public String name() {
     return this.getClass().getSimpleName();
   }
-
-  @Override
-  public void finish() {
-    _finished = true;
-  }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderBytesInDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderBytesInDistributionGoal.java
@@ -180,7 +180,7 @@ public class LeaderBytesInDistributionGoal extends AbstractGoal {
 
   @Override
   public void finish() {
-    _finished = true;
+    super.finish();
     // Clean up the memory
     _overLimitBrokerIds.clear();
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/PotentialNwOutGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/PotentialNwOutGoal.java
@@ -259,11 +259,6 @@ public class PotentialNwOutGoal extends AbstractGoal {
     finish();
   }
 
-  @Override
-  public void finish() {
-    _finished = true;
-  }
-
   /**
    * Rebalance the given broker without violating the constraints of the current goal and optimized goals.
    *

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareDistributionGoal.java
@@ -115,6 +115,13 @@ public class RackAwareDistributionGoal extends AbstractRackAwareGoal {
     return RackAwareDistributionGoal.class.getSimpleName();
   }
 
+  /**
+   * Check whether the given broker is excluded for replica moves.
+   * Such a broker cannot receive replicas, but can give them away.
+   *
+   * @param broker Broker to check for exclusion from replica moves.
+   * @return {@code true} if the given broker is excluded for replica moves, {@code false} otherwise.
+   */
   private boolean isExcludedForReplicaMove(Broker broker) {
     return !_brokersAllowedReplicaMove.contains(broker.id());
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareGoal.java
@@ -200,7 +200,7 @@ public class RackAwareGoal extends AbstractRackAwareGoal {
   }
 
   @Override
-  protected boolean shouldKeepInTheCurrentRack(Replica replica, ClusterModel clusterModel) {
+  protected boolean shouldKeepInTheCurrentBroker(Replica replica, ClusterModel clusterModel) {
     // Rack awareness requires no more than one replica from a given partition residing in any rack in the cluster
     String myRackId = replica.broker().rack().id();
     int myBrokerId = replica.broker().id();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
@@ -103,19 +103,6 @@ public class ReplicaCapacityGoal extends AbstractGoal {
 
   /**
    * This is a hard goal; hence, the proposals are not limited to dead broker replicas in case of self-healing.
-   * Get brokers that the rebalance process will go over to apply balancing actions to replicas they contain.
-   *
-   * @param clusterModel The state of the cluster.
-   * @return A collection of brokers that the rebalance process will go over to apply balancing actions to replicas
-   * they contain.
-   */
-  @Override
-  protected SortedSet<Broker> brokersToBalance(ClusterModel clusterModel) {
-    return clusterModel.brokers();
-  }
-
-  /**
-   * This is a hard goal; hence, the proposals are not limited to dead broker replicas in case of self-healing.
    * Sanity Check: Each node has sufficient number of replicas that can be moved to satisfy the replica capacity goal.
    *
    * @param clusterModel The state of the cluster.
@@ -202,11 +189,6 @@ public class ReplicaCapacityGoal extends AbstractGoal {
     } else {
       _isSelfHealingMode = false;
     }
-  }
-
-  @Override
-  public void finish() {
-    _finished = true;
   }
 
   /**
@@ -310,7 +292,7 @@ public class ReplicaCapacityGoal extends AbstractGoal {
    */
   private static class BrokerReplicaCount implements Comparable<BrokerReplicaCount> {
     private final Broker _broker;
-    private int _replicaCount;
+    private final int _replicaCount;
 
     BrokerReplicaCount(Broker broker) {
       _broker = broker;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionAbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionAbstractGoal.java
@@ -139,6 +139,13 @@ public abstract class ReplicaDistributionAbstractGoal extends AbstractGoal {
     _balanceLowerLimit = balanceLowerLimit(optimizationOptions, balancePercentage());
   }
 
+  /**
+   * Check whether the given broker is excluded for replica moves.
+   * Such a broker cannot receive replicas, but can give them away.
+   *
+   * @param broker Broker to check for exclusion from replica moves.
+   * @return {@code true} if the given broker is excluded for replica moves, {@code false} otherwise.
+   */
   protected boolean isExcludedForReplicaMove(Broker broker) {
     return !_brokersAllowedReplicaMove.contains(broker.id());
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ResourceDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ResourceDistributionGoal.java
@@ -284,11 +284,6 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
     finish();
   }
 
-  @Override
-  public void finish() {
-    _finished = true;
-  }
-
   /**
    * (1) REBALANCE BY LEADERSHIP MOVEMENT:
    * Perform leadership movement to ensure that the load on brokers for the outbound network and CPU load is under the

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicReplicaDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicReplicaDistributionGoal.java
@@ -43,7 +43,7 @@ import static com.linkedin.kafka.cruisecontrol.analyzer.goals.GoalUtils.replicaS
 
 
 /**
- * Soft goal to balance collocations of replicas of the same topic.
+ * Soft goal to balance collocations of replicas of the same topic over alive brokers not excluded for replica moves.
  * <ul>
  * <li>Under: (the average number of topic replicas per broker) * (1 + topic replica count balance percentage)</li>
  * <li>Above: (the average number of topic replicas per broker) * Math.max(0, 1 - topic replica count balance percentage)</li>
@@ -66,6 +66,8 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
   // Must contain all topics to ensure that the lower priority goals work w/o an NPE.
   private final Map<String, Integer> _balanceUpperLimitByTopic;
   private final Map<String, Integer> _balanceLowerLimitByTopic;
+  // This is used to identify brokers not excluded for replica moves.
+  private Set<Integer> _brokersAllowedReplicaMove;
 
   /**
    * A soft goal to balance collocations of replicas of the same topic.
@@ -125,7 +127,7 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
 
   /**
    * Check whether the given action is acceptable by this goal. An action is acceptable if the number of topic replicas at
-   * (1) the source broker does not go under the allowed limit.
+   * (1) the source broker does not go under the allowed limit -- unless the source broker is excluded for replica moves.
    * (2) the destination broker does not go over the allowed limit.
    *
    * @param action Action to be checked for acceptance.
@@ -146,6 +148,7 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
           return ACCEPT;
         }
 
+        // It is guaranteed that neither source nor destination brokers are excluded for replica moves.
         boolean acceptSourceToDest = (isReplicaCountUnderBalanceUpperLimitAfterChange(sourceTopic, destinationBroker, ADD)
                                       && isReplicaCountAboveBalanceLowerLimitAfterChange(sourceTopic, sourceBroker, REMOVE));
         return (acceptSourceToDest
@@ -156,7 +159,8 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
         return ACCEPT;
       case INTER_BROKER_REPLICA_MOVEMENT:
         return (isReplicaCountUnderBalanceUpperLimitAfterChange(sourceTopic, destinationBroker, ADD)
-                && isReplicaCountAboveBalanceLowerLimitAfterChange(sourceTopic, sourceBroker, REMOVE)) ? ACCEPT : REPLICA_REJECT;
+                && (isExcludedForReplicaMove(sourceBroker)
+                    || isReplicaCountAboveBalanceLowerLimitAfterChange(sourceTopic, sourceBroker, REMOVE))) ? ACCEPT : REPLICA_REJECT;
       default:
         throw new IllegalArgumentException("Unsupported balancing action " + action.balancingAction() + " is provided.");
     }
@@ -180,6 +184,10 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
     return changeType == ADD ? numTopicReplicas + 1 >= brokerBalanceLowerLimit : numTopicReplicas - 1 >= brokerBalanceLowerLimit;
   }
 
+  private boolean isExcludedForReplicaMove(Broker broker) {
+    return !_brokersAllowedReplicaMove.contains(broker.id());
+  }
+
   @Override
   public ClusterModelStatsComparator clusterModelStatsComparator() {
     return new TopicReplicaDistrGoalStatsComparator();
@@ -201,57 +209,29 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
   }
 
   /**
-   * Get brokers that the rebalance process will go over to apply balancing actions to replicas they contain.
-   *
-   * @param clusterModel The state of the cluster.
-   * @return A collection of brokers that the rebalance process will go over to apply balancing actions to replicas
-   * they contain.
-   */
-  @Override
-  protected SortedSet<Broker> brokersToBalance(ClusterModel clusterModel) {
-    return clusterModel.brokers();
-  }
-
-  /**
-   * Get the set of topics to rebalance. If there are self healing eligible replicas, gets only their topics.
-   * Otherwise gets all topics except excludedTopics.
-   *
-   * @return The set of topics to rebalance.
-   */
-  private Set<String> topicsToRebalance(ClusterModel clusterModel, Set<String> excludedTopics) {
-    Set<String> topicsToRebalance;
-    if (!clusterModel.selfHealingEligibleReplicas().isEmpty()) {
-      topicsToRebalance = new HashSet<>();
-      for (Replica replica : clusterModel.selfHealingEligibleReplicas()) {
-        topicsToRebalance.add(replica.topicPartition().topic());
-      }
-    } else {
-      topicsToRebalance = new HashSet<>(clusterModel.topics());
-      topicsToRebalance.removeAll(excludedTopics);
-    }
-
-    if (topicsToRebalance.isEmpty()) {
-      LOG.warn("All topics are excluded from {}.", name());
-    }
-
-    return topicsToRebalance;
-  }
-
-  /**
    * Initiates this goal.
    *
    * @param clusterModel The state of the cluster.
    * @param optimizationOptions Options to take into account during optimization.
    */
   @Override
-  protected void initGoalState(ClusterModel clusterModel, OptimizationOptions optimizationOptions) {
+  protected void initGoalState(ClusterModel clusterModel, OptimizationOptions optimizationOptions)
+      throws OptimizationFailureException {
     Set<String> excludedTopics = optimizationOptions.excludedTopics();
-    Set<String> topicsToRebalance = topicsToRebalance(clusterModel, excludedTopics);
+    Set<String> topicsToRebalance = GoalUtils.topicsToRebalance(clusterModel, excludedTopics);
+    if (topicsToRebalance.isEmpty()) {
+      LOG.warn("All topics are excluded from {}.", name());
+    }
 
+    _brokersAllowedReplicaMove = GoalUtils.aliveBrokersNotExcludedForReplicaMove(clusterModel, optimizationOptions);
+    if (_brokersAllowedReplicaMove.isEmpty()) {
+      // Handle the case when all alive brokers are excluded from replica moves.
+      throw new OptimizationFailureException("Cannot take any action as all alive brokers are excluded from replica moves.");
+    }
     // Initialize the average replicas on an alive broker.
     for (String topic : clusterModel.topics()) {
       int numTopicReplicas = clusterModel.numTopicReplicas(topic);
-      _avgTopicReplicasOnAliveBroker.put(topic, (numTopicReplicas / (double) clusterModel.aliveBrokers().size()));
+      _avgTopicReplicasOnAliveBroker.put(topic, (numTopicReplicas / (double) _brokersAllowedReplicaMove.size()));
       _balanceUpperLimitByTopic.put(topic, balanceUpperLimit(topic, optimizationOptions));
       _balanceLowerLimitByTopic.put(topic, balanceLowerLimit(topic, optimizationOptions));
       // Retain only the topics to rebalance in _avgTopicReplicasOnAliveBroker
@@ -296,7 +276,7 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
     String sourceTopic = action.topic();
 
     return isReplicaCountUnderBalanceUpperLimitAfterChange(sourceTopic, destinationBroker, ADD) &&
-           isReplicaCountAboveBalanceLowerLimitAfterChange(sourceTopic, sourceBroker, REMOVE);
+           (isExcludedForReplicaMove(sourceBroker) || isReplicaCountAboveBalanceLowerLimitAfterChange(sourceTopic, sourceBroker, REMOVE));
   }
 
   /**
@@ -331,11 +311,6 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
     finish();
   }
 
-  @Override
-  public void finish() {
-    _finished = true;
-  }
-
   private static boolean skipBrokerRebalance(Broker broker,
                                              ClusterModel clusterModel,
                                              Collection<Replica> replicas,
@@ -343,7 +318,6 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
                                              boolean requireMoreReplicas,
                                              boolean hasOfflineTopicReplicas,
                                              boolean moveImmigrantReplicaOnly) {
-    boolean hasImmigrantTopicReplicas = replicas.stream().anyMatch(replica -> broker.immigrantReplicas().contains(replica));
     if (broker.isAlive() && !requireMoreReplicas && !requireLessReplicas) {
       LOG.trace("Skip rebalance: Broker {} is already within the limit for replicas {}.", broker, replicas);
       return true;
@@ -351,7 +325,9 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
       LOG.trace("Skip rebalance: Cluster has new brokers and this broker {} is not new, but does not require less load "
                 + "for replicas {}. Hence, it does not have any offline replicas.", broker, replicas);
       return true;
-    } else if (!clusterModel.selfHealingEligibleReplicas().isEmpty() && requireLessReplicas
+    }
+    boolean hasImmigrantTopicReplicas = replicas.stream().anyMatch(replica -> broker.immigrantReplicas().contains(replica));
+    if (!clusterModel.selfHealingEligibleReplicas().isEmpty() && requireLessReplicas
                && !hasOfflineTopicReplicas && !hasImmigrantTopicReplicas) {
       LOG.trace("Skip rebalance: Cluster is in self-healing mode and the broker {} requires less load, but none of its "
                 + "current offline or immigrant replicas are from the topic being balanced {}.", broker, replicas);
@@ -363,13 +339,6 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
     }
 
     return false;
-  }
-
-  private static Set<Replica> retainCurrentOfflineBrokerReplicas(Broker broker, Collection<Replica> replicas) {
-    Set<Replica> offlineReplicas = new HashSet<>(replicas);
-    offlineReplicas.retainAll(broker.currentOfflineReplicas());
-
-    return offlineReplicas;
   }
 
   private boolean isTopicExcludedFromRebalance(String topic) {
@@ -399,10 +368,13 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
 
       Collection<Replica> replicas = broker.replicasOfTopicInBroker(topic);
       int numTopicReplicas = replicas.size();
-      int numOfflineTopicReplicas = retainCurrentOfflineBrokerReplicas(broker, replicas).size();
+      int numOfflineTopicReplicas = GoalUtils.retainCurrentOfflineBrokerReplicas(broker, replicas).size();
+      boolean isExcludedForReplicaMove = isExcludedForReplicaMove(broker);
 
-      boolean requireLessReplicas = numOfflineTopicReplicas > 0 || numTopicReplicas > _balanceUpperLimitByTopic.get(topic);
-      boolean requireMoreReplicas = broker.isAlive() && numTopicReplicas - numOfflineTopicReplicas < _balanceLowerLimitByTopic.get(topic);
+      boolean requireLessReplicas = numOfflineTopicReplicas > 0 || numTopicReplicas > _balanceUpperLimitByTopic.get(topic)
+                                    || isExcludedForReplicaMove;
+      boolean requireMoreReplicas = !isExcludedForReplicaMove && broker.isAlive()
+                                    && numTopicReplicas - numOfflineTopicReplicas < _balanceLowerLimitByTopic.get(topic);
 
       if (skipBrokerRebalance(broker, clusterModel, replicas, requireLessReplicas, requireMoreReplicas, numOfflineTopicReplicas > 0,
                               optimizationOptions.onlyMoveImmigrantReplicas())) {
@@ -453,11 +425,13 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
 
     Collection<Replica> replicasOfTopicInBroker = broker.replicasOfTopicInBroker(topic);
     int numReplicasOfTopicInBroker = replicasOfTopicInBroker.size();
-    int numOfflineTopicReplicas = retainCurrentOfflineBrokerReplicas(broker, replicasOfTopicInBroker).size();
+    int numOfflineTopicReplicas = GoalUtils.retainCurrentOfflineBrokerReplicas(broker, replicasOfTopicInBroker).size();
+    // If the source broker is excluded for replica move, set its upper limit to 0.
+    int balanceUpperLimitForSourceBroker = isExcludedForReplicaMove(broker) ? 0 : _balanceUpperLimitByTopic.get(topic);
 
     boolean wasUnableToMoveOfflineReplica = false;
     for (Replica replica : replicasToMoveOut(broker, topic)) {
-      if (wasUnableToMoveOfflineReplica && !replica.isCurrentOffline() && numReplicasOfTopicInBroker <= _balanceUpperLimitByTopic.get(topic)) {
+      if (wasUnableToMoveOfflineReplica && !replica.isCurrentOffline() && numReplicasOfTopicInBroker <= balanceUpperLimitForSourceBroker) {
         // Was unable to move offline replicas from the broker, and remaining replica count is under the balance limit.
         return false;
       }
@@ -470,7 +444,7 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
         if (wasOffline) {
           numOfflineTopicReplicas--;
         }
-        if (--numReplicasOfTopicInBroker <= (numOfflineTopicReplicas == 0 ? _balanceUpperLimitByTopic.get(topic) : 0)) {
+        if (--numReplicasOfTopicInBroker <= (numOfflineTopicReplicas == 0 ? balanceUpperLimitForSourceBroker : 0)) {
           return false;
         }
 
@@ -497,11 +471,11 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
       // B2 Info
       Collection<Replica> replicasOfTopicInB2 = b2.replicasOfTopicInBroker(topic);
       int numReplicasOfTopicInB2 = replicasOfTopicInB2.size();
-      int numOfflineTopicReplicasInB2 = retainCurrentOfflineBrokerReplicas(b2, replicasOfTopicInB2).size();
+      int numOfflineTopicReplicasInB2 = GoalUtils.retainCurrentOfflineBrokerReplicas(b2, replicasOfTopicInB2).size();
       // B1 Info
       Collection<Replica> replicasOfTopicInB1 = b1.replicasOfTopicInBroker(topic);
       int numReplicasOfTopicInB1 = replicasOfTopicInB1.size();
-      int numOfflineTopicReplicasInB1 = retainCurrentOfflineBrokerReplicas(b2, replicasOfTopicInB1).size();
+      int numOfflineTopicReplicasInB1 = GoalUtils.retainCurrentOfflineBrokerReplicas(b1, replicasOfTopicInB1).size();
 
       int resultByOfflineReplicas = Integer.compare(numOfflineTopicReplicasInB2, numOfflineTopicReplicasInB1);
       if (resultByOfflineReplicas == 0) {
@@ -519,7 +493,7 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
     } else {
       for (Broker sourceBroker : clusterModel.brokers()) {
         if (sourceBroker.numReplicasOfTopicInBroker(topic) > _balanceLowerLimitByTopic.get(topic)
-            || !sourceBroker.currentOfflineReplicas().isEmpty()) {
+            || !sourceBroker.currentOfflineReplicas().isEmpty() || isExcludedForReplicaMove(sourceBroker)) {
           eligibleBrokers.add(sourceBroker);
         }
       }
@@ -534,7 +508,7 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
     while (!eligibleBrokers.isEmpty()) {
       Broker sourceBroker = eligibleBrokers.poll();
       SortedSet<Replica> replicasToMove = replicasToMoveOut(sourceBroker, topic);
-      int numOfflineTopicReplicas = retainCurrentOfflineBrokerReplicas(sourceBroker, replicasToMove).size();
+      int numOfflineTopicReplicas = GoalUtils.retainCurrentOfflineBrokerReplicas(sourceBroker, replicasToMove).size();
 
       for (Replica replica : replicasToMove) {
         boolean wasOffline = replica.isCurrentOffline();
@@ -568,7 +542,7 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
 
     @Override
     public int compare(ClusterModelStats stats1, ClusterModelStats stats2) {
-      // Standard deviation of number of topic replicas over brokers in the current must be less than the
+      // Standard deviation of number of topic replicas over brokers not excluded for replica moves must be less than the
       // pre-optimized stats.
       double stdDev1 = stats1.topicReplicaStats().get(Statistic.ST_DEV).doubleValue();
       double stdDev2 = stats2.topicReplicaStats().get(Statistic.ST_DEV).doubleValue();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicReplicaDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicReplicaDistributionGoal.java
@@ -184,6 +184,13 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
     return changeType == ADD ? numTopicReplicas + 1 >= brokerBalanceLowerLimit : numTopicReplicas - 1 >= brokerBalanceLowerLimit;
   }
 
+  /**
+   * Check whether the given broker is excluded for replica moves.
+   * Such a broker cannot receive replicas, but can give them away.
+   *
+   * @param broker Broker to check for exclusion from replica moves.
+   * @return {@code true} if the given broker is excluded for replica moves, {@code false} otherwise.
+   */
   private boolean isExcludedForReplicaMove(Broker broker) {
     return !_brokersAllowedReplicaMove.contains(broker.id());
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Host.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Host.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.model;
 
 import com.linkedin.cruisecontrol.monitor.sampling.aggregator.AggregatedMetricValues;
+import com.linkedin.kafka.cruisecontrol.analyzer.OptimizationOptions;
 import com.linkedin.kafka.cruisecontrol.common.Resource;
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
 import java.io.IOException;
@@ -100,6 +101,23 @@ public class Host implements Serializable {
   public boolean isAlive() {
     for (Broker broker : _brokers.values()) {
       if (broker.isAlive()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Check whether the host is alive and allowed replica moves.
+   *
+   * @param optimizationOptions Options to retrieve excluded brokers for replica moves.
+   * @return Whether the host is alive and allowed replica moves. The host is alive and allowed replica moves as long as
+   * it has at least one broker alive which is not excluded for replica moves.
+   */
+  public boolean isAliveAndAllowedReplicaMoves(OptimizationOptions optimizationOptions) {
+    Set<Integer> excludedBrokers = optimizationOptions.excludedBrokersForReplicaMove();
+    for (Broker broker : _brokers.values()) {
+      if (broker.isAlive() && !excludedBrokers.contains(broker.id())) {
         return true;
       }
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Rack.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Rack.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.model;
 
 import com.linkedin.cruisecontrol.monitor.sampling.aggregator.AggregatedMetricValues;
+import com.linkedin.kafka.cruisecontrol.analyzer.OptimizationOptions;
 import com.linkedin.kafka.cruisecontrol.common.Resource;
 
 import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
@@ -33,7 +34,7 @@ public class Rack implements Serializable {
   private final String _id;
   private final Map<String, Host> _hosts;
   private final Map<Integer, Broker> _brokers;
-  private Load _load;
+  private final Load _load;
   private final double[] _rackCapacity;
 
   /**
@@ -146,6 +147,22 @@ public class Rack implements Serializable {
   public boolean isRackAlive() {
     for (Host host : _hosts.values()) {
       if (host.isAlive()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Check whether the rack is alive and allowed replica moves.
+   *
+   * @param optimizationOptions Options to use in checking if this rack has hosts that are alive and allowed replica moves.
+   * @return Whether the rack is alive and allowed replica moves. The rack is alive and allowed replica moves as long as
+   * it has at least one host alive which is not excluded for replica moves.
+   */
+  public boolean isAliveAndAllowedReplicaMoves(OptimizationOptions optimizationOptions) {
+    for (Host host : _hosts.values()) {
+      if (host.isAliveAndAllowedReplicaMoves(optimizationOptions)) {
         return true;
       }
     }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUnitTestUtils.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerUnitTestUtils.java
@@ -27,6 +27,7 @@ public class AnalyzerUnitTestUtils {
   public static Goal goal(Class<? extends Goal> goalClass) throws Exception {
     Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
     props.setProperty(AnalyzerConfig.MAX_REPLICAS_PER_BROKER_CONFIG, Long.toString(5L));
+    props.setProperty(AnalyzerConfig.TOPIC_REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG, Double.toString(1.2));
     BalancingConstraint balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(props));
     balancingConstraint.setResourceBalancePercentage(TestConstants.LOW_BALANCE_PERCENTAGE);
     balancingConstraint.setCapacityThreshold(TestConstants.MEDIUM_CAPACITY_THRESHOLD);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/IntraBrokerRebalanceTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/IntraBrokerRebalanceTest.java
@@ -38,12 +38,12 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class IntraBrokerRebalanceTest {
 
-  private int _testId;
-  private Map<ClusterProperty, Number> _modifiedProperties;
-  private List<String> _goalNameByPriority;
-  private BalancingConstraint _balancingConstraint;
-  private Set<String> _excludedTopics;
-  private List<OptimizationVerifier.Verification> _verifications;
+  private final int _testId;
+  private final Map<ClusterProperty, Number> _modifiedProperties;
+  private final List<String> _goalNameByPriority;
+  private final BalancingConstraint _balancingConstraint;
+  private final Set<String> _excludedTopics;
+  private final List<OptimizationVerifier.Verification> _verifications;
 
   /**
    * Constructor of Self Healing Test.


### PR DESCRIPTION
* Ensure that `RackAwareDistributionGoal`, `TopicReplicaDistributionGoal`, `ReplicaDistributionGoal`, `LeaderReplicaDistributionGoal` do not include brokers excluded for replica moves while computing balance constraints.
* Fix incorrect `numOfflineTopicReplicasInB1` within `rebalanceByMovingReplicasIn` of `TopicReplicaDistributionGoal`.
* Update the following dead configs, which are not supported after https://github.com/linkedin/cruise-control/pull/985 in `cruisecontrol.properties`:
```
  broker.failure.exclude.recently.demoted.brokers=true
  broker.failure.exclude.recently.removed.brokers=true
  goal.violation.exclude.recently.demoted.brokers=true
  goal.violation.exclude.recently.removed.brokers=true
```
This PR resolves #1382.

--

Selected evaluations on a cluster with 10 brokers with 3 brokers permanently marked as excluded -- i.e. preferred controllers of [LinkedIn Kafka](https://github.com/linkedin/kafka) -- please note standard deviations (lower is better) and averages (closer to average is better).


1. With `ReplicaDistributionGoal`:
Existing approach (std: 163.3 and avg: 260.18 -- considers all brokers):
```
LEADERS/REPLICAS
97/291
129/387
0/0
132/284
148/387
129/352
69/387
129/387
121/387
0/0
0/0
```
New approach (std: 13 and avg: 357.7 -- considers only brokers that are not excluded):
```
LEADERS/REPLICAS
111/364
125/364
0/0
148/325
141/364
129/352
63/364
119/364
118/365
0/0
0/0
```

2. With `LeaderReplicaDistributionGoal`:
Existing approach (std: 55 and avg: 86.7 -- considers all brokers):
```
LEADERS/REPLICAS
95/387
124/387
0/0
113/188
148/387
129/352
95/387
129/387
121/387
0/0
0/0
```
New approach (std: 6.57 and avg: 119.2 -- considers only brokers that are not excluded):
```
LEADERS/REPLICAS
114/387
121/387
0/0
112/188
126/387
124/352
108/387
127/387
122/387
0/0
0/0
```

3. With `TopicReplicaDistributionGoal`:
Existing approach (std: 3.85  and avg: 5  -- considers all brokers):
New approach (std: 2.67 and avg: 6.8 -- considers only brokers that are not excluded):
