### PR TITLE
Bump version for cruise-control-client changes

### DIFF
--- a/cruise-control-client/setup.py
+++ b/cruise-control-client/setup.py
@@ -11,7 +11,7 @@ It comes with a command-line interface to the client (`cccli`) (see [README](htt
 
 setuptools.setup(
     name='cruise-control-client',
-    version='1.1.2',
+    version='1.1.3',
     author='mgrubent',
     author_email='mgrubentrejo@linkedin.com',
     description='A Python client for cruise-control',


### PR DESCRIPTION
#1671 made some changes to `cruise-control-client`, but I neglected to bump its version in the PR.

So, patch-version-bump here.