### PR TITLE
chore: bump dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,12 +268,12 @@ project(':cruise-control') {
     api 'org.apache.commons:commons-math3:3.6.1'
     api 'org.apache.httpcomponents:httpclient:4.5.13'
     api 'commons-codec:commons-codec:1.15'
-    api 'com.google.code.gson:gson:2.8.8'
+    api 'com.google.code.gson:gson:2.8.9'
     api "org.eclipse.jetty:jetty-server:${jettyVersion}"
     api 'io.dropwizard.metrics:metrics-core:3.2.6'
     api 'com.nimbusds:nimbus-jose-jwt:9.15.2'
-    api 'io.swagger.parser.v3:swagger-parser-v3:2.0.28'
-    api 'io.github.classgraph:classgraph:4.8.117'
+    api 'io.swagger.parser.v3:swagger-parser-v3:2.0.29'
+    api 'io.github.classgraph:classgraph:4.8.138'
 
     testImplementation project(path: ':cruise-control-metrics-reporter', configuration: 'testOutput')
     testImplementation project(path: ':cruise-control-core', configuration: 'testOutput')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 org.gradle.daemon=false
 org.gradle.parallel=false
 org.gradle.jvmargs=-Xms512m -Xmx512m
-scalaVersion=2.13.6
-kafkaVersion=2.8.0
-zookeeperVersion=3.5.9
-nettyVersion=4.1.68.Final
-jettyVersion=9.4.43.v20210629
+scalaVersion=2.13.7
+kafkaVersion=2.8.1
+zookeeperVersion=3.6.3
+nettyVersion=4.1.72.Final
+jettyVersion=9.4.44.v20210927


### PR DESCRIPTION
This PR resolves #1770 

Bumped dependencies to next patch version
Zookeeper was bumped over a minor version.  3.6 is compatible with 3.5