### PR TITLE
Fix error message for missing disk information

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -840,7 +840,7 @@ public class ClusterModel implements Serializable {
           if (isOffline) {
             disk = broker.addDeadDisk(logdir);
           } else {
-            throw new IllegalStateException("Missing disk information for disk " + logdir + " on broker " + this);
+            throw new IllegalStateException("Missing disk information for disk " + logdir + " on broker " + broker);
           }
         }
       }


### PR DESCRIPTION
Before this commit, we'd print an error message that looks something like `java.lang.IllegalStateException: Missing disk information for disk /mnt/disk1/kafka on broker ClusterModel[brokerCount=15,partitionCount=0,aliveBrokerCount=15]`. This seems a bit odd, since `ClusterModel` is not a broker.

After this commit, we'll instead print something more like `java.lang.IllegalStateException: Missing disk information for disk /mnt/disk1/kafka on broker Broker[id=1052,rack=kafka1052.us-e.ec2.liftoff.io,state=ALIVE,replicaCount=0,logdirs=[/mnt/disk0, /mnt/disk1, /mnt/disk10, /mnt/disk11, /mnt/disk12, /mnt/disk13, /mnt/disk14, /mnt/disk15, /mnt/disk16, /mnt/disk17, /mnt/disk18, /mnt/disk19, /mnt/disk2, /mnt/disk20, /mnt/disk21, /mnt/disk22, /mnt/disk23, /mnt/disk3, /mnt/disk4, /mnt/disk5, /mnt/disk6, /mnt/disk7, /mnt/disk8, /mnt/disk9]]`. It's a bit more verbose, but very helpful. (See how `/mnt/disk1/kafka` isn't in that list of logdirs, just `/mnt/disk1`?)

This PR resolves #1519.