### PR TITLE
Fix up buildFatJar gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -324,9 +324,10 @@ project(':cruise-control') {
     duplicatesStrategy 'exclude'
   }
 
-  tasks.create(name: "buildFatJar", type: Jar) {
+  tasks.create(name: "buildFatJar", type: Jar, dependsOn: ["createVersionFile", ":cruise-control-metrics-reporter:jar", ":cruise-control-core:jar"]) {
     archiveBaseName = project.name + '-all'
-    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
   }
 


### PR DESCRIPTION
This allows ./gradlew buildFatJar to work again since the migration to
Gradle 7.2

This PR resolves #1699.

Signed-of-by: Mike Lothian <mike@fireburn.co.uk>