### PR TITLE
Consolidate the stop script to avoid stopping the kafka service

### DIFF
--- a/kafka-cruise-control-stop.sh
+++ b/kafka-cruise-control-stop.sh
@@ -3,7 +3,7 @@
 # See License in the project root for license information.
 
 SIGNAL=${SIGNAL:-TERM}
-PIDS=$(ps ax | grep -i 'cruise-control' | grep java | grep -v grep | awk '{print $1}')
+PIDS=$(ps ax | grep -i 'KafkaCruiseControlMain' | grep java | grep -v grep | awk '{print $1}')
 
 if [ -z "$PIDS" ]; then
   echo "No cruise-control to stop"

--- a/kafka-cruise-control-stop.sh
+++ b/kafka-cruise-control-stop.sh
@@ -3,7 +3,7 @@
 # See License in the project root for license information.
 
 SIGNAL=${SIGNAL:-TERM}
-PIDS=$(ps ax | grep -i 'KafkaCruiseControlMain' | grep java | grep -v grep | awk '{print $1}')
+PIDS=$(ps ax | grep 'java.*KafkaCruiseControlMain' | grep -v grep | awk '{print $1}')
 
 if [ -z "$PIDS" ]; then
   echo "No cruise-control to stop"


### PR DESCRIPTION
This PR resolves [1531](https://github.com/linkedin/cruise-control/issues/1531).

For cruise control, we should use the main class to filter the process id in the stop step, so as to avoid accidentally killing other processes that rely on cruise control.