### PR TITLE
Bump up stale dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -245,10 +245,11 @@ project(':cruise-control') {
     compile 'junit:junit:4.13.2'
     compile 'org.apache.commons:commons-math3:3.6.1'
     compile 'org.apache.httpcomponents:httpclient:4.5.13'
+    compile 'commons-codec:commons-codec:1.15'
     compile 'com.google.code.gson:gson:2.8.6'
     compile "org.eclipse.jetty:jetty-server:${jettyVersion}"
     compile 'io.dropwizard.metrics:metrics-core:3.2.6'
-    compile 'com.nimbusds:nimbus-jose-jwt:9.9'
+    compile 'com.nimbusds:nimbus-jose-jwt:9.9.3'
     compile 'com.101tec:zkclient:0.11'
     compile 'io.swagger.parser.v3:swagger-parser-v3:2.0.25'
     compile 'io.github.classgraph:classgraph:4.8.105'


### PR DESCRIPTION
This PR resolves #1556.
* I suspect some of the vulnerabilities (e.g. `PRISMA-2021-0055`) in #1556 are relevant to `commons-codec:commons-codec:1.11`, which is a transitive dependency fetched through the latest version of `httpclient` -- i.e. `org.apache.httpcomponents:httpclient:4.5.13`. I will explicitly specify the latest version of `commons-codec` dependency instead of relying on the version pulled by `httpclient`.
* Bump up `com.nimbusds:nimbus-jose-jwt`