### PR TITLE
Remove the future-level timeout for the processAlterPartitionReassignmentsResult method

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -53,7 +53,6 @@ import org.apache.kafka.common.utils.SystemTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
-
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
@@ -468,12 +468,21 @@ public class ExecutorConfig {
                             DEFAULT_EXECUTOR_NOTIFIER_CLASS,
                             ConfigDef.Importance.LOW,
                             EXECUTOR_NOTIFIER_CLASS_DOC)
+<<<<<<< HEAD
                     .define(ADMIN_CLIENT_REQUEST_TIMEOUT_MS_CONFIG,
                             ConfigDef.Type.INT,
                             DEFAULT_ADMIN_CLIENT_REQUEST_TIMEOUT_MS,
                             atLeast(0),
                             ConfigDef.Importance.MEDIUM,
                             ADMIN_CLIENT_REQUEST_TIMEOUT_MS_DOC)
+=======
+                    .define(KAFKA_REQUEST_TIMEOUT_MS_CONFIG,
+                            ConfigDef.Type.INT,
+                            DEFAULT_KAFKA_REQUEST_TIMEOUT_MS,
+                            atLeast(0),
+                            ConfigDef.Importance.MEDIUM,
+                            KAFKA_REQUEST_TIMEOUT_MS_DOC)
+>>>>>>> Handle issue 1449
                     .define(LEADER_MOVEMENT_TIMEOUT_MS_CONFIG,
                             ConfigDef.Type.LONG,
                             DEFAULT_LEADER_MOVEMENT_TIMEOUT_MS,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
@@ -468,21 +468,12 @@ public class ExecutorConfig {
                             DEFAULT_EXECUTOR_NOTIFIER_CLASS,
                             ConfigDef.Importance.LOW,
                             EXECUTOR_NOTIFIER_CLASS_DOC)
-<<<<<<< HEAD
                     .define(ADMIN_CLIENT_REQUEST_TIMEOUT_MS_CONFIG,
                             ConfigDef.Type.INT,
                             DEFAULT_ADMIN_CLIENT_REQUEST_TIMEOUT_MS,
                             atLeast(0),
                             ConfigDef.Importance.MEDIUM,
                             ADMIN_CLIENT_REQUEST_TIMEOUT_MS_DOC)
-=======
-                    .define(KAFKA_REQUEST_TIMEOUT_MS_CONFIG,
-                            ConfigDef.Type.INT,
-                            DEFAULT_KAFKA_REQUEST_TIMEOUT_MS,
-                            atLeast(0),
-                            ConfigDef.Importance.MEDIUM,
-                            KAFKA_REQUEST_TIMEOUT_MS_DOC)
->>>>>>> Handle issue 1449
                     .define(LEADER_MOVEMENT_TIMEOUT_MS_CONFIG,
                             ConfigDef.Type.LONG,
                             DEFAULT_LEADER_MOVEMENT_TIMEOUT_MS,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
@@ -373,7 +373,11 @@ public final class ExecutionUtils {
           noReassignmentToCancelTopicPartitions.add(tp);
           LOG.debug("Rollback failed for {} due to lack of corresponding ongoing replica reassignment.", tp);
         } else if (org.apache.kafka.common.errors.TimeoutException.class == ee.getCause().getClass()) {
-          LOG.warn("Failed to process AlterPartitionReassignmentsResult of {}.", tp, ee.getCause());
+          throw new IllegalStateException(String.format("An alterPartitionReassignments request timed out. This timeout is specified by"
+                                                        + "the \"admin.client.request.timeout.ms\" config. Please consider increasing"
+                                                        + "this timeout or check if there is any issue on the Kafka broker and/or controller"
+                                                        + "side. This alterPartitionReassignments request is for topic partition(s): %s",
+                                                        result.values().keySet()), ee.getCause());
         } else {
           // Not expected to happen.
           throw new IllegalStateException(String.format("%s encountered an unknown execution exception.", tp), ee);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtils.java
@@ -373,11 +373,11 @@ public final class ExecutionUtils {
           noReassignmentToCancelTopicPartitions.add(tp);
           LOG.debug("Rollback failed for {} due to lack of corresponding ongoing replica reassignment.", tp);
         } else if (org.apache.kafka.common.errors.TimeoutException.class == ee.getCause().getClass()) {
-          throw new IllegalStateException(String.format("An alterPartitionReassignments request timed out. This timeout is specified by"
-                                                        + "the \"admin.client.request.timeout.ms\" config. Please consider increasing"
-                                                        + "this timeout or check if there is any issue on the Kafka broker and/or controller"
-                                                        + "side. This alterPartitionReassignments request is for topic partition(s): %s",
-                                                        result.values().keySet()), ee.getCause());
+          throw new IllegalStateException(String.format("alterPartitionReassignments request timed out for partitions: %s. Check for Kafka "
+                                                        + "broker- or controller-side issues and consider increasing the configured timeout "
+                                                        + "(see %s).",
+                                                        result.values().keySet(),
+                                                        ExecutorConfig.ADMIN_CLIENT_REQUEST_TIMEOUT_MS_CONFIG), ee.getCause());
         } else {
           // Not expected to happen.
           throw new IllegalStateException(String.format("%s encountered an unknown execution exception.", tp), ee);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtilsTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtilsTest.java
@@ -10,8 +10,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 import org.apache.kafka.clients.admin.AlterPartitionReassignmentsResult;
 import org.apache.kafka.common.KafkaFuture;
@@ -88,19 +86,10 @@ public class ExecutionUtilsTest {
     EasyMock.verify(result);
     EasyMock.reset(result);
 
-    // Case 7: Handle future wait timeout exception. Expect no side effect.
-    EasyMock.expect(result.values())
-            .andReturn(getKafkaFutureByTopicPartition(topicName, partitionId, new TimeoutException()))
-            .once();
-    EasyMock.replay(result);
-    ExecutionUtils.processAlterPartitionReassignmentsResult(result, Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
-    EasyMock.verify(result);
-    EasyMock.reset(result);
-
-    // Case 8: Handle future wait interrupted exception
+    // Case 7: Handle future wait interrupted exception
     EasyMock.expect(result.values())
             .andReturn(getKafkaFutureByTopicPartition(topicName, partitionId, new InterruptedException()))
-            .once();
+            .times(2);
     EasyMock.replay(result);
     ExecutionUtils.processAlterPartitionReassignmentsResult(result, Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
     EasyMock.verify(result);
@@ -113,10 +102,10 @@ public class ExecutionUtilsTest {
     Map<TopicPartition, KafkaFuture<Void>> futureByTopicPartition = new HashMap<>(1);
     KafkaFuture<Void> kafkaFuture = EasyMock.mock(KafkaFuture.class);
     if (futureException == null) {
-      EasyMock.expect(kafkaFuture.get(ExecutionUtils.EXECUTION_TASK_FUTURE_ERROR_VERIFICATION_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+      EasyMock.expect(kafkaFuture.get())
               .andReturn(null).once();
     } else {
-      EasyMock.expect(kafkaFuture.get(ExecutionUtils.EXECUTION_TASK_FUTURE_ERROR_VERIFICATION_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+      EasyMock.expect(kafkaFuture.get())
               .andThrow(futureException).once();
     }
     EasyMock.replay(kafkaFuture);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -66,7 +66,6 @@ import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC0;
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC1;
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC2;
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC3;
-import static com.linkedin.kafka.cruisecontrol.executor.ExecutionUtils.*;
 import static com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricSampler.SamplingMode.ALL;
 import static com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricSampler.SamplingMode.BROKER_METRICS_ONLY;
 import static org.easymock.EasyMock.expectLastCall;
@@ -186,8 +185,7 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
   }
 
   @Test
-  public void testSubmitReplicaReassignmentTasksWithDeadTaskAndNoReassignmentInProgress()
-      throws InterruptedException {
+  public void testSubmitReplicaReassignmentTasksWithDeadTaskAndNoReassignmentInProgress() throws InterruptedException {
     AdminClient adminClient = KafkaCruiseControlUtils.createAdminClient(Collections.singletonMap(
         AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()));
 
@@ -212,8 +210,7 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
   }
 
   @Test
-  public void testSubmitReplicaReassignmentTasksWithInProgressTaskAndNonExistingTopic()
-      throws InterruptedException {
+  public void testSubmitReplicaReassignmentTasksWithInProgressTaskAndNonExistingTopic() throws InterruptedException {
     AdminClient adminClient = KafkaCruiseControlUtils.createAdminClient(Collections.singletonMap(
         AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()));
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -187,7 +187,7 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
 
   @Test
   public void testSubmitReplicaReassignmentTasksWithDeadTaskAndNoReassignmentInProgress()
-      throws InterruptedException, TimeoutException {
+      throws InterruptedException {
     AdminClient adminClient = KafkaCruiseControlUtils.createAdminClient(Collections.singletonMap(
         AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()));
 
@@ -213,7 +213,7 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
 
   @Test
   public void testSubmitReplicaReassignmentTasksWithInProgressTaskAndNonExistingTopic()
-      throws InterruptedException, TimeoutException {
+      throws InterruptedException {
     AdminClient adminClient = KafkaCruiseControlUtils.createAdminClient(Collections.singletonMap(
         AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()));
 
@@ -288,13 +288,12 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
                                                                                                      Collections.singletonList(task)));
   }
 
-  private static boolean verifyFutureError(Future<?> future, Class<? extends Throwable> exceptionClass)
-      throws TimeoutException, InterruptedException {
+  private static boolean verifyFutureError(Future<?> future, Class<? extends Throwable> exceptionClass) throws InterruptedException {
     if (future == null) {
       return false;
     }
     try {
-      future.get(EXECUTION_TASK_FUTURE_ERROR_VERIFICATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      future.get();
     } catch (ExecutionException ee) {
       return exceptionClass == ee.getCause().getClass();
     }


### PR DESCRIPTION
This PR resolves #1449.
