### PR TITLE
Allow trusted proxy to fall back to spnego

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/WebServerConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/WebServerConfig.java
@@ -324,6 +324,16 @@ public final class WebServerConfig {
       + "trusted.proxy.services then the operation will be delegated as the user in the doAs parameter. This is an optional "
       + "parameter. Not specifying this means that the IP of the trusted proxy won't be validated.";
 
+  /**
+   * <code>trusted.proxy.spnego.fallback.enabled</code>
+   */
+  public static final String TRUSTED_PROXY_SPNEGO_FALLBACK_ENABLED_CONFIG = "trusted.proxy.spnego.fallback.enabled";
+  public static final boolean DEFAULT_TRUSTED_PROXY_SPNEGO_FALLBACK_ENABLED = false;
+  private static final String TRUSTED_PROXY_SPNEGO_FALLBACK_ENABLED_DOC = "In some cases it is favourable to use "
+      + "the service user if no doAs user is provided. When this flag is enabled and if no doAs user is found in the "
+      + "request, then the service user will be used as the authenticated principal (so there will be no delegation "
+      + "or impersonation but rather a simple fallback to SPNEGO).";
+
   private WebServerConfig() {
   }
 
@@ -487,20 +497,20 @@ public final class WebServerConfig {
                             ConfigDef.Importance.MEDIUM,
                             WEBSERVER_SSL_INCLUDE_CIPHERS_DOC)
                     .define(WEBSERVER_SSL_EXCLUDE_CIPHERS_CONFIG,
-                        ConfigDef.Type.LIST,
-                        DEFAULT_WEBSERVER_SSL_EXCLUDE_CIPHERS,
-                        ConfigDef.Importance.MEDIUM,
-                        WEBSERVER_SSL_EXCLUDE_CIPHERS_DOC)
+                            ConfigDef.Type.LIST,
+                            DEFAULT_WEBSERVER_SSL_EXCLUDE_CIPHERS,
+                            ConfigDef.Importance.MEDIUM,
+                            WEBSERVER_SSL_EXCLUDE_CIPHERS_DOC)
                     .define(WEBSERVER_SSL_INCLUDE_PROTOCOLS_CONFIG,
-                        ConfigDef.Type.LIST,
-                        DEFAULT_WEBSERVER_SSL_INCLUDE_PROTOCOLS,
-                        ConfigDef.Importance.MEDIUM,
-                        WEBSERVER_SSL_INCLUDE_PROTOCOLS_DOC)
+                            ConfigDef.Type.LIST,
+                            DEFAULT_WEBSERVER_SSL_INCLUDE_PROTOCOLS,
+                            ConfigDef.Importance.MEDIUM,
+                            WEBSERVER_SSL_INCLUDE_PROTOCOLS_DOC)
                     .define(WEBSERVER_SSL_EXCLUDE_PROTOCOLS_CONFIG,
-                        ConfigDef.Type.LIST,
-                        DEFAULT_WEBSERVER_SSL_EXCLUDE_PROTOCOLS,
-                        ConfigDef.Importance.MEDIUM,
-                        WEBSERVER_SSL_EXCLUDE_PROTOCOLS_DOC)
+                            ConfigDef.Type.LIST,
+                            DEFAULT_WEBSERVER_SSL_EXCLUDE_PROTOCOLS,
+                            ConfigDef.Importance.MEDIUM,
+                            WEBSERVER_SSL_EXCLUDE_PROTOCOLS_DOC)
                     .define(JWT_AUTHENTICATION_PROVIDER_URL_CONFIG,
                             ConfigDef.Type.STRING,
                             DEFAULT_JWT_AUTHENTICATION_PROVIDER_URL,
@@ -540,6 +550,11 @@ public final class WebServerConfig {
                             ConfigDef.Type.STRING,
                             DEFAULT_TRUSTED_PROXY_SERVICES_IP_REGEX,
                             ConfigDef.Importance.MEDIUM,
-                            TRUSTED_PROXY_SERVICES_IP_REGEX_DOC);
+                            TRUSTED_PROXY_SERVICES_IP_REGEX_DOC)
+                    .define(TRUSTED_PROXY_SPNEGO_FALLBACK_ENABLED_CONFIG,
+                            ConfigDef.Type.BOOLEAN,
+                            DEFAULT_TRUSTED_PROXY_SPNEGO_FALLBACK_ENABLED,
+                            ConfigDef.Importance.MEDIUM,
+                            TRUSTED_PROXY_SPNEGO_FALLBACK_ENABLED_DOC);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxyAuthorizationService.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxyAuthorizationService.java
@@ -20,12 +20,12 @@ import java.util.regex.Pattern;
  */
 public class TrustedProxyAuthorizationService extends AbstractLifeCycle implements AuthorizationService {
 
-  private final UserStore _adminUserStore;
+  private final UserStore _serviceUserStore;
   private final Pattern _trustedProxyIpPattern;
 
   TrustedProxyAuthorizationService(List<String> userNames, String trustedProxyIpPattern) {
-    _adminUserStore = new UserStore();
-    userNames.forEach(u -> _adminUserStore.addUser(u, SecurityUtils.NO_CREDENTIAL, new String[] { DefaultRoleSecurityProvider.ADMIN }));
+    _serviceUserStore = new UserStore();
+    userNames.forEach(u -> _serviceUserStore.addUser(u, SecurityUtils.NO_CREDENTIAL, new String[] { DefaultRoleSecurityProvider.ADMIN }));
     if (trustedProxyIpPattern != null) {
       _trustedProxyIpPattern = Pattern.compile(trustedProxyIpPattern);
     } else {
@@ -38,7 +38,7 @@ public class TrustedProxyAuthorizationService extends AbstractLifeCycle implemen
     // ConfigurableSpnegoAuthenticator may pass names in servicename/host format but we only store the servicename
     int nameHostSeparatorIndex = name.indexOf('/');
     String serviceName = nameHostSeparatorIndex > 0 ? name.substring(0, nameHostSeparatorIndex) : name;
-    UserIdentity serviceIdentity = _adminUserStore.getUserIdentity(serviceName);
+    UserIdentity serviceIdentity = _serviceUserStore.getUserIdentity(serviceName);
     if (_trustedProxyIpPattern != null) {
       return _trustedProxyIpPattern.matcher(request.getRemoteAddr()).matches() ? serviceIdentity : null;
     } else {
@@ -48,13 +48,13 @@ public class TrustedProxyAuthorizationService extends AbstractLifeCycle implemen
 
   @Override
   protected void doStart() throws Exception {
-    _adminUserStore.start();
+    _serviceUserStore.start();
     super.doStart();
   }
 
   @Override
   protected void doStop() throws Exception {
     super.doStop();
-    _adminUserStore.stop();
+    _serviceUserStore.stop();
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxySecurityProvider.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxySecurityProvider.java
@@ -24,6 +24,7 @@ public class TrustedProxySecurityProvider extends SpnegoSecurityProvider {
 
   private List<String> _trustedProxyServices;
   private String _trustedProxyServicesIpRegex;
+  private boolean _fallbackToSpnegoAllowed;
 
   private static final Logger LOG = LoggerFactory.getLogger(TrustedProxySecurityProvider.class);
 
@@ -31,6 +32,7 @@ public class TrustedProxySecurityProvider extends SpnegoSecurityProvider {
   public void init(KafkaCruiseControlConfig config) {
     super.init(config);
     _trustedProxyServices = config.getList(WebServerConfig.TRUSTED_PROXY_SERVICES_CONFIG);
+    _fallbackToSpnegoAllowed = config.getBoolean(WebServerConfig.TRUSTED_PROXY_SPNEGO_FALLBACK_ENABLED_CONFIG);
     String ipWhitelistRegex = config.getString(WebServerConfig.TRUSTED_PROXY_SERVICES_IP_REGEX_CONFIG);
     if (ipWhitelistRegex != null) {
       _trustedProxyServicesIpRegex = ipWhitelistRegex;
@@ -42,7 +44,7 @@ public class TrustedProxySecurityProvider extends SpnegoSecurityProvider {
   @Override
   public LoginService loginService() {
     TrustedProxyLoginService loginService = new TrustedProxyLoginService(
-        _spnegoPrincipal.realm(), authorizationService(), _trustedProxyServices, _trustedProxyServicesIpRegex);
+        _spnegoPrincipal.realm(), authorizationService(), _trustedProxyServices, _trustedProxyServicesIpRegex, _fallbackToSpnegoAllowed);
     loginService.setServiceName(_spnegoPrincipal.serviceName());
     loginService.setHostName(_spnegoPrincipal.hostName());
     loginService.setKeyTabPath(Paths.get(_keyTabPath));

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/SpnegoIntegrationTestHarness.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/SpnegoIntegrationTestHarness.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.security;
+
+import com.linkedin.kafka.cruisecontrol.CruiseControlIntegrationTestHarness;
+import com.linkedin.kafka.cruisecontrol.config.constants.WebServerConfig;
+import com.linkedin.kafka.cruisecontrol.servlet.security.spnego.SpnegoSecurityProvider;
+import org.apache.kerby.kerberos.kerb.KrbException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.linkedin.kafka.cruisecontrol.servlet.security.SecurityTestUtils.AUTH_CREDENTIALS_FILE;
+
+public abstract class SpnegoIntegrationTestHarness extends CruiseControlIntegrationTestHarness {
+
+  public static final String REALM = "LINKEDINTEST.COM";
+  public static final String CC_TEST_ADMIN = "ccTestAdmin";
+  public static final String CLIENT_PRINCIPAL = CC_TEST_ADMIN + "/localhost";
+  public static final String SOME_OTHER_SERVICE_PRINCIPAL = "someotherservice/localhost";
+  public static final String SPNEGO_SERVICE_PRINCIPAL = "HTTP/localhost";
+
+  protected final MiniKdc _miniKdc;
+
+  /**
+   * Instantiates a new object.
+   * @throws KrbException
+   */
+  public SpnegoIntegrationTestHarness() throws KrbException {
+    _miniKdc = new MiniKdc(REALM, principals());
+  }
+
+  /**
+   * Collects a list of principals that will be initialized by the KDC.
+   * @return a list of Strings representing the principals.
+   */
+  public List<String> principals() {
+    List<String> principals = new ArrayList<>();
+    principals.add(CLIENT_PRINCIPAL);
+    principals.add(SPNEGO_SERVICE_PRINCIPAL);
+    principals.add(SOME_OTHER_SERVICE_PRINCIPAL);
+    return principals;
+  }
+
+  @Override
+  protected Map<String, Object> withConfigs() {
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(WebServerConfig.WEBSERVER_SECURITY_ENABLE_CONFIG, true);
+    configs.put(WebServerConfig.WEBSERVER_SECURITY_PROVIDER_CONFIG, SpnegoSecurityProvider.class);
+    configs.put(WebServerConfig.WEBSERVER_AUTH_CREDENTIALS_FILE_CONFIG,
+        Objects.requireNonNull(this.getClass().getClassLoader().getResource(AUTH_CREDENTIALS_FILE)).getPath());
+    configs.put(WebServerConfig.SPNEGO_PRINCIPAL_CONFIG, SPNEGO_SERVICE_PRINCIPAL + "@" + REALM);
+    configs.put(WebServerConfig.SPNEGO_KEYTAB_FILE_CONFIG, _miniKdc.keytab().getAbsolutePath());
+
+    return configs;
+  }
+
+  @Override
+  public void start() throws Exception {
+    _miniKdc.start();
+    super.start();
+  }
+
+  @Override
+  public void stop() {
+    super.stop();
+    try {
+      _miniKdc.stop();
+    } catch (KrbException e) {
+      throw new RuntimeException();
+    }
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxyLoginServiceTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxyLoginServiceTest.java
@@ -6,7 +6,7 @@ package com.linkedin.kafka.cruisecontrol.servlet.security.trustedproxy;
 
 import com.linkedin.kafka.cruisecontrol.servlet.security.DefaultRoleSecurityProvider;
 import com.linkedin.kafka.cruisecontrol.servlet.security.SecurityUtils;
-import org.eclipse.jetty.security.ConfigurableSpnegoLoginService;
+import com.linkedin.kafka.cruisecontrol.servlet.security.spnego.SpnegoLoginServiceWithAuthServiceLifecycle;
 import org.eclipse.jetty.security.SpnegoUserIdentity;
 import org.eclipse.jetty.security.SpnegoUserPrincipal;
 import org.eclipse.jetty.security.UserStore;
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class TrustedProxyLoginServiceTest {
 
@@ -50,7 +51,7 @@ public class TrustedProxyLoginServiceTest {
 
   @Test
   public void testSuccessfulAuthentication() {
-    ConfigurableSpnegoLoginService mockSpnegoLoginService = mock(ConfigurableSpnegoLoginService.class);
+    SpnegoLoginServiceWithAuthServiceLifecycle mockSpnegoLoginService = mock(SpnegoLoginServiceWithAuthServiceLifecycle.class);
 
     SpnegoUserPrincipal servicePrincipal = new SpnegoUserPrincipal(TEST_SERVICE_USER, ENCODED_TOKEN);
     UserIdentity serviceDelegate = mock(UserIdentity.class);
@@ -65,7 +66,7 @@ public class TrustedProxyLoginServiceTest {
 
     replay(mockSpnegoLoginService, mockRequest);
 
-    TrustedProxyLoginService trustedProxyLoginService = new TrustedProxyLoginService(mockSpnegoLoginService, userAuthorizer);
+    TrustedProxyLoginService trustedProxyLoginService = new TrustedProxyLoginService(mockSpnegoLoginService, userAuthorizer, false);
     UserIdentity doAsIdentity = trustedProxyLoginService.login(null, ENCODED_TOKEN, mockRequest);
     assertNotNull(doAsIdentity);
     assertNotNull(doAsIdentity.getUserPrincipal());
@@ -75,7 +76,7 @@ public class TrustedProxyLoginServiceTest {
 
   @Test
   public void testNoDoAsUser() {
-    ConfigurableSpnegoLoginService mockSpnegoLoginService = mock(ConfigurableSpnegoLoginService.class);
+    SpnegoLoginServiceWithAuthServiceLifecycle mockSpnegoLoginService = mock(SpnegoLoginServiceWithAuthServiceLifecycle.class);
 
     SpnegoUserPrincipal servicePrincipal = new SpnegoUserPrincipal(TEST_SERVICE_USER, ENCODED_TOKEN);
     UserIdentity serviceDelegate = mock(UserIdentity.class);
@@ -88,7 +89,7 @@ public class TrustedProxyLoginServiceTest {
     HttpServletRequest mockRequest = mock(HttpServletRequest.class);
     replay(mockSpnegoLoginService);
 
-    TrustedProxyLoginService trustedProxyLoginService = new TrustedProxyLoginService(mockSpnegoLoginService, userAuthorizer);
+    TrustedProxyLoginService trustedProxyLoginService = new TrustedProxyLoginService(mockSpnegoLoginService, userAuthorizer, false);
     UserIdentity doAsIdentity = trustedProxyLoginService.login(null, ENCODED_TOKEN, mockRequest);
     assertNotNull(doAsIdentity);
     assertNotNull(doAsIdentity.getUserPrincipal());
@@ -98,7 +99,7 @@ public class TrustedProxyLoginServiceTest {
 
   @Test
   public void testInvalidAuthServiceUser() {
-    ConfigurableSpnegoLoginService mockSpnegoLoginService = mock(ConfigurableSpnegoLoginService.class);
+    SpnegoLoginServiceWithAuthServiceLifecycle mockSpnegoLoginService = mock(SpnegoLoginServiceWithAuthServiceLifecycle.class);
 
     SpnegoUserPrincipal servicePrincipal = new SpnegoUserPrincipal(TEST_SERVICE_USER, ENCODED_TOKEN);
     Subject subject = new Subject(true, Collections.singleton(servicePrincipal), Collections.emptySet(), Collections.emptySet());
@@ -111,9 +112,54 @@ public class TrustedProxyLoginServiceTest {
     expect(mockRequest.getParameter(DO_AS)).andReturn(TEST_USER);
     replay(mockSpnegoLoginService);
 
-    TrustedProxyLoginService trustedProxyLoginService = new TrustedProxyLoginService(mockSpnegoLoginService, userAuthorizer);
+    TrustedProxyLoginService trustedProxyLoginService = new TrustedProxyLoginService(mockSpnegoLoginService, userAuthorizer, false);
     UserIdentity doAsIdentity = trustedProxyLoginService.login(null, ENCODED_TOKEN, mockRequest);
     assertNotNull(doAsIdentity);
+    assertFalse(((SpnegoUserIdentity) doAsIdentity).isEstablished());
+  }
+
+  @Test
+  public void testFallbackToSpnego() {
+    SpnegoLoginServiceWithAuthServiceLifecycle mockSpnegoLoginService = mock(SpnegoLoginServiceWithAuthServiceLifecycle.class);
+
+    SpnegoUserPrincipal servicePrincipal = new SpnegoUserPrincipal(TEST_SERVICE_USER, ENCODED_TOKEN);
+    UserIdentity serviceDelegate = mock(UserIdentity.class);
+    Subject subject = new Subject(true, Collections.singleton(servicePrincipal), Collections.emptySet(), Collections.emptySet());
+    SpnegoUserIdentity result = new SpnegoUserIdentity(subject, servicePrincipal, serviceDelegate);
+    expect(mockSpnegoLoginService.login(anyString(), anyObject(), anyObject())).andReturn(result);
+
+    TestAuthorizer userAuthorizer = new TestAuthorizer(TEST_USER);
+
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+    replay(mockSpnegoLoginService);
+
+    TrustedProxyLoginService trustedProxyLoginService = new TrustedProxyLoginService(mockSpnegoLoginService, userAuthorizer, true);
+    UserIdentity doAsIdentity = trustedProxyLoginService.login(null, ENCODED_TOKEN, mockRequest);
+    assertNotNull(doAsIdentity);
+    assertNotNull(doAsIdentity.getUserPrincipal());
+    assertEquals(servicePrincipal, doAsIdentity.getUserPrincipal());
+    assertTrue(((SpnegoUserIdentity) doAsIdentity).isEstablished());
+  }
+
+  @Test
+  public void testFallbackToSpnegoWithInvalidServiceUser() {
+    SpnegoLoginServiceWithAuthServiceLifecycle mockSpnegoLoginService = mock(SpnegoLoginServiceWithAuthServiceLifecycle.class);
+
+    SpnegoUserPrincipal servicePrincipal = new SpnegoUserPrincipal(TEST_SERVICE_USER, ENCODED_TOKEN);
+    Subject subject = new Subject(true, Collections.singleton(servicePrincipal), Collections.emptySet(), Collections.emptySet());
+    SpnegoUserIdentity result = new SpnegoUserIdentity(subject, servicePrincipal, null);
+    expect(mockSpnegoLoginService.login(anyString(), anyObject(), anyObject())).andReturn(result);
+
+    TestAuthorizer userAuthorizer = new TestAuthorizer(TEST_USER);
+
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+    replay(mockSpnegoLoginService);
+
+    TrustedProxyLoginService trustedProxyLoginService = new TrustedProxyLoginService(mockSpnegoLoginService, userAuthorizer, true);
+    UserIdentity doAsIdentity = trustedProxyLoginService.login(null, ENCODED_TOKEN, mockRequest);
+    assertNotNull(doAsIdentity);
+    assertNotNull(doAsIdentity.getUserPrincipal());
+    assertEquals(servicePrincipal, doAsIdentity.getUserPrincipal());
     assertFalse(((SpnegoUserIdentity) doAsIdentity).isEstablished());
   }
 }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxySecurityProviderSpnegoFallbackIntegrationTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxySecurityProviderSpnegoFallbackIntegrationTest.java
@@ -1,9 +1,10 @@
 /*
- * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ * Copyright 2021 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
  */
 
-package com.linkedin.kafka.cruisecontrol.servlet.security.spnego;
+package com.linkedin.kafka.cruisecontrol.servlet.security.trustedproxy;
 
+import com.linkedin.kafka.cruisecontrol.config.constants.WebServerConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.security.SpnegoIntegrationTestHarness;
 import org.apache.kerby.kerberos.kerb.KrbException;
 import org.junit.After;
@@ -14,16 +15,41 @@ import javax.servlet.http.HttpServletResponse;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.security.PrivilegedAction;
+import java.util.List;
+import java.util.Map;
 
 import static com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint.STATE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
-public class SpnegoSecurityProviderIntegrationTest extends SpnegoIntegrationTestHarness {
+public class TrustedProxySecurityProviderSpnegoFallbackIntegrationTest extends SpnegoIntegrationTestHarness {
 
   private static final String CRUISE_CONTROL_STATE_ENDPOINT = "kafkacruisecontrol/" + STATE;
 
-  public SpnegoSecurityProviderIntegrationTest() throws KrbException {
+  private static final String AUTH_SERVICE_NAME = "testauthservice";
+  private static final String AUTH_SERVICE_PRINCIPAL = AUTH_SERVICE_NAME + "/localhost";
+  private static final String TEST_USERNAME = "ccTestUser";
+  private static final String TEST_USERNAME_PRINCIPAL = TEST_USERNAME + "/localhost";
+
+  public TrustedProxySecurityProviderSpnegoFallbackIntegrationTest() throws KrbException {
+  }
+
+  @Override
+  public List<String> principals() {
+    List<String> principals = super.principals();
+    principals.add(AUTH_SERVICE_PRINCIPAL);
+    principals.add(TEST_USERNAME_PRINCIPAL);
+    return principals;
+  }
+
+  @Override
+  protected Map<String, Object> withConfigs() {
+    Map<String, Object> configs = super.withConfigs();
+    configs.put(WebServerConfig.WEBSERVER_SECURITY_PROVIDER_CONFIG, TrustedProxySecurityProvider.class);
+    configs.put(WebServerConfig.TRUSTED_PROXY_SERVICES_CONFIG, AUTH_SERVICE_NAME);
+    configs.put(WebServerConfig.TRUSTED_PROXY_SPNEGO_FALLBACK_ENABLED_CONFIG, true);
+
+    return configs;
   }
 
   /**
@@ -45,10 +71,12 @@ public class SpnegoSecurityProviderIntegrationTest extends SpnegoIntegrationTest
 
   @Test
   public void testSuccessfulAuthentication() throws Exception {
-    Subject subject = _miniKdc.loginAs(CLIENT_PRINCIPAL);
+    Subject subject = _miniKdc.loginAs(AUTH_SERVICE_PRINCIPAL);
     Subject.doAs(subject, (PrivilegedAction<Object>) () -> {
+
+      HttpURLConnection stateEndpointConnection;
       try {
-        HttpURLConnection stateEndpointConnection = (HttpURLConnection) new URI(_app.serverUrl())
+        stateEndpointConnection = (HttpURLConnection) new URI(_app.serverUrl())
             .resolve(CRUISE_CONTROL_STATE_ENDPOINT).toURL().openConnection();
         assertEquals(HttpServletResponse.SC_OK, stateEndpointConnection.getResponseCode());
       } catch (Exception e) {
@@ -59,13 +87,14 @@ public class SpnegoSecurityProviderIntegrationTest extends SpnegoIntegrationTest
   }
 
   @Test
-  public void testNotAdminServiceLogin() throws Exception {
-    Subject subject = _miniKdc.loginAs(SOME_OTHER_SERVICE_PRINCIPAL);
+  public void testUnsuccessfulAuthentication() throws Exception {
+    Subject subject = _miniKdc.loginAs(TEST_USERNAME_PRINCIPAL);
     Subject.doAs(subject, (PrivilegedAction<Object>) () -> {
+
       HttpURLConnection stateEndpointConnection;
       try {
         stateEndpointConnection = (HttpURLConnection) new URI(_app.serverUrl())
-            .resolve(CRUISE_CONTROL_STATE_ENDPOINT).toURL().openConnection();
+                .resolve(CRUISE_CONTROL_STATE_ENDPOINT).toURL().openConnection();
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxySecurityProviderSpnegoFallbackIntegrationTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/security/trustedproxy/TrustedProxySecurityProviderSpnegoFallbackIntegrationTest.java
@@ -30,6 +30,7 @@ public class TrustedProxySecurityProviderSpnegoFallbackIntegrationTest extends S
   private static final String AUTH_SERVICE_PRINCIPAL = AUTH_SERVICE_NAME + "/localhost";
   private static final String TEST_USERNAME = "ccTestUser";
   private static final String TEST_USERNAME_PRINCIPAL = TEST_USERNAME + "/localhost";
+  private static final String SOME_OTHER_SERVICE_PRINCIPAL = "someotherservice/localhost";
 
   public TrustedProxySecurityProviderSpnegoFallbackIntegrationTest() throws KrbException {
   }
@@ -71,7 +72,7 @@ public class TrustedProxySecurityProviderSpnegoFallbackIntegrationTest extends S
 
   @Test
   public void testSuccessfulAuthentication() throws Exception {
-    Subject subject = _miniKdc.loginAs(AUTH_SERVICE_PRINCIPAL);
+    Subject subject = _miniKdc.loginAs(TEST_USERNAME_PRINCIPAL);
     Subject.doAs(subject, (PrivilegedAction<Object>) () -> {
 
       HttpURLConnection stateEndpointConnection;
@@ -88,7 +89,7 @@ public class TrustedProxySecurityProviderSpnegoFallbackIntegrationTest extends S
 
   @Test
   public void testUnsuccessfulAuthentication() throws Exception {
-    Subject subject = _miniKdc.loginAs(TEST_USERNAME_PRINCIPAL);
+    Subject subject = _miniKdc.loginAs(SOME_OTHER_SERVICE_PRINCIPAL);
     Subject.doAs(subject, (PrivilegedAction<Object>) () -> {
 
       HttpURLConnection stateEndpointConnection;


### PR DESCRIPTION
In some scenarios we would also like to allow service users to be
authenticated and perform a Cruise Control action that they're
authorized to do. A nice option to enable this is to allow trusted
proxy to fall back to spnego.
That is when this functionality is enabled via the newly created
trusted.proxy.spnego.fallback.enabled option and no doAs user provided,
the TrustedProxySecurityProvider will authenticate and authorize the
service user.

This PR resolves #1617.
