### PR TITLE
Add maven plugin to gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ subprojects {
 
   apply plugin: 'java'
   apply plugin: 'checkstyle'
+  apply plugin: 'maven'
   apply plugin: "com.github.spotbugs"
   apply plugin: 'jacoco'
 


### PR DESCRIPTION
This change enables using the gradle install command to publish artifacts to local maven repository.
