### PR TITLE
Ensure that resource distribution goals compute balance constraints properly

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/OptimizationOptions.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/OptimizationOptions.java
@@ -73,6 +73,15 @@ public class OptimizationOptions {
                              boolean isTriggeredByGoalViolation,
                              Set<Integer> requestedDestinationBrokerIds,
                              boolean onlyMoveImmigrantReplicas) {
+    if (excludedTopics == null) {
+      throw new IllegalArgumentException("Excluded topics cannot be null.");
+    } else if (excludedBrokersForLeadership == null) {
+      throw new IllegalArgumentException("Excluded brokers for leadership cannot be null.");
+    } else if (excludedBrokersForReplicaMove == null) {
+      throw new IllegalArgumentException("Excluded brokers for replica move cannot be null.");
+    } else if (requestedDestinationBrokerIds == null) {
+      throw new IllegalArgumentException("Requested destination broker ids cannot be null.");
+    }
     _excludedTopics = excludedTopics;
     _excludedBrokersForLeadership = excludedBrokersForLeadership;
     _excludedBrokersForReplicaMove = excludedBrokersForReplicaMove;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CapacityGoal.java
@@ -149,7 +149,8 @@ public abstract class CapacityGoal extends AbstractGoal {
 
     // While proposals exclude the excludedTopics, the existingUtilization still considers replicas of the excludedTopics.
     double existingUtilization = recentClusterLoad.expectedUtilizationFor(resource());
-    double allowedCapacity = clusterModel.capacityFor(resource()) * _balancingConstraint.capacityThreshold(resource());
+    double capacity = clusterModel.capacityWithAllowedReplicaMovesFor(resource(), optimizationOptions);
+    double allowedCapacity = capacity * _balancingConstraint.capacityThreshold(resource());
 
     if (allowedCapacity < existingUtilization) {
       throw new OptimizationFailureException(

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/GoalUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/GoalUtils.java
@@ -318,15 +318,14 @@ public class GoalUtils {
   }
 
   /**
-   * Get the utilization percentage of the broker for the given resource, or {@link #DEAD_BROKER_UTILIZATION} if the
-   * broker is dead. The utilization percentage for resources is calculated from broker capacity and
-   * {@link com.linkedin.kafka.cruisecontrol.model.Load#expectedUtilizationFor(Resource)} .
+   * Get the utilization of the broker for the given resource, or {@link #DEAD_BROKER_UTILIZATION} if the broker is dead.
+   * The utilization of an alive broker corresponds to the ratio of its expected utilization to its capacity.
    *
    * @param broker Broker for which the resource utilization percentage has been queried.
    * @param resource Resource for the utilization percentage.
-   * @return Utilization percentage of the broker for the given resource.
+   * @return Utilization of the broker for the given resource as a double in [0.0,1.0].
    */
-  public static double utilizationPercentage(Broker broker, Resource resource) {
+  public static double utilization(Broker broker, Resource resource) {
     double brokerCapacity = broker.capacityFor(resource);
     return brokerCapacity > 0 ? broker.load().expectedUtilizationFor(resource) / brokerCapacity : DEAD_BROKER_UTILIZATION;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/Resource.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/Resource.java
@@ -34,7 +34,7 @@ public enum Resource {
   private final int _id;
   private final boolean _isHostResource;
   private final boolean _isBrokerResource;
-  private double _epsilon;
+  private final double _epsilon;
 
   private static final List<Resource> CACHED_VALUES = Collections.unmodifiableList(Arrays.asList(values()));
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
@@ -123,7 +123,7 @@ public class Broker implements Serializable, Comparable<Broker> {
    * Get broker capacity for the requested resource.
    *
    * @param resource Resource for which the capacity will be provided.
-   * @return If broker is alive, the capacity of the requested resource, DEAD_BROKER_CAPACITY otherwise.
+   * @return If broker is alive, the capacity of the requested resource, {@link #DEAD_BROKER_CAPACITY} otherwise.
    */
   public double capacityFor(Resource resource) {
       return _brokerCapacity[resource.id()];

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -699,6 +699,20 @@ public class ClusterModel implements Serializable {
   }
 
   /**
+   * Get cluster capacity for the requested resource over brokers that are allowed to receive replicas.
+   * Contrary to {@link #capacityFor(Resource)}, drops the capacity of brokers that are excluded from replica moves.
+   *
+   * @param resource Resource for which the capacity will be provided.
+   * @param optimizationOptions Options to take into account while retrieving the capacity.
+   * @return Alive cluster capacity of the resource, excluding the capacity of brokers that are excluded from replica moves.
+   */
+  public double capacityWithAllowedReplicaMovesFor(Resource resource, OptimizationOptions optimizationOptions) {
+    Set<Integer> excluded = optimizationOptions.excludedBrokersForReplicaMove();
+    double capacityToDrop = _aliveBrokers.stream().filter(b -> excluded.contains(b.id())).mapToDouble(b -> b.capacityFor(resource)).sum();
+    return _clusterCapacity[resource.id()] - capacityToDrop;
+  }
+
+  /**
    * Set the load for the given replica. This method should be called only once for each replica.
    *
    * @param rackId         Rack id.

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/ExcludedBrokersForReplicaMoveTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/ExcludedBrokersForReplicaMoveTest.java
@@ -50,6 +50,7 @@ import static com.linkedin.kafka.cruisecontrol.common.DeterministicCluster.unbal
 import static com.linkedin.kafka.cruisecontrol.common.DeterministicCluster.unbalanced2;
 import static com.linkedin.kafka.cruisecontrol.common.DeterministicCluster.unbalanced3;
 import static com.linkedin.kafka.cruisecontrol.common.DeterministicCluster.unbalanced4;
+import static com.linkedin.kafka.cruisecontrol.common.DeterministicCluster.unbalancedWithAFollower;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
@@ -154,6 +155,8 @@ public class ExcludedBrokersForReplicaMoveTest {
       p.add(params(2, goalClass, excludeAllBrokers, OptimizationFailureException.class, unbalanced(), noDeadBroker, null));
       // Test: With all brokers excluded, one dead broker, not satisfiable (Exception)
       p.add(params(3, goalClass, excludeAllBrokers, OptimizationFailureException.class, unbalanced(), deadBroker0, null));
+      // Test: With single excluded broker, unsatisfiable cluster, no dead brokers (Exception)
+      p.add(params(4, goalClass, excludeB1, OptimizationFailureException.class, unbalanced2(), noDeadBroker, null));
     }
 
     for (Class<? extends Goal> goalClass : Arrays.asList(DiskUsageDistributionGoal.class,
@@ -162,14 +165,13 @@ public class ExcludedBrokersForReplicaMoveTest {
                                                          CpuUsageDistributionGoal.class)) {
       // Test: With single excluded broker, balance not satisfiable cluster, no dead broker (No exception, No proposal
       // for excluded broker, Not expected to look optimized)
-      p.add(params(0, goalClass, excludeB1, null, unbalanced(), noDeadBroker, false));
+      p.add(params(0, goalClass, excludeB1, null, unbalanced(), noDeadBroker, true));
       // Test: With single excluded topic, balance not satisfiable cluster, no dead broker (No exception, No proposal
       // for excluded broker, Not expected to look optimized)
-      p.add(params(1, goalClass, excludeB1, null, unbalanced(), deadBroker0, false));
-      // Test: With all brokers excluded, no dead brokers, balance not satisfiable (No exception, No proposal for
-      // excluded brokers, Not expected to look optimized)
-      p.add(params(2, goalClass, excludeAllBrokers, null, unbalanced(), noDeadBroker, false));
-      // Test: With all brokers excluded, no dead brokers, (Exception)
+      p.add(params(1, goalClass, excludeB1, null, unbalanced(), deadBroker0, true));
+      // Test: With all brokers excluded, balance not satisfiable, no dead brokers (Exception)
+      p.add(params(2, goalClass, excludeAllBrokers, OptimizationFailureException.class, unbalanced(), noDeadBroker, null));
+      // Test: With all brokers excluded, one dead broker, (Exception)
       p.add(params(3, goalClass, excludeAllBrokers, OptimizationFailureException.class, unbalanced(), deadBroker0, null));
     }
 
@@ -177,15 +179,16 @@ public class ExcludedBrokersForReplicaMoveTest {
     // Test: With single excluded broker, balance not satisfiable cluster, no dead broker (No exception, No proposal
     // for excluded broker, Not expected to look optimized)
     p.add(params(0, LeaderBytesInDistributionGoal.class, excludeB1, null, unbalanced(), noDeadBroker, false));
-    // Test: With single excluded broker, balance not satisfiable cluster, no dead broker (No exception, No proposal
+    // Test: With single excluded broker, balance not satisfiable cluster, one dead broker (No exception, No proposal
     // for excluded broker, Not expected to look optimized)
     p.add(params(1, LeaderBytesInDistributionGoal.class, excludeB1, null, unbalanced(), deadBroker0, false));
-    // Test: With all brokers excluded, no dead brokers, balance not satisfiable (No exception, No proposal for
-    // excluded brokers, Not expected to look optimized)
-    p.add(params(2, LeaderBytesInDistributionGoal.class, excludeAllBrokers, null, unbalanced(), noDeadBroker, false));
-    // Test: With all brokers excluded, no dead brokers, balance not satisfiable (No exception, No proposal for
-    // excluded brokers, Not expected to look optimized)
-    p.add(params(3, LeaderBytesInDistributionGoal.class, excludeAllBrokers, null, unbalanced(), deadBroker0, false));
+    // Test: With all brokers excluded, no dead broker, (Exception)
+    p.add(params(2, LeaderBytesInDistributionGoal.class, excludeAllBrokers, OptimizationFailureException.class, unbalanced(), noDeadBroker, null));
+    // Test: With all brokers excluded, one dead broker, (Exception)
+    p.add(params(3, LeaderBytesInDistributionGoal.class, excludeAllBrokers, OptimizationFailureException.class, unbalanced(), deadBroker0, null));
+    // Test: With single excluded broker, balance satisfiable cluster, no dead broker (No exception, No proposal
+    // for excluded broker, Expected to look optimized)
+    p.add(params(0, LeaderBytesInDistributionGoal.class, excludeB1, null, unbalancedWithAFollower(), noDeadBroker, true));
 
     // ============PotentialNwOutGoal============
     // Test: With single excluded broker, balance satisfiable cluster, no dead brokers (No exception, No proposal

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/ExcludedBrokersForReplicaMoveTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/ExcludedBrokersForReplicaMoveTest.java
@@ -164,10 +164,10 @@ public class ExcludedBrokersForReplicaMoveTest {
                                                          NetworkOutboundUsageDistributionGoal.class,
                                                          CpuUsageDistributionGoal.class)) {
       // Test: With single excluded broker, balance not satisfiable cluster, no dead broker (No exception, No proposal
-      // for excluded broker, Not expected to look optimized)
+      // for excluded broker, Expected to look optimized)
       p.add(params(0, goalClass, excludeB1, null, unbalanced(), noDeadBroker, true));
       // Test: With single excluded topic, balance not satisfiable cluster, no dead broker (No exception, No proposal
-      // for excluded broker, Not expected to look optimized)
+      // for excluded broker, Expected to look optimized)
       p.add(params(1, goalClass, excludeB1, null, unbalanced(), deadBroker0, true));
       // Test: With all brokers excluded, balance not satisfiable, no dead brokers (Exception)
       p.add(params(2, goalClass, excludeAllBrokers, OptimizationFailureException.class, unbalanced(), noDeadBroker, null));
@@ -219,7 +219,7 @@ public class ExcludedBrokersForReplicaMoveTest {
     // excluded broker, Expected to look optimized)
     p.add(params(0, ReplicaDistributionGoal.class, excludeB1, null, unbalanced2(), noDeadBroker, true));
     // Test: With single excluded broker, satisfiable cluster, one dead broker (No exception, No proposal for
-    // excluded broker, Not expected to look optimized)
+    // excluded broker, Expected to look optimized)
     p.add(params(1, ReplicaDistributionGoal.class, excludeB1, null, unbalanced2(), deadBroker0, true));
     // Test: With all brokers excluded, balance not satisfiable, no dead brokers (Exception)
     p.add(params(2, ReplicaDistributionGoal.class, excludeAllBrokers, OptimizationFailureException.class, unbalanced2(), noDeadBroker, null));

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/DeterministicCluster.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/DeterministicCluster.java
@@ -136,7 +136,7 @@ public class DeterministicCluster {
     cluster.createReplica(RACK_BY_BROKER.get(0).toString(), 0, pInfoT60, 0, true);
 
     AggregatedMetricValues aggregatedMetricValues =
-        getAggregatedMetricValues(TestConstants.LARGE_BROKER_CAPACITY / 2,
+        getAggregatedMetricValues(TestConstants.TYPICAL_CPU_CAPACITY / 2,
                                   TestConstants.LARGE_BROKER_CAPACITY / 2,
                                   TestConstants.MEDIUM_BROKER_CAPACITY / 2,
                                   TestConstants.LARGE_BROKER_CAPACITY / 2);
@@ -147,6 +147,23 @@ public class DeterministicCluster {
     cluster.setReplicaLoad(RACK_BY_BROKER.get(0).toString(), 0, pInfoT50, aggregatedMetricValues, Collections.singletonList(1L));
     cluster.setReplicaLoad(RACK_BY_BROKER.get(0).toString(), 0, pInfoT60, aggregatedMetricValues, Collections.singletonList(1L));
     return cluster;
+  }
+
+  /**
+   * @return {@link #unbalanced()} cluster with an additional follower for an existing partition.
+   */
+  public static ClusterModel unbalancedWithAFollower() {
+    ClusterModel unbalancedWithAFollower = unbalanced();
+
+    TopicPartition pInfoT10 = new TopicPartition(T1, 0);
+    unbalancedWithAFollower.createReplica(RACK_BY_BROKER.get(2).toString(), 2, pInfoT10, 1, false);
+
+    unbalancedWithAFollower.setReplicaLoad(RACK_BY_BROKER.get(2).toString(), 2, pInfoT10,
+                                           createLoad(TestConstants.TYPICAL_CPU_CAPACITY / 8,
+                                                      TestConstants.LARGE_BROKER_CAPACITY / 2,
+                                                      0.0,
+                                                      TestConstants.LARGE_BROKER_CAPACITY / 2), Collections.singletonList(1L));
+    return unbalancedWithAFollower;
   }
 
   /**

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/TestConstants.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/common/TestConstants.java
@@ -119,7 +119,7 @@ public final class TestConstants {
   public static final String LOGDIR1 = "/mnt/i01";
 
   static {
-    Map<Resource, Double> capacity = new HashMap<>();
+    Map<Resource, Double> capacity = new HashMap<>(Resource.cachedValues().size());
     capacity.put(Resource.CPU, TestConstants.TYPICAL_CPU_CAPACITY);
     capacity.put(Resource.DISK, TestConstants.LARGE_BROKER_CAPACITY);
     capacity.put(Resource.NW_IN, TestConstants.LARGE_BROKER_CAPACITY);


### PR DESCRIPTION
* Ensure that `CpuUsageDistributionGoal`, `DiskUsageDistributionGoal`, `NetworkInboundUsageDistributionGoal`, `NetworkOutboundUsageDistributionGoal`, `DiskCapacityGoal`, `NetworkInboundCapacityGoal`, `NetworkOutboundCapacityGoal`, `CpuCapacityGoal`, `LeaderBytesInDistributionGoal` do not include brokers excluded for replica moves while computing balance constraints (`PotentialNwOutGoal` does not need further changes).

This PR resolves #1384.

-- Selected Evaluation --
Selected evaluations on a cluster with 10 brokers with 3 brokers permanently marked as excluded -- i.e. preferred controllers of [LinkedIn Kafka](https://github.com/linkedin/kafka) -- please note standard deviations (lower is better).

Standard deviation **before** and **after**:

- CpuUsageDistributionGoal: 42.917 -> 1.919
- DiskUsageDistributionGoal: 69 ->  0.939
- NetworkInboundUsageDistributionGoal: 0.763 -> 0.039
- NetworkOutboundUsageDistributionGoal: 3.455 ->  0.127
