### PR TITLE
Bump up stale dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ plugins {
   id "com.jfrog.artifactory"
   id "idea"
   id "jacoco" // Java Code Coverage plugin
-  id "com.github.ben-manes.versions" version "0.36.0"
-  id "com.github.spotbugs" version "4.6.0" apply false
+  id "com.github.ben-manes.versions" version "0.38.0"
+  id "com.github.spotbugs" version "4.7.1" apply false
 }
 
 group = 'com.linkedin.cruisecontrol'
@@ -92,13 +92,13 @@ subprojects {
 
   //code quality and inspections
   checkstyle {
-    project.ext.checkstyleVersion = '8.20'
+    project.ext.checkstyleVersion = '8.42'
     ignoreFailures = false
     configDir = file("$rootDir/checkstyle")
   }
 
   spotbugs {
-    toolVersion = '4.1.4'
+    toolVersion = '4.2.2'
     excludeFilter = file("$rootDir/gradle/findbugs-exclude.xml")
     ignoreFailures = false
     jvmArgs = [ '-Xms512m' ]
@@ -159,7 +159,7 @@ project(':cruise-control-core') {
     compile "org.apache.logging.log4j:log4j-slf4j-impl:2.14.1"
     compile 'junit:junit:4.13.2'
     compile 'org.apache.commons:commons-math3:3.6.1'
-    compile 'org.eclipse.jetty:jetty-servlet:9.4.40.v20210413'
+    compile "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
     testOutput sourceSets.test.output
   }
@@ -237,6 +237,8 @@ project(':cruise-control') {
     compile "org.slf4j:slf4j-api:1.7.30" // TODO: Upgrade log4j to log4j2 to use async logger.
     compile "org.apache.logging.log4j:log4j-slf4j-impl:2.14.1"
     compile "org.apache.zookeeper:zookeeper:${zookeeperVersion}"
+    compile "io.netty:netty-handler:${nettyVersion}"
+    compile "io.netty:netty-transport-native-epoll:${nettyVersion}"
     compile "org.apache.kafka:kafka_2.11:$kafkaVersion"
     compile "org.apache.kafka:kafka-clients:$kafkaVersion"
     compile "org.scala-lang:scala-library:2.11.12"
@@ -244,12 +246,12 @@ project(':cruise-control') {
     compile 'org.apache.commons:commons-math3:3.6.1'
     compile 'org.apache.httpcomponents:httpclient:4.5.13'
     compile 'com.google.code.gson:gson:2.8.6'
-    compile 'org.eclipse.jetty:jetty-server:9.4.40.v20210413'
+    compile "org.eclipse.jetty:jetty-server:${jettyVersion}"
     compile 'io.dropwizard.metrics:metrics-core:3.2.6'
-    compile 'com.nimbusds:nimbus-jose-jwt:9.8.1'
+    compile 'com.nimbusds:nimbus-jose-jwt:9.9'
     compile 'com.101tec:zkclient:0.11'
     compile 'io.swagger.parser.v3:swagger-parser-v3:2.0.25'
-    compile 'io.github.classgraph:classgraph:4.8.104'
+    compile 'io.github.classgraph:classgraph:4.8.105'
 
     testCompile project(path: ':cruise-control-metrics-reporter', configuration: 'testOutput')
     testCompile project(path: ':cruise-control-core', configuration: 'testOutput')

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -15,6 +15,7 @@ import com.linkedin.kafka.cruisecontrol.exception.SamplingException;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
 import com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunner;
 import java.util.Collections;
+import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -93,6 +94,7 @@ public class KafkaCruiseControlUtils {
   public static final String ENV_CONFIG_PROVIDER_CLASS_CONFIG = ".env.class";
   public static final long CLIENT_REQUEST_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
   public static final String DEFAULT_CLEANUP_POLICY = "delete";
+  public static final Random RANDOM = new Random();
 
   private KafkaCruiseControlUtils() {
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorManager.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -37,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.OPERATION_LOGGER;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.RANDOM;
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.sanityCheckGoals;
 import static com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorUtils.anomalyComparator;
 import static com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorUtils.getSelfHealingGoalNames;
@@ -203,7 +203,7 @@ public class AnomalyDetectorManager {
   }
 
   private void scheduleDetectorAtFixedRate(KafkaAnomalyType anomalyType, Runnable anomalyDetector) {
-    int jitter = new Random().nextInt(INIT_JITTER_BOUND);
+    int jitter = RANDOM.nextInt(INIT_JITTER_BOUND);
     long anomalyDetectionIntervalMs = _anomalyDetectionIntervalMsByType.get(anomalyType);
     LOG.debug("Starting {} detector with delay of {} ms", anomalyType, jitter);
     _detectorScheduler.scheduleAtFixedRate(anomalyDetector,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorUtils.java
@@ -17,7 +17,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -27,6 +26,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.RANDOM;
 import static com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig.RECONNECT_BACKOFF_MS_CONFIG;
 
 
@@ -39,7 +39,6 @@ public class AnomalyDetectorUtils {
   public static final String ANOMALY_DETECTION_TIME_MS_OBJECT_CONFIG = "anomaly.detection.time.ms.object";
   public static final long MAX_METADATA_WAIT_MS = TimeUnit.MINUTES.toMillis(1);
   public static final Anomaly SHUTDOWN_ANOMALY = new BrokerFailures();
-  public static final Random RANDOM = new Random();
 
   private AnomalyDetectorUtils() {
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/SamplingUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/SamplingUtils.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Random;
 import java.util.Set;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -35,6 +34,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.RANDOM;
 import static com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig.RECONNECT_BACKOFF_MS_CONFIG;
 import static com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig.SAMPLING_ALLOW_CPU_CAPACITY_ESTIMATION_CONFIG;
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.metric.RawMetricType.*;
@@ -45,7 +45,6 @@ public class SamplingUtils {
   private static final Logger LOG = LoggerFactory.getLogger(SamplingUtils.class);
   private static final String SKIP_BUILDING_SAMPLE_PREFIX = "Skip generating metric sample for ";
   public static final int UNRECOGNIZED_BROKER_ID = -1;
-  public static final Random RANDOM = new Random();
 
   private SamplingUtils() {
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,5 @@ org.gradle.parallel=false
 org.gradle.jvmargs=-Xms512m -Xmx512m
 kafkaVersion=2.4.1
 zookeeperVersion=3.5.7
+nettyVersion=4.1.63.Final
+jettyVersion=9.4.40.v20210413


### PR DESCRIPTION
This PR resolves #1539.

* Explicitly specify the version of Netty dependencies instead of relying on the version set by ZooKeeper, which contains several CVEs. I also verified that the dependency tree now has the latest versions for Netty dependencies after this PR.
* Avoid bumping up `spotbugs` `toolVersion` to `4.2.3` due to false positives regarding `DMI_RANDOM_USED_ONLY_ONCE` (see reported issue: https://github.com/spotbugs/spotbugs/issues/1504#issuecomment-821820920)
* Share a single Random object across the main project.