### PR TITLE
Add disk failure test and fix detection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,9 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "build.gradle" }}
       - run:
-          command: ./gradlew --no-daemon -PmaxParallelForks=1 clean integrationTest
+          command: ./gradlew --no-daemon clean
+      - run:
+          command: ./gradlew --no-daemon -PmaxParallelForks=1 integrationTest
       - save_cache:
           key: dependency-cache-{{ checksum "build.gradle" }}
           paths:
@@ -58,6 +60,8 @@ jobs:
           path: ~/test-results
       - store_artifacts:
           path: ~/test-results
+      - store_artifacts:
+          path: build/libs
 
   publish:
     working_directory: ~/workspace
@@ -78,10 +82,12 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - integration-test:
+          requires:
+            - build
       - publish:
           requires:
             - build
-            - integration-test
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,9 +45,7 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "build.gradle" }}
       - run:
-          command: ./gradlew --no-daemon clean
-      - run:
-          command: ./gradlew --no-daemon -PmaxParallelForks=1 integrationTest
+          command: ./gradlew --no-daemon -PmaxParallelForks=1 clean integrationTest
       - save_cache:
           key: dependency-cache-{{ checksum "build.gradle" }}
           paths:
@@ -60,8 +58,6 @@ jobs:
           path: ~/test-results
       - store_artifacts:
           path: ~/test-results
-      - store_artifacts:
-          path: build/libs
 
   publish:
     working_directory: ~/workspace
@@ -85,9 +81,14 @@ workflows:
       - integration-test:
           requires:
             - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
       - publish:
           requires:
-            - build
+            - integration-test
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,9 +45,7 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "build.gradle" }}
       - run:
-          command: ./gradlew --no-daemon clean
-      - run:
-          command: ./gradlew --no-daemon -PmaxParallelForks=1 integrationTest
+          command: ./gradlew --no-daemon -PmaxParallelForks=1 clean integrationTest
       - save_cache:
           key: dependency-cache-{{ checksum "build.gradle" }}
           paths:
@@ -60,8 +58,6 @@ jobs:
           path: ~/test-results
       - store_artifacts:
           path: ~/test-results
-      - store_artifacts:
-          path: build/libs
 
   publish:
     working_directory: ~/workspace
@@ -82,12 +78,10 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - integration-test:
-          requires:
-            - build
       - publish:
           requires:
             - build
+            - integration-test
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,35 @@ jobs:
       - store_artifacts:
           path: build/libs
 
+  integration-test:
+    environment:
+      _JAVA_OPTIONS: "-Xms512m -Xmx1g"
+    working_directory: ~/workspace
+    docker:
+      - image: cimg/openjdk:11.0
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "build.gradle" }}
+      - run:
+          command: ./gradlew --no-daemon clean
+      - run:
+          command: ./gradlew --no-daemon -PmaxParallelForks=1 integrationTest
+      - save_cache:
+          key: dependency-cache-{{ checksum "build.gradle" }}
+          paths:
+            - ~/.gradle
+      - run:
+          command: mkdir ~/test-results
+      - run:
+          command: find ~/workspace -type f -regex ".*/test-results/.*xml" -exec ln {} ~/test-results/ \;
+      - store_test_results:
+          path: ~/test-results
+      - store_artifacts:
+          path: ~/test-results
+      - store_artifacts:
+          path: build/libs
+
   publish:
     working_directory: ~/workspace
     docker:
@@ -53,6 +82,9 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - integration-test:
+          requires:
+            - build
       - publish:
           requires:
             - build

--- a/build.gradle
+++ b/build.gradle
@@ -369,6 +369,10 @@ project(':cruise-control') {
   task integrationTest(type: Test) {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
+    testLogging {
+      events "passed", "failed", "skipped"
+      exceptionFormat = 'full'
+    }
   }
 
   check.dependsOn integrationTest

--- a/build.gradle
+++ b/build.gradle
@@ -375,7 +375,6 @@ project(':cruise-control') {
     }
   }
 
-  check.dependsOn integrationTest
   compileIntegrationTestJava.dependsOn copyDependantLibs
 
   jar {

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/BrokerFailureIntegrationTest.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/BrokerFailureIntegrationTest.java
@@ -4,7 +4,6 @@
 
 package com.linkedin.kafka.cruisecontrol;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
@@ -116,7 +115,7 @@ public class BrokerFailureIntegrationTest extends CruiseControlIntegrationTestHa
             "$.KafkaBrokerState.OfflineReplicaCountByBrokerId");
         return partitionLeaders.size() == PARTITION_COUNT && brokers == KAFKA_CLUSTER_SIZE - 1
             && offlineReplicas.isEmpty();
-    }, 800, new AssertionError("Topic replicas not fixed after broker removed"));
+    }, 80, new AssertionError("Topic replicas not fixed after broker removed"));
   }
 
   private void waitForProposal() {
@@ -124,7 +123,7 @@ public class BrokerFailureIntegrationTest extends CruiseControlIntegrationTestHa
       String responseMessage = KafkaCruiseControlIntegrationTestUtils
           .callCruiseControl(_app.serverUrl(), CRUISE_CONTROL_STATE_ENDPOINT);
       return JsonPath.<Boolean>read(responseMessage, "AnalyzerState.isProposalReady");
-    }, Duration.ofSeconds(800), Duration.ofSeconds(15), new AssertionError("No proposals were ready"));
+    }, 100, new AssertionError("No proposals were ready"));
   }
 
   private void waitForMetadataPropagates() {

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/BrokerFailureIntegrationTest.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/BrokerFailureIntegrationTest.java
@@ -19,7 +19,6 @@ import com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.AnomalyDetectorConfig;
 import com.linkedin.kafka.cruisecontrol.detector.TopicReplicationFactorAnomalyFinder;
 import com.linkedin.kafka.cruisecontrol.detector.notifier.SelfHealingNotifier;
-import com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint;
 import net.minidev.json.JSONArray;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.junit.After;
@@ -27,16 +26,18 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC0;
-
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlIntegrationTestUtils.KAFKA_CRUISE_CONTROL_BASE_PATH;
+import static com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint.KAFKA_CLUSTER_STATE;
+import static com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint.STATE;
 
 public class BrokerFailureIntegrationTest extends CruiseControlIntegrationTestHarness {
 
   private static final int PARTITION_COUNT = 10;
   private static final int KAFKA_CLUSTER_SIZE = 4;
   private static final String CRUISE_CONTROL_KAFKA_CLUSTER_STATE_ENDPOINT =
-      "kafkacruisecontrol/" + CruiseControlEndPoint.KAFKA_CLUSTER_STATE + "?verbose=true&json=true";
+      KAFKA_CRUISE_CONTROL_BASE_PATH + KAFKA_CLUSTER_STATE + "?verbose=true&json=true";
   private static final String CRUISE_CONTROL_STATE_ENDPOINT =
-          "kafkacruisecontrol/" + CruiseControlEndPoint.STATE + "?substates=analyzer&json=true";
+      KAFKA_CRUISE_CONTROL_BASE_PATH + STATE + "?substates=analyzer&json=true";
   private final Configuration _gsonJsonConfig = KafkaCruiseControlIntegrationTestUtils.createJsonMappingConfig();
 
   private static final int BROKER_ID_TO_REMOVE = 1;

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/DiskFailureIntegrationTest.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/DiskFailureIntegrationTest.java
@@ -1,0 +1,180 @@
+/*
+* Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See
+ * License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.StringJoiner;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.TypeRef;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal;
+import com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig;
+import com.linkedin.kafka.cruisecontrol.detector.TopicReplicationFactorAnomalyFinder;
+import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaTestUtils;
+import com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint;
+import kafka.server.KafkaConfig;
+import net.minidev.json.JSONArray;
+import org.apache.commons.io.FileUtils;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC0;
+import static com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint.KAFKA_CLUSTER_STATE;
+
+public class DiskFailureIntegrationTest extends CruiseControlIntegrationTestHarness {
+
+  private static final short TOPIC0_REPLICATION_FACTOR = (short) 2;
+  private static final int BROKER_ID_TO_CAUSE_DISK_FAILURE = 2;
+  private static final int PARTITION_COUNT = 3;
+  private static final int KAFKA_CLUSTER_SIZE = 3;
+  private static final String CRUISE_CONTROL_KAFKA_CLUSTER_STATE_ENDPOINT =
+      "kafkacruisecontrol/" + KAFKA_CLUSTER_STATE + "?verbose=true&json=true";
+  private static final String CRUISE_CONTROL_STATE_ENDPOINT =
+      "kafkacruisecontrol/" + CruiseControlEndPoint.STATE + "?substates=anomaly_detector&json=true";
+  private static final String CRUISE_CONTROL_ANALYZER_STATE_ENDPOINT =
+      "kafkacruisecontrol/" + CruiseControlEndPoint.STATE + "?substates=analyzer&json=true";
+  private final Configuration _gsonJsonConfig = KafkaCruiseControlIntegrationTestUtils.createJsonMappingConfig();
+  private static final Logger LOG = LoggerFactory.getLogger(DiskFailureIntegrationTest.class);
+  private List<Entry<File, File>> _brokerLogDirs = new ArrayList<>(KAFKA_CLUSTER_SIZE);
+  
+  @Before
+  public void setup() throws Exception {
+    super.start();
+  }
+
+  @Override
+  protected int clusterSize() {
+    return KAFKA_CLUSTER_SIZE;
+  }
+
+  @After
+  public void teardown() {
+    super.stop();
+  }
+
+  @Override
+  public Map<Object, Object> overridingProps() {
+    Map<Object, Object> props = KafkaCruiseControlIntegrationTestUtils.createBrokerProps();
+    Entry<File, File> logFolders = Map.entry(CCKafkaTestUtils.newTempDir(), CCKafkaTestUtils.newTempDir());
+    _brokerLogDirs.add(logFolders);
+    props.put(KafkaConfig.LogDirsProp(), logFolders.getKey().getAbsolutePath() + "," + logFolders.getValue().getAbsolutePath());
+    return props;
+  }
+
+  @Override
+  protected Map<String, Object> withConfigs() {
+    Map<String, Object> configs = KafkaCruiseControlIntegrationTestUtils.ccConfigOverrides();
+    configs.put(TopicReplicationFactorAnomalyFinder.SELF_HEALING_TARGET_TOPIC_REPLICATION_FACTOR_CONFIG, "2");
+    
+    configs.put(AnalyzerConfig.DEFAULT_GOALS_CONFIG, new StringJoiner(",")
+        .add(ReplicaDistributionGoal.class.getName())
+        .add(ReplicaCapacityGoal.class.getName())
+        .add(DiskCapacityGoal.class.getName()).toString());
+    
+    configs.put(AnalyzerConfig.HARD_GOALS_CONFIG, new StringJoiner(",")
+        .add(ReplicaCapacityGoal.class.getName())
+        .add(DiskCapacityGoal.class.getName()).toString());
+    
+    return configs;
+  }
+
+  @Test
+  public void testDiskFailure() throws IOException {
+    AdminClient adminClient = KafkaCruiseControlUtils.createAdminClient(Collections
+        .singletonMap(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()));
+    try {
+      adminClient.createTopics(Arrays.asList(new NewTopic(TOPIC0, PARTITION_COUNT, TOPIC0_REPLICATION_FACTOR)));
+
+    } finally {
+      KafkaCruiseControlUtils.closeAdminClientWithTimeout(adminClient);
+    }
+
+    waitForMetadataPropogates();
+
+    KafkaCruiseControlIntegrationTestUtils.produceRandomDataToTopic(TOPIC0, 5, 400, KafkaCruiseControlIntegrationTestUtils
+        .getDefaultProducerProperties(bootstrapServers()));
+
+    waitForProposal();
+    
+    Entry<File, File> entry = _brokerLogDirs.get(BROKER_ID_TO_CAUSE_DISK_FAILURE);
+    FileUtils.deleteDirectory(entry.getKey());
+    LOG.info("Disk failure injected");
+    waitForOfflineReplicaDetection();
+    
+    waitForDiskFailureDetection();
+    
+    waitForOfflineReplicasFixed();
+    
+  }
+
+  private void waitForOfflineReplicasFixed() {
+    KafkaCruiseControlIntegrationTestUtils.waitForConditionMeet(() -> {
+      String responseMessage = KafkaCruiseControlIntegrationTestUtils
+          .callCruiseControl(_app.serverUrl(), CRUISE_CONTROL_KAFKA_CLUSTER_STATE_ENDPOINT);
+      Map<String, String> offlineReplicas = JsonPath.read(responseMessage,
+            "$.KafkaBrokerState.OfflineReplicaCountByBrokerId");
+      return offlineReplicas.isEmpty();
+    }, 800, new AssertionError("There are still offline replica on broker"));
+  }
+
+  private void waitForDiskFailureDetection() {
+    KafkaCruiseControlIntegrationTestUtils.waitForConditionMeet(() -> {
+      String responseMessage = KafkaCruiseControlIntegrationTestUtils
+          .callCruiseControl(_app.serverUrl(), CRUISE_CONTROL_STATE_ENDPOINT);
+      JSONArray diskFailuresArray = JsonPath.read(responseMessage,
+            "$.AnomalyDetectorState.recentDiskFailures[*].anomalyId");
+      return diskFailuresArray.size() == 1;
+    }, 400, new AssertionError("Disk failure anomaly not detected"));
+  }
+
+  private void waitForOfflineReplicaDetection() {
+    KafkaCruiseControlIntegrationTestUtils.waitForConditionMeet(() -> {
+      String responseMessage = KafkaCruiseControlIntegrationTestUtils
+          .callCruiseControl(_app.serverUrl(), CRUISE_CONTROL_KAFKA_CLUSTER_STATE_ENDPOINT);
+      Integer offlineReplicas = JsonPath.read(responseMessage,
+          "$.KafkaBrokerState.OfflineReplicaCountByBrokerId." + BROKER_ID_TO_CAUSE_DISK_FAILURE);
+      return offlineReplicas > 0;
+    }, 400, new AssertionError("Offline replicas not detected"));
+  }
+
+  private void waitForProposal() {
+    KafkaCruiseControlIntegrationTestUtils.waitForConditionMeet(() -> {
+      String responseMessage = KafkaCruiseControlIntegrationTestUtils
+          .callCruiseControl(_app.serverUrl(), CRUISE_CONTROL_ANALYZER_STATE_ENDPOINT);
+      return JsonPath.<Boolean>read(responseMessage, "AnalyzerState.isProposalReady");
+    }, Duration.ofSeconds(200), Duration.ofSeconds(15), new AssertionError("No proposal available"));
+  }
+
+  private void waitForMetadataPropogates() {
+    KafkaCruiseControlIntegrationTestUtils.waitForConditionMeet(() -> {
+      String responseMessage = KafkaCruiseControlIntegrationTestUtils
+          .callCruiseControl(_app.serverUrl(), CRUISE_CONTROL_KAFKA_CLUSTER_STATE_ENDPOINT);
+      JSONArray partitionLeadersArray = JsonPath.<JSONArray>read(responseMessage,
+          "$.KafkaPartitionState.other[?(@.topic == '" + TOPIC0 + "')].leader");
+      List<Integer> partitionLeaders = JsonPath.parse(partitionLeadersArray, _gsonJsonConfig)
+          .read("$.*", new TypeRef<List<Integer>>() { });
+      return partitionLeaders.size() == PARTITION_COUNT;
+    }, 80, new AssertionError("Topic partitions not found for " + TOPIC0));
+  }
+
+}
+

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlIntegrationTestUtils.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlIntegrationTestUtils.java
@@ -80,7 +80,7 @@ public final class KafkaCruiseControlIntegrationTestUtils {
   }
   
   public static void waitForConditionMeet(BooleanSupplier condition, int timeOutInSeconds, Error retriesExceededException) {
-    waitForConditionMeet(condition, Duration.ofSeconds(timeOutInSeconds), Duration.ofSeconds(7), retriesExceededException);
+    waitForConditionMeet(condition, Duration.ofSeconds(timeOutInSeconds), Duration.ofSeconds(5), retriesExceededException);
   }
   /**
    * Execute boolean condition until it returns true

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlIntegrationTestUtils.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlIntegrationTestUtils.java
@@ -25,6 +25,7 @@ import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import com.linkedin.kafka.cruisecontrol.config.constants.AnomalyDetectorConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
+import com.linkedin.kafka.cruisecontrol.config.constants.WebServerConfig;
 import com.linkedin.kafka.cruisecontrol.detector.KafkaMetricAnomalyFinder;
 import com.linkedin.kafka.cruisecontrol.detector.TopicReplicationFactorAnomalyFinder;
 import com.linkedin.kafka.cruisecontrol.detector.notifier.SelfHealingNotifier;
@@ -51,6 +52,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class KafkaCruiseControlIntegrationTestUtils {
 
+  public static final String KAFKA_CRUISE_CONTROL_BASE_PATH = WebServerConfig.DEFAULT_WEBSERVER_API_URLPREFIX.replace("*", "").substring(1);
   private static final Logger LOG = LoggerFactory.getLogger(KafkaCruiseControlIntegrationTestUtils.class);
   private static final Random RANDOM = new Random(0xDEADBEEF);
   private KafkaCruiseControlIntegrationTestUtils() {

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlIntegrationTestUtils.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlIntegrationTestUtils.java
@@ -78,7 +78,7 @@ public final class KafkaCruiseControlIntegrationTestUtils {
   }
   
   public static void waitForConditionMeet(BooleanSupplier condition, int timeOutInSeconds, Error retriesExceededException) {
-    waitForConditionMeet(condition, Duration.ofSeconds(timeOutInSeconds), Duration.ofSeconds(4), retriesExceededException);
+    waitForConditionMeet(condition, Duration.ofSeconds(timeOutInSeconds), Duration.ofSeconds(7), retriesExceededException);
   }
   /**
    * Execute boolean condition until it returns true
@@ -169,6 +169,7 @@ public final class KafkaCruiseControlIntegrationTestUtils {
     props.put(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_CONFIG, "true");
     props.put(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_REPLICATION_FACTOR_CONFIG, "2");
     props.put(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS_CONFIG, "1");
+    props.put(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_REPORTER_INTERVAL_MS_CONFIG, "10000");
     return props;
   }
   /**
@@ -182,15 +183,21 @@ public final class KafkaCruiseControlIntegrationTestUtils {
         TopicReplicationFactorAnomalyFinder.class.getName());
     configs.put(AnomalyDetectorConfig.ANOMALY_NOTIFIER_CLASS_CONFIG, SelfHealingNotifier.class.getName());
     configs.put(AnomalyDetectorConfig.RF_SELF_HEALING_SKIP_RACK_AWARENESS_CHECK_CONFIG, "true");
-
+    configs.put(AnomalyDetectorConfig.ANOMALY_DETECTION_INTERVAL_MS_CONFIG, "40000");
+    
     configs.put(MonitorConfig.METRIC_SAMPLER_CLASS_CONFIG, CruiseControlMetricsReporterSampler.class.getName());
-    configs.put(MonitorConfig.BROKER_METRICS_WINDOW_MS_CONFIG, "36000");
-    configs.put(MonitorConfig.PARTITION_METRICS_WINDOW_MS_CONFIG, "36000");
-    configs.put(MonitorConfig.NUM_PARTITION_METRICS_WINDOWS_CONFIG, "3");
+    configs.put(MonitorConfig.METRIC_SAMPLING_INTERVAL_MS_CONFIG, "15000");
+    configs.put(MonitorConfig.METADATA_MAX_AGE_MS_CONFIG, "10000");
+    
+    configs.put(MonitorConfig.BROKER_METRICS_WINDOW_MS_CONFIG, "30000");
+    configs.put(MonitorConfig.NUM_BROKER_METRICS_WINDOWS_CONFIG, "20");
+    configs.put(MonitorConfig.PARTITION_METRICS_WINDOW_MS_CONFIG, "30000");
+    configs.put(MonitorConfig.NUM_PARTITION_METRICS_WINDOWS_CONFIG, "20");
 
     configs.put(KafkaSampleStore.PARTITION_SAMPLE_STORE_TOPIC_PARTITION_COUNT_CONFIG, "2");
     configs.put(KafkaSampleStore.BROKER_SAMPLE_STORE_TOPIC_PARTITION_COUNT_CONFIG, "2");
     configs.put(SelfHealingNotifier.SELF_HEALING_ENABLED_CONFIG, "true");
+    configs.put(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_REPORTER_INTERVAL_MS_CONFIG, "10000");
     return configs;
   }
   

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/ReplicaCapacityViolationIntegrationTest.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/ReplicaCapacityViolationIntegrationTest.java
@@ -20,7 +20,6 @@ import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
 import com.linkedin.kafka.cruisecontrol.detector.TopicReplicationFactorAnomalyFinder;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporterConfig;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCEmbeddedBroker;
-import com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint;
 import net.minidev.json.JSONArray;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.junit.After;
@@ -29,6 +28,8 @@ import org.junit.Test;
 
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC0;
 import static com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint.KAFKA_CLUSTER_STATE;
+import static com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint.STATE;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlIntegrationTestUtils.KAFKA_CRUISE_CONTROL_BASE_PATH;
 
 
 public class ReplicaCapacityViolationIntegrationTest extends CruiseControlIntegrationTestHarness {
@@ -37,9 +38,9 @@ public class ReplicaCapacityViolationIntegrationTest extends CruiseControlIntegr
   private static final int PARTITION_COUNT = 2;
   private static final int KAFKA_CLUSTER_SIZE = 3;
   private static final String CRUISE_CONTROL_KAFKA_CLUSTER_STATE_ENDPOINT =
-      "kafkacruisecontrol/" + KAFKA_CLUSTER_STATE + "?verbose=true&json=true";
+      KAFKA_CRUISE_CONTROL_BASE_PATH + KAFKA_CLUSTER_STATE + "?verbose=true&json=true";
   private static final String CRUISE_CONTROL_STATE_ENDPOINT =
-      "kafkacruisecontrol/" + CruiseControlEndPoint.STATE + "?substates=anomaly_detector&json=true";
+      KAFKA_CRUISE_CONTROL_BASE_PATH + STATE + "?substates=anomaly_detector&json=true";
   private final Configuration _gsonJsonConfig = KafkaCruiseControlIntegrationTestUtils.createJsonMappingConfig();
 
   @Before

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/ReplicaCapacityViolationIntegrationTest.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/ReplicaCapacityViolationIntegrationTest.java
@@ -114,7 +114,7 @@ public class ReplicaCapacityViolationIntegrationTest extends CruiseControlIntegr
         Integer replicaCountOnBroker = JsonPath.read(responseMessage, "KafkaBrokerState.ReplicaCountByBrokerId."
           + BROKER_ID_TO_ADD);
         return replicaCountOnBroker > 0;
-    }, 600, new AssertionError("No replica found on the new broker"));
+    }, 80, new AssertionError("No replica found on the new broker"));
   }
 
   private void waitForReplicaCapacityGoalViolation() {
@@ -126,7 +126,7 @@ public class ReplicaCapacityViolationIntegrationTest extends CruiseControlIntegr
         List<String> unfixableGoals = JsonPath.parse(unfixableGoalsArray, _gsonJsonConfig)
             .read("$..*", new TypeRef<>() { });
         return unfixableGoals.contains("ReplicaCapacityGoal");
-    }, 300, new AssertionError("Replica capacity goal violation not found"));
+    }, 100, new AssertionError("Replica capacity goal violation not found"));
   }
 
 }

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/TopicAnomalyIntegrationTest.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/TopicAnomalyIntegrationTest.java
@@ -18,7 +18,6 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.AnomalyDetectorConfig;
 import com.linkedin.kafka.cruisecontrol.detector.TopicReplicationFactorAnomalyFinder;
-import com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint;
 import net.minidev.json.JSONArray;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.junit.After;
@@ -26,7 +25,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC0;
-
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlIntegrationTestUtils.KAFKA_CRUISE_CONTROL_BASE_PATH;
+import static com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint.KAFKA_CLUSTER_STATE;
 
 public class TopicAnomalyIntegrationTest extends CruiseControlIntegrationTestHarness {
 
@@ -34,7 +34,7 @@ public class TopicAnomalyIntegrationTest extends CruiseControlIntegrationTestHar
   private static final int PARTITION_COUNT = 2;
   private static final int KAFKA_CLUSTER_SIZE = 3;
   private static final String CRUISE_CONTROL_KAFKA_CLUSTER_STATE_ENDPOINT =
-      "kafkacruisecontrol/" + CruiseControlEndPoint.KAFKA_CLUSTER_STATE + "?verbose=true&json=true";
+      KAFKA_CRUISE_CONTROL_BASE_PATH + KAFKA_CLUSTER_STATE + "?verbose=true&json=true";
   private final Configuration _gsonJsonConfig = KafkaCruiseControlIntegrationTestUtils.createJsonMappingConfig();
 
   @Before

--- a/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/TopicAnomalyIntegrationTest.java
+++ b/cruise-control/src/integrationTest/java/com/linkedin/kafka/cruisecontrol/TopicAnomalyIntegrationTest.java
@@ -4,7 +4,6 @@
 
 package com.linkedin.kafka.cruisecontrol;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
@@ -101,7 +100,7 @@ public class TopicAnomalyIntegrationTest extends CruiseControlIntegrationTestHar
       List<List<Integer>> partitionReplicas = JsonPath.parse(replicasArray, _gsonJsonConfig)
           .read("$.*", new TypeRef<>() { });
       return partitionReplicas.stream().allMatch(i -> i.size() == EXPECTED_REPLICA_COUNT);
-    }, Duration.ofSeconds(800), Duration.ofSeconds(15), new AssertionError("Replica count not match"));
+    }, 100, new AssertionError("Replica count not match"));
   }
 
   private void waitForMetadataPropogates() {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DiskFailureDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DiskFailureDetector.java
@@ -42,6 +42,7 @@ public class DiskFailureDetector extends AbstractAnomalyDetector implements Runn
   public DiskFailureDetector(Queue<Anomaly> anomalies, KafkaCruiseControl kafkaCruiseControl) {
     super(anomalies, kafkaCruiseControl);
     _adminClient = kafkaCruiseControl.adminClient();
+    _lastCheckedModelGeneration = new ModelGeneration(0, -1L);
     _config = _kafkaCruiseControl.config();
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DiskFailureDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DiskFailureDetector.java
@@ -7,6 +7,7 @@ package com.linkedin.kafka.cruisecontrol.detector;
 import com.linkedin.cruisecontrol.detector.Anomaly;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
+import com.linkedin.kafka.cruisecontrol.monitor.ModelGeneration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
@@ -35,13 +36,12 @@ public class DiskFailureDetector extends AbstractAnomalyDetector implements Runn
   private static final Logger LOG = LoggerFactory.getLogger(DiskFailureDetector.class);
   public static final String FAILED_DISKS_OBJECT_CONFIG = "failed.disks.object";
   private final AdminClient _adminClient;
-  private int _lastCheckedClusterGeneration;
+  private ModelGeneration _lastCheckedModelGeneration;
   private final KafkaCruiseControlConfig _config;
 
   public DiskFailureDetector(Queue<Anomaly> anomalies, KafkaCruiseControl kafkaCruiseControl) {
     super(anomalies, kafkaCruiseControl);
     _adminClient = kafkaCruiseControl.adminClient();
-    _lastCheckedClusterGeneration = -1;
     _config = _kafkaCruiseControl.config();
   }
 
@@ -60,15 +60,15 @@ public class DiskFailureDetector extends AbstractAnomalyDetector implements Runn
    * @return The {@link AnomalyDetectionStatus anomaly detection status}, indicating whether the anomaly detector is ready.
    */
   private AnomalyDetectionStatus getDiskFailureDetectionStatus() {
-    int currentClusterGeneration = _kafkaCruiseControl.loadMonitor().clusterModelGeneration().clusterGeneration();
-    if (currentClusterGeneration == _lastCheckedClusterGeneration) {
+    ModelGeneration currentClusterModelGeneration = _kafkaCruiseControl.loadMonitor().clusterModelGeneration();
+    if (currentClusterModelGeneration.equals(_lastCheckedModelGeneration)) {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Skipping disk failure detection because the model generation hasn't changed. Current model generation {}",
                   _kafkaCruiseControl.loadMonitor().clusterModelGeneration());
       }
       return AnomalyDetectionStatus.SKIP_MODEL_GENERATION_NOT_CHANGED;
     }
-    _lastCheckedClusterGeneration = currentClusterGeneration;
+    _lastCheckedModelGeneration = currentClusterModelGeneration;
 
     Set<Integer> deadBrokers = _kafkaCruiseControl.loadMonitor().deadBrokersWithReplicas(MAX_METADATA_WAIT_MS);
     if (!deadBrokers.isEmpty()) {


### PR DESCRIPTION
In this pull request I introduced the disk failure test also with some configuration changes to speed up the tests a little bit. 
The DiskFailureIntegrationTest removes a  Kafka broker log folder and waits until the self healing fix the cluster.
I made a small change in the detector because under certain circumstances (from 10 test run 1 fails) the detector skips the detection. For example if the disk failure is detected but the self healing failed for this anomaly then the fix will not start again until there is no model change. That's why I modified the detector.