### PR TITLE
Move PLE / leadership movement requests from KafkaZkClient to AdminClient

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -245,7 +245,6 @@ public class KafkaCruiseControl {
    * <ol>
    *   <li>execution in current Cruise Control deployment and user does not require stopping the ongoing execution,</li>
    *   <li>partition reassignment triggered by other admin tools or previous Cruise Control deployment.</li>
-   *   <li>leadership reassignment triggered by other admin tools or previous Cruise Control deployment.</li>
    * </ol>
    *
    * This method helps to fail fast if a user attempts to start an execution during an ongoing execution.
@@ -276,9 +275,6 @@ public class KafkaCruiseControl {
       if (!partitionsBeingReassigned.isEmpty()) {
         throw new IllegalStateException(String.format("Cannot execute new proposals while there are ongoing partition reassignments "
                                                       + "initiated by external agent: %s", partitionsBeingReassigned));
-      } else if (_executor.hasOngoingLeaderElection()) {
-        throw new IllegalStateException("Cannot execute new proposals while there are ongoing leadership reassignments initiated by "
-                                        + "external agent.");
       }
     }
   }
@@ -736,11 +732,10 @@ public class KafkaCruiseControl {
   /**
    * Request the executor to stop any ongoing execution.
    *
-   * @param forceExecutionStop Whether force execution to stop.
    * @param stopExternalAgent Whether to stop ongoing execution started by external agents.
    */
-  public void userTriggeredStopExecution(boolean forceExecutionStop, boolean stopExternalAgent) {
-    _executor.userTriggeredStopExecution(forceExecutionStop, stopExternalAgent);
+  public void userTriggeredStopExecution(boolean stopExternalAgent) {
+    _executor.userTriggeredStopExecution(stopExternalAgent);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/TopicMinIsrCache.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/common/TopicMinIsrCache.java
@@ -18,6 +18,7 @@ import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,7 +104,7 @@ public class TopicMinIsrCache {
         short minIsr = Short.parseShort(entry.getValue().get().get(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG).value());
         _minIsrWithTimeByTopic.put(entry.getKey().name(), new MinIsrWithTime(minIsr, updateTimeMs));
       } catch (ExecutionException ee) {
-        if (org.apache.kafka.common.errors.TimeoutException.class == ee.getCause().getClass()) {
+        if (Errors.REQUEST_TIMED_OUT.exception().getClass() == ee.getCause().getClass()) {
           LOG.warn("Failed to retrieve value of config {} for {} topics due to describeConfigs request time out. Check for Kafka-side issues"
                    + " and consider increasing the configured timeout (see {}).", TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG,
                    describeConfigsResult.values().size(), ExecutorConfig.ADMIN_CLIENT_REQUEST_TIMEOUT_MS_CONFIG, ee.getCause());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaAdminTopicConfigProvider.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaAdminTopicConfigProvider.java
@@ -18,6 +18,7 @@ import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.protocol.Errors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +66,7 @@ public class KafkaAdminTopicConfigProvider implements TopicConfigProvider {
               .get()
               .get(topicResource);
     } catch (ExecutionException ee) {
-      if (org.apache.kafka.common.errors.TimeoutException.class == ee.getCause().getClass()) {
+      if (Errors.REQUEST_TIMED_OUT.exception().getClass() == ee.getCause().getClass()) {
         LOG.warn("Failed to retrieve configuration for topic '{}' due to describeConfigs request time out. Check for Kafka-side issues"
                 + " and consider increasing the configured timeout.", topic);
       } else {
@@ -106,7 +107,7 @@ public class KafkaAdminTopicConfigProvider implements TopicConfigProvider {
           Config config = entry.getValue().get();
           propsMap.put(entry.getKey().name(), convertConfigToProperties(config));
         } catch (ExecutionException ee) {
-          if (org.apache.kafka.common.errors.TimeoutException.class == ee.getCause().getClass()) {
+          if (Errors.REQUEST_TIMED_OUT.exception().getClass() == ee.getCause().getClass()) {
             LOG.warn("Failed to retrieve config for topics due to describeConfigs request timing out. "
                     + "Check for Kafka-side issues and consider increasing the configured timeout.");
             // If one has timed out then they all will so abort the loop.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RunnableUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RunnableUtils.java
@@ -247,7 +247,7 @@ public final class RunnableUtils {
     while (kafkaCruiseControl.executionState() != NO_TASK_IN_PROGRESS) {
       // Stop ongoing execution, and wait for the execution to stop.
       try {
-        kafkaCruiseControl.userTriggeredStopExecution(false, false);
+        kafkaCruiseControl.userTriggeredStopExecution(false);
         Thread.sleep(kafkaCruiseControl.executionProgressCheckIntervalMs());
       } catch (InterruptedException e) {
         kafkaCruiseControl.modifyOngoingExecution(false);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/sync/StopProposalRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/sync/StopProposalRequest.java
@@ -8,12 +8,16 @@ import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.StopProposalParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.response.StopProposalResult;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.FORCE_STOP_PARAM;
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.STOP_PROPOSAL_PARAMETER_OBJECT_CONFIG;
 import static com.linkedin.cruisecontrol.common.utils.Utils.validateNotNull;
 
 
 public class StopProposalRequest extends AbstractSyncRequest {
+  private static final Logger LOG = LoggerFactory.getLogger(StopProposalRequest.class);
   protected KafkaCruiseControl _kafkaCruiseControl;
   protected StopProposalParameters _parameters;
 
@@ -23,7 +27,10 @@ public class StopProposalRequest extends AbstractSyncRequest {
 
   @Override
   protected StopProposalResult handle() {
-    _kafkaCruiseControl.userTriggeredStopExecution(_parameters.forceExecutionStop(), _parameters.stopExternalAgent());
+    if (_parameters.forceExecutionStop()) {
+      LOG.info("{} is a deprecated parameter. Force stopping an execution is not supported.", FORCE_STOP_PARAM);
+    }
+    _kafkaCruiseControl.userTriggeredStopExecution(_parameters.stopExternalAgent());
     return new StopProposalResult(_kafkaCruiseControl.config());
   }
 

--- a/cruise-control/src/main/scala/com/linkedin/kafka/cruisecontrol/executor/ExecutorUtils.scala
+++ b/cruise-control/src/main/scala/com/linkedin/kafka/cruisecontrol/executor/ExecutorUtils.scala
@@ -4,15 +4,9 @@
 
 package com.linkedin.kafka.cruisecontrol.executor
 
-import java.util
 import java.util.Properties
-
-import kafka.admin.PreferredReplicaLeaderElectionCommand
-import kafka.zk.{AdminZkClient, KafkaZkClient}
-import org.apache.kafka.common.TopicPartition
+import kafka.zk.AdminZkClient
 import org.slf4j.{Logger, LoggerFactory}
-
-import scala.collection.JavaConverters._
 
 /**
  * This class is a Java interface wrapper of open source ReassignPartitionCommand. This class is needed because
@@ -20,17 +14,6 @@ import scala.collection.JavaConverters._
  */
 object ExecutorUtils {
   val LOG: Logger = LoggerFactory.getLogger(ExecutorUtils.getClass.getName)
-
-  def executePreferredLeaderElection(kafkaZkClient: KafkaZkClient, tasks: java.util.List[ExecutionTask]) {
-    val partitionsToExecute = tasks.asScala.map(task =>
-      new TopicPartition(task.proposal.topic, task.proposal.partitionId)).toSet
-    val preferredReplicaElectionCommand = new PreferredReplicaLeaderElectionCommand(kafkaZkClient, partitionsToExecute)
-    preferredReplicaElectionCommand.moveLeaderToPreferredReplica()
-  }
-
-  def ongoingLeaderElection(kafkaZkClient: KafkaZkClient): util.Set[TopicPartition] = {
-    setAsJavaSet(kafkaZkClient.getPreferredReplicaElection)
-  }
 
   def changeBrokerConfig(adminZkClient: AdminZkClient, brokerId: Int, config: Properties): Unit = {
     adminZkClient.changeBrokerConfig(Some(brokerId), config)

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlTest.java
@@ -60,12 +60,7 @@ public class KafkaCruiseControlTest extends CruiseControlIntegrationTestHarness 
     // For sanityCheckDryRun(false, XXX) (see #4 below)
     EasyMock.expect(executor.hasOngoingExecution()).andReturn(false).once();
     EasyMock.expect(executor.listPartitionsBeingReassigned()).andReturn(Collections.emptySet());
-    EasyMock.expect(executor.hasOngoingLeaderElection()).andReturn(true);
     // For sanityCheckDryRun(false, XXX) (see #5 below)
-    EasyMock.expect(executor.hasOngoingExecution()).andReturn(false).once();
-    EasyMock.expect(executor.listPartitionsBeingReassigned()).andReturn(Collections.emptySet());
-    EasyMock.expect(executor.hasOngoingLeaderElection()).andReturn(false);
-    // For sanityCheckDryRun(false, XXX) (see #6 below)
     EasyMock.expect(executor.hasOngoingExecution()).andReturn(false).once();
     EasyMock.expect(executor.listPartitionsBeingReassigned()).andThrow(new TimeoutException()).once();
 
@@ -82,11 +77,9 @@ public class KafkaCruiseControlTest extends CruiseControlIntegrationTestHarness 
     assertThrows(IllegalStateException.class, () -> kafkaCruiseControl.sanityCheckDryRun(false, false));
     // 3. Expect failure (dryrun = false), there is no execution started by CC, but ongoing replica reassignment, request to stop is irrelevant.
     assertThrows(IllegalStateException.class, () -> kafkaCruiseControl.sanityCheckDryRun(false, false));
-    // 4. Expect failure (dryrun = false), there is no execution started by CC, but ongoing leader election, request to stop is irrelevant.
-    assertThrows(IllegalStateException.class, () -> kafkaCruiseControl.sanityCheckDryRun(false, false));
-    // 5. Expect failure (dryrun = false), there is no execution started by CC or other tools, request to stop is irrelevant.
+    // 4. Expect failure (dryrun = false), there is no execution started by CC or other tools, request to stop is irrelevant.
     kafkaCruiseControl.sanityCheckDryRun(false, false);
-    // 6. Expect failure (dryrun = false), there is no execution started by CC, but checking ongoing executions started
+    // 5. Expect failure (dryrun = false), there is no execution started by CC, but checking ongoing executions started
     // by other tools timed out, request to stop is irrelevant.
     assertThrows(IllegalStateException.class, () -> kafkaCruiseControl.sanityCheckDryRun(false, false));
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtilsTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtilsTest.java
@@ -4,16 +4,25 @@
 
 package com.linkedin.kafka.cruisecontrol.executor;
 
+import java.lang.reflect.Constructor;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 import org.apache.kafka.clients.admin.AlterPartitionReassignmentsResult;
+import org.apache.kafka.clients.admin.ElectLeadersResult;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ElectionNotNeededException;
+import org.apache.kafka.common.errors.InvalidTopicException;
+import org.apache.kafka.common.errors.NotControllerException;
+import org.apache.kafka.common.errors.PreferredLeaderNotAvailableException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.protocol.Errors;
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -23,19 +32,36 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 public class ExecutionUtilsTest {
+  private static final String TOPIC_NAME = "topic-name";
+  private static final TopicPartition P0 = new TopicPartition(TOPIC_NAME, 0);
+  private static final TopicPartition P1 = new TopicPartition(TOPIC_NAME, 1);
+  // Both partitions are successful
+  private static final Map<TopicPartition, Optional<Throwable>> SUCCESSFUL_PARTITIONS = Map.of(P0, Optional.empty(), P1, Optional.empty());
+  // One partition successful, the other has UnknownTopicOrPartitionException
+  private static final Map<TopicPartition, Optional<Throwable>> ONE_WITH_UTOP = Map.of(P0, Optional.empty(), P1,
+                                                                                       Optional.of(new UnknownTopicOrPartitionException()));
+  // One partition successful, the other has InvalidTopicException
+  private static final Map<TopicPartition, Optional<Throwable>> ONE_WITH_IT = Map.of(P0, Optional.empty(), P1,
+                                                                                     Optional.of(new InvalidTopicException()));
+  // One partition successful, the other has ElectionNotNeededException
+  private static final Map<TopicPartition, Optional<Throwable>> ONE_WITH_ENN = Map.of(P0, Optional.empty(), P1,
+                                                                                      Optional.of(new ElectionNotNeededException("")));
+  // One partition successful, the other has PreferredLeaderNotAvailableException
+  private static final Map<TopicPartition, Optional<Throwable>> ONE_WITH_PLNA = Map.of(P0, Optional.empty(), P1,
+                                                                                       Optional.of(new PreferredLeaderNotAvailableException("")));
+  // One partition successful, the other has NotControllerException
+  private static final Map<TopicPartition, Optional<Throwable>> ONE_WITH_NC = Map.of(P0, Optional.empty(), P1,
+                                                                                     Optional.of(new NotControllerException("")));
 
   @Test
   public void testProcessAlterPartitionReassignmentResult() throws Exception {
     // Case 1: Handle null result input. Expect no side effect.
     ExecutionUtils.processAlterPartitionReassignmentsResult(null, Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
 
-    String topicName = "topic-name";
-    int partitionId = 0;
-
     // Case 2: Handle successful execution results
     AlterPartitionReassignmentsResult result = EasyMock.mock(AlterPartitionReassignmentsResult.class);
     EasyMock.expect(result.values())
-            .andReturn(getKafkaFutureByTopicPartition(topicName, partitionId, null))
+            .andReturn(getKafkaFutureByTopicPartition(null))
             .once();
     EasyMock.replay(result);
     ExecutionUtils.processAlterPartitionReassignmentsResult(result, Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
@@ -44,29 +70,29 @@ public class ExecutionUtilsTest {
 
     // Case 3: Handle invalid replica assignment exception
     EasyMock.expect(result.values())
-            .andReturn(getKafkaFutureByTopicPartition(topicName, partitionId, new ExecutionException(Errors.INVALID_REPLICA_ASSIGNMENT.exception())))
+            .andReturn(getKafkaFutureByTopicPartition(new ExecutionException(Errors.INVALID_REPLICA_ASSIGNMENT.exception())))
             .once();
     EasyMock.replay(result);
     Set<TopicPartition> deadTopicPartitions = new HashSet<>(1);
     ExecutionUtils.processAlterPartitionReassignmentsResult(result, Collections.emptySet(), deadTopicPartitions, Collections.emptySet());
-    assertEquals(Collections.singleton(new TopicPartition(topicName, partitionId)), deadTopicPartitions);
+    assertEquals(Collections.singleton(new TopicPartition(TOPIC_NAME, P0.partition())), deadTopicPartitions);
     EasyMock.verify(result);
     EasyMock.reset(result);
 
     // Case 4: Handle unknown topic or partition exception
     EasyMock.expect(result.values())
-            .andReturn(getKafkaFutureByTopicPartition(topicName, partitionId, new ExecutionException(Errors.UNKNOWN_TOPIC_OR_PARTITION.exception())))
+            .andReturn(getKafkaFutureByTopicPartition(new ExecutionException(Errors.UNKNOWN_TOPIC_OR_PARTITION.exception())))
             .once();
     EasyMock.replay(result);
     Set<TopicPartition> deletedTopicPartitions = new HashSet<>(1);
     ExecutionUtils.processAlterPartitionReassignmentsResult(result, deletedTopicPartitions, Collections.emptySet(), Collections.emptySet());
-    assertEquals(Collections.singleton(new TopicPartition(topicName, partitionId)), deletedTopicPartitions);
+    assertEquals(Collections.singleton(new TopicPartition(TOPIC_NAME, P0.partition())), deletedTopicPartitions);
     EasyMock.verify(result);
     EasyMock.reset(result);
 
     // Case 5: Handle no reassign in progress exception
     EasyMock.expect(result.values())
-            .andReturn(getKafkaFutureByTopicPartition(topicName, partitionId, new ExecutionException(Errors.NO_REASSIGNMENT_IN_PROGRESS.exception())))
+            .andReturn(getKafkaFutureByTopicPartition(new ExecutionException(Errors.NO_REASSIGNMENT_IN_PROGRESS.exception())))
             .once();
     EasyMock.replay(result);
     Set<TopicPartition> noReassignmentToCancelTopicPartitions = new HashSet<>(1);
@@ -74,14 +100,14 @@ public class ExecutionUtilsTest {
                                                             Collections.emptySet(),
                                                             Collections.emptySet(),
                                                             noReassignmentToCancelTopicPartitions);
-    assertEquals(Collections.singleton(new TopicPartition(topicName, partitionId)), noReassignmentToCancelTopicPartitions);
+    assertEquals(Collections.singleton(new TopicPartition(TOPIC_NAME, P0.partition())), noReassignmentToCancelTopicPartitions);
     EasyMock.verify(result);
     EasyMock.reset(result);
 
     // Case 6: Handle execution timeout exception. Expect no side effect.
     org.apache.kafka.common.errors.TimeoutException kafkaTimeoutException = new org.apache.kafka.common.errors.TimeoutException();
     EasyMock.expect(result.values())
-            .andReturn(getKafkaFutureByTopicPartition(topicName, partitionId, new ExecutionException(kafkaTimeoutException)))
+            .andReturn(getKafkaFutureByTopicPartition(new ExecutionException(kafkaTimeoutException)))
             .times(2);
     EasyMock.replay(result);
     Exception thrownException = assertThrows(IllegalStateException.class, () -> {
@@ -93,7 +119,7 @@ public class ExecutionUtilsTest {
 
     // Case 7: Handle future wait interrupted exception
     EasyMock.expect(result.values())
-            .andReturn(getKafkaFutureByTopicPartition(topicName, partitionId, new InterruptedException()))
+            .andReturn(getKafkaFutureByTopicPartition(new InterruptedException()))
             .times(2);
     EasyMock.replay(result);
     ExecutionUtils.processAlterPartitionReassignmentsResult(result, Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
@@ -101,9 +127,78 @@ public class ExecutionUtilsTest {
     EasyMock.reset(result);
   }
 
-  private Map<TopicPartition, KafkaFuture<Void>> getKafkaFutureByTopicPartition(String topicName,
-                                                                                int partitionId,
-                                                                                @Nullable Exception futureException) throws Exception {
+  @Test
+  public void testProcessElectLeadersResult() throws Exception {
+    // Case 1: Handle null result input. Expect no side effect.
+    ExecutionUtils.processElectLeadersResult(null, Collections.emptySet());
+
+    KafkaFutureImpl<Map<TopicPartition, Optional<Throwable>>> partitions = EasyMock.mock(KafkaFutureImpl.class);
+    Constructor<ElectLeadersResult> constructor = ElectLeadersResult.class.getDeclaredConstructor(KafkaFutureImpl.class);
+    constructor.setAccessible(true);
+    ElectLeadersResult result;
+
+    // Case 2: Handle both partitions are successful
+    // Case 3: Handle one partition successful, the other has ElectionNotNeededException
+    // Case 4: Handle one partition successful, the other has PreferredLeaderNotAvailableException
+    // Case 5: Handle one partition successful, the other has NotControllerException
+    for (Map<TopicPartition, Optional<Throwable>> entry : Set.of(SUCCESSFUL_PARTITIONS, ONE_WITH_ENN, ONE_WITH_PLNA, ONE_WITH_NC)) {
+      result = constructor.newInstance(partitions);
+
+      EasyMock.expect(partitions.get()).andReturn(entry).once();
+      EasyMock.replay(partitions);
+
+      ExecutionUtils.processElectLeadersResult(result, Collections.emptySet());
+      EasyMock.verify(partitions);
+      EasyMock.reset(partitions);
+    }
+
+    // Case 6: Handle one partition successful, the other has UnknownTopicOrPartitionException
+    // Case 7: Handle one partition successful, the other has InvalidTopicException
+    for (Map<TopicPartition, Optional<Throwable>> entry : Set.of(ONE_WITH_UTOP, ONE_WITH_IT)) {
+      result = constructor.newInstance(partitions);
+
+      EasyMock.expect(partitions.get()).andReturn(entry).once();
+      EasyMock.replay(partitions);
+
+      Set<TopicPartition> deletedTopicPartitions = new HashSet<>();
+      ExecutionUtils.processElectLeadersResult(result, deletedTopicPartitions);
+      Assert.assertEquals(1, deletedTopicPartitions.size());
+      Assert.assertEquals(P1, deletedTopicPartitions.iterator().next());
+      EasyMock.verify(partitions);
+      EasyMock.reset(partitions);
+    }
+
+    // Case 8: Handle execution timeout exception. Expect no side effect.
+    // Case 9: Handle execution ClusterAuthorization exception. Expect no side effect.
+    // Case 10: Handle unexpected execution exception (i.e. ControllerMovedException). Expect no side effect.
+    for (Throwable entry : Set.of(new org.apache.kafka.common.errors.TimeoutException(),
+                                  new org.apache.kafka.common.errors.ClusterAuthorizationException(""),
+                                  new org.apache.kafka.common.errors.ControllerMovedException(""))) {
+      result = constructor.newInstance(partitions);
+
+      EasyMock.expect(partitions.get()).andThrow(new ExecutionException(entry)).once();
+      EasyMock.replay(partitions);
+
+      ElectLeadersResult exceptionResult = result;
+      Exception thrownException = assertThrows(IllegalStateException.class,
+                                               () -> ExecutionUtils.processElectLeadersResult(exceptionResult, Collections.emptySet()));
+      Assert.assertEquals(entry, thrownException.getCause());
+      EasyMock.verify(partitions);
+      EasyMock.reset(partitions);
+    }
+
+    // Case 11: Handle future wait interrupted exception
+    result = constructor.newInstance(partitions);
+
+    EasyMock.expect(partitions.get()).andThrow(new InterruptedException()).once();
+    EasyMock.replay(partitions);
+
+    ExecutionUtils.processElectLeadersResult(result, Collections.emptySet());
+    EasyMock.verify(partitions);
+    EasyMock.reset(partitions);
+  }
+
+  private static Map<TopicPartition, KafkaFuture<Void>> getKafkaFutureByTopicPartition(@Nullable Exception futureException) throws Exception {
     Map<TopicPartition, KafkaFuture<Void>> futureByTopicPartition = new HashMap<>(1);
     KafkaFuture<Void> kafkaFuture = EasyMock.mock(KafkaFuture.class);
     if (futureException == null) {
@@ -112,7 +207,7 @@ public class ExecutionUtilsTest {
       EasyMock.expect(kafkaFuture.get()).andThrow(futureException).once();
     }
     EasyMock.replay(kafkaFuture);
-    futureByTopicPartition.put(new TopicPartition(topicName, partitionId), kafkaFuture);
+    futureByTopicPartition.put(new TopicPartition(TOPIC_NAME, P0.partition()), kafkaFuture);
     return futureByTopicPartition;
   }
 }


### PR DESCRIPTION
This PR resolves #1643.

* Adopt AdminClient-based leadership reassignment to replace KafkaZkClient
* Drop ZK-based calls to check existence of ongoing leadership reassignments (i.e. via `/admin/preferred_replica_election`) as they are no longer relevant under AdminClient-based leadership election
* Make force-stop requests function as the same as regular stop requests -- i.e. deletion of PLE znode and a following controller bounce is no longer relevant.
-- 
In addition to unit tests, I verified the functionality on a test cluster by performing leadership reassignment via demotion and rebalance.