### PR TITLE
Ability to configure TLS protocols and ciphers via configuration (#1582)

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlApp.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlApp.java
@@ -22,6 +22,7 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import javax.servlet.ServletException;
+import java.util.List;
 
 public class KafkaCruiseControlApp {
 
@@ -109,6 +110,7 @@ public class KafkaCruiseControlApp {
       if (keyStoreType != null) {
         sslServerContextFactory.setKeyStoreType(keyStoreType);
       }
+      maybeConfigureTlsProtocolsAndCiphers(sslServerContextFactory);
       serverConnector = new ServerConnector(_server, sslServerContextFactory);
     } else {
       serverConnector = new ServerConnector(_server);
@@ -116,6 +118,27 @@ public class KafkaCruiseControlApp {
     serverConnector.setHost(hostname);
     serverConnector.setPort(port);
     return serverConnector;
+  }
+
+  private void maybeConfigureTlsProtocolsAndCiphers(SslContextFactory sslContextFactory) {
+    List<String> includeProtocols = _config.getList(WebServerConfig.WEBSERVER_SSL_INCLUDE_PROTOCOLS_CONFIG);
+    if (includeProtocols != null) {
+      sslContextFactory.setIncludeProtocols(includeProtocols.toArray(new String[0]));
+    }
+    List<String> excludeProtocols = _config.getList(WebServerConfig.WEBSERVER_SSL_EXCLUDE_PROTOCOLS_CONFIG);
+    if (excludeProtocols != null) {
+      sslContextFactory.setExcludeProtocols(excludeProtocols.toArray(new String[0]));
+    }
+
+    List<String> includeCiphers = _config.getList(WebServerConfig.WEBSERVER_SSL_INCLUDE_CIPHERS_CONFIG);
+    if (includeCiphers != null) {
+      sslContextFactory.setIncludeCipherSuites(includeCiphers.toArray(new String[0]));
+    }
+
+    List<String> excludeCiphers = _config.getList(WebServerConfig.WEBSERVER_SSL_EXCLUDE_CIPHERS_CONFIG);
+    if (excludeCiphers != null) {
+      sslContextFactory.setExcludeCipherSuites(excludeCiphers.toArray(new String[0]));
+    }
   }
 
   private void setupWebUi(ServletContextHandler contextHandler) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/WebServerConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/WebServerConfig.java
@@ -225,6 +225,38 @@ public class WebServerConfig {
   private static final String WEBSERVER_SSL_PROTOCOL_DOC = "Sets the SSL protocol to use. By default it's TLS.";
 
   /**
+   * <code>webserver.ssl.include.ciphers</code>
+   */
+  public static final String WEBSERVER_SSL_INCLUDE_CIPHERS_CONFIG = "webserver.ssl.include.ciphers";
+  public static final String DEFAULT_WEBSERVER_SSL_INCLUDE_CIPHERS = null;
+  private static final String WEBSERVER_SSL_INCLUDE_CIPHERS_DOC = "Sets the included ciphers (list) for the webserver. "
+      + "If not set, it does not change the system defaults.";
+
+  /**
+   * <code>webserver.ssl.exclude.ciphers</code>
+   */
+  public static final String WEBSERVER_SSL_EXCLUDE_CIPHERS_CONFIG = "webserver.ssl.exclude.ciphers";
+  public static final String DEFAULT_WEBSERVER_SSL_EXCLUDE_CIPHERS = null;
+  private static final String WEBSERVER_SSL_EXCLUDE_CIPHERS_DOC = "Sets the excluded ciphers (list of patterns) for the webserver. "
+      + "If not set, it does not change the system defaults.";
+
+  /**
+   * <code>webserver.ssl.include.protocols</code>
+   */
+  public static final String WEBSERVER_SSL_INCLUDE_PROTOCOLS_CONFIG = "webserver.ssl.include.protocols";
+  public static final String DEFAULT_WEBSERVER_SSL_INCLUDE_PROTOCOLS = null;
+  private static final String WEBSERVER_SSL_INCLUDE_PROTOCOLS_DOC = "Sets the included TLS protocols for the webserver. "
+      + "If not set, it does not change the system defaults.";
+
+  /**
+   * <code>webserver.ssl.exclude.protocols</code>
+   */
+  public static final String WEBSERVER_SSL_EXCLUDE_PROTOCOLS_CONFIG = "webserver.ssl.exclude.protocols";
+  public static final String DEFAULT_WEBSERVER_SSL_EXCLUDE_PROTOCOLS = null;
+  private static final String WEBSERVER_SSL_EXCLUDE_PROTOCOLS_DOC = "Sets the excluded protocols (list of patterns) for the webserver. "
+      + "If not set, it does not change the system defaults.";
+
+  /**
    * <code>jwt.authentication.provider.url</code>
    */
   public static final String JWT_AUTHENTICATION_PROVIDER_URL_CONFIG = "jwt.authentication.provider.url";
@@ -449,6 +481,26 @@ public class WebServerConfig {
                             DEFAULT_WEBSERVER_SSL_PROTOCOL,
                             ConfigDef.Importance.MEDIUM,
                             WEBSERVER_SSL_PROTOCOL_DOC)
+                    .define(WEBSERVER_SSL_INCLUDE_CIPHERS_CONFIG,
+                            ConfigDef.Type.LIST,
+                            DEFAULT_WEBSERVER_SSL_INCLUDE_CIPHERS,
+                            ConfigDef.Importance.MEDIUM,
+                            WEBSERVER_SSL_INCLUDE_CIPHERS_DOC)
+                    .define(WEBSERVER_SSL_EXCLUDE_CIPHERS_CONFIG,
+                        ConfigDef.Type.LIST,
+                        DEFAULT_WEBSERVER_SSL_EXCLUDE_CIPHERS,
+                        ConfigDef.Importance.MEDIUM,
+                        WEBSERVER_SSL_EXCLUDE_CIPHERS_DOC)
+                    .define(WEBSERVER_SSL_INCLUDE_PROTOCOLS_CONFIG,
+                        ConfigDef.Type.LIST,
+                        DEFAULT_WEBSERVER_SSL_INCLUDE_PROTOCOLS,
+                        ConfigDef.Importance.MEDIUM,
+                        WEBSERVER_SSL_INCLUDE_PROTOCOLS_DOC)
+                    .define(WEBSERVER_SSL_EXCLUDE_PROTOCOLS_CONFIG,
+                        ConfigDef.Type.LIST,
+                        DEFAULT_WEBSERVER_SSL_EXCLUDE_PROTOCOLS,
+                        ConfigDef.Importance.MEDIUM,
+                        WEBSERVER_SSL_EXCLUDE_PROTOCOLS_DOC)
                     .define(JWT_AUTHENTICATION_PROVIDER_URL_CONFIG,
                             ConfigDef.Type.STRING,
                             DEFAULT_JWT_AUTHENTICATION_PROVIDER_URL,


### PR DESCRIPTION
This PR resolves #1582.

CruiseControl webserver uses Jetty and relies on the Jetty SslContextFactory. In some environments, it is beneficial to configure TLS protocol/cipher whitelist/blacklist that the server should enable.

Four new configuration properties are introduced:
- webserver.ssl.exclude.ciphers
- webserver.ssl.include.ciphers
- webserver.ssl.exclude.protocols
- webserver.ssl.include.protocols

These are used to configure the corresponding properties in the Jetty SslContextFactory.
