### PR TITLE
Add timers to track goal violation detection and fix generation for self-healing

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -75,6 +75,14 @@ import static kafka.log.LogConfig.RetentionMsProp;
  */
 public class KafkaCruiseControlUtils {
   private static final Logger LOG = LoggerFactory.getLogger(KafkaCruiseControlUtils.class);
+  // Cruise Control sensor types -- i.e. the first element of the metric name.
+  public static final String EXECUTOR_SENSOR = "Executor";
+  public static final String LOAD_MONITOR_SENSOR = "LoadMonitor";
+  public static final String USER_TASK_MANAGER_SENSOR = "UserTaskManager";
+  public static final String ANOMALY_DETECTOR_SENSOR = "AnomalyDetector";
+  public static final String GOAL_OPTIMIZER_SENSOR = "GoalOptimizer";
+  public static final String METRIC_FETCHER_MANAGER_SENSOR = "MetricFetcherManager";
+  public static final String KAFKA_CRUISE_CONTROL_SERVLET_SENSOR = "KafkaCruiseControlServlet";
   // Config to pass an Admin client to a pluggable component
   public static final String ADMIN_CLIENT_CONFIG = "admin.client.object";
   public static final double MAX_BALANCEDNESS_SCORE = 100.0;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
@@ -50,6 +50,7 @@ import org.slf4j.LoggerFactory;
 
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.ADMIN_CLIENT_CONFIG;
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.balancednessCostByGoal;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.GOAL_OPTIMIZER_SENSOR;
 import static com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.BOOTSTRAPPING;
 import static com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunner.LoadMonitorTaskRunnerState.LOADING;
 import static com.linkedin.kafka.cruisecontrol.servlet.KafkaCruiseControlServletUtils.KAFKA_CRUISE_CONTROL_CONFIG_OBJECT_CONFIG;
@@ -121,7 +122,7 @@ public class GoalOptimizer implements Runnable {
     // A new AtomicReference with null initial value.
     _proposalGenerationException = new AtomicReference<>();
     _proposalPrecomputingProgress = new OperationProgress();
-    _proposalComputationTimer = dropwizardMetricRegistry.timer(MetricRegistry.name("GoalOptimizer", "proposal-computation-timer"));
+    _proposalComputationTimer = dropwizardMetricRegistry.timer(MetricRegistry.name(GOAL_OPTIMIZER_SENSOR, "proposal-computation-timer"));
     _executor = executor;
     _hasOngoingExplicitPrecomputation = false;
     _priorityWeight = config.getDouble(AnalyzerConfig.GOAL_BALANCEDNESS_PRIORITY_WEIGHT_CONFIG);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorState.java
@@ -22,8 +22,8 @@ import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.ANOMALY_DETECTOR_SENSOR;
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.SEC_TO_MS;
-import static com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorManager.METRIC_REGISTRY_NAME;
 import static com.linkedin.kafka.cruisecontrol.detector.notifier.KafkaAnomalyType.*;
 
 
@@ -109,30 +109,30 @@ public class AnomalyDetectorState {
     _metrics = new AnomalyMetrics(meanTimeBetweenAnomaliesMs, 0.0, 0L, 0L, 0L);
 
     if (dropwizardMetricRegistry != null) {
-      dropwizardMetricRegistry.register(MetricRegistry.name(METRIC_REGISTRY_NAME, "mean-time-to-start-fix-ms"),
+      dropwizardMetricRegistry.register(MetricRegistry.name(ANOMALY_DETECTOR_SENSOR, "mean-time-to-start-fix-ms"),
                                         (Gauge<Double>) this::meanTimeToStartFixMs);
-      dropwizardMetricRegistry.register(MetricRegistry.name(METRIC_REGISTRY_NAME, "number-of-self-healing-started"),
+      dropwizardMetricRegistry.register(MetricRegistry.name(ANOMALY_DETECTOR_SENSOR, "number-of-self-healing-started"),
                                         (Gauge<Long>) this::numSelfHealingStarted);
-      dropwizardMetricRegistry.register(MetricRegistry.name(METRIC_REGISTRY_NAME, "number-of-self-healing-failed-to-start"),
+      dropwizardMetricRegistry.register(MetricRegistry.name(ANOMALY_DETECTOR_SENSOR, "number-of-self-healing-failed-to-start"),
                                         (Gauge<Long>) this::numSelfHealingFailedToStart);
-      dropwizardMetricRegistry.register(MetricRegistry.name(METRIC_REGISTRY_NAME, "ongoing-anomaly-duration-ms"),
+      dropwizardMetricRegistry.register(MetricRegistry.name(ANOMALY_DETECTOR_SENSOR, "ongoing-anomaly-duration-ms"),
                                         (Gauge<Long>) this::ongoingAnomalyDurationMs);
-      dropwizardMetricRegistry.register(MetricRegistry.name(METRIC_REGISTRY_NAME, String.format("%s-has-unfixable-goals", GOAL_VIOLATION)),
+      dropwizardMetricRegistry.register(MetricRegistry.name(ANOMALY_DETECTOR_SENSOR, String.format("%s-has-unfixable-goals", GOAL_VIOLATION)),
                                         (Gauge<Integer>) () -> hasUnfixableGoals() ? 1 : 0);
 
       _anomalyRateByType = new HashMap<>(KafkaAnomalyType.cachedValues().size());
       _anomalyRateByType.put(BROKER_FAILURE,
-                             dropwizardMetricRegistry.meter(MetricRegistry.name(METRIC_REGISTRY_NAME, "broker-failure-rate")));
+                             dropwizardMetricRegistry.meter(MetricRegistry.name(ANOMALY_DETECTOR_SENSOR, "broker-failure-rate")));
       _anomalyRateByType.put(GOAL_VIOLATION,
-                             dropwizardMetricRegistry.meter(MetricRegistry.name(METRIC_REGISTRY_NAME, "goal-violation-rate")));
+                             dropwizardMetricRegistry.meter(MetricRegistry.name(ANOMALY_DETECTOR_SENSOR, "goal-violation-rate")));
       _anomalyRateByType.put(METRIC_ANOMALY,
-                             dropwizardMetricRegistry.meter(MetricRegistry.name(METRIC_REGISTRY_NAME, "metric-anomaly-rate")));
+                             dropwizardMetricRegistry.meter(MetricRegistry.name(ANOMALY_DETECTOR_SENSOR, "metric-anomaly-rate")));
       _anomalyRateByType.put(DISK_FAILURE,
-                             dropwizardMetricRegistry.meter(MetricRegistry.name(METRIC_REGISTRY_NAME, "disk-failure-rate")));
+                             dropwizardMetricRegistry.meter(MetricRegistry.name(ANOMALY_DETECTOR_SENSOR, "disk-failure-rate")));
       _anomalyRateByType.put(TOPIC_ANOMALY,
-                             dropwizardMetricRegistry.meter(MetricRegistry.name(METRIC_REGISTRY_NAME, "topic-anomaly-rate")));
+                             dropwizardMetricRegistry.meter(MetricRegistry.name(ANOMALY_DETECTOR_SENSOR, "topic-anomaly-rate")));
       _anomalyRateByType.put(MAINTENANCE_EVENT,
-                             dropwizardMetricRegistry.meter(MetricRegistry.name(METRIC_REGISTRY_NAME, "maintenance-event-rate")));
+                             dropwizardMetricRegistry.meter(MetricRegistry.name(ANOMALY_DETECTOR_SENSOR, "maintenance-event-rate")));
     } else {
       _anomalyRateByType = new HashMap<>(KafkaAnomalyType.cachedValues().size());
       KafkaAnomalyType.cachedValues().forEach(anomalyType -> _anomalyRateByType.put(anomalyType, new Meter()));

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskTracker.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskTracker.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.kafka.common.utils.Time;
 
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.EXECUTOR_SENSOR;
 import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTask.TaskType;
 
 /**
@@ -71,27 +72,26 @@ public class ExecutionTaskTracker {
   }
 
   private void registerGaugeSensors(MetricRegistry dropwizardMetricRegistry) {
-    String metricName = "Executor";
     for (TaskType type : TaskType.cachedValues()) {
       for (ExecutionTaskState state : ExecutionTaskState.cachedValues()) {
         String typeString = type == TaskType.INTER_BROKER_REPLICA_ACTION
-                             ? INTER_BROKER_REPLICA_ACTION : type == TaskType.INTRA_BROKER_REPLICA_ACTION
-                                                             ? INTRA_BROKER_REPLICA_ACTION : LEADERSHIP_ACTION;
+                            ? INTER_BROKER_REPLICA_ACTION : type == TaskType.INTRA_BROKER_REPLICA_ACTION
+                                                            ? INTRA_BROKER_REPLICA_ACTION : LEADERSHIP_ACTION;
         String stateString = state == ExecutionTaskState.PENDING
-                              ? PENDING : state == ExecutionTaskState.IN_PROGRESS
-                                          ? IN_PROGRESS : state == ExecutionTaskState.ABORTING
-                                                          ? ABORTING : state == ExecutionTaskState.ABORTED
-                                                                       ? ABORTED : state == ExecutionTaskState.COMPLETED
-                                                                                   ? COMPLETED : DEAD;
-        dropwizardMetricRegistry.register(MetricRegistry.name(metricName, typeString + "-" + stateString),
+                             ? PENDING : state == ExecutionTaskState.IN_PROGRESS
+                                         ? IN_PROGRESS : state == ExecutionTaskState.ABORTING
+                                                         ? ABORTING : state == ExecutionTaskState.ABORTED
+                                                                      ? ABORTED : state == ExecutionTaskState.COMPLETED
+                                                                                  ? COMPLETED : DEAD;
+        dropwizardMetricRegistry.register(MetricRegistry.name(EXECUTOR_SENSOR, typeString + "-" + stateString),
                                           (Gauge<Integer>) () -> (state == ExecutionTaskState.PENDING && _stopRequested)
                                                                  ? 0 : _tasksByType.get(type).get(state).size());
       }
     }
-    dropwizardMetricRegistry.register(MetricRegistry.name(metricName, GAUGE_ONGOING_EXECUTION_IN_KAFKA_ASSIGNER_MODE),
+    dropwizardMetricRegistry.register(MetricRegistry.name(EXECUTOR_SENSOR, GAUGE_ONGOING_EXECUTION_IN_KAFKA_ASSIGNER_MODE),
                                       (Gauge<Integer>) () -> _isKafkaAssignerMode
                                                              && !inExecutionTasks(TaskType.cachedValues()).isEmpty() ? 1 : 0);
-    dropwizardMetricRegistry.register(MetricRegistry.name(metricName, GAUGE_ONGOING_EXECUTION_IN_NON_KAFKA_ASSIGNER_MODE),
+    dropwizardMetricRegistry.register(MetricRegistry.name(EXECUTOR_SENSOR, GAUGE_ONGOING_EXECUTION_IN_NON_KAFKA_ASSIGNER_MODE),
                                       (Gauge<Integer>) () -> !_isKafkaAssignerMode
                                                              && !inExecutionTasks(TaskType.cachedValues()).isEmpty() ? 1 : 0);
   }
@@ -326,7 +326,7 @@ public class ExecutionTaskTracker {
                                      _remainingIntraBrokerDataToMoveInMB,
                                      taskStat(),
                                      filteredTasksByState(taskTypesToGetFullList)
-                                     );
+    );
   }
 
   public static class ExecutionTasksSummary {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -54,6 +54,7 @@ import java.util.List;
 
 import static com.linkedin.cruisecontrol.CruiseControlUtils.currentUtcDate;
 import static com.linkedin.cruisecontrol.CruiseControlUtils.utcDateFor;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.EXECUTOR_SENSOR;
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.OPERATION_LOGGER;
 import static com.linkedin.kafka.cruisecontrol.executor.ExecutorState.State.*;
 import static com.linkedin.kafka.cruisecontrol.executor.ExecutionTask.TaskType.*;
@@ -267,20 +268,26 @@ public class Executor {
    * Register gauge sensors.
    */
   private void registerGaugeSensors(MetricRegistry dropwizardMetricRegistry) {
-    String name = "Executor";
-    dropwizardMetricRegistry.register(MetricRegistry.name(name, ExecutionUtils.GAUGE_EXECUTION_STOPPED),
+    dropwizardMetricRegistry.register(MetricRegistry.name(EXECUTOR_SENSOR,
+                                                          ExecutionUtils.GAUGE_EXECUTION_STOPPED),
                                       (Gauge<Integer>) this::numExecutionStopped);
-    dropwizardMetricRegistry.register(MetricRegistry.name(name, ExecutionUtils.GAUGE_EXECUTION_STOPPED_BY_USER),
+    dropwizardMetricRegistry.register(MetricRegistry.name(EXECUTOR_SENSOR,
+                                                          ExecutionUtils.GAUGE_EXECUTION_STOPPED_BY_USER),
                                       (Gauge<Integer>) this::numExecutionStoppedByUser);
-    dropwizardMetricRegistry.register(MetricRegistry.name(name, ExecutionUtils.GAUGE_EXECUTION_STARTED_IN_KAFKA_ASSIGNER_MODE),
+    dropwizardMetricRegistry.register(MetricRegistry.name(EXECUTOR_SENSOR,
+                                                          ExecutionUtils.GAUGE_EXECUTION_STARTED_IN_KAFKA_ASSIGNER_MODE),
                                       (Gauge<Integer>) this::numExecutionStartedInKafkaAssignerMode);
-    dropwizardMetricRegistry.register(MetricRegistry.name(name, ExecutionUtils.GAUGE_EXECUTION_STARTED_IN_NON_KAFKA_ASSIGNER_MODE),
+    dropwizardMetricRegistry.register(MetricRegistry.name(EXECUTOR_SENSOR,
+                                                          ExecutionUtils.GAUGE_EXECUTION_STARTED_IN_NON_KAFKA_ASSIGNER_MODE),
                                       (Gauge<Integer>) this::numExecutionStartedInNonKafkaAssignerMode);
-    dropwizardMetricRegistry.register(MetricRegistry.name(name, ExecutionUtils.GAUGE_EXECUTION_INTER_BROKER_PARTITION_MOVEMENTS_PER_BROKER_CAP),
+    dropwizardMetricRegistry.register(MetricRegistry.name(EXECUTOR_SENSOR,
+                                                          ExecutionUtils.GAUGE_EXECUTION_INTER_BROKER_PARTITION_MOVEMENTS_PER_BROKER_CAP),
                                       (Gauge<Integer>) _executionTaskManager::interBrokerPartitionMovementConcurrency);
-    dropwizardMetricRegistry.register(MetricRegistry.name(name, ExecutionUtils.GAUGE_EXECUTION_INTRA_BROKER_PARTITION_MOVEMENTS_PER_BROKER_CAP),
+    dropwizardMetricRegistry.register(MetricRegistry.name(EXECUTOR_SENSOR,
+                                                          ExecutionUtils.GAUGE_EXECUTION_INTRA_BROKER_PARTITION_MOVEMENTS_PER_BROKER_CAP),
                                       (Gauge<Integer>) _executionTaskManager::intraBrokerPartitionMovementConcurrency);
-    dropwizardMetricRegistry.register(MetricRegistry.name(name, ExecutionUtils.GAUGE_EXECUTION_LEADERSHIP_MOVEMENTS_GLOBAL_CAP),
+    dropwizardMetricRegistry.register(MetricRegistry.name(EXECUTOR_SENSOR,
+                                                          ExecutionUtils.GAUGE_EXECUTION_LEADERSHIP_MOVEMENTS_GLOBAL_CAP),
                                       (Gauge<Integer>) _executionTaskManager::leadershipMovementConcurrency);
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricFetcherManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricFetcherManager.java
@@ -28,6 +28,8 @@ import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.METRIC_FETCHER_MANAGER_SENSOR;
+
 
 /**
  * The class manages the metric fetchers. It periodically kicks off the sampling and refreshes the metadata as well.
@@ -104,13 +106,13 @@ public class MetricFetcherManager {
                                                       MetricSamplerPartitionAssignor.class);
     _partitionAssignor.configure(config.mergedConfigValues());
     _useLinearRegressionModel = config.getBoolean(MonitorConfig.USE_LINEAR_REGRESSION_MODEL_CONFIG);
-    _samplingFetcherTimer = dropwizardMetricRegistry.timer(MetricRegistry.name("MetricFetcherManager",
+    _samplingFetcherTimer = dropwizardMetricRegistry.timer(MetricRegistry.name(METRIC_FETCHER_MANAGER_SENSOR,
                                                                                 "partition-samples-fetcher-timer"));
-    _samplingFetcherFailureRate = dropwizardMetricRegistry.meter(MetricRegistry.name("MetricFetcherManager",
+    _samplingFetcherFailureRate = dropwizardMetricRegistry.meter(MetricRegistry.name(METRIC_FETCHER_MANAGER_SENSOR,
                                                                                       "partition-samples-fetcher-failure-rate"));
-    _trainingSamplesFetcherTimer = dropwizardMetricRegistry.timer(MetricRegistry.name("MetricFetcherManager",
+    _trainingSamplesFetcherTimer = dropwizardMetricRegistry.timer(MetricRegistry.name(METRIC_FETCHER_MANAGER_SENSOR,
                                                                                        "training-samples-fetcher-timer"));
-    _trainingSamplesFetcherFailureRate = dropwizardMetricRegistry.meter(MetricRegistry.name("MetricFetcherManager",
+    _trainingSamplesFetcherFailureRate = dropwizardMetricRegistry.meter(MetricRegistry.name(METRIC_FETCHER_MANAGER_SENSOR,
                                                                                              "training-samples-fetcher-failure-rate"));
 
     _metricSampler = sampler == null

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServlet.java
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.KAFKA_CRUISE_CONTROL_SERVLET_SENSOR;
 import static com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint.REVIEW;
 import static com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint.REVIEW_BOARD;
 import static com.linkedin.kafka.cruisecontrol.servlet.KafkaCruiseControlServletUtils.*;
@@ -59,9 +60,9 @@ public class KafkaCruiseControlServlet extends HttpServlet {
 
     for (CruiseControlEndPoint endpoint : CruiseControlEndPoint.cachedValues()) {
       _requestMeter.put(endpoint, dropwizardMetricRegistry.meter(
-          MetricRegistry.name("KafkaCruiseControlServlet", endpoint.name() + "-request-rate")));
+          MetricRegistry.name(KAFKA_CRUISE_CONTROL_SERVLET_SENSOR, endpoint.name() + "-request-rate")));
       _successfulRequestExecutionTimer.put(endpoint, dropwizardMetricRegistry.timer(
-          MetricRegistry.name("KafkaCruiseControlServlet", endpoint.name() + "-successful-request-execution-timer")));
+          MetricRegistry.name(KAFKA_CRUISE_CONTROL_SERVLET_SENSOR, endpoint.name() + "-successful-request-execution-timer")));
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.OPERATION_LOGGER;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.USER_TASK_MANAGER_SENSOR;
 import static com.linkedin.kafka.cruisecontrol.servlet.KafkaCruiseControlServletUtils.ensureHeaderNotPresent;
 import static com.linkedin.kafka.cruisecontrol.servlet.KafkaCruiseControlServletUtils.httpServletRequestToString;
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.REVIEW_ID_PARAM;
@@ -105,9 +106,9 @@ public class UserTaskManager implements Closeable {
                                                  USER_TASK_SCANNER_INITIAL_DELAY_SECONDS,
                                                  USER_TASK_SCANNER_PERIOD_SECONDS,
                                                  TimeUnit.SECONDS);
-    dropwizardMetricRegistry.register(MetricRegistry.name("UserTaskManager", "num-active-sessions"),
+    dropwizardMetricRegistry.register(MetricRegistry.name(USER_TASK_MANAGER_SENSOR, "num-active-sessions"),
                                       (Gauge<Integer>) _sessionKeyToUserTaskIdMap::size);
-    dropwizardMetricRegistry.register(MetricRegistry.name("UserTaskManager", "num-active-user-tasks"),
+    dropwizardMetricRegistry.register(MetricRegistry.name(USER_TASK_MANAGER_SENSOR, "num-active-user-tasks"),
                                       (Gauge<Integer>) _uuidToActiveUserTaskInfoMap::size);
     _successfulRequestExecutionTimer = successfulRequestExecutionTimer;
   }

--- a/docs/wiki/User Guide/Sensors.md
+++ b/docs/wiki/User Guide/Sensors.md
@@ -80,6 +80,13 @@ Cruise Control metrics are useful to monitor the state of Cruise Control itself.
 | The number of brokers that have recently been identified with a metric anomaly                                    | kafka.cruisecontrol:name=AnomalyDetector.num-recent-metric-anomalies                                      |
 | The number of brokers that continue to be identified with a metric anomaly for a prolonged period                 | kafka.cruisecontrol:name=AnomalyDetector.num-persistent-metric-anomalies                                  |
 | The cluster has partitions with RF > the number of eligible racks (0: No such partitions, 1: Has such partitions) | kafka.cruisecontrol:name=AnomalyDetector.has-partitions-with-replication-factor-greater-than-num-racks    |
+| The time taken by goal violation detection                                                                        | kafka.cruisecontrol:name=AnomalyDetector.goal-violation-detection-timer                                   |
+| The time taken to generate a fix for self-healing for broker failures                                             | kafka.cruisecontrol:name=AnomalyDetector.broker_failure-self-healing-fix-generation-timer                 |
+| The time taken to generate a fix for self-healing for maintenance events                                          | kafka.cruisecontrol:name=AnomalyDetector.maintenance_event-self-healing-fix-generation-timer              |
+| The time taken to generate a fix for self-healing for disk failures                                               | kafka.cruisecontrol:name=AnomalyDetector.disk_failure-self-healing-fix-generation-timer                   |
+| The time taken to generate a fix for self-healing for metric anomalies                                            | kafka.cruisecontrol:name=AnomalyDetector.metric_anomaly-self-healing-fix-generation-timer                 |
+| The time taken to generate a fix for self-healing for goal violations                                             | kafka.cruisecontrol:name=AnomalyDetector.goal_violation-self-healing-fix-generation-timer                 |
+| The time taken to generate a fix for self-healing for topic anomalies                                             | kafka.cruisecontrol:name=AnomalyDetector.topic_anomaly-self-healing-fix-generation-timer                  |
 
 ### GoalOptimizer Sensors
 


### PR DESCRIPTION
This PR resolves #1562 and #1563.

* Also move the `Cruise Control sensor types -- i.e. the first element of the metric name` to a utility class.