### PR TITLE
Bump up stale dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id "idea"
   id "jacoco" // Java Code Coverage plugin
   id "com.github.ben-manes.versions" version "0.39.0"
-  id "com.github.spotbugs" version "4.7.1" apply false
+  id "com.github.spotbugs" version "4.7.2" apply false
   id "checkstyle"
 }
 
@@ -95,13 +95,13 @@ subprojects {
 
   //code quality and inspections
   checkstyle {
-    toolVersion = '8.42'
+    toolVersion = '8.44'
     ignoreFailures = false
     configDir = file("$rootDir/checkstyle")
   }
 
   spotbugs {
-    toolVersion = '4.2.2'
+    toolVersion = '4.3.0'
     excludeFilter = file("$rootDir/gradle/findbugs-exclude.xml")
     ignoreFailures = false
     jvmArgs = [ '-Xms512m' ]
@@ -158,7 +158,7 @@ project(':cruise-control-core') {
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       exclude group: 'log4j', module: 'log4j'
     }
-    compile "org.slf4j:slf4j-api:1.7.30"
+    compile "org.slf4j:slf4j-api:1.7.32"
     compile "org.apache.logging.log4j:log4j-slf4j-impl:2.14.1"
     compile 'junit:junit:4.13.2'
     compile 'org.apache.commons:commons-math3:3.6.1'
@@ -237,7 +237,7 @@ project(':cruise-control') {
     }
     compile project(':cruise-control-metrics-reporter')
     compile project(':cruise-control-core')
-    compile "org.slf4j:slf4j-api:1.7.30" // TODO: Upgrade log4j to log4j2 to use async logger.
+    compile "org.slf4j:slf4j-api:1.7.32"
     compile "org.apache.logging.log4j:log4j-slf4j-impl:2.14.1"
     compile "org.apache.zookeeper:zookeeper:${zookeeperVersion}"
     compile "io.netty:netty-handler:${nettyVersion}"
@@ -252,10 +252,10 @@ project(':cruise-control') {
     compile 'com.google.code.gson:gson:2.8.7'
     compile "org.eclipse.jetty:jetty-server:${jettyVersion}"
     compile 'io.dropwizard.metrics:metrics-core:3.2.6'
-    compile 'com.nimbusds:nimbus-jose-jwt:9.10'
+    compile 'com.nimbusds:nimbus-jose-jwt:9.11.1'
     compile 'com.101tec:zkclient:0.11'
-    compile 'io.swagger.parser.v3:swagger-parser-v3:2.0.26'
-    compile 'io.github.classgraph:classgraph:4.8.108'
+    compile 'io.swagger.parser.v3:swagger-parser-v3:2.0.27'
+    compile 'io.github.classgraph:classgraph:4.8.110'
 
     testCompile project(path: ':cruise-control-metrics-reporter', configuration: 'testOutput')
     testCompile project(path: ':cruise-control-core', configuration: 'testOutput')
@@ -263,7 +263,7 @@ project(':cruise-control') {
     testCompile 'org.easymock:easymock:4.3'
     testCompile "org.apache.kafka:kafka_$scalaBinaryVersion:$kafkaVersion:test"
     testCompile "org.apache.kafka:kafka-clients:$kafkaVersion:test"
-    testCompile 'commons-io:commons-io:2.10.0'
+    testCompile 'commons-io:commons-io:2.11.0'
     testCompile 'org.apache.httpcomponents:httpclient:4.5.13:tests'
     testCompile 'org.bouncycastle:bcpkix-jdk15on:1.69'
     testCompile 'org.apache.kerby:kerb-simplekdc:2.0.1'
@@ -367,7 +367,7 @@ project(':cruise-control-metrics-reporter') {
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       exclude group: 'log4j', module: 'log4j'
     }
-    compile "org.slf4j:slf4j-api:1.7.30"
+    compile "org.slf4j:slf4j-api:1.7.32"
     compile "org.apache.logging.log4j:log4j-slf4j-impl:2.14.1"
     compile "org.apache.kafka:kafka_$scalaBinaryVersion:$kafkaVersion"
     compile "org.apache.kafka:kafka-clients:$kafkaVersion"
@@ -379,7 +379,7 @@ project(':cruise-control-metrics-reporter') {
     testCompile 'org.powermock:powermock-api-easymock:2.0.9'
     testCompile "org.apache.kafka:kafka-clients:$kafkaVersion:test"
     testCompile "org.apache.kafka:kafka-clients:$kafkaVersion"
-    testCompile 'commons-io:commons-io:2.10.0'
+    testCompile 'commons-io:commons-io:2.11.0'
     testOutput sourceSets.test.output
 
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/common/config/Config.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/common/config/Config.java
@@ -3,6 +3,7 @@
  */
 package com.linkedin.cruisecontrol.common.config;
 
+import java.util.Collections;
 import java.util.List;
 
 
@@ -14,7 +15,6 @@ public class Config {
     }
 
     public List<ConfigValue> configValues() {
-        return _configValues;
+        return Collections.unmodifiableList(_configValues);
     }
-
 }

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/common/config/ConfigDef.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/common/config/ConfigDef.java
@@ -410,7 +410,7 @@ public class ConfigDef {
    * @return A map containing all configuration keys
    */
   public Map<String, ConfigKey> configKeys() {
-    return _configKeys;
+    return Collections.unmodifiableMap(_configKeys);
   }
 
   /**
@@ -418,7 +418,7 @@ public class ConfigDef {
    * @return A list of group names
    */
   public List<String> groups() {
-    return _groups;
+    return Collections.unmodifiableList(_groups);
   }
 
   /**
@@ -1026,7 +1026,7 @@ public class ConfigDef {
     }
 
     public List<String> dependents() {
-      return _dependents;
+      return Collections.unmodifiableList(_dependents);
     }
 
     public Recommender recommender() {

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/common/config/ConfigValue.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/common/config/ConfigValue.java
@@ -4,6 +4,7 @@
 package com.linkedin.cruisecontrol.common.config;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -41,7 +42,7 @@ public class ConfigValue {
     }
 
     public List<Object> recommendedValues() {
-        return _recommendedValues;
+        return Collections.unmodifiableList(_recommendedValues);
     }
 
     public void recommendedValues(List<Object> recommendedValues) {
@@ -49,7 +50,7 @@ public class ConfigValue {
     }
 
     public List<String> errorMessages() {
-        return _errorMessages;
+        return Collections.unmodifiableList(_errorMessages);
     }
 
     public boolean visible() {

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/detector/metricanomaly/MetricAnomalyType.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/detector/metricanomaly/MetricAnomalyType.java
@@ -31,6 +31,6 @@ public enum MetricAnomalyType {
    * @return enumerated values in the same order as values()
    */
   public static List<MetricAnomalyType> cachedValues() {
-    return CACHED_VALUES;
+    return Collections.unmodifiableList(CACHED_VALUES);
   }
 }

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/metricdef/MetricDef.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/metricdef/MetricDef.java
@@ -147,7 +147,7 @@ public class MetricDef {
    * @return A set of metric ids that are to be predicted.
    */
   public Set<Short> metricsToPredict() {
-    return _metricsToPredict;
+    return Collections.unmodifiableSet(_metricsToPredict);
   }
 
   public List<MetricInfo> all() {

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregationResult.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleAggregationResult.java
@@ -6,6 +6,7 @@ package com.linkedin.cruisecontrol.monitor.sampling.aggregator;
 
 import com.linkedin.cruisecontrol.common.LongGenerationed;
 import com.linkedin.cruisecontrol.model.Entity;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class MetricSampleAggregationResult<G, E extends Entity<G>> extends LongG
    * @return A mapping from entity to aggregated metric values and potential extrapolations.
    */
   public Map<E, ValuesAndExtrapolations> valuesAndExtrapolations() {
-    return _entityValuesAndExtrapolations;
+    return Collections.unmodifiableMap(_entityValuesAndExtrapolations);
   }
 
   /**
@@ -73,17 +74,14 @@ public class MetricSampleAggregationResult<G, E extends Entity<G>> extends LongG
    * @return The invalid entity set for this aggregation.
    */
   public Set<E> invalidEntities() {
-    return _invalidEntities;
+    return Collections.unmodifiableSet(_invalidEntities);
   }
 
   /**
-   * Get the completeness summary of this aggregation result.
-   *
-   * @return The completeness summary of this aggregation result.
-   * @see MetricSampleCompleteness
+   * @return The valid entity ratio of the underlying {@link #_completeness}.
    */
-  public MetricSampleCompleteness<G, E> completeness() {
-    return _completeness;
+  public float validEntityRatioOfCompleteness() {
+    return _completeness.validEntityRatio();
   }
 
   // package private for modification.

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleCompleteness.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/MetricSampleCompleteness.java
@@ -154,14 +154,14 @@ public class MetricSampleCompleteness<G, E extends Entity<G>> extends LongGenera
    * @return The set of valid entities based on the specified granularity.
    */
   public Set<E> validEntities() {
-    return _validEntities;
+    return Collections.unmodifiableSet(_validEntities);
   }
 
   /**
    * @return The set of valid entity groups.
    */
   public Set<G> validEntityGroups() {
-    return _validEntityGroups;
+    return Collections.unmodifiableSet(_validEntityGroups);
   }
 
   /**

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/ValuesAndExtrapolations.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/monitor/sampling/aggregator/ValuesAndExtrapolations.java
@@ -49,7 +49,7 @@ public class ValuesAndExtrapolations {
    * @return The {@link Extrapolation}s for the values if exist.
    */
   public Map<Integer, Extrapolation> extrapolations() {
-    return _extrapolations;
+    return Collections.unmodifiableMap(_extrapolations);
   }
 
   /**

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/metric/RawMetricType.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/metric/RawMetricType.java
@@ -5,7 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.metricsreporter.metric;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -94,10 +94,10 @@ public enum RawMetricType {
   BROKER_LOG_FLUSH_TIME_MS_50TH(BROKER, (byte) 61, (byte) 5),
   BROKER_LOG_FLUSH_TIME_MS_999TH(BROKER, (byte) 62, (byte) 5);
 
-  private static final List<RawMetricType> CACHED_VALUES = Arrays.asList(RawMetricType.values());
+  private static final List<RawMetricType> CACHED_VALUES = List.of(RawMetricType.values());
   private static final SortedMap<Byte, Set<RawMetricType>> BROKER_METRIC_TYPES_DIFF_BY_VERSION = buildBrokerMetricTypesDiffByVersion();
-  private static final List<RawMetricType> TOPIC_METRIC_TYPES = buildMetricTypeList(TOPIC);
-  private static final List<RawMetricType> PARTITION_METRIC_TYPES = buildMetricTypeList(PARTITION);
+  private static final List<RawMetricType> TOPIC_METRIC_TYPES = Collections.unmodifiableList(buildMetricTypeList(TOPIC));
+  private static final List<RawMetricType> PARTITION_METRIC_TYPES = Collections.unmodifiableList(buildMetricTypeList(PARTITION));
   private final byte _id;
   private final MetricScope _metricScope;
   private final byte _supportedVersionSince;
@@ -125,7 +125,7 @@ public enum RawMetricType {
   }
 
   public static List<RawMetricType> allMetricTypes() {
-    return CACHED_VALUES;
+    return Collections.unmodifiableList(CACHED_VALUES);
   }
 
   public static Map<Byte, Set<RawMetricType>> brokerMetricTypesDiffByVersion() {
@@ -137,11 +137,11 @@ public enum RawMetricType {
   }
 
   public static List<RawMetricType> topicMetricTypes() {
-    return TOPIC_METRIC_TYPES;
+    return Collections.unmodifiableList(TOPIC_METRIC_TYPES);
   }
 
   public static List<RawMetricType> partitionMetricTypes() {
-    return PARTITION_METRIC_TYPES;
+    return Collections.unmodifiableList(PARTITION_METRIC_TYPES);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/ActionAcceptance.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/ActionAcceptance.java
@@ -30,6 +30,6 @@ public enum ActionAcceptance {
    * @return enumerated values in the same order as values()
    */
   public static List<ActionAcceptance> cachedValues() {
-    return CACHED_VALUES;
+    return Collections.unmodifiableList(CACHED_VALUES);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/ActionType.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/ActionType.java
@@ -40,7 +40,7 @@ public enum ActionType {
    * @return enumerated values in the same order as values()
    */
   public static List<ActionType> cachedValues() {
-    return CACHED_VALUES;
+    return Collections.unmodifiableList(CACHED_VALUES);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/AnalyzerState.java
@@ -9,6 +9,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
 import com.linkedin.kafka.cruisecontrol.servlet.response.JsonResponseClass;
 import com.linkedin.kafka.cruisecontrol.servlet.response.JsonResponseField;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -52,7 +53,7 @@ public class AnalyzerState {
    * @return A map of ready goals.
    */
   public Map<Goal, Boolean> readyGoals() {
-    return _readyGoals;
+    return Collections.unmodifiableMap(_readyGoals);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/ProvisionStatus.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/ProvisionStatus.java
@@ -32,6 +32,6 @@ public enum ProvisionStatus {
    * @return enumerated values in the same order as values()
    */
   public static List<ProvisionStatus> cachedValues() {
-    return CACHED_VALUES;
+    return Collections.unmodifiableList(CACHED_VALUES);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/Goal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/Goal.java
@@ -124,8 +124,8 @@ public interface Goal extends CruiseControlConfigurable {
   boolean isHardGoal();
 
   /**
-   * @deprecated Will be removed in a future release -- please use {@link #provisionResponse()}.
    * @return The {@link ProvisionStatus} of this goal.
+   * @deprecated Will be removed in a future release -- please use {@link #provisionResponse()}.
    */
   @Deprecated
   ProvisionStatus provisionStatus();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/Resource.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/Resource.java
@@ -51,7 +51,7 @@ public enum Resource {
    * @return enumerated values in the same order as values()
    */
   public static List<Resource> cachedValues() {
-    return CACHED_VALUES;
+    return Collections.unmodifiableList(CACHED_VALUES);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/Statistic.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/Statistic.java
@@ -39,7 +39,7 @@ public enum Statistic {
    * @return enumerated values in the same order as values()
    */
   public static List<Statistic> cachedValues() {
-    return CACHED_VALUES;
+    return Collections.unmodifiableList(CACHED_VALUES);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectionStatus.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectionStatus.java
@@ -32,6 +32,6 @@ public enum AnomalyDetectionStatus {
    * @return enumerated values in the same order as values()
    */
   public static List<AnomalyDetectionStatus> cachedValues() {
-    return CACHED_VALUES;
+    return Collections.unmodifiableList(CACHED_VALUES);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyState.java
@@ -81,7 +81,7 @@ public class AnomalyState {
      * @return enumerated values in the same order as values()
      */
     public static List<Status> cachedValues() {
-      return CACHED_VALUES;
+      return Collections.unmodifiableList(CACHED_VALUES);
     }
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventType.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/MaintenanceEventType.java
@@ -51,6 +51,6 @@ public enum MaintenanceEventType {
    * @return enumerated values in the same order as values()
    */
   public static List<MaintenanceEventType> cachedValues() {
-    return CACHED_VALUES;
+    return Collections.unmodifiableList(CACHED_VALUES);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/KafkaAnomalyType.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/KafkaAnomalyType.java
@@ -58,6 +58,6 @@ public enum KafkaAnomalyType implements AnomalyType {
    * @return enumerated values in the same order as values()
    */
   public static List<KafkaAnomalyType> cachedValues() {
-    return CACHED_VALUES;
+    return Collections.unmodifiableList(CACHED_VALUES);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ConcurrencyType.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ConcurrencyType.java
@@ -34,6 +34,6 @@ public enum ConcurrencyType {
    * @return enumerated values in the same order as values()
    */
   public static List<ConcurrencyType> cachedValues() {
-    return CACHED_VALUES;
+    return Collections.unmodifiableList(CACHED_VALUES);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTask.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTask.java
@@ -281,7 +281,7 @@ public class ExecutionTask implements Comparable<ExecutionTask> {
      * @return enumerated values in the same order as values()
      */
     public static List<TaskType> cachedValues() {
-      return CACHED_VALUES;
+      return Collections.unmodifiableList(CACHED_VALUES);
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskState.java
@@ -17,6 +17,6 @@ public enum ExecutionTaskState {
      * @return enumerated values in the same order as values()
      */
     public static List<ExecutionTaskState> cachedValues() {
-        return CACHED_VALUES;
+        return Collections.unmodifiableList(CACHED_VALUES);
     }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -10,7 +10,6 @@ import com.codahale.metrics.Timer;
 import com.linkedin.cruisecontrol.exception.NotEnoughValidWindowsException;
 import com.linkedin.cruisecontrol.metricdef.MetricDef;
 import com.linkedin.cruisecontrol.monitor.sampling.aggregator.AggregatedMetricValues;
-import com.linkedin.cruisecontrol.monitor.sampling.aggregator.MetricSampleCompleteness;
 import com.linkedin.cruisecontrol.monitor.sampling.aggregator.ValuesAndExtrapolations;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils;
 import com.linkedin.kafka.cruisecontrol.analyzer.AnalyzerUtils;
@@ -501,8 +500,7 @@ public class LoadMonitor {
     // Create an empty cluster model first.
     long currentLoadGeneration = partitionMetricSampleAggregationResult.generation();
     ModelGeneration modelGeneration = new ModelGeneration(clusterAndGeneration.generation(), currentLoadGeneration);
-    MetricSampleCompleteness<String, PartitionEntity> completeness = partitionMetricSampleAggregationResult.completeness();
-    ClusterModel clusterModel = new ClusterModel(modelGeneration, completeness.validEntityRatio());
+    ClusterModel clusterModel = new ClusterModel(modelGeneration, partitionMetricSampleAggregationResult.validEntityRatioOfCompleteness());
 
     final Timer.Context ctx = _clusterModelCreationTimer.time();
     try {
@@ -765,7 +763,7 @@ public class LoadMonitor {
     });
     _numPartitionsWithExtrapolations = numPartitionsWithExtrapolations.get();
     _totalNumPartitions = MonitorUtils.totalNumPartitions(kafkaCluster);
-    return _totalNumPartitions > 0 ? metricSampleAggregationResult.completeness().validEntityRatio() : 0.0;
+    return _totalNumPartitions > 0 ? metricSampleAggregationResult.validEntityRatioOfCompleteness() : 0.0;
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/metricdefinition/KafkaMetricDef.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/metricdefinition/KafkaMetricDef.java
@@ -220,11 +220,11 @@ public enum KafkaMetricDef {
   }
 
   public static List<KafkaMetricDef> cachedCommonDefValues() {
-    return CACHED_COMMON_DEF_VALUES;
+    return Collections.unmodifiableList(CACHED_COMMON_DEF_VALUES);
   }
 
   public static List<KafkaMetricDef> cachedBrokerDefValues() {
-    return CACHED_BROKER_DEF_VALUES;
+    return Collections.unmodifiableList(CACHED_BROKER_DEF_VALUES);
   }
 
   public static KafkaMetricDef forRawMetricType(RawMetricType type) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSamplerPartitionAssignor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricSamplerPartitionAssignor.java
@@ -16,12 +16,11 @@ import java.util.Set;
 public interface MetricSamplerPartitionAssignor extends CruiseControlConfigurable {
 
   /**
-   * @deprecated Please use {@link #assignPartitions(Cluster)}.
-   * Assign the partitions in the cluster to the metric fetchers.
-   *
    * @param cluster        The Kafka cluster.
    * @param numFetchers    The number of metric fetchers.
    * @return A List of partition assignment for each of the fetchers.
+   * @deprecated Please use {@link #assignPartitions(Cluster)}.
+   * Assign the partitions in the cluster to the metric fetchers.
    */
   @Deprecated
   List<Set<TopicPartition>> assignPartitions(Cluster cluster, int numFetchers);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/CruiseControlEndPoint.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/CruiseControlEndPoint.java
@@ -69,17 +69,17 @@ public enum CruiseControlEndPoint implements EndPoint {
   }
 
   public static List<CruiseControlEndPoint> getEndpoints() {
-    return GET_ENDPOINTS;
+    return Collections.unmodifiableList(GET_ENDPOINTS);
   }
 
   public static List<CruiseControlEndPoint> postEndpoints() {
-    return POST_ENDPOINTS;
+    return Collections.unmodifiableList(POST_ENDPOINTS);
   }
 
   /**
    * @return Cached values of the enum.
    */
   public static List<CruiseControlEndPoint> cachedValues() {
-    return CACHED_VALUES;
+    return Collections.unmodifiableList(CACHED_VALUES);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
@@ -829,7 +829,7 @@ public class UserTaskManager implements Closeable {
      * @return enumerated values in the same order as values()
      */
     public static List<TaskState> cachedValues() {
-      return CACHED_VALUES;
+      return Collections.unmodifiableList(CACHED_VALUES);
     }
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/purgatory/RequestInfo.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/purgatory/RequestInfo.java
@@ -93,7 +93,7 @@ public class RequestInfo {
   }
 
   public Map<String, String[]> parameterMap() {
-    return _parameterMap;
+    return Collections.unmodifiableMap(_parameterMap);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/purgatory/ReviewStatus.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/purgatory/ReviewStatus.java
@@ -22,6 +22,6 @@ public enum ReviewStatus {
    * @return enumerated values in the same order as values()
    */
   public static List<ReviewStatus> cachedValues() {
-    return CACHED_VALUES;
+    return Collections.unmodifiableList(CACHED_VALUES);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/CruiseControlState.java
@@ -60,22 +60,6 @@ public class CruiseControlState extends AbstractCruiseControlResponse {
     _anomalyDetectorState = anomalyDetectorState;
   }
 
-  public ExecutorState executorState() {
-    return _executorState;
-  }
-
-  public LoadMonitorState monitorState() {
-    return _monitorState;
-  }
-
-  public AnalyzerState analyzerState() {
-    return _analyzerState;
-  }
-
-  public AnomalyDetectorState anomalyDetectorState() {
-    return _anomalyDetectorState;
-  }
-
   protected String getJSONString(CruiseControlParameters parameters) {
     Gson gson = new Gson();
     Map<String, Object> jsonStructure = getJsonStructure(((CruiseControlStateParameters) parameters).isVerbose());
@@ -227,7 +211,7 @@ public class CruiseControlState extends AbstractCruiseControlResponse {
      * @return enumerated values in the same order as values()
      */
     public static List<SubState> cachedValues() {
-      return CACHED_VALUES;
+      return Collections.unmodifiableList(CACHED_VALUES);
     }
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/stats/SingleBrokerStats.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/stats/SingleBrokerStats.java
@@ -8,6 +8,7 @@ import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.model.DiskStats;
 import com.linkedin.kafka.cruisecontrol.servlet.response.JsonResponseField;
 import com.linkedin.kafka.cruisecontrol.servlet.response.JsonResponseClass;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -64,7 +65,7 @@ public class SingleBrokerStats extends BasicStats {
    *         replica placement info, otherwise returns an empty map.
    */
   public Map<String, DiskStats> diskStatsByLogdir() {
-    return _diskStatsByLogdir;
+    return Collections.unmodifiableMap(_diskStatsByLogdir);
   }
 
   /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ org.gradle.jvmargs=-Xms512m -Xmx512m
 scalaVersion=2.11.12
 kafkaVersion=2.4.1
 zookeeperVersion=3.5.7
-nettyVersion=4.1.63.Final
-jettyVersion=9.4.42.v20210604
+nettyVersion=4.1.66.Final
+jettyVersion=9.4.43.v20210629

--- a/gradle/findbugs-exclude.xml
+++ b/gradle/findbugs-exclude.xml
@@ -60,9 +60,10 @@
   </Match>
 
   <Match>
-    <Class name="com.linkedin.kafka.cruisecontrol.model.ClusterModelStats" />
-    <Method name="utilizationMatrix" />
-    <Bug pattern="EI_EXPOSE_REP" />
+    <Or>
+      <Bug pattern="EI_EXPOSE_REP"/>
+      <Bug pattern="EI_EXPOSE_REP2"/>
+    </Or>
   </Match>
 
   <Match>
@@ -77,5 +78,9 @@
     <Bug pattern="SF_SWITCH_FALLTHROUGH" />
   </Match>
 
+  <!-- False positive of DMI_RANDOM_USED_ONLY_ONCE (see https://github.com/spotbugs/spotbugs/issues/1539) -->
+  <Match>
+    <Bug pattern="DMI_RANDOM_USED_ONLY_ONCE, ..." />
+  </Match>
 
 </FindBugsFilter>


### PR DESCRIPTION
This PR resolves #1628.

After SpotBugs version bump, new issues have been detected. In particular, this version bump
* introduced false positives of `DMI_RANDOM_USED_ONLY_ONCE` (see https://github.com/spotbugs/spotbugs/issues/1539) -- hence this check is disabled.
* ignores new failures due to `EI_EXPOSE_REP` and `EI_EXPOSE_REP2` for now, because corresponding fixes requires significant code changes.
* introduced several other issues (e.g. ordering of JavaDoc tags, getters with modifiable collections) that have been addressed in this PR.