### PR TITLE
Temporarily pull in jackson-databind 2.12.6.1 to resolve CVE alert

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z0-9_]+)?$/
       - publish:
           requires:
             - integration-test
@@ -133,4 +133,4 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z0-9_]+)?$/

--- a/build.gradle
+++ b/build.gradle
@@ -256,12 +256,6 @@ project(':cruise-control') {
       exclude group: 'log4j', module: 'log4j'
     }
 
-    constraints {
-      implementation('com.fasterxml.jackson.core:jackson-databind:2.12.6.1') {
-        because 'Prior version is vulnerable. Can be unpinned after Apache Kafka 3.1.1 is released and pulled in.'
-      }
-    }
-
     api project(':cruise-control-metrics-reporter')
     api project(':cruise-control-core')
     implementation "org.slf4j:slf4j-api:1.7.36"
@@ -282,6 +276,8 @@ project(':cruise-control') {
     implementation 'io.swagger.parser.v3:swagger-parser-v3:2.0.30'
     implementation 'io.github.classgraph:classgraph:4.8.141'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
+    // Temporary pin for vulnerability
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.6.1'
 
     testImplementation project(path: ':cruise-control-metrics-reporter', configuration: 'testOutput')
     testImplementation project(path: ':cruise-control-core', configuration: 'testOutput')
@@ -404,18 +400,14 @@ project(':cruise-control-metrics-reporter') {
       exclude group: 'log4j', module: 'log4j'
     }
 
-    constraints {
-      implementation('com.fasterxml.jackson.core:jackson-databind:2.12.6.1') {
-        because 'Prior version is vulnerable. Can be unpinned after Apache Kafka 3.1.1 is released and pulled in.'
-      }
-    }
-
     implementation "org.slf4j:slf4j-api:1.7.36"
     implementation "com.yammer.metrics:metrics-core:2.2.0"
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.17.2"
     implementation "org.apache.kafka:kafka_$scalaBinaryVersion:$kafkaVersion"
     implementation "org.apache.kafka:kafka-clients:$kafkaVersion"
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
+    // Temporary pin for vulnerability
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.6.1'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.bouncycastle:bcpkix-jdk15on:1.70'


### PR DESCRIPTION
Attempt to see if such pin can avoid being blocked by LI internal system check