### PR TITLE
Add integration tests for Cruise Control self healing 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -232,7 +232,23 @@ project(':cruise-control') {
       }
     }
 
+    integrationTest {
+      java {
+        srcDirs = ["src/integrationTest/java"]
+      }
+      resources {
+        srcDirs = ['src/integrationTest/resources']
+      }
+      compileClasspath += main.output + test.output
+      runtimeClasspath += main.output + test.output
+    }
+
   }
+
+  configurations {
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntime.extendsFrom testRuntime
+   }
 
   dependencies {
     configurations.all {
@@ -270,6 +286,7 @@ project(':cruise-control') {
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13:tests'
     testImplementation 'org.bouncycastle:bcpkix-jdk15on:1.69'
     testImplementation 'org.apache.kerby:kerb-simplekdc:2.0.1'
+    testImplementation 'com.jayway.jsonpath:json-path:2.4.0'
 
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
 
@@ -348,6 +365,14 @@ project(':cruise-control') {
       receiptFile.setText(content, "ISO-8859-1")
     }
   }
+
+  task integrationTest(type: Test) {
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+  }
+
+  check.dependsOn integrationTest
+  compileIntegrationTestJava.dependsOn copyDependantLibs
 
   jar {
     dependsOn createVersionFile

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/utils/CCKafkaIntegrationTestHarness.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/utils/CCKafkaIntegrationTestHarness.java
@@ -84,26 +84,30 @@ public abstract class CCKafkaIntegrationTestHarness extends CCAbstractZookeeperT
   protected List<Map<Object, Object>> buildBrokerConfigs() {
     List<Map<Object, Object>> configs = new ArrayList<>();
     for (int i = 0; i < clusterSize(); i++) {
-      CCEmbeddedBrokerBuilder builder = new CCEmbeddedBrokerBuilder();
-      builder.zkConnect(zookeeper());
-      builder.nodeId(i);
-      builder.enable(securityProtocol());
-      if (securityProtocol() == SecurityProtocol.SSL) {
-        if (trustStoreFile() != null) {
-          builder.trustStore(trustStoreFile());
-        }
-      } else {
-        if (trustStoreFile() != null) {
-          throw new AssertionError("security protocol not set yet trust store file provided");
-        }
-      }
-      Map<Object, Object> config = builder.buildConfig();
-      config.putAll(overridingProps());
-      configs.add(config);
+      configs.add(createBrokerConfig(i));
     }
     return configs;
   }
 
+  protected Map<Object, Object> createBrokerConfig(int brokerId) {
+    CCEmbeddedBrokerBuilder builder = new CCEmbeddedBrokerBuilder();
+    builder.zkConnect(zookeeper());
+    builder.nodeId(brokerId);
+    builder.enable(securityProtocol());
+    if (securityProtocol() == SecurityProtocol.SSL) {
+      if (trustStoreFile() != null) {
+        builder.trustStore(trustStoreFile());
+      }
+    } else {
+      if (trustStoreFile() != null) {
+        throw new AssertionError("security protocol not set yet trust store file provided");
+      }
+    }
+    Map<Object, Object> config = builder.buildConfig();
+    config.putAll(overridingProps());
+    return config;
+  }
+  
   protected SecurityProtocol securityProtocol() {
     return SecurityProtocol.PLAINTEXT;
   }

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/BrokerFailureIntegrationTest.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/BrokerFailureIntegrationTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See
+ * License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.concurrent.ExecutionException;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.TypeRef;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.MinTopicLeadersPerBrokerGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal;
+import com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig;
+import com.linkedin.kafka.cruisecontrol.config.constants.AnomalyDetectorConfig;
+import com.linkedin.kafka.cruisecontrol.detector.TopicReplicationFactorAnomalyFinder;
+import com.linkedin.kafka.cruisecontrol.detector.notifier.SelfHealingNotifier;
+import com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint;
+import net.minidev.json.JSONArray;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC0;
+
+
+public class BrokerFailureIntegrationTest extends CruiseControlIntegrationTestHarness {
+
+  private static final int PARTITION_COUNT = 10;
+  private static final int KAFKA_CLUSTER_SIZE = 4;
+  private static final String CRUISE_CONTROL_KAFKA_CLUSTER_STATE_ENDPOINT =
+      "kafkacruisecontrol/" + CruiseControlEndPoint.KAFKA_CLUSTER_STATE + "?verbose=true&json=true";
+  private static final String CRUISE_CONTROL_STATE_ENDPOINT =
+          "kafkacruisecontrol/" + CruiseControlEndPoint.STATE + "?substates=analyzer&json=true";
+  private final Configuration _gsonJsonConfig = KafkaCruiseControlIntegrationTestUtils.createJsonMappingConfig();
+
+  private static final int BROKER_ID_TO_REMOVE = 1;
+
+  @Before
+  public void setup() throws Exception {
+    super.start();
+  }
+
+  @Override
+  protected int clusterSize() {
+    return KAFKA_CLUSTER_SIZE;
+  }
+
+  @After
+  public void teardown() {
+    super.stop();
+  }
+
+  @Override
+  public Map<Object, Object> overridingProps() {
+    return KafkaCruiseControlIntegrationTestUtils.createBrokerProps();
+  }
+
+  @Override
+  protected Map<String, Object> withConfigs() {
+    Map<String, Object> configs = KafkaCruiseControlIntegrationTestUtils.ccConfigOverrides();
+    configs.put(SelfHealingNotifier.BROKER_FAILURE_ALERT_THRESHOLD_MS_CONFIG, "1000");
+    configs.put(SelfHealingNotifier.BROKER_FAILURE_SELF_HEALING_THRESHOLD_MS_CONFIG, "1500");
+    configs.put(
+        TopicReplicationFactorAnomalyFinder.SELF_HEALING_TARGET_TOPIC_REPLICATION_FACTOR_CONFIG, "2");
+    configs.put(AnomalyDetectorConfig.ANOMALY_DETECTION_GOALS_CONFIG, new StringJoiner(",")
+        .add(ReplicaCapacityGoal.class.getName())
+        .add(DiskCapacityGoal.class.getName()).toString());
+
+    configs.put(AnalyzerConfig.DEFAULT_GOALS_CONFIG, new StringJoiner(",")
+        .add(MinTopicLeadersPerBrokerGoal.class.getName())
+        .add(ReplicaCapacityGoal.class.getName())
+        .add(ReplicaDistributionGoal.class.getName()).toString());
+    
+    configs.put(AnalyzerConfig.HARD_GOALS_CONFIG, new StringJoiner(",")
+        .add(ReplicaCapacityGoal.class.getName())
+        .add(MinTopicLeadersPerBrokerGoal.class.getName()).toString());
+    
+    return configs;
+  }
+
+  @Test
+  public void testBrokerFailure() throws ExecutionException, InterruptedException {
+    AdminClient adminClient = KafkaCruiseControlUtils.createAdminClient(Collections
+        .singletonMap(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()));
+    try {
+      adminClient.createTopics(Arrays.asList(new NewTopic(TOPIC0, PARTITION_COUNT, (short) 2))).all().get();
+
+    } finally {
+      KafkaCruiseControlUtils.closeAdminClientWithTimeout(adminClient);
+    }
+
+    // wait until metadata propagates to Cruise Control
+    KafkaCruiseControlIntegrationTestUtils.waitForConditionMeet(() -> {
+        String responseMessage = KafkaCruiseControlIntegrationTestUtils
+          .callCruiseControl(_app.serverUrl(), CRUISE_CONTROL_KAFKA_CLUSTER_STATE_ENDPOINT);
+        JSONArray partitionLeadersArray = JsonPath.read(responseMessage,
+            "$.KafkaPartitionState.other[?(@.topic == '" + TOPIC0 + "')].leader");
+        List<Integer> partitionLeaders = JsonPath.parse(partitionLeadersArray, _gsonJsonConfig)
+            .read("$.*", new TypeRef<>() { });
+        return partitionLeaders.size() == PARTITION_COUNT;
+    }, 20, new AssertionError("Topic partitions not found for " + TOPIC0));
+
+    KafkaCruiseControlIntegrationTestUtils.produceRandomDataToTopic(TOPIC0, 4000, 
+        KafkaCruiseControlIntegrationTestUtils.getDefaultProducerProperties(bootstrapServers()));
+
+    // wait for a valid proposal
+    KafkaCruiseControlIntegrationTestUtils.waitForConditionMeet(() -> {
+      String responseMessage = KafkaCruiseControlIntegrationTestUtils
+          .callCruiseControl(_app.serverUrl(), CRUISE_CONTROL_STATE_ENDPOINT);
+      return JsonPath.<Boolean>read(responseMessage, "AnalyzerState.isProposalReady");
+    }, 200, Duration.ofSeconds(15), new AssertionError("No proposals were ready"));
+
+    // shut down a broker to initiate a self-healing action
+    broker(BROKER_ID_TO_REMOVE).shutdown();
+
+    KafkaCruiseControlIntegrationTestUtils.waitForConditionMeet(() -> {
+      String responseMessage = KafkaCruiseControlIntegrationTestUtils
+          .callCruiseControl(_app.serverUrl(), CRUISE_CONTROL_KAFKA_CLUSTER_STATE_ENDPOINT);
+        Integer brokers = JsonPath.<Integer>read(responseMessage, "KafkaBrokerState.Summary.Brokers");
+        JSONArray partitionLeadersArray = JsonPath.read(responseMessage,
+            "$.KafkaPartitionState.other[?(@.topic == '" + TOPIC0 + "')].leader");
+        List<Integer> partitionLeaders = JsonPath.parse(partitionLeadersArray, _gsonJsonConfig)
+            .read("$.*", new TypeRef<>() { });
+        return partitionLeaders.size() == PARTITION_COUNT && brokers == KAFKA_CLUSTER_SIZE - 1;
+    }, 200, new AssertionError("Topic replicas not fixed after broker removed"));
+  }
+
+}

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/BrokerFailureIntegrationTest.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/BrokerFailureIntegrationTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See
- * License in the project root for license information.
+ * Copyright 2021 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
  */
 
 package com.linkedin.kafka.cruisecontrol;
@@ -9,7 +8,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
-import java.util.concurrent.ExecutionException;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.TypeRef;
@@ -87,11 +85,11 @@ public class BrokerFailureIntegrationTest extends CruiseControlIntegrationTestHa
   }
 
   @Test
-  public void testBrokerFailure() throws ExecutionException, InterruptedException {
+  public void testBrokerFailure() {
     KafkaCruiseControlIntegrationTestUtils.createTopic(broker(0).plaintextAddr(), 
         new NewTopic(TOPIC0, PARTITION_COUNT, (short) 2));
 
-    waitForMetadataPropogates();
+    waitForMetadataPropagates();
 
     KafkaCruiseControlIntegrationTestUtils.produceRandomDataToTopic(TOPIC0, 4000, 
         KafkaCruiseControlIntegrationTestUtils.getDefaultProducerProperties(bootstrapServers()));
@@ -128,7 +126,7 @@ public class BrokerFailureIntegrationTest extends CruiseControlIntegrationTestHa
     }, Duration.ofSeconds(800), Duration.ofSeconds(15), new AssertionError("No proposals were ready"));
   }
 
-  private void waitForMetadataPropogates() {
+  private void waitForMetadataPropagates() {
     KafkaCruiseControlIntegrationTestUtils.waitForConditionMeet(() -> {
         String responseMessage = KafkaCruiseControlIntegrationTestUtils
           .callCruiseControl(_app.serverUrl(), CRUISE_CONTROL_KAFKA_CLUSTER_STATE_ENDPOINT);

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlIntegrationTestUtils.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlIntegrationTestUtils.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
+import java.util.StringJoiner;
+import java.util.concurrent.ExecutionException;
+import java.util.function.BooleanSupplier;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.linkedin.kafka.cruisecontrol.config.constants.AnomalyDetectorConfig;
+import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
+import com.linkedin.kafka.cruisecontrol.detector.notifier.SelfHealingNotifier;
+import com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporterConfig;
+import com.linkedin.kafka.cruisecontrol.monitor.sampling.KafkaSampleStore;
+import kafka.server.KafkaConfig;
+import org.apache.commons.io.IOUtils;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A test util class.
+ */
+public final class KafkaCruiseControlIntegrationTestUtils {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaCruiseControlIntegrationTestUtils.class);
+  private static final Random RANDOM = new Random(0xDEADBEEF);
+  private KafkaCruiseControlIntegrationTestUtils() {
+
+  }
+  /**
+   * Create JSON mapping configuration
+   * @return the mapping configuration
+   */
+  public static Configuration createJsonMappingConfig() {
+    return Configuration.builder().jsonProvider(new JacksonJsonProvider())
+      .mappingProvider(new JacksonMappingProvider()).build();
+  }
+  /**
+   * Find a random open port
+   * @return with the port number
+   */
+  public static Integer findRandomOpenPortOnAllLocalInterfaces() {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+  
+  public static void waitForConditionMeet(BooleanSupplier condition, int retries, Error retriesExceededException) {
+    waitForConditionMeet(condition, retries, Duration.ofSeconds(4), retriesExceededException);
+  }
+  /**
+   * Execute boolean condition until it returns true
+   * @param condition the condition to evaluate
+   * @param retries the number of retries
+   * @param retryBackoff the milliseconds between retries
+   * @param retriesExceededException the exception if we run out of retries
+   */
+  public static void waitForConditionMeet(BooleanSupplier condition, int retries, Duration retryBackoff,
+                                    Error retriesExceededException) {
+    int counter = 0;
+    while (! (counter == retries)) {
+      counter++;
+      boolean conditionResult = false;
+      try {
+        conditionResult = condition.getAsBoolean();
+      } catch (Exception e) {
+        LOG.warn("Exception occured", e);
+      }
+      if (conditionResult) {
+        return;
+      } else {
+        try {
+          Thread.sleep(retryBackoff.toMillis());
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+    if (retriesExceededException != null) {
+      throw retriesExceededException;
+    }
+  }
+  
+  public static Properties getDefaultProducerProperties(String bootstrapServers) {
+    return getDefaultProducerProperties(null, bootstrapServers);
+  }
+  /**
+   * Create default producer properties with string key and value serializer
+   * @param overrides the overrides to use
+   * @param bootstrapServers the bootstrap servers url
+   * @return the created properties
+   */
+  public static Properties getDefaultProducerProperties(Properties overrides, String bootstrapServers) {
+    Properties result = new Properties();
+
+    // populate defaults
+    result.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    result.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+        StringSerializer.class.getCanonicalName());
+    result.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+        StringSerializer.class.getCanonicalName());
+    // apply overrides
+    if (overrides != null) {
+      result.putAll(overrides);
+    }
+    return result;
+  }
+  /**
+   * Call cruise control REST API 
+   * @param serverUrl the server base URL
+   * @param path the path with get parameters
+   * @return the response body as string
+   */
+  public static String callCruiseControl(String serverUrl, String path) {
+    try {
+      HttpURLConnection stateEndpointConnection = (HttpURLConnection) new URI(serverUrl)
+          .resolve(path).toURL().openConnection();
+      String responseMessage =
+          IOUtils.toString(stateEndpointConnection.getInputStream(), Charset.defaultCharset());
+      return responseMessage;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Create broker properties with metric reporter configuration
+   * @return the created properties
+   */
+  public static Map<Object, Object> createBrokerProps() {
+    Map<Object, Object> props = new HashMap<>();
+    props.put("metric.reporters",
+        "com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter");
+    StringJoiner csvJoiner = new StringJoiner(",");
+    csvJoiner.add(SecurityProtocol.PLAINTEXT.name + "://localhost:"
+        + KafkaCruiseControlIntegrationTestUtils.findRandomOpenPortOnAllLocalInterfaces());
+    props.put(KafkaConfig.ListenersProp(), csvJoiner.toString());
+    props.put(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_CONFIG, "true");
+    props.put(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_REPLICATION_FACTOR_CONFIG, "2");
+    props.put(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS_CONFIG, "1");
+    return props;
+  }
+  /**
+   * Create basic Cruise Control overrides for integration tests.
+   * @return the configuration
+   */
+  public static Map<String, Object> ccConfigOverrides() {
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(AnomalyDetectorConfig.METRIC_ANOMALY_FINDER_CLASSES_CONFIG,
+        "com.linkedin.kafka.cruisecontrol.detector.KafkaMetricAnomalyFinder");
+    configs.put(AnomalyDetectorConfig.TOPIC_ANOMALY_FINDER_CLASSES_CONFIG,
+        "com.linkedin.kafka.cruisecontrol.detector.TopicReplicationFactorAnomalyFinder");
+    configs.put(AnomalyDetectorConfig.ANOMALY_NOTIFIER_CLASS_CONFIG,
+        "com.linkedin.kafka.cruisecontrol.detector.notifier.SelfHealingNotifier");
+    configs.put(AnomalyDetectorConfig.RF_SELF_HEALING_SKIP_RACK_AWARENESS_CHECK_CONFIG, "true");
+
+    configs.put(MonitorConfig.METRIC_SAMPLER_CLASS_CONFIG,
+        "com.linkedin.kafka.cruisecontrol.monitor.sampling.CruiseControlMetricsReporterSampler");
+    configs.put(MonitorConfig.BROKER_METRICS_WINDOW_MS_CONFIG, "36000");
+    configs.put(MonitorConfig.PARTITION_METRICS_WINDOW_MS_CONFIG, "36000");
+    configs.put(MonitorConfig.NUM_PARTITION_METRICS_WINDOWS_CONFIG, "3");
+
+    configs.put(KafkaSampleStore.PARTITION_SAMPLE_STORE_TOPIC_PARTITION_COUNT_CONFIG, "2");
+    configs.put(KafkaSampleStore.BROKER_SAMPLE_STORE_TOPIC_PARTITION_COUNT_CONFIG, "2");
+    configs.put(SelfHealingNotifier.SELF_HEALING_ENABLED_CONFIG, "true");
+    return configs;
+  }
+  
+  public static void produceRandomDataToTopic(String topicName, int messageSize, Properties producerConfig) {
+    produceRandomDataToTopic(topicName, 1, messageSize, producerConfig);
+  }
+  /**
+   * Produce random data to a kafka topic
+   * @param topicName the topic name
+   * @param messageCount the amount of the messages
+   * @param messageSize the size of a message
+   * @param producerConfig the configuration
+   */
+  public static void produceRandomDataToTopic(String topicName, int messageCount, int messageSize, Properties producerConfig) {
+    if (messageSize > 0 && messageCount > 0) {
+      try (Producer<String, String> producer = new KafkaProducer<>(producerConfig)) {
+        byte[] randomRecords = new byte[messageSize];
+        for (int i = 0; i < messageCount; i++) {
+          RANDOM.nextBytes(randomRecords);
+          producer.send(new ProducerRecord<>(topicName, Arrays.toString(randomRecords))).get();
+          producer.flush();
+        }
+      } catch (InterruptedException | ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlIntegrationTestUtils.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlIntegrationTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ * Copyright 2021 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
  */
 
 package com.linkedin.kafka.cruisecontrol;
@@ -87,15 +87,17 @@ public final class KafkaCruiseControlIntegrationTestUtils {
    * @param retryBackoff the milliseconds between retries
    * @param retriesExceededException the exception if we run out of retries
    */
-  public static void waitForConditionMeet(BooleanSupplier condition, Duration timeOut, Duration retryBackoff,
-                                    Error retriesExceededException) {
+  public static void waitForConditionMeet(BooleanSupplier condition, 
+                                          Duration timeOut, 
+                                          Duration retryBackoff, 
+                                          Error retriesExceededException) {
     long endTime = System.currentTimeMillis() + timeOut.toMillis();
     while (System.currentTimeMillis() < endTime) {
       boolean conditionResult = false;
       try {
         conditionResult = condition.getAsBoolean();
       } catch (Exception e) {
-        LOG.warn("Exception occured", e);
+        LOG.warn("Exception occurred", e);
       }
       if (conditionResult) {
         return;
@@ -147,9 +149,7 @@ public final class KafkaCruiseControlIntegrationTestUtils {
     try {
       HttpURLConnection stateEndpointConnection = (HttpURLConnection) new URI(serverUrl)
           .resolve(path).toURL().openConnection();
-      String responseMessage =
-          IOUtils.toString(stateEndpointConnection.getInputStream(), Charset.defaultCharset());
-      return responseMessage;
+      return IOUtils.toString(stateEndpointConnection.getInputStream(), Charset.defaultCharset());
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/ReplicaCapacityViolationIntegrationTest.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/ReplicaCapacityViolationIntegrationTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See
- * License in the project root for license information.
+ * Copyright 2021 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
  */
 
 package com.linkedin.kafka.cruisecontrol;
@@ -8,7 +7,6 @@ package com.linkedin.kafka.cruisecontrol;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
-import java.util.concurrent.ExecutionException;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.TypeRef;
@@ -33,7 +31,7 @@ import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC0;
 import static com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint.KAFKA_CLUSTER_STATE;
 
 
-public class ReplicaCapcaityViolationIntegrationTest extends CruiseControlIntegrationTestHarness {
+public class ReplicaCapacityViolationIntegrationTest extends CruiseControlIntegrationTestHarness {
 
   private static final int BROKER_ID_TO_ADD = 3;
   private static final int PARTITION_COUNT = 2;
@@ -95,7 +93,7 @@ public class ReplicaCapcaityViolationIntegrationTest extends CruiseControlIntegr
   }
 
   @Test
-  public void testReplicaCapacityViolation() throws InterruptedException, ExecutionException {
+  public void testReplicaCapacityViolation() {
     KafkaCruiseControlIntegrationTestUtils.createTopic(broker(0).plaintextAddr(), 
         new NewTopic(TOPIC0, PARTITION_COUNT, (short) 2));
 
@@ -112,7 +110,7 @@ public class ReplicaCapcaityViolationIntegrationTest extends CruiseControlIntegr
     KafkaCruiseControlIntegrationTestUtils.waitForConditionMeet(() -> {
         String responseMessage = KafkaCruiseControlIntegrationTestUtils
             .callCruiseControl(_app.serverUrl(), CRUISE_CONTROL_KAFKA_CLUSTER_STATE_ENDPOINT);
-        Integer replicaCountOnBroker = JsonPath.<Integer>read(responseMessage, "KafkaBrokerState.ReplicaCountByBrokerId."
+        Integer replicaCountOnBroker = JsonPath.read(responseMessage, "KafkaBrokerState.ReplicaCountByBrokerId."
           + BROKER_ID_TO_ADD);
         return replicaCountOnBroker > 0;
     }, 600, new AssertionError("No replica found on the new broker"));
@@ -122,10 +120,10 @@ public class ReplicaCapcaityViolationIntegrationTest extends CruiseControlIntegr
     KafkaCruiseControlIntegrationTestUtils.waitForConditionMeet(() -> {
         String responseMessage = KafkaCruiseControlIntegrationTestUtils
             .callCruiseControl(_app.serverUrl(), CRUISE_CONTROL_STATE_ENDPOINT);
-        JSONArray unfixableGoalsArray = JsonPath.<JSONArray>read(responseMessage,
+        JSONArray unfixableGoalsArray = JsonPath.read(responseMessage,
             "$.AnomalyDetectorState.recentGoalViolations[*].unfixableViolatedGoals.[*]");
         List<String> unfixableGoals = JsonPath.parse(unfixableGoalsArray, _gsonJsonConfig)
-            .read("$..*", new TypeRef<List<String>>() { });
+            .read("$..*", new TypeRef<>() { });
         return unfixableGoals.contains("ReplicaCapacityGoal");
     }, 300, new AssertionError("Replica capacity goal violation not found"));
   }

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/ReplicaCapcaityViolationIntegrationTest.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/ReplicaCapcaityViolationIntegrationTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See
+ * License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.concurrent.ExecutionException;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.TypeRef;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.MinTopicLeadersPerBrokerGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal;
+import com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig;
+import com.linkedin.kafka.cruisecontrol.config.constants.AnomalyDetectorConfig;
+import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
+import com.linkedin.kafka.cruisecontrol.detector.TopicReplicationFactorAnomalyFinder;
+import com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporterConfig;
+import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCEmbeddedBroker;
+import com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint;
+import net.minidev.json.JSONArray;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC0;
+import static com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint.KAFKA_CLUSTER_STATE;
+
+
+public class ReplicaCapcaityViolationIntegrationTest extends CruiseControlIntegrationTestHarness {
+
+  private static final int BROKER_ID_TO_ADD = 3;
+  private static final int PARTITION_COUNT = 2;
+  private static final int KAFKA_CLUSTER_SIZE = 3;
+  private static final String CRUISE_CONTROL_KAFKA_CLUSTER_STATE_ENDPOINT =
+      "kafkacruisecontrol/" + KAFKA_CLUSTER_STATE + "?verbose=true&json=true";
+  private static final String CRUISE_CONTROL_STATE_ENDPOINT =
+      "kafkacruisecontrol/" + CruiseControlEndPoint.STATE + "?substates=anomaly_detector&json=true";
+  private final Configuration _gsonJsonConfig = KafkaCruiseControlIntegrationTestUtils.createJsonMappingConfig();
+
+  @Before
+  public void setup() throws Exception {
+    super.start();
+  }
+
+  @Override
+  protected int clusterSize() {
+    return KAFKA_CLUSTER_SIZE;
+  }
+
+  @After
+  public void teardown() {
+    super.stop();
+  }
+
+  @Override
+  public Map<Object, Object> overridingProps() {
+    Map<Object, Object> props = KafkaCruiseControlIntegrationTestUtils.createBrokerProps();
+    props.put(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_REPORTER_INTERVAL_MS_CONFIG, "15000");
+    return props;
+  }
+
+  @Override
+  protected Map<String, Object> withConfigs() {
+    Map<String, Object> configs = KafkaCruiseControlIntegrationTestUtils.ccConfigOverrides();
+    configs.put(TopicReplicationFactorAnomalyFinder.SELF_HEALING_TARGET_TOPIC_REPLICATION_FACTOR_CONFIG, "2");
+    
+    configs.put(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_REPORTER_INTERVAL_MS_CONFIG, "15000");
+    configs.put(MonitorConfig.METADATA_MAX_AGE_MS_CONFIG, "15000");
+    configs.put(MonitorConfig.METRIC_SAMPLING_INTERVAL_MS_CONFIG, "20000");
+    configs.put(AnomalyDetectorConfig.ANOMALY_DETECTION_INTERVAL_MS_CONFIG, "20000");
+    
+    configs.put(AnomalyDetectorConfig.ANOMALY_DETECTION_GOALS_CONFIG, new StringJoiner(",")
+        .add(ReplicaCapacityGoal.class.getName())
+        .add(DiskCapacityGoal.class.getName()).toString());
+
+    configs.put(AnalyzerConfig.DEFAULT_GOALS_CONFIG, new StringJoiner(",")
+        .add(MinTopicLeadersPerBrokerGoal.class.getName())
+        .add(ReplicaCapacityGoal.class.getName())
+        .add(ReplicaDistributionGoal.class.getName()).toString());
+    
+    configs.put(AnalyzerConfig.HARD_GOALS_CONFIG, new StringJoiner(",")
+        .add(ReplicaCapacityGoal.class.getName())
+        .add(MinTopicLeadersPerBrokerGoal.class.getName()).toString());
+    
+    configs.put(AnalyzerConfig.MAX_REPLICAS_PER_BROKER_CONFIG, "4");
+    configs.put(AnalyzerConfig.OVERPROVISIONED_MAX_REPLICAS_PER_BROKER_CONFIG, "4");
+    return configs;
+  }
+
+  @Test
+  public void testReplicaCapacityViolation() throws InterruptedException, ExecutionException {
+    AdminClient adminClient = KafkaCruiseControlUtils.createAdminClient(Collections
+        .singletonMap(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()));
+    try {
+      adminClient.createTopics(Arrays.asList(new NewTopic(TOPIC0, PARTITION_COUNT, (short) 2))).all().get();
+
+    } finally {
+      KafkaCruiseControlUtils.closeAdminClientWithTimeout(adminClient);
+    }
+
+    KafkaCruiseControlIntegrationTestUtils.waitForConditionMeet(() -> {
+        String responseMessage = KafkaCruiseControlIntegrationTestUtils
+            .callCruiseControl(_app.serverUrl(), CRUISE_CONTROL_STATE_ENDPOINT);
+        JSONArray unfixableGoalsArray = JsonPath.<JSONArray>read(responseMessage,
+            "$.AnomalyDetectorState.recentGoalViolations[*].unfixableViolatedGoals.[*]");
+        List<String> unfixableGoals = JsonPath.parse(unfixableGoalsArray, _gsonJsonConfig)
+            .read("$..*", new TypeRef<List<String>>() { });
+        return unfixableGoals.contains("ReplicaCapacityGoal");
+    }, 90, new AssertionError("Replica capacity goal violation not found"));
+
+    Map<Object, Object> createBrokerConfig = createBrokerConfig(BROKER_ID_TO_ADD);
+    CCEmbeddedBroker broker = new CCEmbeddedBroker(createBrokerConfig);
+    broker.startup();
+    
+    KafkaCruiseControlIntegrationTestUtils.waitForConditionMeet(() -> {
+        String responseMessage = KafkaCruiseControlIntegrationTestUtils
+            .callCruiseControl(_app.serverUrl(), CRUISE_CONTROL_KAFKA_CLUSTER_STATE_ENDPOINT);
+        Integer replicaCountOnBroker = JsonPath.<Integer>read(responseMessage, "KafkaBrokerState.ReplicaCountByBrokerId."
+          + BROKER_ID_TO_ADD);
+        return replicaCountOnBroker > 0;
+    }, 200, new AssertionError("No replica found on the new broker"));
+  }
+
+}
+

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/TopicAnomalyIntegrationTest.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/TopicAnomalyIntegrationTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See
- * License in the project root for license information.
+ * Copyright 2021 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
  */
 
 package com.linkedin.kafka.cruisecontrol;
@@ -9,7 +8,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
-import java.util.concurrent.ExecutionException;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.TypeRef;
@@ -81,7 +79,7 @@ public class TopicAnomalyIntegrationTest extends CruiseControlIntegrationTestHar
   }
 
   @Test
-  public void testTopicAnomalyFinder() throws ExecutionException, InterruptedException {
+  public void testTopicAnomalyFinder() {
     KafkaCruiseControlIntegrationTestUtils.createTopic(broker(0).plaintextAddr(), 
         new NewTopic(TOPIC0, PARTITION_COUNT, (short) 2));
 

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/TopicAnomalyIntegrationTest.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/TopicAnomalyIntegrationTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See
+ * License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.concurrent.ExecutionException;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.TypeRef;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.MinTopicLeadersPerBrokerGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal;
+import com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig;
+import com.linkedin.kafka.cruisecontrol.config.constants.AnomalyDetectorConfig;
+import com.linkedin.kafka.cruisecontrol.detector.TopicReplicationFactorAnomalyFinder;
+import com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint;
+import net.minidev.json.JSONArray;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC0;
+
+
+public class TopicAnomalyIntegrationTest extends CruiseControlIntegrationTestHarness {
+
+  private static final int EXPECTED_REPLICA_COUNT = 3;
+  private static final int PARTITION_COUNT = 2;
+  private static final int KAFKA_CLUSTER_SIZE = 3;
+  private static final String CRUISE_CONTROL_KAFKA_CLUSTER_STATE_ENDPOINT =
+      "kafkacruisecontrol/" + CruiseControlEndPoint.KAFKA_CLUSTER_STATE + "?verbose=true&json=true";
+  private final Configuration _gsonJsonConfig = KafkaCruiseControlIntegrationTestUtils.createJsonMappingConfig();
+
+  @Before
+  public void setup() throws Exception {
+    super.start();
+  }
+
+  @Override
+  protected int clusterSize() {
+    return KAFKA_CLUSTER_SIZE;
+  }
+
+  @After
+  public void teardown() {
+    super.stop();
+  }
+
+  @Override
+  public Map<Object, Object> overridingProps() {
+    return KafkaCruiseControlIntegrationTestUtils.createBrokerProps();
+  }
+
+  @Override
+  protected Map<String, Object> withConfigs() {
+    Map<String, Object> configs = KafkaCruiseControlIntegrationTestUtils.ccConfigOverrides();
+    configs.put(TopicReplicationFactorAnomalyFinder.SELF_HEALING_TARGET_TOPIC_REPLICATION_FACTOR_CONFIG, "3");
+    configs.put(AnomalyDetectorConfig.ANOMALY_DETECTION_GOALS_CONFIG, new StringJoiner(",")
+        .add(ReplicaCapacityGoal.class.getName())
+        .add(DiskCapacityGoal.class.getName())
+        .add(ReplicaDistributionGoal.class.getName()).toString());
+
+    configs.put(AnalyzerConfig.DEFAULT_GOALS_CONFIG, new StringJoiner(",")
+        .add(MinTopicLeadersPerBrokerGoal.class.getName())
+        .add(ReplicaCapacityGoal.class.getName())
+        .add(ReplicaDistributionGoal.class.getName()).toString());
+
+    configs.put(AnalyzerConfig.HARD_GOALS_CONFIG, new StringJoiner(",")
+        .add(ReplicaCapacityGoal.class.getName())
+        .add(MinTopicLeadersPerBrokerGoal.class.getName()).toString());
+
+    return configs;
+  }
+
+  @Test
+  public void testTopicAnomalyFinder() throws ExecutionException, InterruptedException {
+    AdminClient adminClient = KafkaCruiseControlUtils.createAdminClient(Collections
+        .singletonMap(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()));
+    try {
+      adminClient.createTopics(Arrays.asList(new NewTopic(TOPIC0, PARTITION_COUNT, (short) 2))).all().get();
+
+    } finally {
+      KafkaCruiseControlUtils.closeAdminClientWithTimeout(adminClient);
+    }
+
+    // wait until metadata propagates to Cruise Control
+    KafkaCruiseControlIntegrationTestUtils.waitForConditionMeet(() -> {
+        String responseMessage = KafkaCruiseControlIntegrationTestUtils
+            .callCruiseControl(_app.serverUrl(), CRUISE_CONTROL_KAFKA_CLUSTER_STATE_ENDPOINT);
+        JSONArray partitionLeadersArray = JsonPath.read(responseMessage,
+            "$.KafkaPartitionState.other[?(@.topic == '" + TOPIC0 + "')].leader");
+        List<Integer> partitionLeaders = JsonPath.parse(partitionLeadersArray, _gsonJsonConfig)
+            .read("$.*", new TypeRef<>() { });
+        return partitionLeaders.size() == PARTITION_COUNT;
+    }, 20, new AssertionError("Topic partitions not found for " + TOPIC0));
+
+    KafkaCruiseControlIntegrationTestUtils.produceRandomDataToTopic(TOPIC0, 4000,
+        KafkaCruiseControlIntegrationTestUtils.getDefaultProducerProperties(bootstrapServers()));
+
+    // wait until new replicas appear for the topic
+    KafkaCruiseControlIntegrationTestUtils.waitForConditionMeet(() -> {
+      String responseMessage = KafkaCruiseControlIntegrationTestUtils
+          .callCruiseControl(_app.serverUrl(), CRUISE_CONTROL_KAFKA_CLUSTER_STATE_ENDPOINT);
+      JSONArray replicasArray = JsonPath.read(responseMessage,
+          "$.KafkaPartitionState.other[?(@.topic == '" + TOPIC0 + "')].replicas");
+      List<List<Integer>> partitionReplicas = JsonPath.parse(replicasArray, _gsonJsonConfig)
+          .read("$.*", new TypeRef<>() { });
+      return partitionReplicas.stream().allMatch(i -> i.size() == EXPECTED_REPLICA_COUNT);
+    }, 200, Duration.ofSeconds(15), new AssertionError("Replica count not match"));
+
+  }
+
+}


### PR DESCRIPTION
In this change I would like to add three test cases. Each test cause a goal violation or anomaly detection on a healthy environment and wait until Cruise Control self healing fix the issue.

- **BrokerFailureIntegrationTest** removes a broker from the Kafka cluster and wait until all the partitions are fixed
- **ReplicaCapcaityViolationIntegrationTest** The brokers have more replicas than the allowed maximum replicas. After ReplicaCapacityGoal violated adding a new broker to the cluster should fix 
- **TopicAnomalyIntegrationTest** creates a test topic with less partition replica than the desired value configured by SELF_HEALING_TARGET_TOPIC_REPLICATION_FACTOR_CONFIG. After that it waits until the replica count not fixed. 

Also a new integrationTest task created in the build.gradle file to run these tests separately. 