### PR TITLE
Bump swagger-parser for CVE-2020-36518

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -274,7 +274,7 @@ project(':cruise-control') {
     implementation 'io.dropwizard.metrics:metrics-jmx:4.2.9'
     implementation 'com.nimbusds:nimbus-jose-jwt:9.21'
     implementation 'com.101tec:zkclient:0.11'
-    implementation 'io.swagger.parser.v3:swagger-parser-v3:2.0.30'
+    implementation 'io.swagger.parser.v3:swagger-parser-v3:2.0.32'
     implementation 'io.github.classgraph:classgraph:4.8.141'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     // Temporary pin for vulnerability


### PR DESCRIPTION
swagger-parser transitively pulls in jackson-databind, and the
vulnerable version is bumped in release 2.0.32.

See https://github.com/swagger-api/swagger-parser/releases/tag/v2.0.32

This PR resolves #<Replace-Me-With-The-Issue-Number-Addressed-By-This-PR>.
