### PR TITLE
Cleanup deprecated/unused kafkaZkClient-based ExecutorUtils functions

### DIFF
--- a/cruise-control/src/main/scala/com/linkedin/kafka/cruisecontrol/executor/ExecutorUtils.scala
+++ b/cruise-control/src/main/scala/com/linkedin/kafka/cruisecontrol/executor/ExecutorUtils.scala
@@ -8,7 +8,7 @@ import java.util
 import java.util.Properties
 
 import kafka.admin.PreferredReplicaLeaderElectionCommand
-import kafka.zk.{AdminZkClient, KafkaZkClient, ZkVersion}
+import kafka.zk.{AdminZkClient, KafkaZkClient}
 import org.apache.kafka.common.TopicPartition
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -21,78 +21,6 @@ import scala.collection.JavaConverters._
 object ExecutorUtils {
   val LOG: Logger = LoggerFactory.getLogger(ExecutorUtils.getClass.getName)
 
-  /**
-   * Add a list of replica reassignment tasks to execute. Replica reassignment indicates tasks that (1) relocate a replica
-   * within the cluster, (2) introduce a new replica to the cluster (3) remove an existing replica from the cluster.
-   *
-   * @param kafkaZkClient the KafkaZkClient class to use for partition reassignment.
-   * @param tasksToExecute Replica reassignment tasks to be executed.
-   * @deprecated Use com.linkedin.kafka.cruisecontrol.executor.ExecutionUtils#submitReplicaReassignmentTasks() instead.
-   */
-  def executeReplicaReassignmentTasks(kafkaZkClient: KafkaZkClient,
-                                      tasksToExecute: java.util.List[ExecutionTask]) {
-    if (tasksToExecute != null && !tasksToExecute.isEmpty) {
-      val inProgressReplicaReassignment = kafkaZkClient.getPartitionReassignment
-      // Add the partition being assigned to the newReplicaAssignment because we are going to add the new
-      // reassignment together.
-      val newReplicaAssignment = scala.collection.mutable.Map(inProgressReplicaReassignment.toSeq: _*)
-      tasksToExecute.asScala.foreach({ task =>
-        val tp = task.proposal.topicPartition()
-        val oldReplicas = asScalaBuffer(task.proposal.oldReplicas()).map(_.brokerId.toInt)
-        val newReplicas = asScalaBuffer(task.proposal().newReplicas()).map(_.brokerId.toInt)
-
-        val inProgressReplicasOpt = newReplicaAssignment.get(tp)
-        var addTask = true
-        val replicasToWrite = inProgressReplicasOpt match {
-          case Some(inProgressReplicas) =>
-            if (task.state() == ExecutionTaskState.ABORTING) {
-              oldReplicas
-            } else if (task.state() == ExecutionTaskState.DEAD
-              || task.state() == ExecutionTaskState.ABORTED
-              || task.state() == ExecutionTaskState.COMPLETED) {
-              addTask = false
-              Seq.empty
-            } else if (task.state() == ExecutionTaskState.IN_PROGRESS) {
-              if (!newReplicas.equals(inProgressReplicas)) {
-                throw new RuntimeException(s"The provided new replica list $newReplicas" +
-                  s"is different from the in progress replica list $inProgressReplicas for $tp")
-              }
-              newReplicas
-            } else {
-              throw new IllegalStateException(s"Should never be here, the state is ${task.state()}")
-            }
-          case None =>
-            if (task.state() == ExecutionTaskState.ABORTED
-              || task.state() == ExecutionTaskState.DEAD
-              || task.state() == ExecutionTaskState.ABORTING
-              || task.state() == ExecutionTaskState.COMPLETED) {
-              LOG.warn(s"No need to abort tasks $task because the partition is not in reassignment")
-              addTask = false
-              Seq.empty
-            } else {
-              // verify with current assignment
-              val currentReplicaAssignment = kafkaZkClient.getReplicasForPartition(tp)
-              if (currentReplicaAssignment.isEmpty) {
-                LOG.warn(s"The partition $tp does not exist.")
-                addTask = false
-                Seq.empty
-              } else {
-                // we are not verifying the old replicas because the we may be reexecuting a task,
-                // in which case the replica list could be different from the old replicas.
-                newReplicas
-              }
-            }
-        }
-        if (addTask)
-          newReplicaAssignment += (tp -> replicasToWrite)
-      })
-
-      // We do not use the ReassignPartitionsCommand here because we want to have incremental partition movement.
-      if (newReplicaAssignment.nonEmpty)
-        kafkaZkClient.setOrCreatePartitionReassignment(newReplicaAssignment, ZkVersion.MatchAnyVersion)
-    }
-  }
-
   def executePreferredLeaderElection(kafkaZkClient: KafkaZkClient, tasks: java.util.List[ExecutionTask]) {
     val partitionsToExecute = tasks.asScala.map(task =>
       new TopicPartition(task.proposal.topic, task.proposal.partitionId)).toSet
@@ -100,31 +28,8 @@ object ExecutorUtils {
     preferredReplicaElectionCommand.moveLeaderToPreferredReplica()
   }
 
-  /**
-   * Retrieve the set of partitions that are currently being reassigned.
-   *
-   * @param kafkaZkClient the KafkaZkClient class to use for getting partition reassignment.
-   * @return Set of partitions with ongoing reassignments.
-   * @deprecated Use [[com.linkedin.kafka.cruisecontrol.executor.ExecutionUtils]]#partitionsBeingReassigned instead.
-   */
-  def partitionsBeingReassigned(kafkaZkClient: KafkaZkClient): util.Set[TopicPartition] = {
-    setAsJavaSet(kafkaZkClient.getPartitionReassignment.keys.toSet)
-  }
-
   def ongoingLeaderElection(kafkaZkClient: KafkaZkClient): util.Set[TopicPartition] = {
     setAsJavaSet(kafkaZkClient.getPreferredReplicaElection)
-  }
-
-  def newAssignmentForPartition(kafkaZkClient: KafkaZkClient, tp : TopicPartition): java.util.List[Integer] = {
-    val inProgressReassignment =
-      kafkaZkClient.getPartitionReassignment.getOrElse(new TopicPartition(tp.topic(), tp.partition()),
-      throw new NoSuchElementException(s"Partition $tp is not being reassigned."))
-
-    seqAsJavaList(inProgressReassignment.map(i => i : java.lang.Integer))
-  }
-
-  def currentReplicasForPartition(kafkaZkClient: KafkaZkClient, tp: TopicPartition): java.util.List[java.lang.Integer] = {
-    seqAsJavaList(kafkaZkClient.getReplicasForPartition(new TopicPartition(tp.topic(), tp.partition())).map(i => i : java.lang.Integer))
   }
 
   def changeBrokerConfig(adminZkClient: AdminZkClient, brokerId: Int, config: Properties): Unit = {
@@ -133,9 +38,5 @@ object ExecutorUtils {
 
   def changeTopicConfig(adminZkClient: AdminZkClient, topic: String, config: Properties): Unit = {
     adminZkClient.changeTopicConfig(topic, config)
-  }
-
-  def getAllLiveBrokerIdsInCluster(kafkaZkClient: KafkaZkClient): java.util.List[java.lang.Integer] = {
-    seqAsJavaList(kafkaZkClient.getAllBrokersInCluster.map(_.id : java.lang.Integer))
   }
 }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -172,10 +172,7 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
       Collection<ExecutionProposal> proposalsToExecute = Arrays.asList(proposal0, proposal1);
       executeAndVerifyProposals(kafkaZkClient, proposalsToExecute, Collections.emptyList(), true, null, false, false);
 
-      // We are doing the rollback.
-      assertThrows(java.util.NoSuchElementException.class, () -> ExecutorUtils.newAssignmentForPartition(kafkaZkClient, TP0));
-      assertThrows(java.util.NoSuchElementException.class, () -> ExecutorUtils.newAssignmentForPartition(kafkaZkClient, TP1));
-      // The leadership should be on the alive broker.
+      // We are doing the rollback. -- The leadership should be on the alive broker.
       assertEquals(initialLeader0, kafkaZkClient.getLeaderForPartition(TP0).get());
       assertEquals(initialLeader0, kafkaZkClient.getLeaderForPartition(TP1).get());
     } finally {


### PR DESCRIPTION
This PR resolves #1605.