### PR TITLE
Bump up stale dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id "idea"
   id "jacoco" // Java Code Coverage plugin
   id "com.github.ben-manes.versions" version "0.39.0"
-  id "com.github.spotbugs" version "5.0.3" apply false
+  id "com.github.spotbugs" version "5.0.5" apply false
   id "checkstyle"
 }
 
@@ -97,13 +97,13 @@ subprojects {
 
   //code quality and inspections
   checkstyle {
-    toolVersion = '9.0'
+    toolVersion = '9.3'
     ignoreFailures = false
     configDirectory = file("$rootDir/checkstyle")
   }
 
   spotbugs {
-    toolVersion = '4.4.1'
+    toolVersion = '4.5.3'
     excludeFilter = file("$rootDir/gradle/findbugs-exclude.xml")
     ignoreFailures = false
     jvmArgs = [ '-Xms512m' ]
@@ -160,7 +160,7 @@ project(':cruise-control-core') {
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       exclude group: 'log4j', module: 'log4j'
     }
-    api "org.slf4j:slf4j-api:1.7.32"
+    implementation "org.slf4j:slf4j-api:1.7.36"
     api "org.apache.logging.log4j:log4j-slf4j-impl:2.17.1"
     api 'org.apache.commons:commons-math3:3.6.1'
     api "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
@@ -257,11 +257,11 @@ project(':cruise-control') {
     }
     api project(':cruise-control-metrics-reporter')
     api project(':cruise-control-core')
-    api "org.slf4j:slf4j-api:1.7.32"
+    implementation "org.slf4j:slf4j-api:1.7.36"
     api "org.apache.logging.log4j:log4j-slf4j-impl:2.17.1"
     api "org.apache.zookeeper:zookeeper:${zookeeperVersion}"
-    api "io.netty:netty-handler:${nettyVersion}"
-    api "io.netty:netty-transport-native-epoll:${nettyVersion}"
+    implementation "io.netty:netty-handler:${nettyVersion}"
+    implementation "io.netty:netty-transport-native-epoll:${nettyVersion}"
     api "org.apache.kafka:kafka_$scalaBinaryVersion:$kafkaVersion"
     api "org.apache.kafka:kafka-clients:$kafkaVersion"
     api "org.scala-lang:scala-library:$scalaVersion"
@@ -270,10 +270,10 @@ project(':cruise-control') {
     api 'commons-codec:commons-codec:1.15'
     api 'com.google.code.gson:gson:2.8.9'
     api "org.eclipse.jetty:jetty-server:${jettyVersion}"
-    api 'io.dropwizard.metrics:metrics-jmx:4.2.6'
-    api 'com.nimbusds:nimbus-jose-jwt:9.15.2'
+    api 'io.dropwizard.metrics:metrics-jmx:4.2.8'
+    api 'com.nimbusds:nimbus-jose-jwt:9.19'
     api 'com.101tec:zkclient:0.11'
-    api 'io.swagger.parser.v3:swagger-parser-v3:2.0.28'
+    implementation 'io.swagger.parser.v3:swagger-parser-v3:2.0.30'
     api 'io.github.classgraph:classgraph:4.8.138'
 
     testImplementation project(path: ':cruise-control-metrics-reporter', configuration: 'testOutput')
@@ -287,7 +287,7 @@ project(':cruise-control') {
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13:tests'
     testImplementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
     testImplementation 'org.apache.kerby:kerb-simplekdc:2.0.1'
-    testImplementation 'com.jayway.jsonpath:json-path:2.6.0'
+    testImplementation 'com.jayway.jsonpath:json-path:2.7.0'
 
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
 
@@ -396,7 +396,7 @@ project(':cruise-control-metrics-reporter') {
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       exclude group: 'log4j', module: 'log4j'
     }
-    api "org.slf4j:slf4j-api:1.7.32"
+    implementation "org.slf4j:slf4j-api:1.7.36"
     api "org.apache.logging.log4j:log4j-slf4j-impl:2.17.1"
     api "org.apache.kafka:kafka_$scalaBinaryVersion:$kafkaVersion"
     api "org.apache.kafka:kafka-clients:$kafkaVersion"
@@ -469,6 +469,6 @@ static def getScalaBinaryVersion(versionStr) {
 
 //wrapper generation task
 wrapper {
-  gradleVersion = '7.3.2'
+  gradleVersion = '7.4'
   distributionType = Wrapper.DistributionType.ALL
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfigUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfigUtils.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.config;
 
 import com.linkedin.cruisecontrol.common.CruiseControlConfigurable;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
 
@@ -25,15 +26,19 @@ public final class KafkaCruiseControlConfigUtils {
    * @return A configured instance of the class c
    */
   public static <T> T getConfiguredInstance(Class<?> c, Class<T> t, Map<String, Object> configs) {
+    if (c == null) {
+      throw new IllegalArgumentException("Attempt to get configured instance of null configuration " + t.getName());
+    }
+
     Object instance;
     try {
-      instance = c.newInstance();
-    } catch (IllegalAccessException e) {
+      instance = c.getDeclaredConstructor().newInstance();
+    } catch (IllegalAccessException | InvocationTargetException e) {
       throw new IllegalArgumentException("Could not instantiate class " + c.getName(), e);
     } catch (InstantiationException e) {
       throw new IllegalArgumentException("Could not instantiate class " + c.getName() + " Does it have a public no-argument constructor?", e);
-    } catch (NullPointerException e) {
-      throw new IllegalArgumentException("Attempt to get configured instance of null configuration " + t.getName(), e);
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException("Could not find a public no-argument constructor for " + c.getName(), e);
     }
 
     if (!t.isInstance(instance)) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/TopicReplicationFactorAnomalyFinder.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/TopicReplicationFactorAnomalyFinder.java
@@ -235,21 +235,25 @@ public class TopicReplicationFactorAnomalyFinder implements TopicAnomalyFinder {
       }
     }
     try {
-      _topicReplicationFactorMargin = Short.parseShort((String) configs.get(TOPIC_REPLICATION_FACTOR_MARGIN_CONFIG));
+      String topicReplicationFactorMargin = (String) configs.get(TOPIC_REPLICATION_FACTOR_MARGIN_CONFIG);
+      _topicReplicationFactorMargin = topicReplicationFactorMargin == null ? DEFAULT_TOPIC_REPLICATION_FACTOR_MARGIN
+                                                                           : Short.parseShort(topicReplicationFactorMargin);
       if (_topicReplicationFactorMargin < 0) {
         throw new IllegalArgumentException(String.format("%s config of replication factor anomaly finder should not be set to negative,"
             + " provided %d.", TOPIC_REPLICATION_FACTOR_MARGIN_CONFIG, _topicReplicationFactorMargin));
       }
-    } catch (NumberFormatException | NullPointerException e) {
+    } catch (NumberFormatException e) {
       _topicReplicationFactorMargin = DEFAULT_TOPIC_REPLICATION_FACTOR_MARGIN;
     }
     try {
-      _topicMinISRRecordRetentionTimeMs = Long.parseLong((String) configs.get(TOPIC_MIN_ISR_RECORD_RETENTION_TIME_MS_CONFIG));
+      String topicMinISRRecordRetentionTimeMs = (String) configs.get(TOPIC_MIN_ISR_RECORD_RETENTION_TIME_MS_CONFIG);
+      _topicMinISRRecordRetentionTimeMs = topicMinISRRecordRetentionTimeMs == null ? DEFAULT_TOPIC_MIN_ISR_RECORD_RETENTION_TIME_MS
+                                                                                   : Long.parseLong(topicMinISRRecordRetentionTimeMs);
       if (_topicMinISRRecordRetentionTimeMs <= 0) {
         throw new IllegalArgumentException(String.format("%s config of replication factor anomaly finder should be set to positive,"
             + " provided %d.", TOPIC_MIN_ISR_RECORD_RETENTION_TIME_MS_CONFIG, _topicMinISRRecordRetentionTimeMs));
       }
-    } catch (NumberFormatException | NullPointerException e) {
+    } catch (NumberFormatException e) {
       _topicMinISRRecordRetentionTimeMs = DEFAULT_TOPIC_MIN_ISR_RECORD_RETENTION_TIME_MS;
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ org.gradle.jvmargs=-Xms512m -Xmx512m
 scalaVersion=2.12.10
 kafkaVersion=2.4.1
 zookeeperVersion=3.5.7
-nettyVersion=4.1.72.Final
+nettyVersion=4.1.73.Final
 jettyVersion=9.4.44.v20210927

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR resolves #1784.

Notes:
1. Bumping up spotbugs version requires fixes on handling NPEs (i.e. via null checks).
2. Selected dependencies are moved from `api` to `implementation`. Eventually more dependencies will gradually be moved to `implementation` -- i.e. to avoid leaking dependencies.
3. Avoided migration to `io.netty:netty-handler:4.1.74.Final` due to vulnerability detected in this version.