### PR TITLE
Create ConfigProvider in Cruise-Control-Metrics-Reporter modul and optimise dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -371,9 +371,8 @@ project(':cruise-control-metrics-reporter') {
     compile "org.apache.logging.log4j:log4j-slf4j-impl:2.14.1"
     compile "org.apache.kafka:kafka_$scalaBinaryVersion:$kafkaVersion"
     compile "org.apache.kafka:kafka-clients:$kafkaVersion"
-    compile 'junit:junit:4.13.2'
-    compile 'org.apache.commons:commons-math3:3.6.1'
 
+    testCompile 'junit:junit:4.13.2'
     testCompile 'org.bouncycastle:bcpkix-jdk15on:1.69'
     testCompile 'org.powermock:powermock-module-junit4:2.0.9'
     testCompile 'org.powermock:powermock-api-easymock:2.0.9'

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/config/EnvConfigProvider.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/config/EnvConfigProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+package com.linkedin.kafka.cruisecontrol.metricsreporter.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.config.ConfigData;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.provider.ConfigProvider;
+
+/**
+ * Enables config properties of the form ${env:ENV_KEY}
+ */
+public class EnvConfigProvider implements ConfigProvider {
+
+  private Map<String, String> _preConfiguredEnvironmentVariables;
+
+  @Override
+  public ConfigData get(String path) {
+    assertNoPath(path);
+    return new ConfigData(getEnv());
+  }
+
+  @Override
+  public ConfigData get(String path, Set<String> keys) {
+    assertNoPath(path);
+    Map<String, String> filtered = new HashMap<>(getEnv());
+    filtered.keySet().retainAll(keys);
+    return new ConfigData(filtered);
+  }
+
+  @Override
+  public void close() {
+    if (_preConfiguredEnvironmentVariables != null) {
+      _preConfiguredEnvironmentVariables.clear();
+    }
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    _preConfiguredEnvironmentVariables = configs.entrySet()
+      .stream()
+      .collect(Collectors.toMap(Entry::getKey, kv -> (String) kv.getValue()));
+  }
+
+  private static void assertNoPath(String path) {
+    if (path != null && !path.isEmpty()) {
+      throw new ConfigException("EnvConfigProvider does not support paths. Found: " + path);
+    }
+  }
+
+  private Map<String, String> getEnv() {
+    if (_preConfiguredEnvironmentVariables == null) {
+      return System.getenv();
+    } else {
+      return _preConfiguredEnvironmentVariables;
+    }
+  }
+
+}

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/config/EnvConfigProviderTest.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/config/EnvConfigProviderTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+package com.linkedin.kafka.cruisecontrol.metricsreporter.config;
+
+import com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporterConfig;
+import com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsUtils;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.kafka.common.config.ConfigData;
+import org.junit.Test;
+
+import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_CONFIG;
+import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporterConfig.PREFIX;
+import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for EnvConfigProvider class
+ */
+public class EnvConfigProviderTest {
+
+  public static final String CLIENT_ID = "client1";
+  public static final String NOT_SUBSTITUTED_CONFIG = "${env:TOPIC}";
+  public static final String ENV_CONFIG_PROVIDER_TEST_PROPERTIES = "envConfigProviderTest.properties";
+  public static final String WEBSERVER_SSL_KEYSTORE_PASSWORD_CONFIG = "webserver.ssl.keystore.password";
+
+  @Test
+  public void testEnvConfigProvider() throws IOException {
+    CruiseControlMetricsReporterConfig configs = CruiseControlMetricsUtils.readConfig(
+      Objects.requireNonNull(getClass().getClassLoader().getResource(ENV_CONFIG_PROVIDER_TEST_PROPERTIES)).getPath());
+
+    String actualClientId = configs.getString(PREFIX + CLIENT_ID_CONFIG);
+    String expectedClientId = CLIENT_ID;
+    assertEquals(expectedClientId, actualClientId);
+
+    String actualTopic = configs.getString(CRUISE_CONTROL_METRICS_TOPIC_CONFIG);
+    String expectedTopic = NOT_SUBSTITUTED_CONFIG;
+    assertEquals(expectedTopic, actualTopic);
+  }
+
+  @Test
+  public void testExistingEnvReturnsValue() {
+    String key = System.getenv().keySet().stream().findFirst().orElse("");
+    String expected = System.getenv(key);
+    Set<String> set = new HashSet<>();
+    set.add(key);
+    ConfigData actual;
+
+    try (EnvConfigProvider configProvider = new EnvConfigProvider()) {
+      actual = configProvider.get("", set);
+    }
+
+    assertEquals(expected, actual.data().get(key));
+  }
+
+  @Test
+  public void testNonExistingEnvReturnsEmpty() {
+    Set<String> set = new HashSet<>();
+    set.add("NON_EXISTING_ENV");
+    ConfigData actual;
+
+    try (EnvConfigProvider configProvider = new EnvConfigProvider()) {
+      actual = configProvider.get("", set);
+    }
+
+    assertEquals(0, actual.data().size());
+  }
+
+}

--- a/cruise-control-metrics-reporter/src/test/resources/envConfigProviderTest.properties
+++ b/cruise-control-metrics-reporter/src/test/resources/envConfigProviderTest.properties
@@ -1,0 +1,5 @@
+cruise.control.metrics.reporter.client.id=${env:CLIENT_ID}
+cruise.control.metrics.topic=${env:TOPIC}
+# the only way to initialize this for testing is to pass a preconfigured list of environment variables
+# but this shouldn't be configured in production but taken from System.getenv()
+config.providers.env.param.CLIENT_ID=client1


### PR DESCRIPTION
This development enables parsing config values from environment variables. This is particularly useful if sensitive information can't be hardcoded in the config files but instead passed to Cruise Control via an environment variable.
Furthermore this change is optimise the dependencies by removing unused one and rearrange groups.
