### PR TITLE
Add Java version compatibility to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Cruise Control for Apache Kafka
 * `message.format.version` `0.10.0` and above is needed
 * The `master` and `kafka_0_11_and_1_0` branch compile with `Scala 2.11`
 * The development branches `migrate_to_kafka_2_4` and `migrate_to_kafka_2_5` compile with `Scala 2.12`
+* This project requires Java 11
 
 #### Known Compatibility Issues ####
 * Support for Apache Kafka `2.0`, `2.1`, `2.2`, and `2.3` requires [KAFKA-8875](https://issues.apache.org/jira/browse/KAFKA-8875) hotfix.
@@ -71,7 +72,7 @@ Cruise Control for Apache Kafka
         && git tag -a 0.1.10 -m "Init local version."`
 1. This step is required if `CruiseControlMetricsReporter` is used for metrics collection (i.e. the default for Cruise
 Control). The metrics reporter periodically samples the Kafka raw metrics on the broker and sends them to a Kafka topic.
-    * `./gradlew jar`
+    * `./gradlew jar` (Note: This project requires Java 11)
     * Copy `./cruise-control-metrics-reporter/build/libs/cruise-control-metrics-reporter-A.B.C.jar` (Where `A.B.C` is
     the version of the Cruise Control) to your Kafka server dependency jar folder. For Apache Kafka, the folder would
     be `core/build/dependant-libs-SCALA_VERSION/` (for a Kafka source checkout) or `libs/` (for a Kafka release download).

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,6 @@ allprojects {
 
   repositories {
     mavenCentral()
-    jcenter()
   }
 
   apply plugin: 'com.github.ben-manes.versions'
@@ -81,13 +80,16 @@ subprojects {
   apply plugin: "com.github.spotbugs"
   apply plugin: 'jacoco'
 
+  // This project requires Java 11
+  sourceCompatibility = JavaVersion.VERSION_11
+
   task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
+    archiveClassifier.set("sources")
     from sourceSets.main.allSource
   }
 
   task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
+    archiveClassifier.set("javadoc")
     from javadoc.destinationDir
   }
 


### PR DESCRIPTION
This PR resolves #1600.

**Notes.** It also drops
1. the deprecated `classifier` and adds  `archiveClassifier.set(xxx)` instead, and
2. `jcenter()` dependency, which shows the warning -- _Builds will no longer be able to resolve artifacts from JCenter after February 1st, 2022_