### PR TITLE
Add (optional) checkstyle pre-commit hook script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,3 +29,4 @@ discussed are unlikely to be accepted.
 7. If there are no existing issues about a PR, create one before submitting the PR.
 8. We strongly encourage the use of recommended code-style for the project 
 (see [code-style.xml](https://github.com/linkedin/cruise-control/blob/master/docs/code-style.xml)).
+9. A pre-commit CheckStyle hook can be run by adding `./checkstyle/checkstyle-pre-commit` to your `.git/hooks/pre-commit` script.

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
   id "jacoco" // Java Code Coverage plugin
   id "com.github.ben-manes.versions" version "0.38.0"
   id "com.github.spotbugs" version "4.7.1" apply false
+  id "checkstyle"
 }
 
 group = 'com.linkedin.cruisecontrol'

--- a/checkstyle/checkstyle-pre-commit
+++ b/checkstyle/checkstyle-pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+./gradlew checkstyleMain
+STATUS=$?
+if [ $STATUS -eq 0 ]; then
+    exit 0
+else
+    printf >&2 "\nERROR: Checkstyle issues found! Check the log output above for ERROR lines.\n\n"
+    exit 1
+fi


### PR DESCRIPTION
I often forget to run CheckStyle before pushing a commit, which then fails the CI build. Therefore I added a pre-commit hook to run checkstyle (via the gradle checkstyle plugin). This is obviously optional, it does increase the time to do a commit, but it reduces the wasted effort of running CI on something that has style issues.
