### PR TITLE
Add information about `capacity.config.file` to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Control). The metrics reporter periodically samples the Kafka raw metrics on the
 2. Start ZooKeeper and Kafka server ([See tutorial](https://kafka.apache.org/quickstart)).
 3. Modify `config/cruisecontrol.properties` of Cruise Control:
     * (Required) fill in `bootstrap.servers` and `zookeeper.connect` to the Kafka cluster to be monitored.
+    * (Required) update `capacity.config.file` to the path of your capacity file.  
+      * Capacity file is a JSON file that provides the capacity of the brokers
+      * You can start Cruise Control server with the default file (`config/capacityJBOD.json`), but it may not reflect the actual capacity your brokers 
+      * See [BrokerCapacityConfigurationFileResolver configurations](https://github.com/linkedin/cruise-control/wiki/Configurations#brokercapacityconfigurationfileresolver-configurations) for more information and examples
     * (Optional) set `metric.sampler.class` to your implementation (the default sampler class is `CruiseControlMetricsReporterSampler`) 
     * (Optional) set `sample.store.class` to your implementation if you have one (the default `SampleStore` is `KafkaSampleStore`)
 4. Run the following command 


### PR DESCRIPTION
Add information about `capacity.config.file` to README.md. 

Cruise Control server can start with the default file, but the capacity information may not be correct. This is because the default resolver of Cruise Control uses `capacity.config.file` as the source of truth to determine the capacity of brokers. 

Thus, `capacity.config.file` should be specified by the user. Without doing so, the default file may not show the correct capacity of brokers, which might fail the proposal process in further.

This PR resolves #1052 #325.
