### PR TITLE
Fix the problem that the lack of available brokers causes the cc startup to fail

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -155,13 +155,15 @@ public class KafkaCruiseControlUtils {
    */
   public static boolean createTopic(AdminClient adminClient, NewTopic topicToBeCreated) {
     try {
+      Set<String> allTopics = adminClient.listTopics().names().get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      if (allTopics.contains(topicToBeCreated.name())) {
+        LOG.info("Topic {} has already been created.", topicToBeCreated.name());
+        return false;
+      }
       CreateTopicsResult createTopicsResult = adminClient.createTopics(Collections.singletonList(topicToBeCreated));
       createTopicsResult.values().get(topicToBeCreated.name()).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
       LOG.info("Topic {} has been created.", topicToBeCreated.name());
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      if (e.getCause() instanceof TopicExistsException) {
-        return false;
-      }
       throw new IllegalStateException(String.format("Unable to create topic %s.", topicToBeCreated.name()), e);
     }
     return true;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -43,7 +43,6 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.errors.ReassignmentInProgressException;
-import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.AbstractResponse;

--- a/kafka-cruise-control-stop.sh
+++ b/kafka-cruise-control-stop.sh
@@ -3,7 +3,7 @@
 # See License in the project root for license information.
 
 SIGNAL=${SIGNAL:-TERM}
-PIDS=$(ps ax | grep -i 'cruise-control' | grep java | grep -v grep | awk '{print $1}')
+PIDS=$(ps ax | grep -i 'KafkaCruiseControlMain' | grep java | grep -v grep | awk '{print $1}')
 
 if [ -z "$PIDS" ]; then
   echo "No cruise-control to stop"

--- a/kafka-cruise-control-stop.sh
+++ b/kafka-cruise-control-stop.sh
@@ -3,7 +3,7 @@
 # See License in the project root for license information.
 
 SIGNAL=${SIGNAL:-TERM}
-PIDS=$(ps ax | grep -i 'KafkaCruiseControlMain' | grep java | grep -v grep | awk '{print $1}')
+PIDS=$(ps ax | grep 'java.*KafkaCruiseControlMain' | grep -v grep | awk '{print $1}')
 
 if [ -z "$PIDS" ]; then
   echo "No cruise-control to stop"


### PR DESCRIPTION
This PR resolves [1535](https://github.com/linkedin/cruise-control/issues/1535).

When creating a sample topic, we should first determine whether the topic exists, otherwise the error reported by [1535](https://github.com/linkedin/cruise-control/issues/1535) will occur.
