### PR TITLE
Add a sensor to indicate if the cluster has partitions with RF > the number of eligible racks

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorManager.java
@@ -197,6 +197,9 @@ public class AnomalyDetectorManager {
                                                             String.format("num-%s-metric-anomalies", type.toString().toLowerCase())),
                                         (Gauge<Integer>) () -> _metricAnomalyDetector.numAnomaliesOfType(type));
     }
+    // The cluster has partitions with RF > the number of eligible racks (0: No such partitions, 1: Has such partitions)
+    dropwizardMetricRegistry.register(MetricRegistry.name(METRIC_REGISTRY_NAME, "has-partitions-with-replication-factor-greater-than-num-racks"),
+                                      (Gauge<Integer>) () -> _goalViolationDetector.hasPartitionsWithRFGreaterThanNumRacks() ? 1 : 0);
   }
 
   private void scheduleDetectorAtFixedRate(KafkaAnomalyType anomalyType, Runnable anomalyDetector) {

--- a/docs/wiki/User Guide/Sensors.md
+++ b/docs/wiki/User Guide/Sensors.md
@@ -55,29 +55,30 @@ Cruise Control metrics are useful to monitor the state of Cruise Control itself.
 
 ### AnomalyDetector Sensors
 
-| DESCRIPTION                                                                                               | MBEAN NAME                                        				            |
-|-----------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| The number of self healing started                                                                        | kafka.cruisecontrol:name=AnomalyDetector.number-of-self-healing-started       |
-| The ongoing anomaly duration in ms                                                                        | kafka.cruisecontrol:name=AnomalyDetector.ongoing-anomaly-duration-ms          |
-| Whether broker failure self-healing is enabled or not                                                     | kafka.cruisecontrol:name=AnomalyDetector.broker_failure-self-healing-enabled  |
-| Whether goal violation self-healing is enabled or not                                                     | kafka.cruisecontrol:name=AnomalyDetector.goal_violation-self-healing-enabled  |
-| Whether disk failure self-healing is enabled or not                                                       | kafka.cruisecontrol:name=AnomalyDetector.disk_failure-self-healing-enabled    |
-| Whether metric anomaly self-healing is enabled or not                                                     | kafka.cruisecontrol:name=AnomalyDetector.metric_anomaly-self-healing-enabled  |
-| Whether topic anomaly self-healing is enabled or not                                                      | kafka.cruisecontrol:name=AnomalyDetector.topic_anomaly-self-healing-enabled   |
-| Whether goal violation detector identified goals that require human intervention (e.g. cluster expansion) | kafka.cruisecontrol:name=AnomalyDetector.GOAL_VIOLATION-has-unfixable-goals   |
-| Balancedness score (100 = fully-balanced, 0 = fully-unbalanced, -1 = has dead-brokers / disks in cluster) | kafka.cruisecontrol:name=AnomalyDetector.balancedness-score                   |
-| Whether the cluster is under-provisioned or not                                                           | kafka.cruisecontrol:name=AnomalyDetector.under-provisioned                    |
-| Whether the cluster is over-provisioned or not                                                            | kafka.cruisecontrol:name=AnomalyDetector.over-provisioned                     |
-| Whether the cluster is right-sized or not                                                                 | kafka.cruisecontrol:name=AnomalyDetector.right-sized                          |
-| Mean time to start a self-healing fix                                                                     | kafka.cruisecontrol:name=AnomalyDetector.mean-time-to-start-fix-ms            |
-| Broker failure rate                                                                                       | kafka.cruisecontrol:name=AnomalyDetector.broker-failure-rate                  |
-| Goal violation rate                                                                                       | kafka.cruisecontrol:name=AnomalyDetector.goal-violation-rate                  |
-| Metric anomaly rate                                                                                       | kafka.cruisecontrol:name=AnomalyDetector.metric-anomaly-rate                  |
-| Disk failure rate                                                                                         | kafka.cruisecontrol:name=AnomalyDetector.disk-failure-rate                    |
-| Topic anomaly rate                                                                                        | kafka.cruisecontrol:name=AnomalyDetector.topic-anomaly-rate                   |
-| The number of brokers that are metric anomaly suspects, pending more evidence to conclude either way      | kafka.cruisecontrol:name=AnomalyDetector.num-suspect-metric-anomalies         |
-| The number of brokers that have recently been identified with a metric anomaly                            | kafka.cruisecontrol:name=AnomalyDetector.num-recent-metric-anomalies          |
-| The number of brokers that continue to be identified with a metric anomaly for a prolonged period         | kafka.cruisecontrol:name=AnomalyDetector.num-persistent-metric-anomalies      |
+| DESCRIPTION                                                                                                       | MBEAN NAME                                        				                                        |
+|-------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| The number of self healing started                                                                                | kafka.cruisecontrol:name=AnomalyDetector.number-of-self-healing-started                                   |
+| The ongoing anomaly duration in ms                                                                                | kafka.cruisecontrol:name=AnomalyDetector.ongoing-anomaly-duration-ms                                      |
+| Whether broker failure self-healing is enabled or not                                                             | kafka.cruisecontrol:name=AnomalyDetector.broker_failure-self-healing-enabled                              |
+| Whether goal violation self-healing is enabled or not                                                             | kafka.cruisecontrol:name=AnomalyDetector.goal_violation-self-healing-enabled                              |
+| Whether disk failure self-healing is enabled or not                                                               | kafka.cruisecontrol:name=AnomalyDetector.disk_failure-self-healing-enabled                                |
+| Whether metric anomaly self-healing is enabled or not                                                             | kafka.cruisecontrol:name=AnomalyDetector.metric_anomaly-self-healing-enabled                              |
+| Whether topic anomaly self-healing is enabled or not                                                              | kafka.cruisecontrol:name=AnomalyDetector.topic_anomaly-self-healing-enabled                               |
+| Whether goal violation detector identified goals that require human intervention (e.g. cluster expansion)         | kafka.cruisecontrol:name=AnomalyDetector.GOAL_VIOLATION-has-unfixable-goals                               |
+| Balancedness score (100 = fully-balanced, 0 = fully-unbalanced, -1 = has dead-brokers / disks in cluster)         | kafka.cruisecontrol:name=AnomalyDetector.balancedness-score                                               |
+| Whether the cluster is under-provisioned or not                                                                   | kafka.cruisecontrol:name=AnomalyDetector.under-provisioned                                                |
+| Whether the cluster is over-provisioned or not                                                                    | kafka.cruisecontrol:name=AnomalyDetector.over-provisioned                                                 |
+| Whether the cluster is right-sized or not                                                                         | kafka.cruisecontrol:name=AnomalyDetector.right-sized                                                      |
+| Mean time to start a self-healing fix                                                                             | kafka.cruisecontrol:name=AnomalyDetector.mean-time-to-start-fix-ms                                        |
+| Broker failure rate                                                                                               | kafka.cruisecontrol:name=AnomalyDetector.broker-failure-rate                                              |
+| Goal violation rate                                                                                               | kafka.cruisecontrol:name=AnomalyDetector.goal-violation-rate                                              |
+| Metric anomaly rate                                                                                               | kafka.cruisecontrol:name=AnomalyDetector.metric-anomaly-rate                                              |
+| Disk failure rate                                                                                                 | kafka.cruisecontrol:name=AnomalyDetector.disk-failure-rate                                                |
+| Topic anomaly rate                                                                                                | kafka.cruisecontrol:name=AnomalyDetector.topic-anomaly-rate                                               |
+| The number of brokers that are metric anomaly suspects, pending more evidence to conclude either way              | kafka.cruisecontrol:name=AnomalyDetector.num-suspect-metric-anomalies                                     |
+| The number of brokers that have recently been identified with a metric anomaly                                    | kafka.cruisecontrol:name=AnomalyDetector.num-recent-metric-anomalies                                      |
+| The number of brokers that continue to be identified with a metric anomaly for a prolonged period                 | kafka.cruisecontrol:name=AnomalyDetector.num-persistent-metric-anomalies                                  |
+| The cluster has partitions with RF > the number of eligible racks (0: No such partitions, 1: Has such partitions) | kafka.cruisecontrol:name=AnomalyDetector.has-partitions-with-replication-factor-greater-than-num-racks    |
 
 ### GoalOptimizer Sensors
 


### PR DESCRIPTION
This PR resolves #1365.

Relevant Notes
* An _eligible_ rack is an alive rack that is allowed replica moves. A rack is alive and allowed replica moves as long as it has at least one alive host, which is not excluded for replica moves. A host is alive and allowed replica moves if it has at least one alive broker, which is not excluded for replica moves.
* An ongoing execution may modify the replication factor of partitions; hence, the detector avoids reporting potential false positives.
* The sensor is configured to be refreshed once in every `goal.violation.detection.interval.ms`; hence, it could be temporarily stale at most as long as this interval if during this time
    (1) new topics would be created with a replication factor > number of eligible racks in a cluster for the first time, or
    (2) the replication factor of existing topics are changed in either direction.
* Making this check based on cluster model rather than raw cluster metadata enables CC to (1) have fewer false positives by making sure that there are no ongoing executions, (2) take "rack exclusion" into account -- e.g. if a rack contains only excluded brokers (e.g. preferred controllers or brokers under-maintenance), then it is not an eligible rack, and (3) has negligible overhead compared to parsing raw cluster metadata to compute maximum replication factor and rack count.