### PR TITLE
Add support for kafka version 2.7

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/KafkaNetworkClientProvider.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/KafkaNetworkClientProvider.java
@@ -35,11 +35,14 @@ public class KafkaNetworkClientProvider implements NetworkClientProvider {
                                            int socketSendBuffer,
                                            int socketReceiveBuffer,
                                            int defaultRequestTimeoutMs,
+                                           long connectionSetupTimeoutMs,
+                                           long connectionSetupTimeoutMaxMs,
                                            boolean discoverBrokerVersions,
                                            ApiVersions apiVersions) {
     return new NetworkClient(new Selector(connectionMaxIdleMS, metrics, time, metricGrpPrefix, channelBuilder, new LogContext()),
                              metadata, clientId, maxInFlightRequestsPerConnection, reconnectBackoffMs,
                              reconnectBackoffMax, socketSendBuffer, socketReceiveBuffer, defaultRequestTimeoutMs,
-                             ClientDnsLookup.DEFAULT, time, discoverBrokerVersions, apiVersions, new LogContext());
+                             connectionSetupTimeoutMs, connectionSetupTimeoutMaxMs, ClientDnsLookup.DEFAULT,
+                             time, discoverBrokerVersions, apiVersions, new LogContext());
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/MetadataClient.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/MetadataClient.java
@@ -73,6 +73,8 @@ public class MetadataClient {
                                                   config.getInt(MonitorConfig.SEND_BUFFER_CONFIG),
                                                   config.getInt(MonitorConfig.RECEIVE_BUFFER_CONFIG),
                                                   config.getInt(MonitorConfig.REQUEST_TIMEOUT_MS_CONFIG),
+                                                  config.getLong(MonitorConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG),
+                                                  config.getLong(MonitorConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),
                                                   true,
                                                   new ApiVersions());
     _metadataTTL = metadataTTL;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/NetworkClientProvider.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/NetworkClientProvider.java
@@ -33,6 +33,8 @@ public interface NetworkClientProvider {
                                     int socketSendBuffer,
                                     int socketReceiveBuffer,
                                     int defaultRequestTimeoutMs,
+                                    long connectionSetupTimeoutMs,
+                                    long connectionSetupTimeoutMaxMs,
                                     boolean discoverBrokerVersions,
                                     ApiVersions apiVersions);
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/MonitorConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/MonitorConfig.java
@@ -62,6 +62,26 @@ public class MonitorConfig {
   public static final String SEND_BUFFER_DOC = CommonClientConfigs.SEND_BUFFER_DOC;
 
   /**
+   * <code>socket.connection.setup.timeout.ms</code>
+   */
+  public static final String SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG =
+          CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG;
+  public static final long DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MS =
+          CommonClientConfigs.DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MS;
+  public static final String SOCKET_CONNECTION_SETUP_TIMEOUT_MS_DOC =
+          CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_DOC;
+
+  /**
+   * <code>socket.connection.setup.timeout.max.ms</code>
+   */
+  public static final String SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG =
+          CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG;
+  public static final long DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS =
+          CommonClientConfigs.DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS;
+  public static final String SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_DOC =
+          CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_DOC;
+
+  /**
    * <code>receive.buffer.bytes</code>
    */
   public static final String RECEIVE_BUFFER_CONFIG = CommonClientConfigs.RECEIVE_BUFFER_CONFIG;
@@ -554,6 +574,16 @@ public class MonitorConfig {
                             ConfigDef.Type.LONG,
                             DEFAULT_MONITOR_STATE_UPDATE_INTERVAL_MS,
                             ConfigDef.Importance.LOW,
-                            MONITOR_STATE_UPDATE_INTERVAL_MS_DOC);
+                            MONITOR_STATE_UPDATE_INTERVAL_MS_DOC)
+                    .define(SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG,
+                            ConfigDef.Type.LONG,
+                            DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MS,
+                            ConfigDef.Importance.MEDIUM,
+                            SOCKET_CONNECTION_SETUP_TIMEOUT_MS_DOC)
+                    .define(SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG,
+                            ConfigDef.Type.LONG,
+                            DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS,
+                            ConfigDef.Importance.MEDIUM,
+                            SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_DOC);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/MonitorConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/MonitorConfig.java
@@ -578,11 +578,13 @@ public class MonitorConfig {
                     .define(SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG,
                             ConfigDef.Type.LONG,
                             DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MS,
+                            atLeast(0),
                             ConfigDef.Importance.MEDIUM,
                             SOCKET_CONNECTION_SETUP_TIMEOUT_MS_DOC)
                     .define(SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG,
                             ConfigDef.Type.LONG,
                             DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS,
+                            atLeast(0),
                             ConfigDef.Importance.MEDIUM,
                             SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_DOC);
   }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
@@ -36,10 +36,10 @@ import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeLogDirsResult;
+import org.apache.kafka.clients.admin.LogDirDescription;
+import org.apache.kafka.clients.admin.ReplicaInfo;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.requests.DescribeLogDirsResponse;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.easymock.EasyMock;
@@ -580,26 +580,26 @@ public class LoadMonitorTest {
       Constructor<DescribeLogDirsResult> constructor = DescribeLogDirsResult.class.getDeclaredConstructor(Map.class);
       constructor.setAccessible(true);
 
-      Map<Integer, KafkaFuture<Map<String, DescribeLogDirsResponse.LogDirInfo>>> futureByBroker = new HashMap<>();
-      Map<String, DescribeLogDirsResponse.LogDirInfo> logdirInfoBylogdir =  new HashMap<>();
-      Map<TopicPartition, DescribeLogDirsResponse.ReplicaInfo> replicaInfoByPartition = new HashMap<>();
-      replicaInfoByPartition.put(T0P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-      replicaInfoByPartition.put(T0P1, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-      replicaInfoByPartition.put(T1P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-      replicaInfoByPartition.put(T1P1, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-      logdirInfoBylogdir.put("/tmp/kafka-logs", new DescribeLogDirsResponse.LogDirInfo(Errors.NONE, replicaInfoByPartition));
+      Map<Integer, KafkaFuture<Map<String, LogDirDescription>>> futureByBroker = new HashMap<>();
+      Map<String, LogDirDescription> logdirInfoBylogdir =  new HashMap<>();
+      Map<TopicPartition, ReplicaInfo> replicaInfoByPartition = new HashMap<>();
+      replicaInfoByPartition.put(T0P0, new ReplicaInfo(0, 0, false));
+      replicaInfoByPartition.put(T0P1, new ReplicaInfo(0, 0, false));
+      replicaInfoByPartition.put(T1P0, new ReplicaInfo(0, 0, false));
+      replicaInfoByPartition.put(T1P1, new ReplicaInfo(0, 0, false));
+      logdirInfoBylogdir.put("/tmp/kafka-logs", new LogDirDescription(null, replicaInfoByPartition));
       futureByBroker.put(0, completedFuture(logdirInfoBylogdir));
 
       logdirInfoBylogdir =  new HashMap<>();
       replicaInfoByPartition = new HashMap<>();
-      replicaInfoByPartition.put(T0P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-      replicaInfoByPartition.put(T0P1, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-      replicaInfoByPartition.put(T1P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-      logdirInfoBylogdir.put("/tmp/kafka-logs-1", new DescribeLogDirsResponse.LogDirInfo(Errors.NONE, replicaInfoByPartition));
+      replicaInfoByPartition.put(T0P0, new ReplicaInfo(0, 0, false));
+      replicaInfoByPartition.put(T0P1, new ReplicaInfo(0, 0, false));
+      replicaInfoByPartition.put(T1P0, new ReplicaInfo(0, 0, false));
+      logdirInfoBylogdir.put("/tmp/kafka-logs-1", new LogDirDescription(null, replicaInfoByPartition));
       logdirInfoBylogdir.put("/tmp/kafka-logs-2",
-                             new DescribeLogDirsResponse.LogDirInfo(Errors.NONE,
+                             new LogDirDescription(null,
                                                                     Collections.singletonMap(T1P1,
-                                                                                             new DescribeLogDirsResponse.ReplicaInfo(0, 0, false))));
+                                                                                             new ReplicaInfo(0, 0, false))));
       futureByBroker.put(1, completedFuture(logdirInfoBylogdir));
       return constructor.newInstance(futureByBroker);
     } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
@@ -24,8 +24,6 @@ import com.linkedin.kafka.cruisecontrol.monitor.sampling.NoopSampleStore;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.holder.PartitionEntity;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.aggregator.KafkaPartitionMetricSampleAggregator;
 import com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunner;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -36,10 +34,10 @@ import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeLogDirsResult;
-import org.apache.kafka.clients.admin.LogDirDescription;
-import org.apache.kafka.clients.admin.ReplicaInfo;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.DescribeLogDirsResponse;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.easymock.EasyMock;
@@ -528,13 +526,20 @@ public class LoadMonitorTest {
             .anyTimes();
     EasyMock.replay(mockMetadataClient);
 
+    // Create mock DescribeLogDirsResult
+    DescribeLogDirsResult mockDescribeLogDirsResult = EasyMock.mock(DescribeLogDirsResult.class);
+    EasyMock.expect(mockDescribeLogDirsResult.values())
+            .andReturn(getDescribeLogDirsResultValues())
+            .anyTimes();
+    EasyMock.replay(mockDescribeLogDirsResult);
+
     // Create mock admin client.
     AdminClient mockAdminClient = EasyMock.mock(AdminClient.class);
     EasyMock.expect(mockAdminClient.describeLogDirs(Arrays.asList(0, 1)))
-            .andReturn(getDescribeLogDirsResult())
+            .andReturn(mockDescribeLogDirsResult)
             .anyTimes();
     EasyMock.expect(mockAdminClient.describeLogDirs(Arrays.asList(1, 0)))
-            .andReturn(getDescribeLogDirsResult())
+            .andReturn(mockDescribeLogDirsResult)
             .anyTimes();
     EasyMock.replay(mockAdminClient);
 
@@ -574,38 +579,30 @@ public class LoadMonitorTest {
                   "Load monitor state did not get updated within the time limit", WAIT_DEADLINE_MS, CHECK_MS);
   }
 
-  private DescribeLogDirsResult getDescribeLogDirsResult() {
-    try {
-      // Reflectively set DescribeLogDirsResult's constructor from package private to public.
-      Constructor<DescribeLogDirsResult> constructor = DescribeLogDirsResult.class.getDeclaredConstructor(Map.class);
-      constructor.setAccessible(true);
+  private Map<Integer, KafkaFuture<Map<String, DescribeLogDirsResponse.LogDirInfo>>> getDescribeLogDirsResultValues() {
 
-      Map<Integer, KafkaFuture<Map<String, LogDirDescription>>> futureByBroker = new HashMap<>();
-      Map<String, LogDirDescription> logdirInfoBylogdir =  new HashMap<>();
-      Map<TopicPartition, ReplicaInfo> replicaInfoByPartition = new HashMap<>();
-      replicaInfoByPartition.put(T0P0, new ReplicaInfo(0, 0, false));
-      replicaInfoByPartition.put(T0P1, new ReplicaInfo(0, 0, false));
-      replicaInfoByPartition.put(T1P0, new ReplicaInfo(0, 0, false));
-      replicaInfoByPartition.put(T1P1, new ReplicaInfo(0, 0, false));
-      logdirInfoBylogdir.put("/tmp/kafka-logs", new LogDirDescription(null, replicaInfoByPartition));
-      futureByBroker.put(0, completedFuture(logdirInfoBylogdir));
+    Map<Integer, KafkaFuture<Map<String, DescribeLogDirsResponse.LogDirInfo>>> futureByBroker = new HashMap<>();
+    Map<String, DescribeLogDirsResponse.LogDirInfo> logdirInfoBylogdir =  new HashMap<>();
+    Map<TopicPartition, DescribeLogDirsResponse.ReplicaInfo> replicaInfoByPartition = new HashMap<>();
+    replicaInfoByPartition.put(T0P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
+    replicaInfoByPartition.put(T0P1, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
+    replicaInfoByPartition.put(T1P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
+    replicaInfoByPartition.put(T1P1, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
+    logdirInfoBylogdir.put("/tmp/kafka-logs", new DescribeLogDirsResponse.LogDirInfo(Errors.NONE, replicaInfoByPartition));
+    futureByBroker.put(0, completedFuture(logdirInfoBylogdir));
 
-      logdirInfoBylogdir =  new HashMap<>();
-      replicaInfoByPartition = new HashMap<>();
-      replicaInfoByPartition.put(T0P0, new ReplicaInfo(0, 0, false));
-      replicaInfoByPartition.put(T0P1, new ReplicaInfo(0, 0, false));
-      replicaInfoByPartition.put(T1P0, new ReplicaInfo(0, 0, false));
-      logdirInfoBylogdir.put("/tmp/kafka-logs-1", new LogDirDescription(null, replicaInfoByPartition));
-      logdirInfoBylogdir.put("/tmp/kafka-logs-2",
-                             new LogDirDescription(null,
-                                                                    Collections.singletonMap(T1P1,
-                                                                                             new ReplicaInfo(0, 0, false))));
-      futureByBroker.put(1, completedFuture(logdirInfoBylogdir));
-      return constructor.newInstance(futureByBroker);
-    } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-      // Let it go.
-    }
-    return null;
+    logdirInfoBylogdir =  new HashMap<>();
+    replicaInfoByPartition = new HashMap<>();
+    replicaInfoByPartition.put(T0P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
+    replicaInfoByPartition.put(T0P1, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
+    replicaInfoByPartition.put(T1P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
+    logdirInfoBylogdir.put("/tmp/kafka-logs-1", new DescribeLogDirsResponse.LogDirInfo(Errors.NONE, replicaInfoByPartition));
+    logdirInfoBylogdir.put("/tmp/kafka-logs-2",
+            new DescribeLogDirsResponse.LogDirInfo(Errors.NONE,
+                    Collections.singletonMap(T1P1,
+                            new DescribeLogDirsResponse.ReplicaInfo(0, 0, false))));
+    futureByBroker.put(1, completedFuture(logdirInfoBylogdir));
+    return futureByBroker;
   }
 
   private static class TestContext {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.daemon=false
 org.gradle.parallel=false
 org.gradle.jvmargs=-Xms512m -Xmx512m
-kafkaVersion=2.6.0
+kafkaVersion=2.7.0
 zookeeperVersion=3.5.8


### PR DESCRIPTION
This PR adds support for kafka version 2.7.
It adds support for the configurable socket connection timeout in NetworkClient introduced in [KIP-601](https://cwiki.apache.org/confluence/display/KAFKA/KIP-601%3A+Configurable+socket+connection+timeout+in+NetworkClient)
