### PR TITLE
Disable bootstrap endpoint in non-developer_mode

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/sync/BootstrapRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/sync/BootstrapRequest.java
@@ -26,7 +26,10 @@ public class BootstrapRequest extends AbstractSyncRequest {
     Long startMs = _parameters.startMs();
     Long endMs = _parameters.endMs();
     boolean clearMetrics = _parameters.clearMetrics();
-    _kafkaCruiseControl.bootstrap(startMs, endMs, clearMetrics);
+    if (_parameters.developerMode()) {
+      // This endpoint is used only for development purposes in developer_mode=true.
+      _kafkaCruiseControl.bootstrap(startMs, endMs, clearMetrics);
+    }
 
     return new BootstrapResult(_kafkaCruiseControl.config());
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/BootstrapParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/BootstrapParameters.java
@@ -15,6 +15,7 @@ import java.util.TreeSet;
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.START_MS_PARAM;
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.END_MS_PARAM;
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.CLEAR_METRICS_PARAM;
+import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.DEVELOPER_MODE_PARAM;
 
 
 /**
@@ -23,13 +24,13 @@ import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils
  * <pre>
  * 1. RANGE MODE:
  *    GET /kafkacruisecontrol/bootstrap?start=[START_TIMESTAMP]&amp;end=[END_TIMESTAMP]&amp;clearmetrics=[true/false]
- *    &amp;json=[true/false]&amp;get_response_schema=[true/false]
+ *    &amp;json=[true/false]&amp;get_response_schema=[true/false]&amp;developer_mode=[true/false]
  * 2. SINCE MODE:
  *    GET /kafkacruisecontrol/bootstrap?start=[START_TIMESTAMP]&amp;clearmetrics=[true/false]&amp;json=[true/false]
- *    &amp;get_response_schema=[true/false]
+ *    &amp;get_response_schema=[true/false]&amp;developer_mode=[true/false]
  * 3. RECENT MODE:
  *    GET /kafkacruisecontrol/bootstrap?clearmetrics=[true/false]&amp;json=[true/false]
- *    &amp;get_response_schema=[true/false]
+ *    &amp;get_response_schema=[true/false]&amp;developer_mode=[true/false]
  * </pre>
  */
 public class BootstrapParameters extends AbstractParameters {
@@ -39,12 +40,14 @@ public class BootstrapParameters extends AbstractParameters {
     validParameterNames.add(START_MS_PARAM);
     validParameterNames.add(END_MS_PARAM);
     validParameterNames.add(CLEAR_METRICS_PARAM);
+    validParameterNames.add(DEVELOPER_MODE_PARAM);
     validParameterNames.addAll(AbstractParameters.CASE_INSENSITIVE_PARAMETER_NAMES);
     CASE_INSENSITIVE_PARAMETER_NAMES = Collections.unmodifiableSortedSet(validParameterNames);
   }
   protected Long _startMs;
   protected Long _endMs;
   protected boolean _clearMetrics;
+  protected boolean _developerMode;
 
   public BootstrapParameters() {
     super();
@@ -56,6 +59,7 @@ public class BootstrapParameters extends AbstractParameters {
     _startMs = ParameterUtils.startMsOrDefault(_request, null);
     _endMs = ParameterUtils.endMsOrDefault(_request, null);
     _clearMetrics = ParameterUtils.clearMetrics(_request);
+    _developerMode = ParameterUtils.developerMode(_request);
     if (_startMs == null && _endMs != null) {
       throw new UserRequestException("The start time cannot be empty when end time is specified.");
     }
@@ -74,6 +78,10 @@ public class BootstrapParameters extends AbstractParameters {
 
   public boolean clearMetrics() {
     return _clearMetrics;
+  }
+
+  public boolean developerMode() {
+    return _developerMode;
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
@@ -131,6 +131,7 @@ public class ParameterUtils {
   public static final String FORCE_STOP_PARAM = "force_stop";
   public static final String FAST_MODE_PARAM = "fast_mode";
   public static final String STOP_EXTERNAL_AGENT_PARAM = "stop_external_agent";
+  public static final String DEVELOPER_MODE_PARAM = "developer_mode";
   private static final int MAX_REASON_LENGTH = 50;
   private static final String DELIMITER_BETWEEN_BROKER_ID_AND_LOGDIR = "-";
   public static final long DEFAULT_START_TIME_FOR_CLUSTER_MODEL = -1L;
@@ -402,6 +403,10 @@ public class ParameterUtils {
 
   static boolean stopExternalAgent(HttpServletRequest request) {
     return getBooleanParam(request, STOP_EXTERNAL_AGENT_PARAM, true);
+  }
+
+  static boolean developerMode(HttpServletRequest request) {
+    return getBooleanParam(request, DEVELOPER_MODE_PARAM, false);
   }
 
   static boolean throttleAddedOrRemovedBrokers(HttpServletRequest request, EndPoint endPoint) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/BootstrapResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/BootstrapResult.java
@@ -7,6 +7,8 @@ package com.linkedin.kafka.cruisecontrol.servlet.response;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint;
 import com.linkedin.cruisecontrol.servlet.parameters.CruiseControlParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.BootstrapParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils;
 
 import static com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils.getBaseJSONString;
 
@@ -22,7 +24,9 @@ public class BootstrapResult extends AbstractCruiseControlResponse {
   @Override
   protected void discardIrrelevantAndCacheRelevant(CruiseControlParameters parameters) {
     // Cache relevant response.
-    String message = String.format("Bootstrap started. Check status through the %s endpoint", CruiseControlEndPoint.STATE);
+    String message = ((BootstrapParameters) parameters).developerMode()
+                     ? String.format("Bootstrap started. Check status through the %s endpoint", CruiseControlEndPoint.STATE)
+                     : String.format("This endpoint is used only for development purposes in %s=true.", ParameterUtils.DEVELOPER_MODE_PARAM);
     _cachedResponse = parameters.json() ? getBaseJSONString(message) : message;
   }
 }

--- a/cruise-control/src/yaml/endpoints/bootstrap.yaml
+++ b/cruise-control/src/yaml/endpoints/bootstrap.yaml
@@ -21,7 +21,13 @@ BootstrapEndpoint:
           minimum: 0
       - name: clearmetrics
         in: query
-        description: Whethere clear the collected metrics sample during bootstrap.
+        description: Whether to clear the collected metric samples during bootstrap.
+        schema:
+          type: boolean
+          default: false
+      - name: developer_mode
+        in: query
+        description: Whether to run the request in developer mode.
         schema:
           type: boolean
           default: false


### PR DESCRIPTION
This PR resolves #1579.

With this PR, bootstrap endpoint will be disabled unless the request explicitly sets the `developer_mode` parameter to `true`.