### PR TITLE
Fix empty OUT-OF-SYNC replica

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/PartitionState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/PartitionState.java
@@ -48,7 +48,7 @@ public class PartitionState {
     _leader = partitionInfo.leader() == null ? -1 : partitionInfo.leader().id();
     _replicas = Arrays.stream(partitionInfo.replicas()).map(Node::id).collect(Collectors.toList());
     _inSyncReplicas = Arrays.stream(partitionInfo.inSyncReplicas()).map(Node::id).collect(Collectors.toList());
-    _outOfSyncReplicas = new HashSet<>();
+    _outOfSyncReplicas = new HashSet<>(_replicas);
     _outOfSyncReplicas.removeAll(_inSyncReplicas);
     _offlineReplicas = Arrays.stream(partitionInfo.offlineReplicas()).map(Node::id).collect(Collectors.toSet());
     _minIsr = minIsr;


### PR DESCRIPTION
This PR resolves #1692.
OUT-OF-SYNC replica should initialize to full replica set, yet it was accidentally removed in [#1693](https://github.com/linkedin/cruise-control/pull/1693/files#diff-ad39105a41d3577bd7075e50071df2b09e49e6018d90bd829ee5f961be13a7d1L52).
