### PR TITLE
feat: Retry metrics reporter producer creation

### DIFF
--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
@@ -105,7 +105,6 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
 
   @Override
   public void close() {
-
     LOG.info("Closing Cruise Control metrics reporter.");
     _shutdown = true;
     if (_metricsReporterRunner != null) {
@@ -250,7 +249,7 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
                     config.getString(ProducerConfig.CLIENT_DNS_LOOKUP_CONFIG));
           } catch (ConfigException ce) {
             // dns resolution may not be complete yet, let's retry again later
-            LOG.warn("Unable to create Cruise Control metrics producer. ", e.getCause());
+            LOG.warn("Unable to create Cruise Control metrics producer. ", ce.getCause());
           }
           return true;
         }

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
@@ -244,10 +244,10 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
         if (e.getCause() instanceof ConfigException
                 && e.getCause().toString().contains("No resolvable bootstrap urls given in bootstrap.servers")) {
           // dns resolution may not be complete yet, let's retry again later
-          LOG.error("Unable to create Cruise Control metrics producer. ", e.getCause());
+          LOG.warn("Unable to create Cruise Control metrics producer. ", e.getCause());
           return true;
         }
-        throw (KafkaException) e.getCause();
+        throw e;
       }
     }, _metricsReporterCreateRetries);
   }

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterConfig.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterConfig.java
@@ -40,7 +40,7 @@ public class CruiseControlMetricsReporterConfig extends AbstractConfig {
   private static final String CRUISE_CONTROL_METRICS_TOPIC_MIN_INSYNC_REPLICAS_DOC = "The minimum number of insync replicas for the Cruise "
       + "Control metrics topic";
   public static final String CRUISE_CONTROL_METRICS_REPORTER_CREATE_RETRIES_CONFIG = "cruise.control.metrics.reporter.create.retries";
-  private static final String CRUISE_CONTROL_METRICS_REPORTER_CREATE_RETRIES_DOC = "Number of times the Cruise Control metrics reporter will"
+  private static final String CRUISE_CONTROL_METRICS_REPORTER_CREATE_RETRIES_DOC = "Number of times the Cruise Control metrics reporter will "
       + "attempt to create the producer while starting up.";
   public static final String CRUISE_CONTROL_METRICS_REPORTER_INTERVAL_MS_CONFIG = PREFIX + "metrics.reporting.interval.ms";
   private static final String CRUISE_CONTROL_METRICS_REPORTER_INTERVAL_MS_DOC = "The interval in milliseconds the "

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterConfig.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterConfig.java
@@ -39,6 +39,9 @@ public class CruiseControlMetricsReporterConfig extends AbstractConfig {
   public static final String CRUISE_CONTROL_METRICS_TOPIC_MIN_INSYNC_REPLICAS_CONFIG = "cruise.control.metrics.topic.min.insync.replicas";
   private static final String CRUISE_CONTROL_METRICS_TOPIC_MIN_INSYNC_REPLICAS_DOC = "The minimum number of insync replicas for the Cruise "
       + "Control metrics topic";
+  public static final String CRUISE_CONTROL_METRICS_REPORTER_CREATE_RETRIES_CONFIG = "cruise.control.metrics.reporter.create.retries";
+  private static final String CRUISE_CONTROL_METRICS_REPORTER_CREATE_RETRIES_DOC = "Number of times the Cruise Control metrics reporter will"
+      + "attempt to create the producer while starting up.";
   public static final String CRUISE_CONTROL_METRICS_REPORTER_INTERVAL_MS_CONFIG = PREFIX + "metrics.reporting.interval.ms";
   private static final String CRUISE_CONTROL_METRICS_REPORTER_INTERVAL_MS_DOC = "The interval in milliseconds the "
       + "metrics reporter should report the metrics.";
@@ -69,6 +72,7 @@ public class CruiseControlMetricsReporterConfig extends AbstractConfig {
   public static final int DEFAULT_CRUISE_CONTROL_METRICS_REPORTER_MAX_BLOCK_MS = (int) TimeUnit.MINUTES.toMillis(1);
   public static final int DEFAULT_CRUISE_CONTROL_METRICS_BATCH_SIZE = 800 * 1000;
   public static final boolean DEFAULT_CRUISE_CONTROL_METRICS_REPORTER_KUBERNETES_MODE = false;
+  public static final int DEFAULT_CRUISE_CONTROL_METRICS_REPORTER_CREATE_RETRIES = 2;
 
   public CruiseControlMetricsReporterConfig(Map<?, ?> originals, boolean doLog) {
     super(CONFIG, originals, doLog);
@@ -112,6 +116,11 @@ public class CruiseControlMetricsReporterConfig extends AbstractConfig {
                 DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_RETRIES,
                 ConfigDef.Importance.LOW,
                 CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_RETRIES_DOC)
+        .define(CRUISE_CONTROL_METRICS_REPORTER_CREATE_RETRIES_CONFIG,
+                ConfigDef.Type.INT,
+                DEFAULT_CRUISE_CONTROL_METRICS_REPORTER_CREATE_RETRIES,
+                ConfigDef.Importance.LOW,
+                CRUISE_CONTROL_METRICS_REPORTER_CREATE_RETRIES_DOC)
         .define(CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS_CONFIG,
                 ConfigDef.Type.INT,
                 DEFAULT_CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS,

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsUtils.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsUtils.java
@@ -186,7 +186,7 @@ public final class CruiseControlMetricsUtils {
         }
       } while (retry);
     } else {
-      throw new ConfigException("Max attempts on metrics topic creation has to be greater than zero.");
+      throw new ConfigException("Max attempts has to be greater than zero.");
     }
     return true;
   }


### PR DESCRIPTION
This PR attempts to resolve: https://github.com/linkedin/cruise-control/issues/1760

Add the ability for the metrics reporter to retry creating the producer while starting up. The number of retries is a configurable value, called "cruise.control.metrics.reporter.create.retries". The default number of retries is 2.