### PR TITLE
Revert "Update ReplicationThrottleHelper to use AdminClient (#1752)"

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
@@ -6,23 +6,19 @@ package com.linkedin.kafka.cruisecontrol.executor;
 
 import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
 import kafka.log.LogConfig;
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.AlterConfigOp;
-import org.apache.kafka.clients.admin.Config;
-import org.apache.kafka.clients.admin.ConfigEntry;
-import org.apache.kafka.common.config.ConfigResource;
+import kafka.server.ConfigType;
+import kafka.zk.AdminZkClient;
+import kafka.zk.KafkaZkClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -37,25 +33,25 @@ class ReplicationThrottleHelper {
   static final String LEADER_THROTTLED_REPLICAS = LogConfig.LeaderReplicationThrottledReplicasProp();
   static final String FOLLOWER_THROTTLED_REPLICAS = LogConfig.FollowerReplicationThrottledReplicasProp();
 
-  private final AdminClient _adminClient;
+  private final KafkaZkClient _kafkaZkClient;
+  private final AdminZkClient _adminZkClient;
   private final Long _throttleRate;
 
-  ReplicationThrottleHelper(AdminClient adminClient, Long throttleRate) {
-    this._adminClient = adminClient;
+  ReplicationThrottleHelper(KafkaZkClient kafkaZkClient, Long throttleRate) {
+    this._kafkaZkClient = kafkaZkClient;
+    this._adminZkClient = new AdminZkClient(kafkaZkClient);
     this._throttleRate = throttleRate;
   }
 
-  void setThrottles(List<ExecutionProposal> replicaMovementProposals) throws ExecutionException, InterruptedException {
+  void setThrottles(List<ExecutionProposal> replicaMovementProposals) {
     if (throttlingEnabled()) {
       LOG.info("Setting a rebalance throttle of {} bytes/sec", _throttleRate);
       Set<Integer> participatingBrokers = getParticipatingBrokers(replicaMovementProposals);
       Map<String, Set<String>> throttledReplicas = getThrottledReplicasByTopic(replicaMovementProposals);
-      for (int broker : participatingBrokers) {
-        setThrottledRateIfUnset(broker);
-      }
-      for (Map.Entry<String, Set<String>> entry : throttledReplicas.entrySet()) {
-        setThrottledReplicas(entry.getKey(), entry.getValue());
-      }
+      participatingBrokers.forEach(this::setLeaderThrottledRateIfUnset);
+      participatingBrokers.forEach(this::setFollowerThrottledRateIfUnset);
+      throttledReplicas.forEach(this::setLeaderThrottledReplicas);
+      throttledReplicas.forEach(this::setFollowerThrottledReplicas);
     }
   }
 
@@ -77,7 +73,7 @@ class ReplicationThrottleHelper {
   }
 
   // clear throttles for a specific list of execution tasks
-  void clearThrottles(List<ExecutionTask> completedTasks, List<ExecutionTask> inProgressTasks) throws ExecutionException, InterruptedException {
+  void clearThrottles(List<ExecutionTask> completedTasks, List<ExecutionTask> inProgressTasks) {
     if (throttlingEnabled()) {
       List<ExecutionProposal> completedProposals =
         completedTasks
@@ -108,14 +104,10 @@ class ReplicationThrottleHelper {
       brokersToRemoveThrottlesFrom.removeAll(brokersWithInProgressTasks);
 
       LOG.info("Removing replica movement throttles from brokers in the cluster: {}", brokersToRemoveThrottlesFrom);
-      for (int broker : brokersToRemoveThrottlesFrom) {
-        removeThrottledRateFromBroker(broker);
-      }
+      brokersToRemoveThrottlesFrom.forEach(this::removeThrottledRateFromBroker);
 
       Map<String, Set<String>> throttledReplicas = getThrottledReplicasByTopic(completedProposals);
-      for (Map.Entry<String, Set<String>> entry : throttledReplicas.entrySet()) {
-        removeThrottledReplicasFromTopic(entry.getKey(), entry.getValue());
-      }
+      throttledReplicas.forEach(this::removeThrottledReplicasFromTopic);
     }
   }
 
@@ -147,179 +139,180 @@ class ReplicationThrottleHelper {
     return throttledReplicasByTopic;
   }
 
-  private void setThrottledRateIfUnset(int brokerId) throws ExecutionException, InterruptedException {
+  private void setLeaderThrottledRateIfUnset(int brokerId) {
+    setThrottledRateIfUnset(brokerId, true);
+  }
+
+  private void setFollowerThrottledRateIfUnset(int brokerId) {
+    setThrottledRateIfUnset(brokerId, false);
+  }
+
+  private void setThrottledRateIfUnset(int brokerId, boolean throttleLeaderReplicaRate) {
     if (_throttleRate == null) {
       throw new IllegalStateException("Throttle rate cannot be null");
     }
-    Config brokerConfigs = getBrokerConfigs(brokerId);
-    List<AlterConfigOp> ops = new ArrayList<>();
-    for (String replicaThrottleRateConfigKey : Arrays.asList(LEADER_THROTTLED_RATE, FOLLOWER_THROTTLED_RATE)) {
-      ConfigEntry currThrottleRate = brokerConfigs.get(replicaThrottleRateConfigKey);
-      if (currThrottleRate == null) {
-        LOG.debug("Setting {} to {} bytes/second for broker {}", replicaThrottleRateConfigKey, _throttleRate, brokerId);
-       ops.add(new AlterConfigOp(new ConfigEntry(replicaThrottleRateConfigKey, String.valueOf(_throttleRate)), AlterConfigOp.OpType.SET));
-      } else {
-        LOG.debug("Not setting {} for broker {} because pre-existing throttle of {} was already set",
-                replicaThrottleRateConfigKey, brokerId, currThrottleRate);
-      }
-    }
-    if (!ops.isEmpty()) {
-      changeBrokerConfigs(brokerId, ops);
+    String replicaThrottleRateConfigKey = throttleLeaderReplicaRate ? LEADER_THROTTLED_RATE : FOLLOWER_THROTTLED_RATE;
+    Properties brokerConfigs = _kafkaZkClient.getEntityConfigs(ConfigType.Broker(), String.valueOf(brokerId));
+    Object currThrottleRate = brokerConfigs.setProperty(replicaThrottleRateConfigKey, String.valueOf(_throttleRate));
+    if (currThrottleRate == null) {
+      LOG.debug("Setting {} to {} bytes/second for broker {}", replicaThrottleRateConfigKey, _throttleRate, brokerId);
+      ExecutorUtils.changeBrokerConfig(_adminZkClient, brokerId, brokerConfigs);
+    } else {
+      LOG.debug("Not setting {} for broker {} because pre-existing throttle of {} was already set",
+          replicaThrottleRateConfigKey, brokerId, currThrottleRate);
     }
   }
 
-  private Config getTopicConfigs(String topic) throws ExecutionException, InterruptedException {
+  private void setLeaderThrottledReplicas(String topic, Set<String> replicas) {
+    setThrottledReplicas(topic, replicas, true);
+  }
+
+  private void setFollowerThrottledReplicas(String topic, Set<String> replicas) {
+    setThrottledReplicas(topic, replicas, false);
+  }
+
+  private void setThrottledReplicas(String topic, Set<String> replicas, boolean throttleLeaderReplica) {
+    String replicaThrottleConfigKey = throttleLeaderReplica ? LEADER_THROTTLED_REPLICAS : FOLLOWER_THROTTLED_REPLICAS;
+    Properties topicConfigs = _kafkaZkClient.getEntityConfigs(ConfigType.Topic(), topic);
+    String currThrottledReplicas = topicConfigs.getProperty(replicaThrottleConfigKey);
+    if (currThrottledReplicas != null && currThrottledReplicas.trim().equals(WILDCARD_ASTERISK)) {
+      // The existing setup throttles all replica. So, nothing needs to be changed.
+      return;
+    }
+
+    // Merge new throttled replicas with existing configuration values.
+    Set<String> newThrottledReplicas = new TreeSet<>(replicas);
+    if (currThrottledReplicas != null) {
+      newThrottledReplicas.addAll(Arrays.asList(currThrottledReplicas.split(",")));
+    }
+    topicConfigs.setProperty(replicaThrottleConfigKey, String.join(",", newThrottledReplicas));
+    changeTopicConfigs(topic, topicConfigs);
+  }
+
+  /**
+   * Update topic configuration properties if a topic exist. No-op for non-existent topic
+   *
+   * @param topicName topic name
+   * @param topicConfigs configuration properties to update
+   */
+  private void changeTopicConfigs(String topicName, Properties topicConfigs) {
     try {
-      return getEntityConfigs(new ConfigResource(ConfigResource.Type.TOPIC, topic));
+      ExecutorUtils.changeTopicConfig(_adminZkClient, topicName, topicConfigs);
     } catch (Exception e) {
-      if (!topicExists(topic)) {
-        return new Config(Collections.emptyList());
-      }
-      throw e;
-    }
-  }
-
-  private Config getBrokerConfigs(int brokerId) throws ExecutionException, InterruptedException {
-    return getEntityConfigs(new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(brokerId)));
-  }
-
-  private Config getEntityConfigs(ConfigResource cf) throws ExecutionException, InterruptedException {
-    Map<ConfigResource, Config> configs = _adminClient.describeConfigs(Collections.singletonList(cf)).all().get();
-    return configs.get(cf);
-  }
-
-  private void setThrottledReplicas(String topic, Set<String> replicas)
-  throws ExecutionException, InterruptedException {
-    Config topicConfigs = getTopicConfigs(topic);
-    List<AlterConfigOp> ops = new ArrayList<>();
-    for (String replicaThrottleConfigKey : Arrays.asList(LEADER_THROTTLED_REPLICAS, FOLLOWER_THROTTLED_REPLICAS)) {
-      ConfigEntry currThrottledReplicas = topicConfigs.get(replicaThrottleConfigKey);
-      if (currThrottledReplicas != null && currThrottledReplicas.value().trim().equals(WILDCARD_ASTERISK)) {
-        // The existing setup throttles all replica. So, nothing needs to be changed.
-        continue;
-      }
-
-      // Merge new throttled replicas with existing configuration values.
-      Set<String> newThrottledReplicas = new TreeSet<>(replicas);
-      if (currThrottledReplicas != null && !currThrottledReplicas.value().equals("")) {
-        newThrottledReplicas.addAll(Arrays.asList(currThrottledReplicas.value().split(",")));
-      }
-      ops.add(new AlterConfigOp(new ConfigEntry(replicaThrottleConfigKey, String.join(",", newThrottledReplicas)), AlterConfigOp.OpType.SET));
-    }
-    if (!ops.isEmpty()) {
-      changeTopicConfigs(topic, ops);
-    }
-  }
-
-  void changeTopicConfigs(String topic, Collection<AlterConfigOp> ops) throws ExecutionException, InterruptedException {
-    Map<ConfigResource, Collection<AlterConfigOp>> configs = Collections.singletonMap(
-            new ConfigResource(ConfigResource.Type.TOPIC, topic), ops
-    );
-    try {
-      _adminClient.incrementalAlterConfigs(configs).all().get();
-    } catch (Exception e) {
-      if (!topicExists(topic)) {
-        LOG.debug("Failed to change configs for topic {} since it does not exist", topic);
+      if (!_kafkaZkClient.topicExists(topicName)) {
+        LOG.debug("Failed to change configs for topic {} since it does not exist", topicName);
         return;
       }
       throw e;
     }
   }
 
-  void changeBrokerConfigs(int brokerId, Collection<AlterConfigOp> ops) throws ExecutionException, InterruptedException {
-    Map<ConfigResource, Collection<AlterConfigOp>> configs = Collections.singletonMap(
-            new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(brokerId)),
-            ops
-    );
-    _adminClient.incrementalAlterConfigs(configs).all().get();
-  }
-
-  boolean topicExists(String topic) {
-    try {
-      return _adminClient.listTopics().names().get().contains(topic);
-    } catch (InterruptedException | ExecutionException e) {
-      return false;
-    }
-  }
-
   static String removeReplicasFromConfig(String throttleConfig, Set<String> replicas) {
-    List<String> throttles = new ArrayList<>(Arrays.asList(throttleConfig.split(",")));
+    ArrayList<String> throttles = new ArrayList<>(Arrays.asList(throttleConfig.split(",")));
     throttles.removeIf(replicas::contains);
     return String.join(",", throttles);
   }
 
   /**
-   * It gets whether there is any throttled replica specified in the configuration property. If there is and the
-   * specified throttled replica does not equal to "*", it modifies the configuration property by removing a
-   * given set of replicas from the set of throttled replicas
+   * It gets whether there is any throttled leader replica specified in the configuration property. If there is and the
+   * specified throttled leader replica does not equal to "*", it modifies the configuration property by removing a
+   * given set of replicas from the a set of throttled leader replica
    *
+   * @param config configuration properties
    * @param topic name of topic which contains <code>replicas</code>
    * @param replicas replicas to remove from the configuration properties
+   * @return {@code true} if the given configuration properties are modified and {@code false} otherwise
    */
-  private void removeThrottledReplicasFromTopic(String topic, Set<String> replicas) throws ExecutionException, InterruptedException {
-    Config topicConfigs = getTopicConfigs(topic);
-    if (topicConfigs == null) {
+  private boolean removeLeaderThrottledReplicasFromTopic(Properties config, String topic, Set<String> replicas) {
+    String currLeaderThrottledReplicas = config.getProperty(LEADER_THROTTLED_REPLICAS);
+    if (currLeaderThrottledReplicas != null) {
+      if (currLeaderThrottledReplicas.equals(WILDCARD_ASTERISK)) {
+        LOG.debug("Existing config throttles all leader replicas. So, do not remove any leader replica throttle");
+        return false;
+      }
+
+      replicas.forEach(r -> LOG.debug("Removing leader throttles for topic {} on replica {}", topic, r));
+      String newLeaderThrottledReplicas = removeReplicasFromConfig(currLeaderThrottledReplicas, replicas);
+      if (newLeaderThrottledReplicas.isEmpty()) {
+        config.remove(LEADER_THROTTLED_REPLICAS);
+      } else {
+        config.setProperty(LEADER_THROTTLED_REPLICAS, newLeaderThrottledReplicas);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * It gets whether there is any throttled follower replica specified in the configuration property. If there is and the
+   * specified throttled follower replica does not equal to "*", it modifies the configuration property by removing a
+   * given set of replicas from the a set of throttled follower replica
+   *
+   * @param config configuration properties
+   * @param topic name of topic which contains <code>replicas</code>
+   * @param replicas replicas to remove from the configuration properties
+   * @return {@code true} if the given configuration properties are modified and {@code false} otherwise
+   */
+  private boolean removeFollowerThrottledReplicasFromTopic(Properties config, String topic, Set<String> replicas) {
+    String currLeaderThrottledReplicas = config.getProperty(FOLLOWER_THROTTLED_REPLICAS);
+    if (currLeaderThrottledReplicas != null) {
+      if (currLeaderThrottledReplicas.equals(WILDCARD_ASTERISK)) {
+        LOG.debug("Existing config throttles all follower replicas. So, do not remove any follower replica throttle");
+        return false;
+      }
+
+      replicas.forEach(r -> LOG.debug("Removing follower throttles for topic {} and replica {}", topic, r));
+      String newLeaderThrottledReplicas = removeReplicasFromConfig(currLeaderThrottledReplicas, replicas);
+      if (newLeaderThrottledReplicas.isEmpty()) {
+        config.remove(FOLLOWER_THROTTLED_REPLICAS);
+      } else {
+        config.setProperty(FOLLOWER_THROTTLED_REPLICAS, newLeaderThrottledReplicas);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  private void removeThrottledReplicasFromTopic(String topic, Set<String> replicas) {
+    Properties topicConfigs = _kafkaZkClient.getEntityConfigs(ConfigType.Topic(), topic);
+    if (topicConfigs.isEmpty()) {
       LOG.debug("Skip removing throttled replicas {} from topic {} since no configs can be read", String.join(",", replicas), topic);
       return;
     }
-    List<AlterConfigOp> ops = new ArrayList<>();
+    boolean removedLeaderThrottle = removeLeaderThrottledReplicasFromTopic(topicConfigs, topic, replicas);
+    boolean removedFollowerThrottle = removeFollowerThrottledReplicasFromTopic(topicConfigs, topic, replicas);
 
-    ConfigEntry currentLeaderThrottledReplicas = topicConfigs.get(LEADER_THROTTLED_REPLICAS);
-    if (currentLeaderThrottledReplicas != null) {
-      if (currentLeaderThrottledReplicas.value().equals(WILDCARD_ASTERISK)) {
-        LOG.debug("Existing config throttles all leader replicas. So, do not remove any leader replica throttle");
-      } else {
-        replicas.forEach(r -> LOG.debug("Removing leader throttles for topic {} and replica {}", topic, r));
-        String newThrottledReplicas = removeReplicasFromConfig(currentLeaderThrottledReplicas.value(), replicas);
-        if (newThrottledReplicas.isEmpty()) {
-          ops.add(new AlterConfigOp(new ConfigEntry(LEADER_THROTTLED_REPLICAS, null), AlterConfigOp.OpType.DELETE));
-        } else {
-          ops.add(new AlterConfigOp(new ConfigEntry(LEADER_THROTTLED_REPLICAS, newThrottledReplicas), AlterConfigOp.OpType.SET));
-        }
-      }
-    }
-    ConfigEntry currentFollowerThrottledReplicas = topicConfigs.get(FOLLOWER_THROTTLED_REPLICAS);
-    if (currentFollowerThrottledReplicas != null) {
-      if (currentFollowerThrottledReplicas.value().equals(WILDCARD_ASTERISK)) {
-        LOG.debug("Existing config throttles all follower replicas. So, do not remove any follower replica throttle");
-      } else {
-        replicas.forEach(r -> LOG.debug("Removing follower throttles for topic {} and replica {}", topic, r));
-        String newThrottledReplicas = removeReplicasFromConfig(currentFollowerThrottledReplicas.value(), replicas);
-        if (newThrottledReplicas.isEmpty()) {
-          ops.add(new AlterConfigOp(new ConfigEntry(FOLLOWER_THROTTLED_REPLICAS, null), AlterConfigOp.OpType.DELETE));
-        } else {
-          ops.add(new AlterConfigOp(new ConfigEntry(FOLLOWER_THROTTLED_REPLICAS, newThrottledReplicas), AlterConfigOp.OpType.SET));
-        }
-      }
-    }
-    if (!ops.isEmpty()) {
-      changeTopicConfigs(topic, ops);
+    if (removedLeaderThrottle || removedFollowerThrottle) {
+      changeTopicConfigs(topic, topicConfigs);
     }
   }
 
-  private void removeThrottledRateFromBroker(Integer brokerId) throws ExecutionException, InterruptedException {
-    Config brokerConfigs = getBrokerConfigs(brokerId);
-    ConfigEntry currLeaderThrottle = brokerConfigs.get(LEADER_THROTTLED_RATE);
-    ConfigEntry currFollowerThrottle = brokerConfigs.get(FOLLOWER_THROTTLED_RATE);
-    List<AlterConfigOp> ops = new ArrayList<>();
+  private void removeThrottledRateFromBroker(Integer brokerId) {
+    Properties brokerConfigs = _kafkaZkClient.getEntityConfigs(ConfigType.Broker(), String.valueOf(brokerId));
+    Object currLeaderThrottle = brokerConfigs.get(LEADER_THROTTLED_RATE);
+    Object currFollowerThrottle = brokerConfigs.get(FOLLOWER_THROTTLED_RATE);
+    boolean configChange = false;
+
     if (currLeaderThrottle != null) {
-      if (currLeaderThrottle.value().equals(WILDCARD_ASTERISK)) {
+      if (currLeaderThrottle.equals(WILDCARD_ASTERISK)) {
         LOG.debug("Existing config throttles all leader replicas. So, do not remove any leader replica throttle on broker {}", brokerId);
       } else {
         LOG.debug("Removing leader throttle on broker {}", brokerId);
-        ops.add(new AlterConfigOp(new ConfigEntry(LEADER_THROTTLED_RATE, null), AlterConfigOp.OpType.DELETE));
+        brokerConfigs.remove(LEADER_THROTTLED_RATE);
+        configChange = true;
       }
     }
     if (currFollowerThrottle != null) {
-      if (currFollowerThrottle.value().equals(WILDCARD_ASTERISK)) {
+      if (currFollowerThrottle.equals(WILDCARD_ASTERISK)) {
         LOG.debug("Existing config throttles all follower replicas. So, do not remove any follower replica throttle on broker {}", brokerId);
       } else {
         LOG.debug("Removing follower throttle on broker {}", brokerId);
-        ops.add(new AlterConfigOp(new ConfigEntry(FOLLOWER_THROTTLED_RATE, null), AlterConfigOp.OpType.DELETE));
+        brokerConfigs.remove(FOLLOWER_THROTTLED_RATE);
+        configChange = true;
       }
     }
-    if (!ops.isEmpty()) {
-      changeBrokerConfigs(brokerId, ops);
+    if (configChange) {
+      ExecutorUtils.changeBrokerConfig(_adminZkClient, brokerId, brokerConfigs);
     }
   }
 }

--- a/cruise-control/src/main/scala/com/linkedin/kafka/cruisecontrol/executor/ExecutorUtils.scala
+++ b/cruise-control/src/main/scala/com/linkedin/kafka/cruisecontrol/executor/ExecutorUtils.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.executor
+
+import java.util.Properties
+import kafka.zk.AdminZkClient
+import org.slf4j.{Logger, LoggerFactory}
+
+/**
+ * This class is a Java interface wrapper of open source ReassignPartitionCommand. This class is needed because
+ * scala classes and Java classes are not compatible.
+ */
+object ExecutorUtils {
+  val LOG: Logger = LoggerFactory.getLogger(ExecutorUtils.getClass.getName)
+
+  def changeBrokerConfig(adminZkClient: AdminZkClient, brokerId: Int, config: Properties): Unit = {
+    adminZkClient.changeBrokerConfig(Some(brokerId), config)
+  }
+
+  def changeTopicConfig(adminZkClient: AdminZkClient, topic: String, config: Properties): Unit = {
+    adminZkClient.changeTopicConfig(topic, config)
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
@@ -7,88 +7,64 @@ package com.linkedin.kafka.cruisecontrol.executor;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaIntegrationTestHarness;
 import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
+import kafka.server.ConfigType;
+import kafka.zk.AdminZkClient;
+import kafka.zk.KafkaZkClient;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.admin.AlterConfigOp;
-import org.apache.kafka.clients.admin.AlterConfigsResult;
-import org.apache.kafka.clients.admin.Config;
-import org.apache.kafka.clients.admin.ConfigEntry;
-import org.apache.kafka.clients.admin.DescribeConfigsResult;
-import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.config.ConfigResource;
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC0;
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC1;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness {
   private static final long TASK_EXECUTION_ALERTING_THRESHOLD_MS = 100L;
-  private static final Config EMPTY_CONFIG = new Config(Collections.emptyList());
-
-  /**
-   * The admin client
-   */
-  private AdminClient _adminClient;
 
   @Override
   public int clusterSize() {
     return 4;
   }
 
-  /**
-   * Setup the test.
-   */
   @Before
   public void setUp() {
     super.setUp();
-    _adminClient = KafkaCruiseControlUtils.createAdminClient(Collections.singletonMap(
-            AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()));
   }
 
-  /**
-   * Teardown the test.
-   */
   @After
   public void tearDown() {
     super.tearDown();
-    if (_adminClient != null) {
-      _adminClient.close(Duration.ofMillis(1000L));
+  }
+
+  private void createTopics() {
+    AdminClient adminClient = KafkaCruiseControlUtils.createAdminClient(Collections.singletonMap(
+        AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()));
+    try {
+      adminClient.createTopics(Arrays.asList(
+          new NewTopic(TOPIC0, 2, (short) 2),
+          new NewTopic(TOPIC1, 2, (short) 2)
+      ));
+    } finally {
+      KafkaCruiseControlUtils.closeAdminClientWithTimeout(adminClient);
     }
   }
 
-  private void createTopics() throws ExecutionException, InterruptedException {
-    _adminClient.createTopics(Arrays.asList(
-        new NewTopic(TOPIC0, 2, (short) 2),
-        new NewTopic(TOPIC1, 2, (short) 2)
-    )).all().get();
-  }
-
-  private static void setWildcardThrottleReplicaForTopic(ReplicationThrottleHelper helper, String topicName) throws Exception {
+  private static void setWildcardThrottleReplicaForTopic(KafkaZkClient kafkaZkClient, String topicName) {
     for (String replicaThrottleProp : Arrays.asList(ReplicationThrottleHelper.LEADER_THROTTLED_REPLICAS,
                                                     ReplicationThrottleHelper.FOLLOWER_THROTTLED_REPLICAS)) {
-      Collection<AlterConfigOp> configs = Collections.singletonList(
-              new AlterConfigOp(new ConfigEntry(replicaThrottleProp, ReplicationThrottleHelper.WILDCARD_ASTERISK), AlterConfigOp.OpType.SET)
-      );
-      helper.changeTopicConfigs(topicName, configs);
+      Properties config = kafkaZkClient.getEntityConfigs(ConfigType.Topic(), topicName);
+      config.setProperty(replicaThrottleProp, ReplicationThrottleHelper.WILDCARD_ASTERISK);
+      ExecutorUtils.changeTopicConfig(new AdminZkClient(kafkaZkClient), topicName, config);
     }
   }
 
@@ -105,12 +81,12 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
   }
 
   @Test
-  public void testIsNoOpWhenThrottleIsNull() throws Exception {
-    AdminClient mockAdminClient = EasyMock.strictMock(AdminClient.class);
-    EasyMock.replay(mockAdminClient);
+  public void testIsNoOpWhenThrottleIsNull() {
+    KafkaZkClient mockKafkaZkClient = EasyMock.strictMock(KafkaZkClient.class);
+    EasyMock.replay(mockKafkaZkClient);
 
     // Test would fail on any unexpected interactions with the kafkaZkClient
-    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, null);
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockKafkaZkClient, null);
     ExecutionProposal proposal = new ExecutionProposal(new TopicPartition("topic", 0),
                                            100,
                                                        new ReplicaPlacementInfo(0),
@@ -121,16 +97,14 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
 
     throttleHelper.setThrottles(Collections.singletonList(proposal));
     throttleHelper.clearThrottles(Collections.singletonList(task), Collections.emptyList());
-    EasyMock.verify(mockAdminClient);
   }
 
   @Test
-  public void testClearThrottleOnNonExistentTopic() throws Exception {
+  public void testClearThrottleOnNonExistentTopic() {
     final long throttleRate = 100L;
     final int brokerId0 = 0;
     final int brokerId1 = 1;
     final int brokerId2 = 2;
-    final List<Integer> brokers = Arrays.asList(brokerId0, brokerId1, brokerId2);
     final int partitionId = 0;
     // A proposal to move a partition with 2 replicas from broker 0 and 1 to broker 0 and 2
     ExecutionProposal proposal = new ExecutionProposal(new TopicPartition(TOPIC0, partitionId),
@@ -139,46 +113,38 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
                                                        Arrays.asList(new ReplicaPlacementInfo(brokerId0), new ReplicaPlacementInfo(brokerId1)),
                                                        Arrays.asList(new ReplicaPlacementInfo(brokerId0), new ReplicaPlacementInfo(brokerId2)));
 
-    AdminClient mockAdminClient = EasyMock.mock(AdminClient.class);
-    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, throttleRate);
-
     // Case 1: a situation where Topic0 does not exist. Hence no property is returned upon read.
-    expectDescribeBrokerConfigs(mockAdminClient, brokers);
-    expectIncrementalBrokerConfigs(mockAdminClient, brokers);
-    expectDescribeTopicConfigs(mockAdminClient, TOPIC0, EMPTY_CONFIG, false);
-    expectListTopics(mockAdminClient, Collections.emptySet());
+    KafkaZkClient mockKafkaZkClient = prepareMockKafkaZkClient(new Properties());
     ExecutionTask mockCompleteTask = prepareMockCompleteTask(proposal);
-    EasyMock.replay(mockAdminClient);
+    EasyMock.replay(mockCompleteTask, mockKafkaZkClient);
 
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockKafkaZkClient, throttleRate);
     throttleHelper.clearThrottles(Collections.singletonList(mockCompleteTask), Collections.emptyList());
-    EasyMock.verify(mockAdminClient, mockCompleteTask);
+    EasyMock.verify(mockKafkaZkClient, mockCompleteTask);
 
     // Case 2: a situation where Topic0 gets deleted after its configs were read.
-    EasyMock.reset(mockAdminClient);
-    expectDescribeBrokerConfigs(mockAdminClient, brokers);
-    expectIncrementalBrokerConfigs(mockAdminClient, brokers);
+    Properties topicConfigProps = new Properties();
     String throttledReplicas = brokerId0 + "," + brokerId1;
-    Config topicConfigProps = new Config(Arrays.asList(
-            new ConfigEntry(ReplicationThrottleHelper.LEADER_THROTTLED_REPLICAS, throttledReplicas),
-            new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_THROTTLED_REPLICAS, throttledReplicas)));
-    expectDescribeTopicConfigs(mockAdminClient, TOPIC0, topicConfigProps, true);
-    expectIncrementalTopicConfigs(mockAdminClient, TOPIC0, false);
-    expectListTopics(mockAdminClient, Collections.emptySet());
-    mockCompleteTask = prepareMockCompleteTask(proposal);
-    EasyMock.replay(mockAdminClient);
+    topicConfigProps.put(ReplicationThrottleHelper.LEADER_THROTTLED_REPLICAS, throttledReplicas);
+    topicConfigProps.put(ReplicationThrottleHelper.FOLLOWER_THROTTLED_REPLICAS, throttledReplicas);
+    mockKafkaZkClient = prepareMockKafkaZkClient(topicConfigProps);
+    EasyMock.expect(mockKafkaZkClient.topicExists(TOPIC0)).andReturn(false).times(2);
 
+    mockCompleteTask = prepareMockCompleteTask(proposal);
+    EasyMock.replay(mockCompleteTask, mockKafkaZkClient);
+
+    throttleHelper = new ReplicationThrottleHelper(mockKafkaZkClient, throttleRate);
     // Expect no exception
     throttleHelper.clearThrottles(Collections.singletonList(mockCompleteTask), Collections.emptyList());
-    EasyMock.verify(mockAdminClient, mockCompleteTask);
+    EasyMock.verify(mockKafkaZkClient, mockCompleteTask);
   }
 
   @Test
-  public void testSetThrottleOnNonExistentTopic() throws Exception {
+  public void testSetThrottleOnNonExistentTopic() {
     final long throttleRate = 100L;
     final int brokerId0 = 0;
     final int brokerId1 = 1;
     final int brokerId2 = 2;
-    final List<Integer> brokers = Arrays.asList(brokerId0, brokerId1, brokerId2);
     final int partitionId = 0;
     // A proposal to move a partition with 2 replicas from broker 0 and 1 to broker 0 and 2
     ExecutionProposal proposal = new ExecutionProposal(new TopicPartition(TOPIC0, partitionId),
@@ -187,42 +153,44 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
                                                        Arrays.asList(new ReplicaPlacementInfo(brokerId0), new ReplicaPlacementInfo(brokerId1)),
                                                        Arrays.asList(new ReplicaPlacementInfo(brokerId0), new ReplicaPlacementInfo(brokerId2)));
 
-    AdminClient mockAdminClient = EasyMock.strictMock(AdminClient.class);
-    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, throttleRate);
-
+    KafkaZkClient mockKafkaZkClient = EasyMock.mock(KafkaZkClient.class);
+    prepareKafkaZkClientMockWithBrokerConfigs(mockKafkaZkClient, 2);
     // Case 1: a situation where Topic0 does not exist. Hence no property is returned upon read.
-    expectDescribeBrokerConfigs(mockAdminClient, brokers);
-    expectDescribeTopicConfigs(mockAdminClient, TOPIC0, EMPTY_CONFIG, false);
-    expectListTopics(mockAdminClient, Collections.emptySet());
-    expectIncrementalTopicConfigs(mockAdminClient, TOPIC0, false);
-    expectListTopics(mockAdminClient, Collections.emptySet());
-    EasyMock.replay(mockAdminClient);
-    // Expect no exception
+    EasyMock.expect(mockKafkaZkClient.getEntityConfigs(ConfigType.Topic(), TOPIC0)).andReturn(new Properties()).times(2);
+    EasyMock.expect(mockKafkaZkClient.topicExists(TOPIC0)).andReturn(false).times(4);
+    EasyMock.replay(mockKafkaZkClient);
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockKafkaZkClient, throttleRate);
+
     throttleHelper.setThrottles(Collections.singletonList(proposal));
-    EasyMock.verify(mockAdminClient);
+    EasyMock.verify(mockKafkaZkClient);
 
     // Case 2: a situation where Topic0 gets deleted after its configs were read. Change configs should not fail.
-    EasyMock.reset(mockAdminClient);
-    expectDescribeBrokerConfigs(mockAdminClient, brokers);
+    EasyMock.reset(mockKafkaZkClient);
+    prepareKafkaZkClientMockWithBrokerConfigs(mockKafkaZkClient, 2);
+    Properties topicConfigProps = new Properties();
     String throttledReplicas = brokerId0 + "," + brokerId1;
-    Config topicConfigs = new Config(Arrays.asList(
-      new ConfigEntry(ReplicationThrottleHelper.LEADER_THROTTLED_REPLICAS, throttledReplicas),
-      new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_THROTTLED_REPLICAS, throttledReplicas)));
-    expectDescribeTopicConfigs(mockAdminClient, TOPIC0, topicConfigs, true);
-    expectIncrementalTopicConfigs(mockAdminClient, TOPIC0, false);
-    expectListTopics(mockAdminClient, Collections.emptySet());
-    EasyMock.replay(mockAdminClient);
+    topicConfigProps.put(ReplicationThrottleHelper.LEADER_THROTTLED_REPLICAS, throttledReplicas);
+    topicConfigProps.put(ReplicationThrottleHelper.FOLLOWER_THROTTLED_REPLICAS, throttledReplicas);
+    EasyMock.expect(mockKafkaZkClient.getEntityConfigs(ConfigType.Topic(), TOPIC0)).andReturn(topicConfigProps).times(2);
+    EasyMock.expect(mockKafkaZkClient.topicExists(TOPIC0)).andReturn(false).times(4);
+    EasyMock.replay(mockKafkaZkClient);
     // Expect no exception
     throttleHelper.setThrottles(Collections.singletonList(proposal));
-    EasyMock.verify(mockAdminClient);
+    EasyMock.verify(mockKafkaZkClient);
   }
 
   @Test
-  public void testAddingThrottlesWithNoPreExistingThrottles() throws Exception {
+  public void testAddingThrottlesWithNoPreExistingThrottles() {
     createTopics();
+    KafkaZkClient kafkaZkClient = KafkaCruiseControlUtils.createKafkaZkClient(zookeeper().connectionString(),
+                                                                  "ReplicationThrottleHelperTestMetricGroup",
+                                                                  "AddingThrottlesWithNoPreExistingThrottles",
+                                                                  false,
+                                                                  null);
 
     final long throttleRate = 100L;
-    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(_adminClient, throttleRate);
+
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(kafkaZkClient, throttleRate);
     ExecutionProposal proposal = new ExecutionProposal(new TopicPartition(TOPIC0, 0),
                                            100,
                                                        new ReplicaPlacementInfo(0),
@@ -233,28 +201,32 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
 
     throttleHelper.setThrottles(Collections.singletonList(proposal));
 
-    assertExpectedThrottledRateForBroker(0, throttleRate);
-    assertExpectedThrottledRateForBroker(1, throttleRate);
-    assertExpectedThrottledRateForBroker(2, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 0, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 1, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 2, throttleRate);
     // No throttle on broker 3 because it's not involved in any of the execution proposals:
-    assertExpectedThrottledRateForBroker(3, null);
-    assertExpectedThrottledReplicas(TOPIC0, "0:0,0:1,0:2");
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 3, null);
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC0, "0:0,0:1,0:2");
 
     // We expect all throttles to be cleaned up
     throttleHelper.clearThrottles(Collections.singletonList(task), Collections.emptyList());
 
-    for (int i = 0; i < clusterSize(); i++) {
-      assertExpectedThrottledRateForBroker(i, null);
-    }
-    assertExpectedThrottledReplicas(TOPIC0, "");
+    Arrays.asList(0, 1, 2, 3).forEach(i -> assertExpectedThrottledRateForBroker(kafkaZkClient, i, null));
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC0, null);
   }
 
   @Test
-  public void testAddingThrottlesWithPreExistingThrottles() throws Exception {
+  public void testAddingThrottlesWithPreExistingThrottles() {
     createTopics();
+    KafkaZkClient kafkaZkClient = KafkaCruiseControlUtils.createKafkaZkClient(zookeeper().connectionString(),
+                                                                  "ReplicationThrottleHelperTestMetricGroup",
+                                                                  "AddingThrottlesWithNoPreExistingThrottles",
+                                                                  false,
+                                                                  null);
 
     final long throttleRate = 100L;
-    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(_adminClient, throttleRate);
+
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(kafkaZkClient, throttleRate);
     ExecutionProposal proposal = new ExecutionProposal(
         new TopicPartition(TOPIC0, 0),
         100,
@@ -265,42 +237,37 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     ExecutionTask task = completedTaskForProposal(0, proposal);
 
     // Broker 0 has an existing leader and follower throttle; we expect these to be preserved.
+    Properties broker0Config = new Properties();
     long preExistingBroker0ThrottleRate = 200L;
-    List<AlterConfigOp> broker0Configs = Arrays.asList(
-      new AlterConfigOp(
-              new ConfigEntry(ReplicationThrottleHelper.LEADER_THROTTLED_RATE, String.valueOf(preExistingBroker0ThrottleRate)),
-              AlterConfigOp.OpType.SET),
-      new AlterConfigOp(
-              new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_THROTTLED_RATE, String.valueOf(preExistingBroker0ThrottleRate)),
-              AlterConfigOp.OpType.SET)
-    );
-    throttleHelper.changeBrokerConfigs(0, broker0Configs);
+    broker0Config.setProperty(ReplicationThrottleHelper.LEADER_THROTTLED_RATE, String.valueOf(preExistingBroker0ThrottleRate));
+    broker0Config.setProperty(ReplicationThrottleHelper.FOLLOWER_THROTTLED_RATE, String.valueOf(preExistingBroker0ThrottleRate));
+    ExecutorUtils.changeBrokerConfig(new AdminZkClient(kafkaZkClient), 0, broker0Config);
 
     // Partition 1 (which is not involved in any execution proposal) has pre-existing throttled
     // replicas (on both leaders and followers); we expect these configurations to be merged
     // with our new throttled replicas.
-    List<AlterConfigOp> topic0Configs = Arrays.asList(
-      new AlterConfigOp(new ConfigEntry(ReplicationThrottleHelper.LEADER_THROTTLED_REPLICAS, "1:0,1:1"), AlterConfigOp.OpType.SET),
-      new AlterConfigOp(new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_THROTTLED_REPLICAS, "1:0,1:1"), AlterConfigOp.OpType.SET));
-    throttleHelper.changeTopicConfigs(TOPIC0, topic0Configs);
+    Properties topic0Config = kafkaZkClient.getEntityConfigs(ConfigType.Topic(), TOPIC0);
+    topic0Config.setProperty(ReplicationThrottleHelper.LEADER_THROTTLED_REPLICAS, "1:0,1:1");
+    topic0Config.setProperty(ReplicationThrottleHelper.FOLLOWER_THROTTLED_REPLICAS, "1:0,1:1");
+    ExecutorUtils.changeTopicConfig(new AdminZkClient(kafkaZkClient), TOPIC0, topic0Config);
 
     // Topic 1 is not involved in any execution proposal. It has pre-existing throttled replicas.
-    List<AlterConfigOp> topic1Config = Arrays.asList(
-      new AlterConfigOp(new ConfigEntry(ReplicationThrottleHelper.LEADER_THROTTLED_REPLICAS, "1:1"), AlterConfigOp.OpType.SET),
-      new AlterConfigOp(new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_THROTTLED_REPLICAS, "1:1"), AlterConfigOp.OpType.SET));
-    throttleHelper.changeTopicConfigs(TOPIC1, topic1Config);
+    Properties topic1Config = kafkaZkClient.getEntityConfigs(ConfigType.Topic(), TOPIC1);
+    topic1Config.setProperty(ReplicationThrottleHelper.LEADER_THROTTLED_REPLICAS, "1:1");
+    topic1Config.setProperty(ReplicationThrottleHelper.FOLLOWER_THROTTLED_REPLICAS, "1:1");
+    ExecutorUtils.changeTopicConfig(new AdminZkClient(kafkaZkClient), TOPIC1, topic1Config);
 
     throttleHelper.setThrottles(Collections.singletonList(proposal));
 
-    assertExpectedThrottledRateForBroker(0, preExistingBroker0ThrottleRate);
-    assertExpectedThrottledRateForBroker(1, throttleRate);
-    assertExpectedThrottledRateForBroker(2, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 0, preExistingBroker0ThrottleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 1, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 2, throttleRate);
     // No throttle on broker 3 because it's not involved in any of the execution proposals:
-    assertExpectedThrottledRateForBroker(3, null);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 3, null);
     // Existing throttled replicas are merged with new throttled replicas for topic 0:
-    assertExpectedThrottledReplicas(TOPIC0, "0:0,0:1,0:2,1:0,1:1");
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC0, "0:0,0:1,0:2,1:0,1:1");
     // Existing throttled replicas are unchanged for topic 1:
-    assertExpectedThrottledReplicas(TOPIC1, "1:1");
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC1, "1:1");
 
     throttleHelper.clearThrottles(Collections.singletonList(task), Collections.emptyList());
 
@@ -308,24 +275,28 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     // any throttles related to partitions which were not moved will remain.
     // However, we do expect the broker throttles to be removed.
     throttleHelper.clearThrottles(Collections.singletonList(task), Collections.emptyList());
-    for (int i = 0; i < clusterSize(); i++) {
-      assertExpectedThrottledRateForBroker(i, null);
-    }
-    assertExpectedThrottledReplicas(TOPIC0, "1:0,1:1");
-    assertExpectedThrottledReplicas(TOPIC1, "1:1");
+    Arrays.asList(0, 1, 2, 3).forEach(i -> assertExpectedThrottledRateForBroker(kafkaZkClient, i, null));
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC0, "1:0,1:1");
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC1, "1:1");
   }
 
   @Test
-  public void testDoNotModifyExistingWildcardReplicaThrottles() throws Exception {
+  public void testDoNotModifyExistingWildcardReplicaThrottles() {
     createTopics();
+
+    KafkaZkClient kafkaZkClient = KafkaCruiseControlUtils.createKafkaZkClient(zookeeper().connectionString(),
+                                                                  "ReplicationThrottleHelperTestMetricGroup",
+                                                                  "AddingThrottlesWithNoPreExistingThrottles",
+                                                                  false,
+                                                                  null);
+
+    // Set replica throttle config values for both topics
+    setWildcardThrottleReplicaForTopic(kafkaZkClient, TOPIC0);
+    setWildcardThrottleReplicaForTopic(kafkaZkClient, TOPIC1);
 
     final long throttleRate = 100L;
 
-    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(_adminClient, throttleRate);
-
-    // Set replica throttle config values for both topics
-    setWildcardThrottleReplicaForTopic(throttleHelper, TOPIC0);
-    setWildcardThrottleReplicaForTopic(throttleHelper, TOPIC1);
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(kafkaZkClient, throttleRate);
     ExecutionProposal proposal = new ExecutionProposal(new TopicPartition(TOPIC0, 0),
                                            100,
                                                        new ReplicaPlacementInfo(0),
@@ -343,56 +314,59 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     ExecutionTask completedTask = completedTaskForProposal(0, proposal);
     ExecutionTask inProgressTask = inProgressTaskForProposal(1, proposal2);
 
-    assertExpectedThrottledRateForBroker(0, throttleRate);
-    assertExpectedThrottledRateForBroker(1, throttleRate);
-    assertExpectedThrottledRateForBroker(2, throttleRate);
-    assertExpectedThrottledRateForBroker(3, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 0, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 1, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 2, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 3, throttleRate);
     // Topic-level throttled replica config value should remain as "*"
-    assertExpectedThrottledReplicas(TOPIC0, ReplicationThrottleHelper.WILDCARD_ASTERISK);
-    assertExpectedThrottledReplicas(TOPIC1, ReplicationThrottleHelper.WILDCARD_ASTERISK);
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC0, ReplicationThrottleHelper.WILDCARD_ASTERISK);
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC1, ReplicationThrottleHelper.WILDCARD_ASTERISK);
 
     throttleHelper.clearThrottles(Collections.singletonList(completedTask), Collections.singletonList(inProgressTask));
-    assertExpectedThrottledRateForBroker(0, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 0, throttleRate);
     // we expect broker 1 to be null since all replica movement related to it has completed.
-    assertExpectedThrottledRateForBroker(1, null);
-    assertExpectedThrottledRateForBroker(2, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 1, null);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 2, throttleRate);
     // We expect broker 3 to have a throttle on it because there is an in-progress replica being moved
-    assertExpectedThrottledRateForBroker(3, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 3, throttleRate);
     // Topic-level throttled replica config value should remain as "*"
-    assertExpectedThrottledReplicas(TOPIC0, ReplicationThrottleHelper.WILDCARD_ASTERISK);
-    assertExpectedThrottledReplicas(TOPIC1, ReplicationThrottleHelper.WILDCARD_ASTERISK);
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC0, ReplicationThrottleHelper.WILDCARD_ASTERISK);
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC1, ReplicationThrottleHelper.WILDCARD_ASTERISK);
 
     // passing an inProgress task that is not complete should have no effect.
     throttleHelper.clearThrottles(Collections.singletonList(completedTask), Collections.singletonList(inProgressTask));
-    assertExpectedThrottledRateForBroker(0, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 0, throttleRate);
     // we expect broker 1 to be null since all replica movement related to it has completed.
-    assertExpectedThrottledRateForBroker(1, null);
-    assertExpectedThrottledRateForBroker(2, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 1, null);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 2, throttleRate);
     // We expect broker 3 to have a throttle on it because there is an in-progress replica being moved
-    assertExpectedThrottledRateForBroker(3, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 3, throttleRate);
     // Topic-level throttled replica config value should remain as "*"
-    assertExpectedThrottledReplicas(TOPIC0, ReplicationThrottleHelper.WILDCARD_ASTERISK);
-    assertExpectedThrottledReplicas(TOPIC1, ReplicationThrottleHelper.WILDCARD_ASTERISK);
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC0, ReplicationThrottleHelper.WILDCARD_ASTERISK);
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC1, ReplicationThrottleHelper.WILDCARD_ASTERISK);
 
     // Completing the in-progress task and the "*" should not be cleaned up.
     inProgressTask.completed(3);
     throttleHelper.clearThrottles(Arrays.asList(completedTask, inProgressTask), Collections.emptyList());
 
-    for (int i = 0; i < clusterSize(); i++) {
-      assertExpectedThrottledRateForBroker(i, null);
-    }
+    Arrays.asList(0, 1, 2, 3).forEach(i -> assertExpectedThrottledRateForBroker(kafkaZkClient, i, null));
     // Topic-level throttled replica config value should remain as "*"
-    assertExpectedThrottledReplicas(TOPIC0, ReplicationThrottleHelper.WILDCARD_ASTERISK);
-    assertExpectedThrottledReplicas(TOPIC1, ReplicationThrottleHelper.WILDCARD_ASTERISK);
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC0, ReplicationThrottleHelper.WILDCARD_ASTERISK);
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC1, ReplicationThrottleHelper.WILDCARD_ASTERISK);
   }
 
   @Test
-  public void testDoNotRemoveThrottlesForInProgressTasks() throws Exception {
+  public void testDoNotRemoveThrottlesForInProgressTasks() {
     createTopics();
+    KafkaZkClient kafkaZkClient = KafkaCruiseControlUtils.createKafkaZkClient(zookeeper().connectionString(),
+                                                                  "ReplicationThrottleHelperTestMetricGroup",
+                                                                  "AddingThrottlesWithNoPreExistingThrottles",
+                                                                  false,
+                                                                  null);
 
     final long throttleRate = 100L;
 
-    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(_adminClient, throttleRate);
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(kafkaZkClient, throttleRate);
     ExecutionProposal proposal = new ExecutionProposal(new TopicPartition(TOPIC0, 0),
                                            100,
                                                        new ReplicaPlacementInfo(0),
@@ -410,39 +384,37 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     ExecutionTask completedTask = completedTaskForProposal(0, proposal);
     ExecutionTask inProgressTask = inProgressTaskForProposal(1, proposal2);
 
-    assertExpectedThrottledRateForBroker(0, throttleRate);
-    assertExpectedThrottledRateForBroker(1, throttleRate);
-    assertExpectedThrottledRateForBroker(2, throttleRate);
-    assertExpectedThrottledRateForBroker(3, throttleRate);
-    assertExpectedThrottledReplicas(TOPIC0, "0:0,0:1,0:2,1:0,1:2,1:3");
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 0, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 1, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 2, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 3, throttleRate);
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC0, "0:0,0:1,0:2,1:0,1:2,1:3");
 
     throttleHelper.clearThrottles(Collections.singletonList(completedTask), Collections.singletonList(inProgressTask));
-    assertExpectedThrottledRateForBroker(0, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 0, throttleRate);
     // we expect broker 1 to be null since all replica movement related to it has completed.
-    assertExpectedThrottledRateForBroker(1, null);
-    assertExpectedThrottledRateForBroker(2, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 1, null);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 2, throttleRate);
     // We expect broker 3 to have a throttle on it because there is an in-progress replica being moved
-    assertExpectedThrottledRateForBroker(3, throttleRate);
-    assertExpectedThrottledReplicas(TOPIC0, "1:0,1:2,1:3");
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 3, throttleRate);
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC0, "1:0,1:2,1:3");
 
     // passing an inProgress task that is not complete should have no effect.
     throttleHelper.clearThrottles(Collections.singletonList(completedTask), Collections.singletonList(inProgressTask));
-    assertExpectedThrottledRateForBroker(0, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 0, throttleRate);
     // we expect broker 1 to be null since all replica movement related to it has completed.
-    assertExpectedThrottledRateForBroker(1, null);
-    assertExpectedThrottledRateForBroker(2, throttleRate);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 1, null);
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 2, throttleRate);
     // We expect broker 3 to have a throttle on it because there is an in-progress replica being moved
-    assertExpectedThrottledRateForBroker(3, throttleRate);
-    assertExpectedThrottledReplicas(TOPIC0, "1:0,1:2,1:3");
+    assertExpectedThrottledRateForBroker(kafkaZkClient, 3, throttleRate);
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC0, "1:0,1:2,1:3");
 
     // Completing the in-progress task and clearing the throttles should clean everything up.
     inProgressTask.completed(3);
     throttleHelper.clearThrottles(Arrays.asList(completedTask, inProgressTask), Collections.emptyList());
 
-    for (int i = 0; i < clusterSize(); i++) {
-      assertExpectedThrottledRateForBroker(i, null);
-    }
-    assertExpectedThrottledReplicas(TOPIC0, "");
+    Arrays.asList(0, 1, 2, 3).forEach(i -> assertExpectedThrottledRateForBroker(kafkaZkClient, i, null));
+    assertExpectedThrottledReplicas(kafkaZkClient, TOPIC0, null);
   }
 
   @Test
@@ -456,107 +428,49 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     assertEquals(result, "qux,qaz");
   }
 
+  private KafkaZkClient prepareMockKafkaZkClient(Properties topicConfigProps) {
+    KafkaZkClient mockKafkaZkClient = EasyMock.mock(KafkaZkClient.class);
+    prepareKafkaZkClientMockWithBrokerConfigs(mockKafkaZkClient, 1);
+    EasyMock.expect(mockKafkaZkClient.getEntityConfigs(ConfigType.Topic(), TOPIC0)).andReturn(topicConfigProps).once();
+    mockKafkaZkClient.setOrCreateEntityConfigs("brokers", "0", new Properties());
+    EasyMock.expectLastCall().anyTimes();
+    mockKafkaZkClient.createConfigChangeNotification("brokers/0");
+    EasyMock.expectLastCall().anyTimes();
+    return mockKafkaZkClient;
+  }
+
   private ExecutionTask prepareMockCompleteTask(ExecutionProposal proposal) {
     ExecutionTask mockCompleteTask = EasyMock.mock(ExecutionTask.class);
     EasyMock.expect(mockCompleteTask.state()).andReturn(ExecutionTaskState.COMPLETED).times(2);
     EasyMock.expect(mockCompleteTask.type()).andReturn(ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION).once();
     EasyMock.expect(mockCompleteTask.proposal()).andReturn(proposal).once();
-    EasyMock.replay(mockCompleteTask);
     return mockCompleteTask;
   }
 
-  private void expectDescribeTopicConfigs(AdminClient adminClient, String topic, Config topicConfig, boolean topicExists)
-  throws ExecutionException, InterruptedException {
-    ConfigResource cf = new ConfigResource(ConfigResource.Type.TOPIC, topic);
-    Map<ConfigResource, Config> topicConfigs = Collections.singletonMap(cf, topicConfig);
-    DescribeConfigsResult mockDescribeConfigsResult = EasyMock.mock(DescribeConfigsResult.class);
-    KafkaFuture<Map<ConfigResource, Config>> mockFuture = EasyMock.mock(KafkaFuture.class);
-    if (topicExists) {
-      EasyMock.expect(mockFuture.get()).andReturn(topicConfigs);
-    } else {
-      EasyMock.expect(mockFuture.get()).andThrow(new ExecutionException(new UnknownTopicOrPartitionException()));
-    }
-    EasyMock.expect(mockDescribeConfigsResult.all()).andReturn(mockFuture);
-    EasyMock.expect(adminClient.describeConfigs(Collections.singletonList(cf))).andReturn(mockDescribeConfigsResult);
-    EasyMock.replay(mockDescribeConfigsResult, mockFuture);
-  }
-
-  private void expectIncrementalTopicConfigs(AdminClient adminClient, String topic, boolean topicExists)
-  throws ExecutionException, InterruptedException {
-    ConfigResource cf = new ConfigResource(ConfigResource.Type.TOPIC, topic);
-    AlterConfigsResult mockAlterConfigsResult = EasyMock.mock(AlterConfigsResult.class);
-    KafkaFuture<Void> mockFuture = EasyMock.mock(KafkaFuture.class);
-    EasyMock.expect(mockAlterConfigsResult.all()).andReturn(mockFuture);
-    if (topicExists) {
-      EasyMock.expect(mockFuture.get()).andReturn(null);
-    } else {
-      EasyMock.expect(mockFuture.get()).andThrow(new ExecutionException(new UnknownTopicOrPartitionException()));
-    }
-    EasyMock.expect(adminClient.incrementalAlterConfigs(Collections.singletonMap(cf, EasyMock.anyObject()))).andReturn(mockAlterConfigsResult);
-    EasyMock.replay(mockAlterConfigsResult, mockFuture);
-  }
-
-  private void expectListTopics(AdminClient adminClient, Set<String> topics)
-  throws ExecutionException, InterruptedException {
-    ListTopicsResult mockListTopicsResult = EasyMock.mock(ListTopicsResult.class);
-    KafkaFuture<Set<String>> mockFuture = EasyMock.mock(KafkaFuture.class);
-    EasyMock.expect(mockListTopicsResult.names()).andReturn(mockFuture);
-    EasyMock.expect(mockFuture.get()).andReturn(topics);
-    EasyMock.expect(adminClient.listTopics()).andReturn(mockListTopicsResult);
-    EasyMock.replay(mockListTopicsResult, mockFuture);
-  }
-
-  private void expectDescribeBrokerConfigs(AdminClient adminClient, List<Integer> brokers)
-  throws ExecutionException, InterruptedException {
+  private void prepareKafkaZkClientMockWithBrokerConfigs(KafkaZkClient mockKafkaZkClient, int expectInvokeCount) {
     // All participating brokers have throttled rate set already
-    Config brokerConfig = new Config(Arrays.asList(
-      new ConfigEntry(ReplicationThrottleHelper.LEADER_THROTTLED_RATE, "100"),
-      new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_THROTTLED_RATE, "100")));
+    Properties brokerThrottledRateProps = new Properties();
+    brokerThrottledRateProps.put(ReplicationThrottleHelper.LEADER_THROTTLED_RATE, String.valueOf(100));
+    brokerThrottledRateProps.put(ReplicationThrottleHelper.FOLLOWER_THROTTLED_RATE, String.valueOf(100));
 
-    for (int i : brokers) {
-      ConfigResource cf = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(i));
-      Map<ConfigResource, Config> brokerConfigs = Collections.singletonMap(cf, brokerConfig);
-      DescribeConfigsResult mockDescribeConfigsResult = EasyMock.mock(DescribeConfigsResult.class);
-      KafkaFuture<Map<ConfigResource, Config>> mockFuture = EasyMock.mock(KafkaFuture.class);
-      EasyMock.expect(mockFuture.get()).andReturn(brokerConfigs);
-      EasyMock.expect(mockDescribeConfigsResult.all()).andReturn(mockFuture);
-      EasyMock.expect(adminClient.describeConfigs(Collections.singletonList(cf))).andReturn(mockDescribeConfigsResult);
-      EasyMock.replay(mockDescribeConfigsResult, mockFuture);
-    }
+    EasyMock.expect(mockKafkaZkClient.getEntityConfigs(ConfigType.Broker(), String.valueOf(0))).
+        andReturn(brokerThrottledRateProps).times(expectInvokeCount);
+    EasyMock.expect(mockKafkaZkClient.getEntityConfigs(ConfigType.Broker(), String.valueOf(1))).
+        andReturn(brokerThrottledRateProps).times(expectInvokeCount);
+    EasyMock.expect(mockKafkaZkClient.getEntityConfigs(ConfigType.Broker(), String.valueOf(2))).
+        andReturn(brokerThrottledRateProps).times(expectInvokeCount);
   }
 
-  private void expectIncrementalBrokerConfigs(AdminClient adminClient, List<Integer> brokers)
-  throws ExecutionException, InterruptedException {
-    for (int brokerId : brokers) {
-      ConfigResource cf = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(brokerId));
-      AlterConfigsResult mockAlterConfigsResult = EasyMock.mock(AlterConfigsResult.class);
-      KafkaFuture<Void> mockFuture = EasyMock.mock(KafkaFuture.class);
-      EasyMock.expect(mockAlterConfigsResult.all()).andReturn(mockFuture);
-      EasyMock.expect(mockFuture.get()).andReturn(null);
-      EasyMock.expect(adminClient.incrementalAlterConfigs(Collections.singletonMap(cf, EasyMock.anyObject()))).andReturn(mockAlterConfigsResult);
-      EasyMock.replay(mockAlterConfigsResult, mockFuture);
-    }
-  }
-
-  private void assertExpectedThrottledRateForBroker(int brokerId, Long expectedRate) throws ExecutionException, InterruptedException {
-    ConfigResource cf = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(brokerId));
-    Map<ConfigResource, Config> brokerConfig = _adminClient.describeConfigs(Collections.singletonList(cf)).all().get();
+  private void assertExpectedThrottledRateForBroker(KafkaZkClient kafkaZkClient, int broker, Long expectedRate) {
+    Properties brokerConfig = kafkaZkClient.getEntityConfigs(ConfigType.Broker(), String.valueOf(broker));
     String expectedString = expectedRate == null ? null : String.valueOf(expectedRate);
-    assertNotNull(brokerConfig.get(cf));
-    if (expectedRate == null) {
-      assertNull(brokerConfig.get(cf).get(ReplicationThrottleHelper.LEADER_THROTTLED_RATE));
-      assertNull(brokerConfig.get(cf).get(ReplicationThrottleHelper.FOLLOWER_THROTTLED_RATE));
-    } else {
-      assertEquals(expectedString, brokerConfig.get(cf).get(ReplicationThrottleHelper.LEADER_THROTTLED_RATE).value());
-      assertEquals(expectedString, brokerConfig.get(cf).get(ReplicationThrottleHelper.FOLLOWER_THROTTLED_RATE).value());
-    }
+    assertEquals(expectedString, brokerConfig.getProperty(ReplicationThrottleHelper.LEADER_THROTTLED_RATE));
+    assertEquals(expectedString, brokerConfig.getProperty(ReplicationThrottleHelper.FOLLOWER_THROTTLED_RATE));
   }
 
-  private void assertExpectedThrottledReplicas(String topic, String expectedReplicas) throws ExecutionException, InterruptedException {
-    ConfigResource cf = new ConfigResource(ConfigResource.Type.TOPIC, topic);
-    Map<ConfigResource, Config> topicConfig = _adminClient.describeConfigs(Collections.singletonList(cf)).all().get();
-    assertNotNull(topicConfig.get(cf));
-    assertEquals(expectedReplicas, topicConfig.get(cf).get(ReplicationThrottleHelper.LEADER_THROTTLED_REPLICAS).value());
-    assertEquals(expectedReplicas, topicConfig.get(cf).get(ReplicationThrottleHelper.FOLLOWER_THROTTLED_REPLICAS).value());
+  private void assertExpectedThrottledReplicas(KafkaZkClient kafkaZkClient, String topic, String expectedReplicas) {
+    Properties topicConfig = kafkaZkClient.getEntityConfigs(ConfigType.Topic(), topic);
+    assertEquals(expectedReplicas, topicConfig.getProperty(ReplicationThrottleHelper.LEADER_THROTTLED_REPLICAS));
+    assertEquals(expectedReplicas, topicConfig.getProperty(ReplicationThrottleHelper.FOLLOWER_THROTTLED_REPLICAS));
   }
 }


### PR DESCRIPTION
This reverts commit cf4585d799b3ada3027b72ba2deef3bf9af4a52f
This commit has caused the tests that are relevant to replication throttle to be flaky (see [CI#4984](https://app.circleci.com/pipelines/github/linkedin/cruise-control/1689/workflows/27696a50-fe52-4231-8edd-ac821716e16f/jobs/4984), [CI#4972](https://app.circleci.com/pipelines/github/linkedin/cruise-control/1684/workflows/8e138488-addf-4e91-b996-d8345a3eb4ed/jobs/4972), [CI#4977](https://app.circleci.com/pipelines/github/linkedin/cruise-control/1686/workflows/cf13b527-0502-409e-ad38-93aaa236e72d/jobs/4977)). For example, the stack trace for the following test indicate that the admin client may fail to retrieve the expected throttle value from the broker. 

```
com.linkedin.kafka.cruisecontrol.executor.ReplicationThrottleHelperTest > testDoNotModifyExistingWildcardReplicaThrottles FAILED
    java.lang.AssertionError: expected null, but was:<ConfigEntry(name=leader.replication.throttled.rate, value=100, source=DEFAULT_CONFIG, isSensitive=false, isReadOnly=true, synonyms=[])>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotNull(Assert.java:756)
        at org.junit.Assert.assertNull(Assert.java:738)
        at org.junit.Assert.assertNull(Assert.java:748)
        at com.linkedin.kafka.cruisecontrol.executor.ReplicationThrottleHelperTest.assertExpectedThrottledRateForBroker(ReplicationThrottleHelperTest.java:547)
        at com.linkedin.kafka.cruisecontrol.executor.ReplicationThrottleHelperTest.testDoNotModifyExistingWildcardReplicaThrottles(ReplicationThrottleHelperTest.java:357)
```

We can revisit this patch once the flaky test issue is addressed.
(cc @mimaison)