### PR TITLE
Identify and fix inefficient code paths in goal optimization

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CapacityGoal.java
@@ -179,8 +179,10 @@ public abstract class CapacityGoal extends AbstractGoal {
     boolean onlyMoveImmigrantReplicas = optimizationOptions.onlyMoveImmigrantReplicas();
     // Sort all replicas for each broker based on resource utilization.
     new SortedReplicasHelper().maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectImmigrants(), onlyMoveImmigrantReplicas)
-                              .addSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics))
-                              .addPriorityFunc(ReplicaSortFunctionFactory.prioritizeOfflineReplicas())
+                              .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics),
+                                                     !excludedTopics.isEmpty())
+                              .maybeAddPriorityFunc(ReplicaSortFunctionFactory.prioritizeOfflineReplicas(),
+                                                    !clusterModel.selfHealingEligibleReplicas().isEmpty())
                               .maybeAddPriorityFunc(ReplicaSortFunctionFactory.prioritizeImmigrants(), !onlyMoveImmigrantReplicas)
                               .setScoreFunc(ReplicaSortFunctionFactory.reverseSortByMetricGroupValue(resource().name()))
                               .trackSortedReplicasFor(replicaSortName(this, true, false), clusterModel);
@@ -188,7 +190,8 @@ public abstract class CapacityGoal extends AbstractGoal {
     // Sort leader replicas for each broker based on resource utilization.
     new SortedReplicasHelper().addSelectionFunc(ReplicaSortFunctionFactory.selectLeaders())
                               .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectImmigrants(), onlyMoveImmigrantReplicas)
-                              .addSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics))
+                              .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics),
+                                                     !excludedTopics.isEmpty())
                               .maybeAddPriorityFunc(ReplicaSortFunctionFactory.prioritizeImmigrants(), !onlyMoveImmigrantReplicas)
                               .setScoreFunc(ReplicaSortFunctionFactory.reverseSortByMetricGroupValue(resource().name()))
                               .trackSortedReplicasFor(replicaSortName(this, true, true), clusterModel);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskCapacityGoal.java
@@ -90,7 +90,8 @@ public class IntraBrokerDiskCapacityGoal extends AbstractGoal {
     Set<String> excludedTopics = optimizationOptions.excludedTopics();
     // Sort all the replicas for each disk based on disk utilization.
     new SortedReplicasHelper().addSelectionFunc(ReplicaSortFunctionFactory.selectOnlineReplicas())
-                              .addSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics))
+                              .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics),
+                                                     !excludedTopics.isEmpty())
                               .addPriorityFunc(ReplicaSortFunctionFactory.prioritizeDiskImmigrants())
                               .setScoreFunc(ReplicaSortFunctionFactory.reverseSortByMetricGroupValue(RESOURCE.name()))
                               .trackSortedReplicasFor(replicaSortName(this, true, false), clusterModel);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskUsageDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskUsageDistributionGoal.java
@@ -94,12 +94,14 @@ public class IntraBrokerDiskUsageDistributionGoal extends AbstractGoal {
     // Sort all the replicas for each disk based on disk utilization.
     Set<String> excludedTopics = optimizationOptions.excludedTopics();
     new SortedReplicasHelper().addSelectionFunc(ReplicaSortFunctionFactory.selectOnlineReplicas())
-                              .addSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics))
+                              .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics),
+                                                     !excludedTopics.isEmpty())
                               .addPriorityFunc(ReplicaSortFunctionFactory.prioritizeDiskImmigrants())
                               .setScoreFunc(ReplicaSortFunctionFactory.reverseSortByMetricGroupValue(RESOURCE.name()))
                               .trackSortedReplicasFor(replicaSortName(this, true, false), clusterModel);
     new SortedReplicasHelper().addSelectionFunc(ReplicaSortFunctionFactory.selectOnlineReplicas())
-                              .addSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics))
+                              .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics),
+                                                     !excludedTopics.isEmpty())
                               .addPriorityFunc(ReplicaSortFunctionFactory.prioritizeDiskImmigrants())
                               .setScoreFunc(ReplicaSortFunctionFactory.sortByMetricGroupValue(RESOURCE.name()))
                               .trackSortedReplicasFor(replicaSortName(this, false, false), clusterModel);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderReplicaDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderReplicaDistributionGoal.java
@@ -260,7 +260,8 @@ public class LeaderReplicaDistributionGoal extends ReplicaDistributionAbstractGo
                               .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectImmigrants(),
                                                      (!_fixOfflineReplicasOnly && !clusterModel.selfHealingEligibleReplicas().isEmpty())
                                                      || optimizationOptions.onlyMoveImmigrantReplicas())
-                              .addSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics))
+                              .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics),
+                                                     !excludedTopics.isEmpty())
                               .trackSortedReplicasFor(replicaSortName, broker);
     SortedSet<Replica> candidateReplicas = broker.trackedSortedReplicas(replicaSortName).sortedReplicas(true);
     int numReplicas = candidateReplicas.size();
@@ -313,7 +314,8 @@ public class LeaderReplicaDistributionGoal extends ReplicaDistributionAbstractGo
     new SortedReplicasHelper().addSelectionFunc(ReplicaSortFunctionFactory.selectLeaders())
                               .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectImmigrants(),
                                                      !clusterModel.brokenBrokers().isEmpty() || onlyMoveImmigrantReplicas)
-                              .addSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics))
+                              .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics),
+                                                     !excludedTopics.isEmpty())
                               .trackSortedReplicasFor(replicaSortName, clusterModel);
     int numLeaderReplicas = broker.leaderReplicas().size();
     while (!eligibleBrokers.isEmpty()) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/PotentialNwOutGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/PotentialNwOutGoal.java
@@ -231,7 +231,8 @@ public class PotentialNwOutGoal extends AbstractGoal {
 
     // Filter out some replicas based on optimization options.
     Set<String> excludedTopics = optimizationOptions.excludedTopics();
-    new SortedReplicasHelper().maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectImmigrants(), optimizationOptions.onlyMoveImmigrantReplicas())
+    new SortedReplicasHelper().maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectImmigrants(),
+                                                     optimizationOptions.onlyMoveImmigrantReplicas())
                               .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics),
                                                      !excludedTopics.isEmpty())
                               .trackSortedReplicasFor(replicaSortName(this, false, false), clusterModel);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareDistributionGoal.java
@@ -159,7 +159,8 @@ public class RackAwareDistributionGoal extends AbstractRackAwareGoal {
     // Filter out some replicas based on optimization options.
     new SortedReplicasHelper().maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectImmigrants(),
                                                      optimizationOptions.onlyMoveImmigrantReplicas())
-                              .addSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics))
+                              .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics),
+                                                     !excludedTopics.isEmpty())
                               .trackSortedReplicasFor(replicaSortName(this, false, false), clusterModel);
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareGoal.java
@@ -116,7 +116,8 @@ public class RackAwareGoal extends AbstractRackAwareGoal {
     // Filter out some replicas based on optimization options.
     new SortedReplicasHelper().maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectImmigrants(),
                                                      optimizationOptions.onlyMoveImmigrantReplicas())
-                              .addSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics))
+                              .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics),
+                                                     !excludedTopics.isEmpty())
                               .trackSortedReplicasFor(replicaSortName(this, false, false), clusterModel);
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
@@ -161,7 +161,8 @@ public class ReplicaCapacityGoal extends AbstractGoal {
     // Filter out some replicas based on optimization options.
     new SortedReplicasHelper().maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectImmigrants(),
                                                      optimizationOptions.onlyMoveImmigrantReplicas())
-                              .addSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics))
+                              .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics),
+                                                     !excludedTopics.isEmpty())
                               .trackSortedReplicasFor(replicaSortName(this, false, false), clusterModel);
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionGoal.java
@@ -164,8 +164,10 @@ public class ReplicaDistributionGoal extends ReplicaDistributionAbstractGoal {
                                                        optimizationOptions.onlyMoveImmigrantReplicas())
                                 .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectImmigrantOrOfflineReplicas(),
                                                        !clusterModel.selfHealingEligibleReplicas().isEmpty() && broker.isAlive())
-                                .addSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics))
-                                .addPriorityFunc(ReplicaSortFunctionFactory.prioritizeOfflineReplicas())
+                                .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics),
+                                                       !excludedTopics.isEmpty())
+                                .maybeAddPriorityFunc(ReplicaSortFunctionFactory.prioritizeOfflineReplicas(),
+                                                      !clusterModel.selfHealingEligibleReplicas().isEmpty())
                                 .maybeAddPriorityFunc(ReplicaSortFunctionFactory.prioritizeImmigrants(),
                                                       !optimizationOptions.onlyMoveImmigrantReplicas())
                                 .setScoreFunc(ReplicaSortFunctionFactory.sortByMetricGroupValue(DISK.name()))

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicReplicaDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicReplicaDistributionGoal.java
@@ -282,7 +282,8 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
                                                        optimizationOptions.onlyMoveImmigrantReplicas())
                                 .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectImmigrantOrOfflineReplicas(),
                                                        !clusterModel.selfHealingEligibleReplicas().isEmpty() && broker.isAlive())
-                                .addSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics))
+                                .maybeAddSelectionFunc(ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics),
+                                                       !excludedTopics.isEmpty())
                                 .trackSortedReplicasFor(replicaSortName(this, false, false), broker);
     }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Host.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Host.java
@@ -61,21 +61,6 @@ public class Host implements Serializable {
   }
 
   /**
-   * Get the number of replicas with the given topic name in this host.
-   *
-   * @param topic Name of the topic for which the number of replicas in this rack will be counted.
-   * @return Number of replicas with the given topic name in this host.
-   */
-  public int numTopicReplicas(String topic) {
-    int numTopicReplicas = 0;
-
-    for (Broker broker : _brokers.values()) {
-      numTopicReplicas += broker.numReplicasOfTopicInBroker(topic);
-    }
-    return numTopicReplicas;
-  }
-
-  /**
    * @return All the topics that have at least one partition on the host.
    */
   public Set<String> topics() {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ModelUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ModelUtils.java
@@ -152,11 +152,11 @@ public class ModelUtils {
    * @return A single representative utilization value on a resource, or {@code 0} if the given aggregatedMetricValues is empty.
    */
   public static double expectedUtilizationFor(Resource resource, AggregatedMetricValues aggregatedMetricValues) {
-    validateNotNull(resource, "Resource cannot be null.");
     validateNotNull(aggregatedMetricValues, "AggregatedMetricValues cannot be null.");
     if (aggregatedMetricValues.isEmpty()) {
       return 0.0;
     }
+    validateNotNull(resource, "Resource cannot be null.");
     double result = 0;
     for (MetricInfo info : KafkaMetricDef.resourceToMetricInfo(resource)) {
       MetricValues valuesForId = aggregatedMetricValues.valuesFor(info.id());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Rack.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Rack.java
@@ -100,21 +100,6 @@ public class Rack implements Serializable {
   }
 
   /**
-   * Get the number of replicas with the given topic name in this rack.
-   *
-   * @param topic Name of the topic for which the number of replicas in this rack will be counted.
-   * @return Number of replicas with the given topic name in this rack.
-   */
-  public int numTopicReplicas(String topic) {
-    int numTopicReplicas = 0;
-
-    for (Host host : _hosts.values()) {
-      numTopicReplicas += host.numTopicReplicas(topic);
-    }
-    return numTopicReplicas;
-  }
-
-  /**
    * @return A set of topic names in the cluster.
    */
   public Set<String> topics() {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicas.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicas.java
@@ -135,7 +135,7 @@ public class SortedReplicas {
   }
 
   /**
-   * Add a new replicas to the sorted replicas. The replica will be included if it satisfies the requirement of all
+   * Add a new replica to the sorted replicas. The replica will be included if it satisfies the requirement of all
    * selection functions. It has no impact if this {@link SortedReplicas} has not been initialized.
    *
    * @param replica the replica to add.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicasHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicasHelper.java
@@ -30,8 +30,8 @@ import java.util.function.Function;
  */
 public class SortedReplicasHelper {
 
-  private Set<Function<Replica, Boolean>> _selectionFuncs;
-  private Set<Function<Replica, Integer>> _priorityFuncs;
+  private final Set<Function<Replica, Boolean>> _selectionFuncs;
+  private final Set<Function<Replica, Integer>> _priorityFuncs;
   private Function<Replica, Double> _scoreFunc;
 
   public SortedReplicasHelper() {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/OptimizationVerifier.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/OptimizationVerifier.java
@@ -230,9 +230,7 @@ class OptimizationVerifier {
   }
 
   private static boolean verifyBrokenBrokers(ClusterModel clusterModel) {
-    Set<Broker> deadBrokers = clusterModel.brokers();
-    deadBrokers.removeAll(clusterModel.aliveBrokers());
-    for (Broker deadBroker : deadBrokers) {
+    for (Broker deadBroker : clusterModel.deadBrokers()) {
       if (deadBroker.replicas().size() > 0) {
         LOG.error("Failed to move {} replicas on dead broker {} to other brokers.", deadBroker.replicas().size(),
                   deadBroker.id());


### PR DESCRIPTION
This PR resolves #1580.

The selected inefficiencies addressed in this PR have been identified based on CPU profiling during optimization of goals. This patch does not cover _all_ potential inefficient code paths, but only addresses key inefficiencies that stand out in profiling results.

As a result of these improvements, clean build time of Cruise Control with all unit tests and static analysis dropped from
* [on Local box] `~16 minutes` to `~14.5 minutes` -- i.e. local CC build is `9.4%` faster

In particular, local run of the `RandomClusterExpDistNewBrokerTest` (i.e. one of the most expensive CC test that performs multiple goal optimizations with different parameters) has dropped from 
* [on Local box] `3minutes 50s` to `3minutes 10s`, which means `~17.4%` improvement. _Note: Performance numbers are collected from running the test 3 times before and after the change and comparing the average._

Notes -- notable changes:
* Avoid cloning sortedReplicas in `ResourceDistributionGoal#rebalanceByMovingLoadIn` as this operation is expensive and has been performed frequently in this function.
* Add priority function `ReplicaSortFunctionFactory.prioritizeOfflineReplicas()` only if the cluster has offline replicas
* Add selection function `ReplicaSortFunctionFactory.selectReplicasBasedOnExcludedTopics(excludedTopics)` only if the cluster has excluded topics.
* Cache number of replicas by topic rather than recomputing it every time based on topics on each brokers.