### PR TITLE
Fix miscalculated recommendation for the number of racks to drop for clusters over-provisioned wrt rack count.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/OptimizerResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/OptimizerResult.java
@@ -273,7 +273,7 @@ public class OptimizerResult {
                          _clusterModelStats.monitoredPartitionsPercentage(), excludedTopics(),
                          excludedBrokersForLeadership(), excludedBrokersForReplicaMove(), _clusterModelStats.toStringCounts(),
                          _onDemandBalancednessScoreBefore, _onDemandBalancednessScoreAfter, _provisionResponse.status(),
-                         recommendation.isEmpty() ? "" : String.format("%nProvision Recommendation: %s.", recommendation));
+                         recommendation.isEmpty() ? "" : String.format("%nProvision Recommendation: %s", recommendation));
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareDistributionGoal.java
@@ -146,7 +146,7 @@ public class RackAwareDistributionGoal extends AbstractRackAwareGoal {
     _balanceLimit = new BalanceLimit(clusterModel, optimizationOptions);
     int numExtraRacks = _balanceLimit.numAliveRacksAllowedReplicaMoves() - clusterModel.maxReplicationFactor();
     if (numExtraRacks >= _balancingConstraint.overprovisionedMinExtraRacks()) {
-      int numRacksToDrop = numExtraRacks - _balancingConstraint.overprovisionedMinExtraRacks() - 1;
+      int numRacksToDrop = numExtraRacks - _balancingConstraint.overprovisionedMinExtraRacks() + 1;
       String recommendation = String.format("Reduce rack diversity by at least %d racks.", numRacksToDrop);
       _provisionResponse = new ProvisionResponse(ProvisionStatus.OVER_PROVISIONED, recommendation, name());
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareGoal.java
@@ -104,7 +104,7 @@ public class RackAwareGoal extends AbstractRackAwareGoal {
     }
     int numExtraRacks = numAliveRacks - clusterModel.maxReplicationFactor();
     if (numExtraRacks >= _balancingConstraint.overprovisionedMinExtraRacks()) {
-      int numRacksToDrop = numExtraRacks - _balancingConstraint.overprovisionedMinExtraRacks() - 1;
+      int numRacksToDrop = numExtraRacks - _balancingConstraint.overprovisionedMinExtraRacks() + 1;
       String recommendation = String.format("Reduce rack diversity by at least %d racks.", numRacksToDrop);
       _provisionResponse = new ProvisionResponse(ProvisionStatus.OVER_PROVISIONED, recommendation, name());
     }


### PR DESCRIPTION
This PR resolves #1475.
* It also removes an extra `dot` from provision response.