### PR TITLE
Add documentation regarding Kafka 2.7 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Cruise Control for Apache Kafka
 
 ### Introduction ###
   Cruise Control is a product that helps run Apache Kafka clusters at large scale. Due to the popularity of 
-  Apache Kafka, many companies have bigger and bigger Kafka clusters. At LinkedIn, we have 2.6K+ Kafka brokers, 
+  Apache Kafka, many companies have bigger and bigger Kafka clusters. At LinkedIn, we have ~7K+ Kafka brokers, 
   which means broker deaths are an almost daily occurrence and balancing the workload of Kafka also becomes a big overhead. 
   
   Kafka Cruise Control is designed to address this operation scalability issue.
@@ -34,21 +34,24 @@ Cruise Control for Apache Kafka
     * Broker failure detection
     * Metric anomaly detection
     * Disk failure detection (not available in `kafka_0_11_and_1_0` branch)
+    * Slow broker detection (not available in `kafka_0_11_and_1_0` branch)
   
   * Admin operations, including:
     * Add brokers
-    * Decommission brokers
+    * Remove brokers
     * Demote brokers
     * Rebalance the cluster
     * Fix offline replicas (not available in `kafka_0_11_and_1_0` branch)
     * Perform preferred leader election (PLE)
     * Fix offline replicas
+    * Adjust replication factor
 
 ### Environment Requirements
 * The current `master` branch of Cruise Control is compatible with Apache Kafka `2.0`, `2.1`, `2.2`, and `2.3` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.0.*`)
 * The `kafka_0_11_and_1_0` branch of Cruise Control is compatible with Apache Kafka `0.11.0.0`, `1.0`, and `1.1` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `0.1.*`)
 * The `migrate_to_kafka_2_4` (development) branch of Cruise Control is compatible with Apache Kafka `2.4` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.4.*`)
-* The `migrate_to_kafka_2_5` (development) branch of Cruise Control is compatible with Apache Kafka `2.5` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.*`) and `2.6` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.11+`)
+* The `migrate_to_kafka_2_5` (development) branch of Cruise Control is compatible with Apache Kafka `2.5` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.*`),
+  `2.6` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.11+`), and `2.7` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.36+`)
 * `message.format.version` `0.10.0` and above is needed
 * The `master` and `kafka_0_11_and_1_0` branch compile with `Scala 2.11`
 * The development branches `migrate_to_kafka_2_4` and `migrate_to_kafka_2_5` compile with `Scala 2.12`
@@ -185,6 +188,7 @@ The anomaly notifier allows users to be notified when an anomaly is detected. An
  * Slow brokers (not available in `kafka_0_11_and_1_0` branch)
  * Topic replication factor anomaly (not available in `kafka_0_11_and_1_0` branch)
  * Topic partition size anomaly (not available in `kafka_0_11_and_1_0` branch)
+ * Maintenance Events (not available in `kafka_0_11_and_1_0` branch)
  
 In addition to anomaly notifications, users can enable actions to be taken in response to an anomaly by turning self-healing
 on for the relevant anomaly detectors. Multiple anomaly detectors work in harmony using distinct mitigation mechanisms.

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
@@ -598,9 +598,9 @@ public class LoadMonitorTest {
     replicaInfoByPartition.put(T1P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
     logdirInfoBylogdir.put("/tmp/kafka-logs-1", new DescribeLogDirsResponse.LogDirInfo(Errors.NONE, replicaInfoByPartition));
     logdirInfoBylogdir.put("/tmp/kafka-logs-2",
-            new DescribeLogDirsResponse.LogDirInfo(Errors.NONE,
-                    Collections.singletonMap(T1P1,
-                            new DescribeLogDirsResponse.ReplicaInfo(0, 0, false))));
+                           new DescribeLogDirsResponse.LogDirInfo(Errors.NONE,
+                                                                  Collections.singletonMap(T1P1,
+                                                                                           new DescribeLogDirsResponse.ReplicaInfo(0, 0, false))));
     futureByBroker.put(1, completedFuture(logdirInfoBylogdir));
     return futureByBroker;
   }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
@@ -24,8 +24,6 @@ import com.linkedin.kafka.cruisecontrol.monitor.sampling.NoopSampleStore;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.holder.PartitionEntity;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.aggregator.KafkaPartitionMetricSampleAggregator;
 import com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunner;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -528,13 +526,20 @@ public class LoadMonitorTest {
             .anyTimes();
     EasyMock.replay(mockMetadataClient);
 
+    // Create mock DescribeLogDirsResult
+    DescribeLogDirsResult mockDescribeLogDirsResult = EasyMock.mock(DescribeLogDirsResult.class);
+    EasyMock.expect(mockDescribeLogDirsResult.values())
+            .andReturn(getDescribeLogDirsResultValues())
+            .anyTimes();
+    EasyMock.replay(mockDescribeLogDirsResult);
+
     // Create mock admin client.
     AdminClient mockAdminClient = EasyMock.mock(AdminClient.class);
     EasyMock.expect(mockAdminClient.describeLogDirs(Arrays.asList(0, 1)))
-            .andReturn(getDescribeLogDirsResult())
+            .andReturn(mockDescribeLogDirsResult)
             .anyTimes();
     EasyMock.expect(mockAdminClient.describeLogDirs(Arrays.asList(1, 0)))
-            .andReturn(getDescribeLogDirsResult())
+            .andReturn(mockDescribeLogDirsResult)
             .anyTimes();
     EasyMock.replay(mockAdminClient);
 
@@ -574,38 +579,30 @@ public class LoadMonitorTest {
                   "Load monitor state did not get updated within the time limit", WAIT_DEADLINE_MS, CHECK_MS);
   }
 
-  private DescribeLogDirsResult getDescribeLogDirsResult() {
-    try {
-      // Reflectively set DescribeLogDirsResult's constructor from package private to public.
-      Constructor<DescribeLogDirsResult> constructor = DescribeLogDirsResult.class.getDeclaredConstructor(Map.class);
-      constructor.setAccessible(true);
+  private Map<Integer, KafkaFuture<Map<String, DescribeLogDirsResponse.LogDirInfo>>> getDescribeLogDirsResultValues() {
 
-      Map<Integer, KafkaFuture<Map<String, DescribeLogDirsResponse.LogDirInfo>>> futureByBroker = new HashMap<>();
-      Map<String, DescribeLogDirsResponse.LogDirInfo> logdirInfoBylogdir =  new HashMap<>();
-      Map<TopicPartition, DescribeLogDirsResponse.ReplicaInfo> replicaInfoByPartition = new HashMap<>();
-      replicaInfoByPartition.put(T0P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-      replicaInfoByPartition.put(T0P1, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-      replicaInfoByPartition.put(T1P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-      replicaInfoByPartition.put(T1P1, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-      logdirInfoBylogdir.put("/tmp/kafka-logs", new DescribeLogDirsResponse.LogDirInfo(Errors.NONE, replicaInfoByPartition));
-      futureByBroker.put(0, completedFuture(logdirInfoBylogdir));
+    Map<Integer, KafkaFuture<Map<String, DescribeLogDirsResponse.LogDirInfo>>> futureByBroker = new HashMap<>();
+    Map<String, DescribeLogDirsResponse.LogDirInfo> logdirInfoBylogdir =  new HashMap<>();
+    Map<TopicPartition, DescribeLogDirsResponse.ReplicaInfo> replicaInfoByPartition = new HashMap<>();
+    replicaInfoByPartition.put(T0P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
+    replicaInfoByPartition.put(T0P1, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
+    replicaInfoByPartition.put(T1P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
+    replicaInfoByPartition.put(T1P1, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
+    logdirInfoBylogdir.put("/tmp/kafka-logs", new DescribeLogDirsResponse.LogDirInfo(Errors.NONE, replicaInfoByPartition));
+    futureByBroker.put(0, completedFuture(logdirInfoBylogdir));
 
-      logdirInfoBylogdir =  new HashMap<>();
-      replicaInfoByPartition = new HashMap<>();
-      replicaInfoByPartition.put(T0P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-      replicaInfoByPartition.put(T0P1, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-      replicaInfoByPartition.put(T1P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-      logdirInfoBylogdir.put("/tmp/kafka-logs-1", new DescribeLogDirsResponse.LogDirInfo(Errors.NONE, replicaInfoByPartition));
-      logdirInfoBylogdir.put("/tmp/kafka-logs-2",
-                             new DescribeLogDirsResponse.LogDirInfo(Errors.NONE,
-                                                                    Collections.singletonMap(T1P1,
-                                                                                             new DescribeLogDirsResponse.ReplicaInfo(0, 0, false))));
-      futureByBroker.put(1, completedFuture(logdirInfoBylogdir));
-      return constructor.newInstance(futureByBroker);
-    } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-      // Let it go.
-    }
-    return null;
+    logdirInfoBylogdir =  new HashMap<>();
+    replicaInfoByPartition = new HashMap<>();
+    replicaInfoByPartition.put(T0P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
+    replicaInfoByPartition.put(T0P1, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
+    replicaInfoByPartition.put(T1P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
+    logdirInfoBylogdir.put("/tmp/kafka-logs-1", new DescribeLogDirsResponse.LogDirInfo(Errors.NONE, replicaInfoByPartition));
+    logdirInfoBylogdir.put("/tmp/kafka-logs-2",
+            new DescribeLogDirsResponse.LogDirInfo(Errors.NONE,
+                    Collections.singletonMap(T1P1,
+                            new DescribeLogDirsResponse.ReplicaInfo(0, 0, false))));
+    futureByBroker.put(1, completedFuture(logdirInfoBylogdir));
+    return futureByBroker;
   }
 
   private static class TestContext {


### PR DESCRIPTION
This PR resolves #1479.

* Makes other minor updates in readme (e.g. Kafka scale at LinkedIn)
* Cherrypicks `LoadMonitorTest` changes from https://github.com/linkedin/cruise-control/pull/1471 for consistency across branches