### PR TITLE
Allow webserver.ssl.key.password to rely on default value

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlApp.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlApp.java
@@ -12,6 +12,7 @@ import com.linkedin.kafka.cruisecontrol.config.constants.WebServerConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.KafkaCruiseControlServlet;
 import com.linkedin.kafka.cruisecontrol.servlet.security.CruiseControlSecurityHandler;
 import com.linkedin.kafka.cruisecontrol.servlet.security.SecurityProvider;
+import org.apache.kafka.common.config.types.Password;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.NCSARequestLog;
@@ -104,7 +105,10 @@ public class KafkaCruiseControlApp {
       SslContextFactory sslServerContextFactory = new SslContextFactory.Server();
       sslServerContextFactory.setKeyStorePath(_config.getString(WebServerConfig.WEBSERVER_SSL_KEYSTORE_LOCATION_CONFIG));
       sslServerContextFactory.setKeyStorePassword(_config.getPassword(WebServerConfig.WEBSERVER_SSL_KEYSTORE_PASSWORD_CONFIG).value());
-      sslServerContextFactory.setKeyManagerPassword(_config.getPassword(WebServerConfig.WEBSERVER_SSL_KEY_PASSWORD_CONFIG).value());
+      Password sslKeyPassword = _config.getPassword(WebServerConfig.WEBSERVER_SSL_KEY_PASSWORD_CONFIG);
+      if (sslKeyPassword != null) {
+        sslServerContextFactory.setKeyManagerPassword(sslKeyPassword.value());
+      }
       sslServerContextFactory.setProtocol(_config.getString(WebServerConfig.WEBSERVER_SSL_PROTOCOL_CONFIG));
       String keyStoreType = _config.getString(WebServerConfig.WEBSERVER_SSL_KEYSTORE_TYPE_CONFIG);
       if (keyStoreType != null) {


### PR DESCRIPTION
This PR resolves #1707

When `webserver.ssl.enable` is `true`, CC throws a NPE when `webserver.ssl.key.password` is not set in the CC configuration. [1]  Since Jetty automatically sets the KeyManagerPassword to the keystore password when the KeyManagerPassword is not explicitly set, [2] we don't always need to set it. We only need to set our client's KeyManagerPassword when the Kafka cluster we are connecting to sets it.  This PR just removes the requirement to set `webserver.ssl.key.password` when the Kafka cluster we are connecting to does not explicitly set the KeyManagerPassword.


[1] https://github.com/linkedin/cruise-control/blob/migrate_to_kafka_2_4/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlApp.java#L107
[2] https://github.com/eclipse/jetty.project/blob/jetty-9.4.43.v20210629/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java#L1249