### PR TITLE
Drop the use of AdminZkClient for topic creation

### DIFF
--- a/cruise-control/src/main/scala/com/linkedin/kafka/cruisecontrol/executor/ExecutorUtils.scala
+++ b/cruise-control/src/main/scala/com/linkedin/kafka/cruisecontrol/executor/ExecutorUtils.scala
@@ -121,19 +121,11 @@ object ExecutorUtils {
     seqAsJavaList(inProgressReassignment.map(i => i : java.lang.Integer))
   }
 
-  def currentReplicasForPartition(kafkaZkClient: KafkaZkClient, tp: TopicPartition): java.util.List[java.lang.Integer] = {
-    seqAsJavaList(kafkaZkClient.getReplicasForPartition(new TopicPartition(tp.topic(), tp.partition())).map(i => i : java.lang.Integer))
-  }
-
   def changeBrokerConfig(adminZkClient: AdminZkClient, brokerId: Int, config: Properties): Unit = {
     adminZkClient.changeBrokerConfig(Some(brokerId), config)
   }
 
   def changeTopicConfig(adminZkClient: AdminZkClient, topic: String, config: Properties): Unit = {
     adminZkClient.changeTopicConfig(topic, config)
-  }
-
-  def getAllLiveBrokerIdsInCluster(kafkaZkClient: KafkaZkClient): java.util.List[java.lang.Integer] = {
-    seqAsJavaList(kafkaZkClient.getAllBrokersInCluster.map(_.id : java.lang.Integer))
   }
 }


### PR DESCRIPTION
This PR resolves #1640.

* Also drop unused `KafkaZkClient`-based functions from the `master` branch, which were already removed from other active branches.