### PR TITLE
Fix the unit in TopicPartitionSizeAnomaly#toString() to MB from bytes.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/TopicPartitionSizeAnomaly.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/TopicPartitionSizeAnomaly.java
@@ -56,7 +56,7 @@ public class TopicPartitionSizeAnomaly extends TopicAnomaly {
     StringBuilder sb = new StringBuilder();
     sb.append("{Detected large topic partitions: ");
     for (Map.Entry<TopicPartition, Double> entry : _sizeInMbByPartition.entrySet()) {
-      sb.append(String.format("%s : %.3f bytes, ", entry.getKey().toString(), entry.getValue()));
+      sb.append(String.format("%s: %.3f MB, ", entry.getKey().toString(), entry.getValue()));
     }
     sb.setLength(sb.length() - 2);
     sb.append("}");


### PR DESCRIPTION
This PR resolves #1528.

- Looks like this change was missed in the [earlier PR](https://github.com/linkedin/cruise-control/pull/1609).
- As a side note, I also verified that after the [earlier PR](https://github.com/linkedin/cruise-control/pull/1609), the topic size anomaly detection works as expected.