### PR TITLE
Add missing population of anomaly details for maintenance events

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/KafkaMetricAnomaly.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/KafkaMetricAnomaly.java
@@ -68,19 +68,6 @@ public class KafkaMetricAnomaly extends KafkaAnomaly implements MetricAnomaly<Br
     return String.format("%s anomaly with id: %s. Anomaly description: %s", METRIC_ANOMALY, anomalyId(), _description);
   }
 
-  /**
-   * Get the optimization result of self healing process, or null if no optimization result is available.
-   *
-   * @param isJson True for JSON response, false otherwise.
-   * @return The optimization result of self healing process, or null if no optimization result is available.
-   */
-  public String optimizationResult(boolean isJson) {
-    if (_optimizationResult == null) {
-      return null;
-    }
-    return isJson ? _optimizationResult.cachedJSONResponse() : _optimizationResult.cachedPlaintextResponse();
-  }
-
   @Override
   public Supplier<String> reasonSupplier() {
     return () -> String.format("Self healing for %s: %s", METRIC_ANOMALY, this);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetailsTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetailsTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.detector;
+
+import com.linkedin.cruisecontrol.detector.Anomaly;
+import com.linkedin.kafka.cruisecontrol.detector.notifier.KafkaAnomalyType;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import static com.linkedin.kafka.cruisecontrol.detector.AnomalyState.Status.DETECTED;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
+
+
+public class AnomalyDetailsTest {
+  private static final String MOCK_ANOMALY_ID = UUID.randomUUID().toString();
+  private static final long MOCK_DETECTION_MS = 100L;
+  private static final long MOCK_STATUS_UPDATE_MS = 200L;
+  private static final Map<Boolean, List<String>> VIOLATED_GOALS_BY_FIXABILITY;
+  static {
+    Map<Boolean, List<String>> violatedGoalsByFixability = new HashMap<>(2);
+    violatedGoalsByFixability.put(true, Collections.singletonList("Goal-1"));
+    violatedGoalsByFixability.put(false, Collections.singletonList("Goal-2"));
+    VIOLATED_GOALS_BY_FIXABILITY = Collections.unmodifiableMap(violatedGoalsByFixability);
+  }
+  private static final Map<Integer, Long> FAILED_BROKERS = Collections.singletonMap(1, 100L);
+  private static final Map<Integer, Map<String, Long>> FAILED_DISKS = Collections.singletonMap(1, Collections.singletonMap("logDir", 100L));
+  private static final String MOCK_DESCRIPTION = "MockDescription";
+
+  @Test
+  public void testPopulateAnomalyDetails() {
+    AnomalyState mockAnomalyState = EasyMock.mock(AnomalyState.class);
+
+    for (KafkaAnomalyType anomalyType : KafkaAnomalyType.cachedValues()) {
+      AnomalyDetails details = new AnomalyDetails(mockAnomalyState, anomalyType, false, false);
+      EasyMock.expect(mockAnomalyState.detectionMs()).andReturn(MOCK_DETECTION_MS).once();
+      EasyMock.expect(mockAnomalyState.status()).andReturn(DETECTED).once();
+      EasyMock.expect(mockAnomalyState.anomalyId()).andReturn(MOCK_ANOMALY_ID).once();
+      EasyMock.expect(mockAnomalyState.statusUpdateMs()).andReturn(MOCK_STATUS_UPDATE_MS).once();
+
+      switch (anomalyType) {
+        case GOAL_VIOLATION:
+          GoalViolations goalViolations = EasyMock.mock(GoalViolations.class);
+          EasyMock.expect(goalViolations.violatedGoalsByFixability()).andReturn(VIOLATED_GOALS_BY_FIXABILITY).once();
+          replayAndVerify(mockAnomalyState, details, goalViolations);
+          break;
+        case BROKER_FAILURE:
+          BrokerFailures brokerFailures = EasyMock.mock(BrokerFailures.class);
+          EasyMock.expect(brokerFailures.failedBrokers()).andReturn(FAILED_BROKERS).once();
+          replayAndVerify(mockAnomalyState, details, brokerFailures);
+          break;
+        case DISK_FAILURE:
+          DiskFailures diskFailures = EasyMock.mock(DiskFailures.class);
+          EasyMock.expect(diskFailures.failedDisks()).andReturn(FAILED_DISKS).once();
+          replayAndVerify(mockAnomalyState, details, diskFailures);
+          break;
+        case METRIC_ANOMALY:
+          KafkaMetricAnomaly kafkaMetricAnomaly = EasyMock.mock(KafkaMetricAnomaly.class);
+          EasyMock.expect(kafkaMetricAnomaly.description()).andReturn(MOCK_DESCRIPTION).once();
+          replayAndVerify(mockAnomalyState, details, kafkaMetricAnomaly);
+          break;
+        case TOPIC_ANOMALY:
+          TopicAnomaly topicAnomaly = EasyMock.mock(TopicAnomaly.class);
+          // Note: EasyMock provides a built-in behavior for equals(), toString(), hashCode() and finalize() even for class mocking.
+          // Hence, we cannot record our own behavior for topicAnomaly.toString().
+          replayAndVerify(mockAnomalyState, details, topicAnomaly);
+          break;
+        case MAINTENANCE_EVENT:
+          MaintenanceEvent maintenanceEvent = EasyMock.mock(MaintenanceEvent.class);
+          // Note: EasyMock provides a built-in behavior for equals(), toString(), hashCode() and finalize() even for class mocking.
+          // Hence, we cannot record our own behavior for maintenanceEvent.toString().
+          replayAndVerify(mockAnomalyState, details, maintenanceEvent);
+          break;
+        default:
+          throw new IllegalStateException("Unrecognized anomaly type " + anomalyType);
+      }
+    }
+  }
+
+  private static void replayAndVerify(AnomalyState mockAnomalyState, AnomalyDetails details, Anomaly anomaly) {
+    EasyMock.expect(mockAnomalyState.anomaly()).andReturn(anomaly).once();
+    EasyMock.replay(mockAnomalyState, anomaly);
+    Map<String, Object> populatedAnomalyDetails = details.populateAnomalyDetails();
+    assertNotNull(populatedAnomalyDetails);
+    assertFalse(populatedAnomalyDetails.isEmpty());
+    EasyMock.verify(mockAnomalyState, anomaly);
+    EasyMock.reset(mockAnomalyState, anomaly);
+  }
+}

--- a/docs/wiki/User Guide/Pluggable-Components.md
+++ b/docs/wiki/User Guide/Pluggable-Components.md
@@ -4,7 +4,8 @@ The metric sampler is one of the most important pluggables in Kafka Cruise Contr
 The default implementation of metric sampler is reading the broker metrics produced by `CruiseControlMetricsReporter` on the broker. This is assuming that users are running Kafka brokers by setting the `metric.reporters` configuration on the Kafka brokers to be `com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter`(see [quick start](https://github.com/linkedin/cruise-control#quick-start) on how to do that).
 
 ## Metric Sampler Partition Assignor
-When users have multiple metric sampler threads, the metric sampler partition assignor is responsible for assign the partitions to the metric samplers. This is useful when users have some existing metric system. The default implementation assigns all the partitions of the same topic to the same metric sampler.
+When users have multiple metric sampler threads, the metric sampler partition assignor is responsible for assigning partitions to the metric samplers.
+This is useful when users have some existing metric system. The default implementation assigns all the partitions of the same topic to the same metric sampler.
 
 ## Sample Store
 The Sample Store is used to store the collected metric samples and training samples to external storage. One problem in metric sampling is that we are using some derived data from the raw metrics. And the way we derive the data relies on the metadata of the cluster at that moment. So when we look at the old metrics, if we do not know the metadata at the point the metric was collected the derived data would be inaccurate. Sample Store helps solve this problem by storing the derived data directly to an external storage for later loading.
@@ -57,7 +58,8 @@ The goals in Kafka Cruise Control are pluggable with different priorities.
 * **IntraBrokerDiskUsageDistributionGoal**: Attempt to make the utilization variance among all the disks within same broker are within a certain range. This goal will be pick up if `rebalance_disk` parameter is set to `true` in [rebalance request](https://github.com/linkedin/cruise-control/wiki/REST-APIs#trigger-a-workload-balance). Not available in `kafka_0_11_and_1_0` branch. 
 
 ## Anomaly Notifier
-The anomaly notifier is a communication channel between cruise control and users. It notify the users about the anomaly detected in the cluster and let users make decision on what action to take about the anomaly. The anomalies include:
+The anomaly notifier is a communication channel between Cruise Control and users.
+It notifies users about the anomalies detected in the cluster as well as actions taken about the anomaly. Anomalies include:
 * Broker failure
 * Goal violation
 * Metric Anomaly
@@ -72,9 +74,20 @@ The actions users can take are:
 By default Cruise Control is configured to use `NoopNotifier` which ignores all the anomalies.
 
 ## Replica Movement Strategy
-The strategy determine the execution order for generated proposals. By default `BaseReplicaMovementStrategy` is used, which is totally random. Sometimes this could result in prolonged execution time due to some long tail tasks in each execution batches. Other available strategies includes:
+The strategy to determine the execution order for generated proposals. By default `BaseReplicaMovementStrategy` is used, which is totally random.
+Sometimes this could result in prolonged execution time due to some long tail tasks in each execution batches. Other available strategies includes:
 * **PrioritizeSmallReplicaMovementStrategy**: first move small sized replicas
 * **PrioritizeLargeReplicaMovementStrategy**: first move large sized replicas
 * **PostponeUrpReplicaMovementStrategy**: first move replicas for partition having no out-of-sync replica
 
 The strategies can be chained to use and can be dynamically set using `replica_movement_strategies` in corresponding request(e.g. [rebalance request](https://github.com/linkedin/cruise-control/wiki/REST-APIs#trigger-a-workload-balance)).
+
+## Maintenance Event Reader
+When a system/tool in Kafka Ecosystem has knowledge about an upcoming planned maintenance, such as a switch change, an upcoming VM freeze, 
+or reboot of VMs on cloud deployments, the desired preventative mitigation strategy (i.e. `maintenance event`) can be conveyed to 
+Cruise Control for automated execution of it without human intervention.
+
+Such maintenance events correspond to admin operations that the relevant system/tool submits to Cruise Control via a generic maintenance event store.
+Then, Maintenance Event Reader retrieves the maintenance events from the relevant event store for automated execution.
+
+The default implementation of Maintenance Event Reader (see `MaintenanceEventTopicReader`) consumes maintenance events from a Kafka topic.


### PR DESCRIPTION
* Drop redundant override for `KafkaMetricAnomaly#optimizationResult`

This PR resolves #1417.
