### PR TITLE
Migrate from the OpenJDK legacy image to the newest image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       _JAVA_OPTIONS: "-Xms512m -Xmx1g"
     working_directory: ~/workspace
     docker:
-      - image: cimg/openjdk:11.0.0
+      - image: cimg/openjdk:11.0
     steps:
       - checkout
       - restore_cache:
@@ -38,7 +38,7 @@ jobs:
   publish:
     working_directory: ~/workspace
     docker:
-      - image: cimg/openjdk:11.0.0
+      - image: cimg/openjdk:11.0
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ jobs:
 
   build:
     environment:
-      JAVA_HOME: "/usr/local/jdk-11"
       _JAVA_OPTIONS: "-Xms512m -Xmx1g"
     working_directory: ~/workspace
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       _JAVA_OPTIONS: "-Xms512m -Xmx1g"
     working_directory: ~/workspace
     docker:
-      - image: circleci/openjdk:11-jdk
+      - image: cimg/openjdk:11.0.0
     steps:
       - checkout
       - restore_cache:
@@ -37,7 +37,7 @@ jobs:
   publish:
     working_directory: ~/workspace
     docker:
-      - image: circleci/openjdk:11-jdk
+      - image: cimg/openjdk:11.0.0
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
 
   build:
     environment:
+      JAVA_HOME: "/usr/local/jdk-11"
       _JAVA_OPTIONS: "-Xms512m -Xmx1g"
     working_directory: ~/workspace
     docker:


### PR DESCRIPTION
This PR resolves #1685.