### PR TITLE
Add support to dynamically enable/disable minIsr-based concurrency adjustment

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -411,6 +411,16 @@ public class KafkaCruiseControl {
   }
 
   /**
+   * Enable or disable (At/Under)MinISR-based concurrency adjustment.
+   *
+   * @param isMinIsrBasedConcurrencyAdjustmentEnabled {@code true} to enable (At/Under)MinISR-based concurrency adjustment, {@code false} otherwise.
+   * @return {@code true} if (At/Under)MinISR-based concurrency adjustment was enabled before, {@code false} otherwise.
+   */
+  public boolean setConcurrencyAdjusterMinIsrCheck(boolean isMinIsrBasedConcurrencyAdjustmentEnabled) {
+    return _executor.setConcurrencyAdjusterMinIsrCheck(isMinIsrBasedConcurrencyAdjustmentEnabled);
+  }
+
+  /**
    * Drop the given brokers from the recently removed/demoted brokers.
    *
    * @param brokersToDrop Brokers to drop from the recently removed or demoted brokers.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -119,7 +119,7 @@ public class Executor {
   private final ConcurrencyAdjuster _concurrencyAdjuster;
   private final ScheduledExecutorService _concurrencyAdjusterExecutor;
   private final ConcurrentMap<ConcurrencyType, Boolean> _concurrencyAdjusterEnabled;
-  private final boolean _concurrencyAdjusterMinIsrCheckEnabled;
+  private volatile boolean _concurrencyAdjusterMinIsrCheckEnabled;
   private final TopicMinIsrCache _topicMinIsrCache;
   private final long _minExecutionProgressCheckIntervalMs;
   public final long _slowTaskAlertingBackoffTimeMs;
@@ -517,6 +517,18 @@ public class Executor {
       throw new IllegalArgumentException(String.format("Concurrency adjuster for %s is not yet supported.", concurrencyType));
     }
     return _concurrencyAdjusterEnabled.put(concurrencyType, isConcurrencyAdjusterEnabled);
+  }
+
+  /**
+   * Enable or disable (At/Under)MinISR-based concurrency adjustment.
+   *
+   * @param isMinIsrBasedConcurrencyAdjustmentEnabled {@code true} to enable (At/Under)MinISR-based concurrency adjustment, {@code false} otherwise.
+   * @return {@code true} if (At/Under)MinISR-based concurrency adjustment was enabled before, {@code false} otherwise.
+   */
+  public boolean setConcurrencyAdjusterMinIsrCheck(boolean isMinIsrBasedConcurrencyAdjustmentEnabled) {
+    boolean oldValue = _concurrencyAdjusterMinIsrCheckEnabled;
+    _concurrencyAdjusterMinIsrCheckEnabled = isMinIsrBasedConcurrencyAdjustmentEnabled;
+    return oldValue;
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AbstractParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AbstractParameters.java
@@ -103,8 +103,8 @@ public abstract class AbstractParameters implements CruiseControlParameters {
   @Override
   public void configure(Map<String, ?> configs) {
     _request = (HttpServletRequest) validateNotNull(configs.get(KAFKA_CRUISE_CONTROL_HTTP_SERVLET_REQUEST_OBJECT_CONFIG),
-            "HttpServletRequest configuration is missing from the request.");
+                                                    "HttpServletRequest configuration is missing from the request.");
     _config = (KafkaCruiseControlConfig) validateNotNull(configs.get(KAFKA_CRUISE_CONTROL_CONFIG_OBJECT_CONFIG),
-            "KafkaCruiseControlConfig configuration is missing from the request.");
+                                                         "KafkaCruiseControlConfig configuration is missing from the request.");
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AdminParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/AdminParameters.java
@@ -37,6 +37,7 @@ import static com.linkedin.kafka.cruisecontrol.servlet.parameters.UpdateSelfHeal
  *    &amp;execution_progress_check_interval_ms=[interval_in_ms]&amp;get_response_schema=[true/false]
  *    &amp;disable_concurrency_adjuster_for=[Set-of-{@link com.linkedin.kafka.cruisecontrol.executor.ConcurrencyType}]
  *    &amp;enable_concurrency_adjuster_for=[Set-of-{@link com.linkedin.kafka.cruisecontrol.executor.ConcurrencyType}]
+ *    &amp;min_isr_based_concurrency_adjustment=[true/false]
  * </pre>
  */
 public class AdminParameters extends AbstractParameters {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
@@ -116,6 +116,7 @@ public class ParameterUtils {
   public static final String ENABLE_SELF_HEALING_FOR_PARAM = "enable_self_healing_for";
   public static final String DISABLE_CONCURRENCY_ADJUSTER_FOR_PARAM = "disable_concurrency_adjuster_for";
   public static final String ENABLE_CONCURRENCY_ADJUSTER_FOR_PARAM = "enable_concurrency_adjuster_for";
+  public static final String MIN_ISR_BASED_CONCURRENCY_ADJUSTMENT_PARAM = "min_isr_based_concurrency_adjustment";
   public static final String EXCLUDE_RECENTLY_DEMOTED_BROKERS_PARAM = "exclude_recently_demoted_brokers";
   public static final String EXCLUDE_RECENTLY_REMOVED_BROKERS_PARAM = "exclude_recently_removed_brokers";
   public static final String REPLICA_MOVEMENT_STRATEGIES_PARAM = "replica_movement_strategies";
@@ -662,6 +663,18 @@ public class ParameterUtils {
     concurrencyAdjusterFor.put(false, disableConcurrencyAdjusterFor);
 
     return concurrencyAdjusterFor;
+  }
+
+  /**
+   * @param request The http request.
+   * @return {@code true}: enable or {@code false} disable MinISR-based concurrency adjustment, {@code null} if the request parameter is unset.
+   */
+  @Nullable static Boolean minIsrBasedConcurrencyAdjustment(HttpServletRequest request) {
+    String parameterString = caseSensitiveParameterName(request.getParameterMap(), MIN_ISR_BASED_CONCURRENCY_ADJUSTMENT_PARAM);
+    if (parameterString == null) {
+      return null;
+    }
+    return Boolean.parseBoolean(request.getParameter(parameterString));
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
@@ -667,7 +667,7 @@ public class ParameterUtils {
 
   /**
    * @param request The http request.
-   * @return {@code true}: enable or {@code false} disable MinISR-based concurrency adjustment, {@code null} if the request parameter is unset.
+   * @return {@code true}: enable or {@code false}: disable MinISR-based concurrency adjustment, {@code null} if the request parameter is unset.
    */
   @Nullable static Boolean minIsrBasedConcurrencyAdjustment(HttpServletRequest request) {
     String parameterString = caseSensitiveParameterName(request.getParameterMap(), MIN_ISR_BASED_CONCURRENCY_ADJUSTMENT_PARAM);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/UpdateConcurrencyAdjusterParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/UpdateConcurrencyAdjusterParameters.java
@@ -15,6 +15,7 @@ import java.util.TreeSet;
 
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.DISABLE_CONCURRENCY_ADJUSTER_FOR_PARAM;
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.ENABLE_CONCURRENCY_ADJUSTER_FOR_PARAM;
+import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.MIN_ISR_BASED_CONCURRENCY_ADJUSTMENT_PARAM;
 
 
 /**
@@ -27,11 +28,13 @@ public class UpdateConcurrencyAdjusterParameters extends AbstractParameters {
     SortedSet<String> validParameterNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     validParameterNames.add(DISABLE_CONCURRENCY_ADJUSTER_FOR_PARAM);
     validParameterNames.add(ENABLE_CONCURRENCY_ADJUSTER_FOR_PARAM);
+    validParameterNames.add(MIN_ISR_BASED_CONCURRENCY_ADJUSTMENT_PARAM);
     validParameterNames.addAll(AbstractParameters.CASE_INSENSITIVE_PARAMETER_NAMES);
     CASE_INSENSITIVE_PARAMETER_NAMES = Collections.unmodifiableSortedSet(validParameterNames);
   }
   protected Set<ConcurrencyType> _disableConcurrencyAdjusterFor;
   protected Set<ConcurrencyType> _enableConcurrencyAdjusterFor;
+  protected Boolean _minIsrBasedConcurrencyAdjustment;
 
   protected UpdateConcurrencyAdjusterParameters() {
     super();
@@ -43,6 +46,7 @@ public class UpdateConcurrencyAdjusterParameters extends AbstractParameters {
     Map<Boolean, Set<ConcurrencyType>> concurrencyAdjusterFor = ParameterUtils.concurrencyAdjusterFor(_request);
     _enableConcurrencyAdjusterFor = concurrencyAdjusterFor.get(true);
     _disableConcurrencyAdjusterFor = concurrencyAdjusterFor.get(false);
+    _minIsrBasedConcurrencyAdjustment = ParameterUtils.minIsrBasedConcurrencyAdjustment(_request);
   }
 
   /**
@@ -57,9 +61,10 @@ public class UpdateConcurrencyAdjusterParameters extends AbstractParameters {
     UpdateConcurrencyAdjusterParameters updateConcurrencyAdjusterParameters = new UpdateConcurrencyAdjusterParameters();
     updateConcurrencyAdjusterParameters.configure(configs);
     updateConcurrencyAdjusterParameters.initParameters();
-    // If no concurrency adjuster is enabled/disabled in the request, return null.
+    // If no concurrency adjuster is enabled/disabled in the request and there is no MinISR-based concurrency adjustment, return null.
     if (updateConcurrencyAdjusterParameters.enableConcurrencyAdjusterFor().isEmpty()
-        && updateConcurrencyAdjusterParameters.disableConcurrencyAdjusterFor().isEmpty()) {
+        && updateConcurrencyAdjusterParameters.disableConcurrencyAdjusterFor().isEmpty()
+        && updateConcurrencyAdjusterParameters.minIsrBasedConcurrencyAdjustment() == null) {
       return null;
     }
     return updateConcurrencyAdjusterParameters;
@@ -71,6 +76,10 @@ public class UpdateConcurrencyAdjusterParameters extends AbstractParameters {
 
   public Set<ConcurrencyType> enableConcurrencyAdjusterFor() {
     return _enableConcurrencyAdjusterFor;
+  }
+
+  public Boolean minIsrBasedConcurrencyAdjustment() {
+    return _minIsrBasedConcurrencyAdjustment;
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/AdminResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/AdminResult.java
@@ -29,12 +29,15 @@ public class AdminResult extends AbstractCruiseControlResponse {
   protected static final String CONCURRENCY_ADJUSTER_ENABLED_BEFORE = "concurrencyAdjusterEnabledBefore";
   @JsonResponseField(required = false)
   protected static final String CONCURRENCY_ADJUSTER_ENABLED_AFTER = "concurrencyAdjusterEnabledAfter";
+  @JsonResponseField(required = false)
+  protected static final String MIN_ISR_BASED_CONCURRENCY_ADJUSTMENT_REQUEST = "minIsrBasedConcurrencyAdjustmentRequest";
   protected final Map<AnomalyType, Boolean> _selfHealingEnabledBefore;
   protected final Map<AnomalyType, Boolean> _selfHealingEnabledAfter;
   protected String _ongoingConcurrencyChangeRequest;
   protected String _dropRecentBrokersRequest;
   protected final Map<ConcurrencyType, Boolean> _concurrencyAdjusterEnabledBefore;
   protected final Map<ConcurrencyType, Boolean> _concurrencyAdjusterEnabledAfter;
+  protected String _minIsrBasedConcurrencyAdjustmentRequest;
 
   public AdminResult(Map<AnomalyType, Boolean> selfHealingEnabledBefore,
                      Map<AnomalyType, Boolean> selfHealingEnabledAfter,
@@ -42,6 +45,7 @@ public class AdminResult extends AbstractCruiseControlResponse {
                      String dropRecentBrokersRequest,
                      Map<ConcurrencyType, Boolean> concurrencyAdjusterEnabledBefore,
                      Map<ConcurrencyType, Boolean> concurrencyAdjusterEnabledAfter,
+                     String minIsrBasedConcurrencyAdjustmentRequest,
                      KafkaCruiseControlConfig config) {
     super(config);
     _selfHealingEnabledBefore = selfHealingEnabledBefore;
@@ -50,6 +54,7 @@ public class AdminResult extends AbstractCruiseControlResponse {
     _dropRecentBrokersRequest = dropRecentBrokersRequest;
     _concurrencyAdjusterEnabledBefore = concurrencyAdjusterEnabledBefore;
     _concurrencyAdjusterEnabledAfter = concurrencyAdjusterEnabledAfter;
+    _minIsrBasedConcurrencyAdjustmentRequest = minIsrBasedConcurrencyAdjustmentRequest;
   }
 
   @Override
@@ -63,11 +68,12 @@ public class AdminResult extends AbstractCruiseControlResponse {
     _dropRecentBrokersRequest = null;
     _concurrencyAdjusterEnabledBefore.clear();
     _concurrencyAdjusterEnabledAfter.clear();
+    _minIsrBasedConcurrencyAdjustmentRequest = null;
   }
 
   protected String getJSONString() {
     // Set initial capacity to max possible capacity to avoid rehashing.
-    Map<String, Object> jsonStructure = new HashMap<>(7);
+    Map<String, Object> jsonStructure = new HashMap<>(8);
     if (!_selfHealingEnabledBefore.isEmpty()) {
       jsonStructure.put(SELF_HEALING_ENABLED_BEFORE, _selfHealingEnabledBefore);
       jsonStructure.put(SELF_HEALING_ENABLED_AFTER, _selfHealingEnabledAfter);
@@ -81,6 +87,9 @@ public class AdminResult extends AbstractCruiseControlResponse {
     if (!_concurrencyAdjusterEnabledBefore.isEmpty()) {
       jsonStructure.put(CONCURRENCY_ADJUSTER_ENABLED_BEFORE, _concurrencyAdjusterEnabledBefore);
       jsonStructure.put(CONCURRENCY_ADJUSTER_ENABLED_AFTER, _concurrencyAdjusterEnabledAfter);
+    }
+    if (_minIsrBasedConcurrencyAdjustmentRequest != null && !_minIsrBasedConcurrencyAdjustmentRequest.isEmpty()) {
+      jsonStructure.put(MIN_ISR_BASED_CONCURRENCY_ADJUSTMENT_REQUEST, _minIsrBasedConcurrencyAdjustmentRequest);
     }
     jsonStructure.put(VERSION, JSON_VERSION);
     return new Gson().toJson(jsonStructure);
@@ -102,6 +111,9 @@ public class AdminResult extends AbstractCruiseControlResponse {
     if (!_concurrencyAdjusterEnabledBefore.isEmpty()) {
       sb.append(String.format("%s: %s, %s: %s%n", CONCURRENCY_ADJUSTER_ENABLED_BEFORE, _concurrencyAdjusterEnabledBefore,
                               CONCURRENCY_ADJUSTER_ENABLED_AFTER, _concurrencyAdjusterEnabledAfter));
+    }
+    if (_minIsrBasedConcurrencyAdjustmentRequest != null && !_minIsrBasedConcurrencyAdjustmentRequest.isEmpty()) {
+      sb.append(String.format("%s: %s%n", MIN_ISR_BASED_CONCURRENCY_ADJUSTMENT_REQUEST, _minIsrBasedConcurrencyAdjustmentRequest));
     }
     sb.append("}");
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtilsTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtilsTest.java
@@ -58,6 +58,35 @@ public class ParameterUtilsTest {
   }
 
   @Test
+  public void testMinIsrBasedConcurrencyAdjustment() {
+    String firstResponse = Boolean.TRUE.toString();
+    String secondResponse = Boolean.FALSE.toString();
+
+    // Mock for (1) default response (2) response for valid input with true/false.
+    HttpServletRequest mockRequest = EasyMock.mock(HttpServletRequest.class);
+    EasyMock.expect(mockRequest.getParameterMap()).andReturn(Collections.emptyMap())
+            .andReturn(Collections.singletonMap(ParameterUtils.MIN_ISR_BASED_CONCURRENCY_ADJUSTMENT_PARAM, new String[]{firstResponse}))
+            .andReturn(Collections.singletonMap(ParameterUtils.MIN_ISR_BASED_CONCURRENCY_ADJUSTMENT_PARAM, new String[]{secondResponse}));
+    EasyMock.expect(mockRequest.getParameter(ParameterUtils.MIN_ISR_BASED_CONCURRENCY_ADJUSTMENT_PARAM))
+            .andReturn(firstResponse).andReturn(secondResponse);
+
+    // Verify default response.
+    EasyMock.replay(mockRequest);
+    Boolean minIsrBasedConcurrencyAdjustment = ParameterUtils.minIsrBasedConcurrencyAdjustment(mockRequest);
+    Assert.assertNull(minIsrBasedConcurrencyAdjustment);
+
+    // Verify response for valid input.
+    minIsrBasedConcurrencyAdjustment = ParameterUtils.minIsrBasedConcurrencyAdjustment(mockRequest);
+    Assert.assertNotNull(minIsrBasedConcurrencyAdjustment);
+    Assert.assertTrue(minIsrBasedConcurrencyAdjustment);
+    minIsrBasedConcurrencyAdjustment = ParameterUtils.minIsrBasedConcurrencyAdjustment(mockRequest);
+    Assert.assertNotNull(minIsrBasedConcurrencyAdjustment);
+    Assert.assertFalse(minIsrBasedConcurrencyAdjustment);
+
+    EasyMock.verify(mockRequest);
+  }
+
+  @Test
   public void testParseTimeRangeNotSet() {
     HttpServletRequest mockRequest = EasyMock.mock(HttpServletRequest.class);
     // Mock the request so that it does not contain start/end time

--- a/cruise-control/src/yaml/endpoints/addBroker.yaml
+++ b/cruise-control/src/yaml/endpoints/addBroker.yaml
@@ -132,7 +132,7 @@ AddBrokerEndpoint:
           type: string
       - name: review_id
         in: query
-        description: Review id for 2FA.
+        description: Review id for 2-step verification.
         schema:
           type: integer
           format: int32
@@ -152,7 +152,7 @@ AddBrokerEndpoint:
           minimum: 1
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/admin.yaml
+++ b/cruise-control/src/yaml/endpoints/admin.yaml
@@ -80,7 +80,7 @@ AdminEndpoint:
           minimum: 5000
       - name: review_id
         in: query
-        description: Review id for 2FA
+        description: Review id for 2-step verification.
         schema:
           type: integer
           format: int32
@@ -93,7 +93,7 @@ AdminEndpoint:
           default: false
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false
@@ -104,7 +104,7 @@ AdminEndpoint:
           type: string
       - name: disable_concurrency_adjuster_for
         in: query
-        description: Disable concurrency adjuster for certain concurrency types.
+        description: Disable concurrency adjuster for given concurrency types.
         schema:
           type: array
           items:
@@ -116,7 +116,7 @@ AdminEndpoint:
           example: ["INTER_BROKER_REPLICA"]
       - name: enable_concurrency_adjuster_for
         in: query
-        description: Enable concurrency adjuster for certain concurrency types.
+        description: Enable concurrency adjuster for given concurrency types.
         schema:
           type: array
           items:
@@ -126,6 +126,11 @@ AdminEndpoint:
               - LEADERSHIP
               - INTRA_BROKER_REPLICA
           example: ["INTER_BROKER_REPLICA"]
+      - name: min_isr_based_concurrency_adjustment
+        in: query
+        description: Whether to enable (true) or disable (false) MinISR-based concurrency adjustment
+        schema:
+          type: boolean
     responses:
       '200':
         description: Successful admin response.

--- a/cruise-control/src/yaml/endpoints/bootstrap.yaml
+++ b/cruise-control/src/yaml/endpoints/bootstrap.yaml
@@ -33,7 +33,7 @@ BootstrapEndpoint:
           default: false
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/demoteBroker.yaml
+++ b/cruise-control/src/yaml/endpoints/demoteBroker.yaml
@@ -108,14 +108,14 @@ DemoteBrokerEndpoint:
           default: false
       - name: review_id
         in: query
-        description: Review id for 2FA.
+        description: Review id for 2-step verification.
         schema:
           type: integer
           format: int32
           minimum: 0
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/fixOfflineReplicas.yaml
+++ b/cruise-control/src/yaml/endpoints/fixOfflineReplicas.yaml
@@ -96,7 +96,7 @@ FixOfflineReplicasEndpoint:
           example: ["PrioritizeLargeReplicaMovementStrategy", "PostponeUrpReplicaMovementStrategy"]
       - name: review_id
         in: query
-        description: Review id for 2FA
+        description: Review id for 2-step verification.
         schema:
           type: integer
           format: int32
@@ -129,7 +129,7 @@ FixOfflineReplicasEndpoint:
           default: false
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/kafkaClusterState.yaml
+++ b/cruise-control/src/yaml/endpoints/kafkaClusterState.yaml
@@ -24,7 +24,7 @@ KafkaClusterStateEndpoint:
           default: false
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/load.yaml
+++ b/cruise-control/src/yaml/endpoints/load.yaml
@@ -51,7 +51,7 @@ LoadEndpoint:
           default: false
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/partitionLoad.yaml
+++ b/cruise-control/src/yaml/endpoints/partitionLoad.yaml
@@ -104,7 +104,7 @@ PartitionLoadEndpoint:
           default: false
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/pauseSampling.yaml
+++ b/cruise-control/src/yaml/endpoints/pauseSampling.yaml
@@ -10,7 +10,7 @@ PauseSamplingEndpoint:
           type: string
       - name: review_id
         in: query
-        description: Review id for 2FA
+        description: Review id for 2-step verification.
         schema:
           type: integer
           format: int32
@@ -23,7 +23,7 @@ PauseSamplingEndpoint:
           default: false
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/proposals.yaml
+++ b/cruise-control/src/yaml/endpoints/proposals.yaml
@@ -93,7 +93,7 @@ ProposalsEndpoint:
           default: false
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/rebalance.yaml
+++ b/cruise-control/src/yaml/endpoints/rebalance.yaml
@@ -135,7 +135,7 @@ RebalanceEndpoint:
           default: false
       - name: review_id
         in: query
-        description: Review id for 2FA.
+        description: Review id for 2-step verification.
         schema:
           type: integer
           format: int32
@@ -162,7 +162,7 @@ RebalanceEndpoint:
         example: "Balance disk utilization across all brokers in the cluster."
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/removeBroker.yaml
+++ b/cruise-control/src/yaml/endpoints/removeBroker.yaml
@@ -140,7 +140,7 @@ RemoveBrokerEndpoint:
           type: string
       - name: review_id
         in: query
-        description: Review id for 2FA.
+        description: Review id for 2-step verification.
         schema:
           type: integer
           format: int32
@@ -160,7 +160,7 @@ RemoveBrokerEndpoint:
           minimum: 1
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/resumeSampling.yaml
+++ b/cruise-control/src/yaml/endpoints/resumeSampling.yaml
@@ -10,7 +10,7 @@ ResumeSamplingEndpoint:
           type: string
       - name: review_id
         in: query
-        description: Review id for 2FA.
+        description: Review id for 2-step verification.
         schema:
           type: integer
           format: int32
@@ -23,7 +23,7 @@ ResumeSamplingEndpoint:
           default: false
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/review.yaml
+++ b/cruise-control/src/yaml/endpoints/review.yaml
@@ -35,7 +35,7 @@ ReviewEndpoint:
           default: false
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/reviewBoard.yaml
+++ b/cruise-control/src/yaml/endpoints/reviewBoard.yaml
@@ -20,7 +20,7 @@ ReviewBoardEndpoint:
           default: false
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/state.yaml
+++ b/cruise-control/src/yaml/endpoints/state.yaml
@@ -19,6 +19,7 @@ StateEndpoint:
         description: Whether to return in JSON format or not.
         schema:
           type: boolean
+          default: false
       - name: verbose
         in: query
         description: Return detailed state information.
@@ -33,7 +34,7 @@ StateEndpoint:
           default: false
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/stopProposalExecution.yaml
+++ b/cruise-control/src/yaml/endpoints/stopProposalExecution.yaml
@@ -12,7 +12,7 @@ StopProposalExecutionEndpoint:
           default: false
       - name: review_id
         in: query
-        description: Review id for 2FA.
+        description: Review id for 2-step verification.
         schema:
           type: integer
           format: int32
@@ -22,10 +22,10 @@ StopProposalExecutionEndpoint:
         description: Whether to return in JSON format or not.
         schema:
           type: boolean
-          default: true
+          default: false
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/topicConfiguration.yaml
+++ b/cruise-control/src/yaml/endpoints/topicConfiguration.yaml
@@ -117,7 +117,7 @@ TopicConfigurationEndpoint:
           default: false
       - name: review_id
         in: query
-        description: Review id for 2FA.
+        description: Review id for 2-step verification.
         schema:
           type: string
       - name: skip_rack_awareness_check
@@ -146,7 +146,7 @@ TopicConfigurationEndpoint:
           default: false
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/train.yaml
+++ b/cruise-control/src/yaml/endpoints/train.yaml
@@ -27,7 +27,7 @@ TrainEndpoint:
           default: false
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/userTasks.yaml
+++ b/cruise-control/src/yaml/endpoints/userTasks.yaml
@@ -47,7 +47,7 @@ UserTasksEndpoint:
           default: false
       - name: get_response_schema
         in: query
-        description: Whether to return in JSON schema in response header or not.
+        description: Whether to return JSON schema in response header or not.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/responses/adminResult.yaml
+++ b/cruise-control/src/yaml/responses/adminResult.yaml
@@ -23,6 +23,8 @@ AdminResult:
       type: object
       additionalProperties:
         type: boolean
+    minIsrBasedConcurrencyAdjustmentRequest:
+      type: string
     version:
       type: integer
       format: int32

--- a/docs/wiki/User Guide/REST-APIs.md
+++ b/docs/wiki/User Guide/REST-APIs.md
@@ -550,10 +550,12 @@ Changing topic's replication factor will not move any existing replicas. `goals`
 Note sometimes the topic regex can be too long to put at POST request head, in this case user can specify topic regex and target replication factor pairs in POST request body. For details, check [Change-topic-replication-factor-through-Cruise-Control wiki page](https://github.com/linkedin/cruise-control/wiki/Change-topic-replication-factor-through-Cruise-Control).
 
 ### Change Cruise Control configuration
-Some of Cruise Control's configs can be changed dynamically via `admin` endpoint, which includes
-* enable/disable self-healing
-* increase/decrease execution concurrency
-* drop recently removed/demoted brokers
+Some Cruise Control configs can be changed dynamically via `admin` endpoint, which includes
+* Dynamically change the partition and leadership concurrency and the interval between checking and updating (if needed) the progress of an ongoing execution.
+* Enable/disable self-healing for the specified anomaly types.
+* Drop selected recently removed/demoted brokers.
+* Enable/disable the specified concurrency adjusters.
+* Enable/disable the (At/Under)MinISR-based concurrency adjustment.
 
 Supported parameters are:
 
@@ -567,6 +569,13 @@ Supported parameters are:
 | drop_recently_removed_brokers                 | list      | list of id of recently removed brokers to be dropped                      | N/A       | yes       |
 | drop_recently_demoted_brokers                 | list      | list of id of recently demoted brokers to be dropped                      | N/A       | yes       |
 | doAs                                          | string    | propagated user by the trusted proxy service                              | null      | yes       | 
+| json                                          | boolean   | return in JSON format or not                                              | false     | yes       |
+| review_id                                     | integer   | review id for 2-step verification                                         | N/A       | yes       |
+| execution_progress_check_interval_ms          | long      | execution progress check interval in milliseconds                         | N/A       | yes       |
+| get_response_schema                           | boolean   | return JSON schema in response header or not                              | false     | yes       |
+| disable_concurrency_adjuster_for              | list      | disable concurrency adjuster for given concurrency types                  | N/A       | yes       |
+| enable_concurrency_adjuster_for               | list      | enable concurrency adjuster for given concurrency types                   | N/A       | yes       |
+| min_isr_based_concurrency_adjustment          | boolean   | enable (true) or disable (false) MinISR-based concurrency adjustment      | N/A       | yes       |
 
 To Enable/disable self-healing, send POST request like:
 


### PR DESCRIPTION
This PR resolves #1534.

* This is a followup patch for https://github.com/linkedin/cruise-control/pull/1525
This change has been verified in a test environment via an actual deployment (results below)

1. `POST /kafkacruisecontrol/admin?min_isr_based_concurrency_adjustment=true`
```
{
minIsrBasedConcurrencyAdjustmentRequest: MinISR-based concurrency adjustment is modified (before: false after: true).
}
```

2. Corresponding log:
```
MinISR-based concurrency adjustment is modified by user (before: false after: true).
```

3. `POST /kafkacruisecontrol/admin?min_isr_based_concurrency_adjustment=false&json=true`
```
{"minIsrBasedConcurrencyAdjustmentRequest":"MinISR-based concurrency adjustment is modified (before: true after: false).","version":1}
```

4. Corresponding log:
```
MinISR-based concurrency adjustment is modified by user (before: true after: false).
```

Other Notes:
* Fix the incorrect default value for "json" in `stopProposalExecution.yaml`
* Add the missing default value for "json" in `state.yaml`
* Fix description of selected parameters in yaml files