### PR TITLE
Stop deploying builds from Artifactory to Bintray

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "build.gradle" }}
       - run:
-          command: ./gradlew distributeBuild
+          command: ./gradlew :artifactoryPublish :cruise-control:artifactoryPublish :cruise-control-core:artifactoryPublish :cruise-control-metrics-reporter:artifactoryPublish
 
 workflows:
   version: 2


### PR DESCRIPTION
This PR is relevant to #1493.

Cruise Control artifacts (along with artifacts of other open source LinkedIn projects) have always been published to public [LinkedIn JFrog](https://linkedin.jfrog.io/). In addition to deployed artifacts in JFrog, CC has been distributing these artifacts from JFrog to Bintray.

Since `Bintray` will be shutdown in May 1st (see [link](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)), CC should stop distributing artifacts to Bintray.