### PR TITLE
Make SLF4J API use Log4j2 as the implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,12 @@ project(':cruise-control-core') {
   }
 
   dependencies {
+    configurations.all {
+      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+      exclude group: 'log4j', module: 'log4j'
+    }
     compile "org.slf4j:slf4j-api:1.7.30"
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.14.0"
     compile 'junit:junit:4.13'
     compile 'org.apache.commons:commons-math3:3.6.1'
     compile 'org.eclipse.jetty:jetty-servlet:9.4.35.v20201120'
@@ -223,9 +228,14 @@ project(':cruise-control') {
   }
 
   dependencies {
+    configurations.all {
+      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+      exclude group: 'log4j', module: 'log4j'
+    }
     compile project(':cruise-control-metrics-reporter')
     compile project(':cruise-control-core')
     compile "org.slf4j:slf4j-api:1.7.30" // TODO: Upgrade log4j to log4j2 to use async logger.
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.14.0"
     compile "org.apache.zookeeper:zookeeper:${zookeeperVersion}"
     compile "org.apache.kafka:kafka_2.11:$kafkaVersion"
     compile "org.apache.kafka:kafka-clients:$kafkaVersion"
@@ -277,7 +287,7 @@ project(':cruise-control') {
 
   tasks.create(name: "copyDependantLibs", type: Copy) {
     from (configurations.testRuntime) {
-      include('slf4j-log4j12*')
+      include('log4j-slf4j-impl*')
     }
     from (configurations.runtime) {
 
@@ -347,7 +357,12 @@ project(':cruise-control-metrics-reporter') {
   }
 
   dependencies {
+    configurations.all {
+      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+      exclude group: 'log4j', module: 'log4j'
+    }
     compile "org.slf4j:slf4j-api:1.7.30"
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.14.0"
     compile "org.apache.kafka:kafka_2.11:$kafkaVersion"
     compile "org.apache.kafka:kafka-clients:$kafkaVersion"
     compile 'junit:junit:4.13'

--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -2,35 +2,66 @@
 # Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
 #
 
-log4j.rootLogger=INFO, stdout
+rootLogger.level=INFO
+appenders=console, kafkaCruiseControlAppender, operationAppender, requestAppender
 
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+property.filename=./logs
 
-log4j.appender.kafkaCruiseControlAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.kafkaCruiseControlAppender.DatePattern='.'yyyy-MM-dd-HH
-log4j.appender.kafkaCruiseControlAppender.File=${kafka.logs.dir}/kafkacruisecontrol.log
-log4j.appender.kafkaCruiseControlAppender.layout=org.apache.log4j.PatternLayout
-log4j.appender.kafkaCruiseControlAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=[%d] %p %m (%c)%n
 
-log4j.appender.operationAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.operationAppender.DatePattern='.'yyyy-MM-dd
-log4j.appender.operationAppender.File=${kafka.logs.dir}/kafkacruisecontrol-operation.log
-log4j.appender.operationAppender.layout=org.apache.log4j.PatternLayout
-log4j.appender.operationAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+appender.kafkaCruiseControlAppender.type=RollingFile
+appender.kafkaCruiseControlAppender.name=kafkaCruiseControlFile
+appender.kafkaCruiseControlAppender.fileName=${filename}/kafkacruisecontrol.log
+appender.kafkaCruiseControlAppender.filePattern=${filename}/kafkacruisecontrol.log.%d{yyyy-MM-dd-HH}
+appender.kafkaCruiseControlAppender.layout.type=PatternLayout
+appender.kafkaCruiseControlAppender.layout.pattern=[%d] %p %m (%c)%n
+appender.kafkaCruiseControlAppender.policies.type=Policies
+appender.kafkaCruiseControlAppender.policies.time.type=TimeBasedTriggeringPolicy
+appender.kafkaCruiseControlAppender.policies.time.interval=1
 
-log4j.appender.requestAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.requestAppender.DatePattern='.'yyyy-MM-dd-HH
-log4j.appender.requestAppender.File=${kafka.logs.dir}/kafkacruisecontrol-request.log
-log4j.appender.requestAppender.layout=org.apache.log4j.PatternLayout
-log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+appender.operationAppender.type=RollingFile
+appender.operationAppender.name=operationFile
+appender.operationAppender.fileName=${filename}/kafkacruisecontrol-operation.log
+appender.operationAppender.filePattern=${filename}/kafkacruisecontrol-operation.log.%d{yyyy-MM-dd}
+appender.operationAppender.layout.type=PatternLayout
+appender.operationAppender.layout.pattern=[%d] %p [%c] %m %n
+appender.operationAppender.policies.type=Policies
+appender.operationAppender.policies.time.type=TimeBasedTriggeringPolicy
+appender.operationAppender.policies.time.interval=1
+
+appender.requestAppender.type=RollingFile
+appender.requestAppender.name=requestFile
+appender.requestAppender.fileName=${filename}/kafkacruisecontrol-request.log
+appender.requestAppender.filePattern=${filename}/kafkacruisecontrol-request.log.%d{yyyy-MM-dd-HH}
+appender.requestAppender.layout.type=PatternLayout
+appender.requestAppender.layout.pattern=[%d] %p %m (%c)%n
+appender.requestAppender.policies.type=Policies
+appender.requestAppender.policies.time.type=TimeBasedTriggeringPolicy
+appender.requestAppender.policies.time.interval=1
 
 # Loggers
-log4j.logger.com.linkedin.kafka.cruisecontrol=INFO, kafkaCruiseControlAppender
-log4j.logger.com.linkedin.kafka.cruisecontrol.detector=INFO, kafkaCruiseControlAppender
-log4j.logger.operationLogger=INFO, operationAppender
+logger.cruisecontrol.name=com.linkedin.kafka.cruisecontrol
+logger.cruisecontrol.level=info
+logger.cruisecontrol.appenderRef.kafkaCruiseControlAppender.ref=kafkaCruiseControlFile
 
-log4j.logger.CruiseControlPublicAccessLogger=INFO, requestAppender
-log4j.additivity.kafka.request.logger=false
+logger.detector.name=com.linkedin.kafka.cruisecontrol.detector
+logger.detector.level=info
+logger.detector.appenderRef.kafkaCruiseControlAppender.ref=kafkaCruiseControlFile
 
+logger.operationLogger.name=operationLogger
+logger.operationLogger.level=info
+logger.operationLogger.appenderRef.operationAppender.ref=operationFile
+
+logger.CruiseControlPublicAccessLogger.name=CruiseControlPublicAccessLogger
+logger.CruiseControlPublicAccessLogger.level=info
+logger.CruiseControlPublicAccessLogger.appenderRef.requestAppender.ref=requestFile
+
+logger.kafkaRequest.name=kafka.request.logger
+logger.kafkaRequest.additivity=false
+
+rootLogger.appenderRefs=console, kafkaCruiseControlAppender
+rootLogger.appenderRef.console.ref=STDOUT
+rootLogger.appenderRef.kafkaCruiseControlAppender.ref=kafkaCruiseControlFile

--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -59,9 +59,6 @@ logger.CruiseControlPublicAccessLogger.name=CruiseControlPublicAccessLogger
 logger.CruiseControlPublicAccessLogger.level=info
 logger.CruiseControlPublicAccessLogger.appenderRef.requestAppender.ref=requestFile
 
-logger.kafkaRequest.name=kafka.request.logger
-logger.kafkaRequest.additivity=false
-
 rootLogger.appenderRefs=console, kafkaCruiseControlAppender
 rootLogger.appenderRef.console.ref=STDOUT
 rootLogger.appenderRef.kafkaCruiseControlAppender.ref=kafkaCruiseControlFile

--- a/cruise-control-core/src/test/resources/log4j.properties
+++ b/cruise-control-core/src/test/resources/log4j.properties
@@ -2,17 +2,27 @@
 # Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
 #
 
-log4j.rootLogger=OFF, stdout
+rootLogger.level=OFF
+appenders=console
 
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=[%d] %p %m (%c:%L)%n
 
-log4j.logger.org.apache.kafka=ERROR
-log4j.logger.kafka=ERROR
+# Loggers
+logger.orgApacheKafka.name=org.apache.kafka
+logger.orgApacheKafka.level=error
+
+logger.kafka.name=kafka
+logger.kafka.level=error
 
 # zkclient can be verbose, during debugging it is common to adjust is separately
-log4j.logger.org.I0Itec.zkclient.ZkClient=WARN
-log4j.logger.org.apache.zookeeper=WARN
+logger.zkclient.name=org.I0Itec.zkclient.ZkClient
+logger.zkclient.level=warn
 
-log4j.logger.com.linkedin.cruisecontrol.monitor.sampling.newaggregator=ERROR
+logger.zookeeper.name=org.apache.zookeeper
+logger.zookeeper.level=warn
+
+rootLogger.appenderRefs=console
+rootLogger.appenderRef.console.ref=STDOUT

--- a/cruise-control-metrics-reporter/src/test/resources/log4j.properties
+++ b/cruise-control-metrics-reporter/src/test/resources/log4j.properties
@@ -2,17 +2,30 @@
 # Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
 #
 
-log4j.rootLogger=OFF, stdout
+rootLogger.level=OFF
+appenders=console
 
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=[%d] %p %m (%c:%L)%n
 
-log4j.logger.org.apache.kafka=ERROR
-log4j.logger.kafka=ERROR
+# Loggers
+logger.orgApacheKafka.name=org.apache.kafka
+logger.orgApacheKafka.level=error
+
+logger.kafka.name=kafka
+logger.kafka.level=error
 
 # zkclient can be verbose, during debugging it is common to adjust is separately
-log4j.logger.org.I0Itec.zkclient.ZkClient=WARN
-log4j.logger.org.apache.zookeeper=WARN
+logger.zkclient.name=org.I0Itec.zkclient.ZkClient
+logger.zkclient.level=warn
 
-log4j.logger.com.linkedin.kafka.cruisecontrol=ERROR
+logger.zookeeper.name=org.apache.zookeeper
+logger.zookeeper.level=warn
+
+logger.cruisecontrol.name=com.linkedin.kafka.cruisecontrol
+logger.cruisecontrol.level=error
+
+rootLogger.appenderRefs=console
+rootLogger.appenderRef.console.ref=STDOUT

--- a/cruise-control/src/test/resources/log4j.properties
+++ b/cruise-control/src/test/resources/log4j.properties
@@ -1,13 +1,30 @@
 #
 # Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
 #
-log4j.rootLogger=OFF, stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
-log4j.logger.org.apache.kafka.clients.Metadata=ERROR
-log4j.logger.kafka.controller=ERROR
+rootLogger.level=OFF
+appenders=console
+
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=[%d] %p %m (%c:%L)%n
+
+# Loggers
+logger.metadata.name=org.apache.kafka.clients.Metadata
+logger.metadata.level=error
+
+logger.controller.name=kafka.controller
+logger.controller.level=error
+
 # zkclient can be verbose, during debugging it is common to adjust is separately
-log4j.logger.org.I0Itec.zkclient.ZkClient=WARN
-log4j.logger.org.apache.zookeeper=WARN
-log4j.logger.com.linkedin.kafka=ERROR
+logger.zkclient.name=org.I0Itec.zkclient.ZkClient
+logger.zkclient.level=warn
+
+logger.zookeeper.name=org.apache.zookeeper
+logger.zookeeper.level=warn
+
+logger.linkedinKafka.name=com.linkedin.kafka
+logger.linkedinKafka.level=error
+
+rootLogger.appenderRefs=console
+rootLogger.appenderRef.console.ref=STDOUT

--- a/kafka-cruise-control-start.sh
+++ b/kafka-cruise-control-start.sh
@@ -82,7 +82,7 @@ if [ -z "$KAFKA_LOG4J_OPTS" ]; then
   LOG4J_DIR="$base_dir/config/log4j.properties"
   # If Cygwin is detected, LOG4J_DIR is converted to Windows format.
   (( CYGWIN )) && LOG4J_DIR=$(cygpath --path --mixed "${LOG4J_DIR}")
-  KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:${LOG4J_DIR}"
+  KAFKA_LOG4J_OPTS="-Dlog4j.configurationFile=file:${LOG4J_DIR}"
 else
   # create logs directory
   if [ ! -d "$LOG_DIR" ]; then


### PR DESCRIPTION
This PR resolves #1473.

* Verified via local deployment that the current logs in use (i.e. `kafkacruisecontrol.log` and `kafkacruisecontrol-operation.log`) are populated as expected.

* The `kafka-cruise-control-start.sh` starts Cruise Control without errors or warning such as the following:
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/some-path-here/cruise-control/cruise-control/build/dependant-libs/slf4j-log4j12-1.7.25.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/some-path-here/cruise-control/cruise-control/build/dependant-libs/log4j-slf4j-impl-2.14.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
```

* The new `LoggerFactoryClass` is the one for `Log4j2` -- i.e. running the following code

```
final StaticLoggerBinder binder = StaticLoggerBinder.getSingleton();
System.out.println(binder.getLoggerFactoryClassStr());
```
generates the following output:
```
org.apache.logging.slf4j.Log4jLoggerFactory
```

* Each module now has `org.apache.logging.log4j:log4j-slf4j-impl:2.14.0` as the dependency.

1. `> Task :cruise-control:dependencies`
 
```
------------------------------------------------------------
Project :cruise-control
------------------------------------------------------------

runtime - Runtime dependencies for source set 'main' (deprecated, use 'runtimeOnly' instead).
+--- project :cruise-control-metrics-reporter
|    +--- org.slf4j:slf4j-api:1.7.30
|    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.14.0
|    |    +--- org.slf4j:slf4j-api:1.7.25 -> 1.7.30
|    |    +--- org.apache.logging.log4j:log4j-api:2.14.0
|    |    \--- org.apache.logging.log4j:log4j-core:2.14.0
|    |         \--- org.apache.logging.log4j:log4j-api:2.14.0
|    +--- org.apache.kafka:kafka_2.11:2.4.1
|    |    +--- org.apache.kafka:kafka-clients:2.4.1
|    |    |    +--- com.github.luben:zstd-jni:1.4.3-1
|    |    |    +--- org.lz4:lz4-java:1.6.0
|    |    |    +--- org.xerial.snappy:snappy-java:1.1.7.3
|    |    |    \--- org.slf4j:slf4j-api:1.7.28 -> 1.7.30
|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.10.0 -> 2.11.1
|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.11.1
|    |    |    \--- com.fasterxml.jackson.core:jackson-core:2.11.1
|    |    +--- com.fasterxml.jackson.module:jackson-module-scala_2.11:2.10.0
|    |    |    +--- org.scala-lang:scala-library:2.11.12
|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.10.0 -> 2.11.1
|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.10.0 -> 2.11.1
|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.10.0 -> 2.11.1 (*)
|    |    |    \--- com.fasterxml.jackson.module:jackson-module-paranamer:2.10.0
|    |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.10.0 -> 2.11.1 (*)
|    |    |         \--- com.thoughtworks.paranamer:paranamer:2.8
|    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.10.0
|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.10.0 -> 2.11.1 (*)
|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.10.0 -> 2.11.1
|    |    |    \--- com.fasterxml.jackson.core:jackson-core:2.10.0 -> 2.11.1
|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.10.0
|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.10.0 -> 2.11.1
|    |    |    \--- com.fasterxml.jackson.core:jackson-databind:2.10.0 -> 2.11.1 (*)
|    |    +--- net.sf.jopt-simple:jopt-simple:5.0.4
|    |    +--- com.yammer.metrics:metrics-core:2.2.0
|    |    |    \--- org.slf4j:slf4j-api:1.7.2 -> 1.7.30
|    |    +--- org.scala-lang.modules:scala-collection-compat_2.11:2.1.2
|    |    |    \--- org.scala-lang:scala-library:2.11.12
|    |    +--- org.scala-lang.modules:scala-java8-compat_2.11:0.9.0
|    |    |    \--- org.scala-lang:scala-library:2.11.12
|    |    +--- org.scala-lang:scala-library:2.11.12
|    |    +--- org.scala-lang:scala-reflect:2.11.12
|    |    |    \--- org.scala-lang:scala-library:2.11.12
|    |    +--- com.typesafe.scala-logging:scala-logging_2.11:3.9.2
|    |    |    +--- org.scala-lang:scala-library:2.11.11 -> 2.11.12
|    |    |    +--- org.scala-lang:scala-reflect:2.11.11 -> 2.11.12 (*)
|    |    |    \--- org.slf4j:slf4j-api:1.7.26 -> 1.7.30
|    |    +--- org.slf4j:slf4j-api:1.7.28 -> 1.7.30
|    |    +--- org.apache.zookeeper:zookeeper:3.5.7
|    |    |    +--- org.apache.zookeeper:zookeeper-jute:3.5.7
|    |    |    |    \--- org.apache.yetus:audience-annotations:0.5.0
|    |    |    +--- org.apache.yetus:audience-annotations:0.5.0
|    |    |    +--- io.netty:netty-handler:4.1.45.Final
|    |    |    |    +--- io.netty:netty-common:4.1.45.Final
|    |    |    |    +--- io.netty:netty-buffer:4.1.45.Final
|    |    |    |    |    \--- io.netty:netty-common:4.1.45.Final
|    |    |    |    +--- io.netty:netty-transport:4.1.45.Final
|    |    |    |    |    +--- io.netty:netty-common:4.1.45.Final
|    |    |    |    |    +--- io.netty:netty-buffer:4.1.45.Final (*)
|    |    |    |    |    \--- io.netty:netty-resolver:4.1.45.Final
|    |    |    |    |         \--- io.netty:netty-common:4.1.45.Final
|    |    |    |    \--- io.netty:netty-codec:4.1.45.Final
|    |    |    |         +--- io.netty:netty-common:4.1.45.Final
|    |    |    |         +--- io.netty:netty-buffer:4.1.45.Final (*)
|    |    |    |         \--- io.netty:netty-transport:4.1.45.Final (*)
|    |    |    +--- io.netty:netty-transport-native-epoll:4.1.45.Final
|    |    |    |    +--- io.netty:netty-common:4.1.45.Final
|    |    |    |    +--- io.netty:netty-buffer:4.1.45.Final (*)
|    |    |    |    +--- io.netty:netty-transport:4.1.45.Final (*)
|    |    |    |    \--- io.netty:netty-transport-native-unix-common:4.1.45.Final
|    |    |    |         +--- io.netty:netty-common:4.1.45.Final
|    |    |    |         +--- io.netty:netty-buffer:4.1.45.Final (*)
|    |    |    |         \--- io.netty:netty-transport:4.1.45.Final (*)
|    |    |    \--- org.slf4j:slf4j-api:1.7.25 -> 1.7.30
|    |    \--- commons-cli:commons-cli:1.4
|    +--- org.apache.kafka:kafka-clients:2.4.1 (*)
|    +--- junit:junit:4.13
|    |    \--- org.hamcrest:hamcrest-core:1.3
|    +--- org.apache.commons:commons-math3:3.6.1
|    \--- com.google.code.findbugs:jsr305:3.0.2
+--- project :cruise-control-core
|    +--- org.slf4j:slf4j-api:1.7.30
|    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.14.0 (*)
|    +--- junit:junit:4.13 (*)
|    +--- org.apache.commons:commons-math3:3.6.1
|    +--- org.eclipse.jetty:jetty-servlet:9.4.35.v20201120
|    |    +--- org.eclipse.jetty:jetty-security:9.4.35.v20201120
|    |    |    \--- org.eclipse.jetty:jetty-server:9.4.35.v20201120
|    |    |         +--- javax.servlet:javax.servlet-api:3.1.0
|    |    |         +--- org.eclipse.jetty:jetty-http:9.4.35.v20201120
|    |    |         |    +--- org.eclipse.jetty:jetty-util:9.4.35.v20201120
|    |    |         |    \--- org.eclipse.jetty:jetty-io:9.4.35.v20201120
|    |    |         |         \--- org.eclipse.jetty:jetty-util:9.4.35.v20201120
|    |    |         \--- org.eclipse.jetty:jetty-io:9.4.35.v20201120 (*)
|    |    \--- org.eclipse.jetty:jetty-util-ajax:9.4.35.v20201120
|    |         \--- org.eclipse.jetty:jetty-util:9.4.35.v20201120
|    \--- com.google.code.findbugs:jsr305:3.0.2
+--- org.slf4j:slf4j-api:1.7.30
+--- org.apache.logging.log4j:log4j-slf4j-impl:2.14.0 (*)
+--- org.apache.zookeeper:zookeeper:3.5.7 (*)
+--- org.apache.kafka:kafka_2.11:2.4.1 (*)
+--- org.apache.kafka:kafka-clients:2.4.1 (*)
+--- org.scala-lang:scala-library:2.11.12
+--- junit:junit:4.13 (*)
+--- org.apache.commons:commons-math3:3.6.1
+--- org.apache.httpcomponents:httpclient:4.5.12
|    +--- org.apache.httpcomponents:httpcore:4.4.13
|    +--- commons-logging:commons-logging:1.2
|    \--- commons-codec:commons-codec:1.11
+--- com.google.code.gson:gson:2.8.6
+--- org.eclipse.jetty:jetty-server:9.4.35.v20201120 (*)
+--- io.dropwizard.metrics:metrics-core:3.2.6
|    \--- org.slf4j:slf4j-api:1.7.22 -> 1.7.30
+--- com.nimbusds:nimbus-jose-jwt:9.4.1
|    \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+--- com.101tec:zkclient:0.11
|    +--- org.apache.zookeeper:zookeeper:3.4.13 -> 3.5.7 (*)
|    \--- org.slf4j:slf4j-api:1.6.1 -> 1.7.30
+--- io.swagger.parser.v3:swagger-parser-v3:2.0.24
|    +--- io.swagger.core.v3:swagger-models:2.1.5
|    |    \--- com.fasterxml.jackson.core:jackson-annotations:2.11.1
|    +--- io.swagger.core.v3:swagger-core:2.1.5
|    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
|    |    |    \--- jakarta.activation:jakarta.activation-api:1.2.1
|    |    +--- org.apache.commons:commons-lang3:3.7
|    |    +--- org.slf4j:slf4j-api:1.7.25 -> 1.7.30
|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.11.1
|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.11.1 (*)
|    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.1
|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.11.1 (*)
|    |    |    +--- org.yaml:snakeyaml:1.26
|    |    |    \--- com.fasterxml.jackson.core:jackson-core:2.11.1
|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.1
|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.11.1
|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.11.1
|    |    |    \--- com.fasterxml.jackson.core:jackson-databind:2.11.1 (*)
|    |    +--- io.swagger.core.v3:swagger-annotations:2.1.5
|    |    +--- io.swagger.core.v3:swagger-models:2.1.5 (*)
|    |    \--- jakarta.validation:jakarta.validation-api:2.0.2
|    +--- io.swagger.parser.v3:swagger-parser-core:2.0.24
|    |    \--- io.swagger.core.v3:swagger-models:2.1.5 (*)
|    +--- commons-io:commons-io:2.6
|    +--- com.fasterxml.jackson.core:jackson-annotations:2.11.1
|    +--- com.fasterxml.jackson.core:jackson-databind:2.11.1 (*)
|    \--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.1 (*)
\--- io.github.classgraph:classgraph:4.8.98

(*) - dependencies omitted (listed previously)
```

2. `> Task :cruise-control-core:dependencies`
```
------------------------------------------------------------
Project :cruise-control-core
------------------------------------------------------------

runtime - Runtime dependencies for source set 'main' (deprecated, use 'runtimeOnly' instead).
+--- org.slf4j:slf4j-api:1.7.30
+--- org.apache.logging.log4j:log4j-slf4j-impl:2.14.0
|    +--- org.slf4j:slf4j-api:1.7.25 -> 1.7.30
|    +--- org.apache.logging.log4j:log4j-api:2.14.0
|    \--- org.apache.logging.log4j:log4j-core:2.14.0
|         \--- org.apache.logging.log4j:log4j-api:2.14.0
+--- junit:junit:4.13
|    \--- org.hamcrest:hamcrest-core:1.3
+--- org.apache.commons:commons-math3:3.6.1
\--- org.eclipse.jetty:jetty-servlet:9.4.35.v20201120
     +--- org.eclipse.jetty:jetty-security:9.4.35.v20201120
     |    \--- org.eclipse.jetty:jetty-server:9.4.35.v20201120
     |         +--- javax.servlet:javax.servlet-api:3.1.0
     |         +--- org.eclipse.jetty:jetty-http:9.4.35.v20201120
     |         |    +--- org.eclipse.jetty:jetty-util:9.4.35.v20201120
     |         |    \--- org.eclipse.jetty:jetty-io:9.4.35.v20201120
     |         |         \--- org.eclipse.jetty:jetty-util:9.4.35.v20201120
     |         \--- org.eclipse.jetty:jetty-io:9.4.35.v20201120 (*)
     \--- org.eclipse.jetty:jetty-util-ajax:9.4.35.v20201120
          \--- org.eclipse.jetty:jetty-util:9.4.35.v20201120

(*) - dependencies omitted (listed previously)

A web-based, searchable dependency report is available by adding the --scan option.
```

3.  `> Task :cruise-control-metrics-reporter:dependencies`
```
------------------------------------------------------------
Project :cruise-control-metrics-reporter
------------------------------------------------------------

runtime - Runtime dependencies for source set 'main' (deprecated, use 'runtimeOnly' instead).
+--- org.slf4j:slf4j-api:1.7.30
+--- org.apache.logging.log4j:log4j-slf4j-impl:2.14.0
|    +--- org.slf4j:slf4j-api:1.7.25 -> 1.7.30
|    +--- org.apache.logging.log4j:log4j-api:2.14.0
|    \--- org.apache.logging.log4j:log4j-core:2.14.0
|         \--- org.apache.logging.log4j:log4j-api:2.14.0
+--- org.apache.kafka:kafka_2.11:2.4.1
|    +--- org.apache.kafka:kafka-clients:2.4.1
|    |    +--- com.github.luben:zstd-jni:1.4.3-1
|    |    +--- org.lz4:lz4-java:1.6.0
|    |    +--- org.xerial.snappy:snappy-java:1.1.7.3
|    |    \--- org.slf4j:slf4j-api:1.7.28 -> 1.7.30
|    +--- com.fasterxml.jackson.core:jackson-databind:2.10.0
|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.10.0
|    |    \--- com.fasterxml.jackson.core:jackson-core:2.10.0
|    +--- com.fasterxml.jackson.module:jackson-module-scala_2.11:2.10.0
|    |    +--- org.scala-lang:scala-library:2.11.12
|    |    +--- com.fasterxml.jackson.core:jackson-core:2.10.0
|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.10.0
|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.10.0 (*)
|    |    \--- com.fasterxml.jackson.module:jackson-module-paranamer:2.10.0
|    |         +--- com.fasterxml.jackson.core:jackson-databind:2.10.0 (*)
|    |         \--- com.thoughtworks.paranamer:paranamer:2.8
|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.10.0
|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.10.0 (*)
|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.10.0
|    |    \--- com.fasterxml.jackson.core:jackson-core:2.10.0
|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.10.0
|    |    +--- com.fasterxml.jackson.core:jackson-core:2.10.0
|    |    \--- com.fasterxml.jackson.core:jackson-databind:2.10.0 (*)
|    +--- net.sf.jopt-simple:jopt-simple:5.0.4
|    +--- com.yammer.metrics:metrics-core:2.2.0
|    |    \--- org.slf4j:slf4j-api:1.7.2 -> 1.7.30
|    +--- org.scala-lang.modules:scala-collection-compat_2.11:2.1.2
|    |    \--- org.scala-lang:scala-library:2.11.12
|    +--- org.scala-lang.modules:scala-java8-compat_2.11:0.9.0
|    |    \--- org.scala-lang:scala-library:2.11.12
|    +--- org.scala-lang:scala-library:2.11.12
|    +--- org.scala-lang:scala-reflect:2.11.12
|    |    \--- org.scala-lang:scala-library:2.11.12
|    +--- com.typesafe.scala-logging:scala-logging_2.11:3.9.2
|    |    +--- org.scala-lang:scala-library:2.11.11 -> 2.11.12
|    |    +--- org.scala-lang:scala-reflect:2.11.11 -> 2.11.12 (*)
|    |    \--- org.slf4j:slf4j-api:1.7.26 -> 1.7.30
|    +--- org.slf4j:slf4j-api:1.7.28 -> 1.7.30
|    +--- org.apache.zookeeper:zookeeper:3.5.7
|    |    +--- org.apache.zookeeper:zookeeper-jute:3.5.7
|    |    |    \--- org.apache.yetus:audience-annotations:0.5.0
|    |    +--- org.apache.yetus:audience-annotations:0.5.0
|    |    +--- io.netty:netty-handler:4.1.45.Final
|    |    |    +--- io.netty:netty-common:4.1.45.Final
|    |    |    +--- io.netty:netty-buffer:4.1.45.Final
|    |    |    |    \--- io.netty:netty-common:4.1.45.Final
|    |    |    +--- io.netty:netty-transport:4.1.45.Final
|    |    |    |    +--- io.netty:netty-common:4.1.45.Final
|    |    |    |    +--- io.netty:netty-buffer:4.1.45.Final (*)
|    |    |    |    \--- io.netty:netty-resolver:4.1.45.Final
|    |    |    |         \--- io.netty:netty-common:4.1.45.Final
|    |    |    \--- io.netty:netty-codec:4.1.45.Final
|    |    |         +--- io.netty:netty-common:4.1.45.Final
|    |    |         +--- io.netty:netty-buffer:4.1.45.Final (*)
|    |    |         \--- io.netty:netty-transport:4.1.45.Final (*)
|    |    +--- io.netty:netty-transport-native-epoll:4.1.45.Final
|    |    |    +--- io.netty:netty-common:4.1.45.Final
|    |    |    +--- io.netty:netty-buffer:4.1.45.Final (*)
|    |    |    +--- io.netty:netty-transport:4.1.45.Final (*)
|    |    |    \--- io.netty:netty-transport-native-unix-common:4.1.45.Final
|    |    |         +--- io.netty:netty-common:4.1.45.Final
|    |    |         +--- io.netty:netty-buffer:4.1.45.Final (*)
|    |    |         \--- io.netty:netty-transport:4.1.45.Final (*)
|    |    \--- org.slf4j:slf4j-api:1.7.25 -> 1.7.30
|    \--- commons-cli:commons-cli:1.4
+--- org.apache.kafka:kafka-clients:2.4.1 (*)
+--- junit:junit:4.13
|    \--- org.hamcrest:hamcrest-core:1.3
\--- org.apache.commons:commons-math3:3.6.1

(*) - dependencies omitted (listed previously)
```

Some references:
1. https://logging.apache.org/log4j/2.x/manual/migration.html
2. http://logging.apache.org/log4j/2.x/manual/configuration.html
3. https://stackoverflow.com/a/37783054