### PR TITLE
Remove execution tasks that have in-movement partitions from re-execution candidates

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -1859,18 +1859,19 @@ public class Executor {
      *             corresponding inter-broker replica reassignment tasks.
      */
     private void maybeReexecuteInterBrokerReplicaTasks(Set<TopicPartition> deleted, Set<TopicPartition> dead) {
-      List<ExecutionTask> interBrokerReplicaTasksToReexecute =
+      List<ExecutionTask> candidateInterBrokerReplicaTasksToReexecute =
           new ArrayList<>(_executionTaskManager.inExecutionTasks(Collections.singleton(INTER_BROKER_REPLICA_ACTION)));
-      boolean shouldReexecute = false;
+      List<ExecutionTask> tasksToReexecute;
       try {
-        shouldReexecute = !ExecutionUtils.isSubset(ExecutionUtils.partitionsBeingReassigned(_adminClient), interBrokerReplicaTasksToReexecute);
+        tasksToReexecute = ExecutionUtils.getInterBrokerReplicaTasksToReexecute(ExecutionUtils.partitionsBeingReassigned(_adminClient),
+            candidateInterBrokerReplicaTasksToReexecute);
       } catch (TimeoutException | InterruptedException | ExecutionException e) {
         // This may indicate transient (e.g. network) issues.
         LOG.warn("Failed to retrieve partitions being reassigned. Skipping reexecution check for inter-broker replica actions.", e);
+        tasksToReexecute = Collections.emptyList();
       }
-      if (shouldReexecute) {
-        LOG.info("Reexecuting tasks {}", interBrokerReplicaTasksToReexecute);
-        AlterPartitionReassignmentsResult result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, interBrokerReplicaTasksToReexecute);
+      if (!tasksToReexecute.isEmpty()) {
+        AlterPartitionReassignmentsResult result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, tasksToReexecute);
         // Process the partition reassignment result.
         Set<TopicPartition> noReassignmentToCancel = new HashSet<>();
         ExecutionUtils.processAlterPartitionReassignmentsResult(result, deleted, dead, noReassignmentToCancel);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtilsTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionUtilsTest.java
@@ -4,10 +4,12 @@
 
 package com.linkedin.kafka.cruisecontrol.executor;
 
+import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
 import java.lang.reflect.Constructor;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -28,6 +30,7 @@ import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static com.linkedin.kafka.cruisecontrol.executor.ExecutorTestUtils.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -35,6 +38,7 @@ public class ExecutionUtilsTest {
   private static final String TOPIC_NAME = "topic-name";
   private static final TopicPartition P0 = new TopicPartition(TOPIC_NAME, 0);
   private static final TopicPartition P1 = new TopicPartition(TOPIC_NAME, 1);
+  private static final TopicPartition P2 = new TopicPartition(TOPIC_NAME, 2);
   // Both partitions are successful
   private static final Map<TopicPartition, Optional<Throwable>> SUCCESSFUL_PARTITIONS = Map.of(P0, Optional.empty(), P1, Optional.empty());
   // One partition successful, the other has UnknownTopicOrPartitionException
@@ -125,6 +129,48 @@ public class ExecutionUtilsTest {
     ExecutionUtils.processAlterPartitionReassignmentsResult(result, Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
     EasyMock.verify(result);
     EasyMock.reset(result);
+  }
+
+  @Test
+  public void testGetInterBrokerReplicaTasksToReexecute() {
+    Set<TopicPartition> partitionsInMovement = Set.of(P0, P1);
+    ReplicaPlacementInfo replicaPlacementInfoPlaceHolder = new ReplicaPlacementInfo(BROKER_ID_PLACEHOLDER);
+
+    ExecutionProposal proposalForPartition0 =
+        new ExecutionProposal(P0, PRODUCE_SIZE_IN_BYTES, replicaPlacementInfoPlaceHolder,
+                              Collections.singletonList(replicaPlacementInfoPlaceHolder),
+                              Collections.singletonList(replicaPlacementInfoPlaceHolder));
+    ExecutionProposal proposalForPartition1 =
+        new ExecutionProposal(P1, PRODUCE_SIZE_IN_BYTES, replicaPlacementInfoPlaceHolder,
+                              Collections.singletonList(replicaPlacementInfoPlaceHolder),
+                              Collections.singletonList(replicaPlacementInfoPlaceHolder));
+    ExecutionProposal proposalForPartition2 =
+        new ExecutionProposal(P2, PRODUCE_SIZE_IN_BYTES, replicaPlacementInfoPlaceHolder,
+                              Collections.singletonList(replicaPlacementInfoPlaceHolder),
+                              Collections.singletonList(replicaPlacementInfoPlaceHolder));
+
+    ExecutionTask executionTaskForPartition0 = new ExecutionTask(EXECUTION_ID_PLACEHOLDER, proposalForPartition0,
+                                                                 ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION, EXECUTION_ALERTING_THRESHOLD_MS);
+    ExecutionTask executionTaskForPartition1 = new ExecutionTask(EXECUTION_ID_PLACEHOLDER, proposalForPartition1,
+                                                                 ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION, EXECUTION_ALERTING_THRESHOLD_MS);
+    ExecutionTask executionTaskForPartition2 = new ExecutionTask(EXECUTION_ID_PLACEHOLDER, proposalForPartition2,
+                                                                 ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION, EXECUTION_ALERTING_THRESHOLD_MS);
+
+    // Case 1: all partitions in candidate tasks are already in movement. Expect nothing to re-execute
+    List<ExecutionTask> tasks1 = List.of(executionTaskForPartition0, executionTaskForPartition1);
+    List<ExecutionTask> tasksToReexecute1 = ExecutionUtils.getInterBrokerReplicaTasksToReexecute(partitionsInMovement, tasks1);
+    Assert.assertTrue(tasksToReexecute1.isEmpty());
+
+    // Case 2: some of partitions in candidate tasks are in movement and some are not. Expect some tasks to re-execute
+    List<ExecutionTask> tasks2 = List.of(executionTaskForPartition0, executionTaskForPartition1, executionTaskForPartition2);
+    List<ExecutionTask> tasksToReexecute2 = ExecutionUtils.getInterBrokerReplicaTasksToReexecute(partitionsInMovement, tasks2);
+    Assert.assertEquals(1, tasksToReexecute2.size());
+    Assert.assertEquals(P2, tasksToReexecute2.get(0).proposal().topicPartition());
+
+    // Case 3: Partitions of candidate tasks is subset of partitions in movement. Expect nothing to re-execute
+    List<ExecutionTask> tasks3 = List.of(executionTaskForPartition0);
+    List<ExecutionTask> tasksToReexecute3 = ExecutionUtils.getInterBrokerReplicaTasksToReexecute(partitionsInMovement, tasks3);
+    Assert.assertTrue(tasksToReexecute3.isEmpty());
   }
 
   @Test

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -34,7 +34,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import kafka.zk.KafkaZkClient;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -61,12 +60,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUnitTestUtils.waitUntilTrue;
-import static com.linkedin.kafka.cruisecontrol.common.TestConstants.DEFAULT_BROKER_CAPACITY_CONFIG_FILE;
-import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC0;
-import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC1;
-import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC2;
-import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC3;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUnitTestUtils.*;
+import static com.linkedin.kafka.cruisecontrol.common.TestConstants.*;
+import static com.linkedin.kafka.cruisecontrol.executor.ExecutorTestUtils.*;
 import static com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricSampler.SamplingMode.*;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.isA;
@@ -82,20 +78,8 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
   private static final TopicPartition TP1 = new TopicPartition(TOPIC1, PARTITION);
   private static final TopicPartition TP2 = new TopicPartition(TOPIC2, PARTITION);
   private static final TopicPartition TP3 = new TopicPartition(TOPIC3, PARTITION);
-  private static final String RANDOM_UUID = "random_uuid";
-  // A UUID to test the proposal execution to be started with UNKNOWN_UUID, but the executor received RANDOM_UUID.
-  private static final String UNKNOWN_UUID = "unknown_uuid";
-  private static final long REMOVAL_HISTORY_RETENTION_TIME_MS = TimeUnit.HOURS.toMillis(12);
-  private static final long DEMOTION_HISTORY_RETENTION_TIME_MS = TimeUnit.DAYS.toMillis(1);
-  private static final long PRODUCE_SIZE_IN_BYTES = 10000L;
-  private static final long EXECUTION_DEADLINE_MS = TimeUnit.SECONDS.toMillis(30);
-  private static final long EXECUTION_SHORT_CHECK_MS = 10L;
-  private static final long EXECUTION_REGULAR_CHECK_MS = 100L;
   private static final Random RANDOM = new Random(0xDEADBEEF);
   private static final int MOCK_BROKER_ID_TO_DROP = 1;
-  private static final long LIST_PARTITION_REASSIGNMENTS_TIMEOUT_MS = 1000L;
-  private static final int LIST_PARTITION_REASSIGNMENTS_MAX_ATTEMPTS = 1;
-  private static final long EXECUTION_ALERTING_THRESHOLD_MS = 100L;
   private static final long MOCK_CURRENT_TIME = 1596842708000L;
 
   @Override

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTestUtils.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTestUtils.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.executor;
+
+import java.util.concurrent.TimeUnit;
+
+
+public final class ExecutorTestUtils {
+
+  static final String RANDOM_UUID = "random_uuid";
+  // A UUID to test the proposal execution to be started with UNKNOWN_UUID, but the executor received RANDOM_UUID.
+  static final String UNKNOWN_UUID = "unknown_uuid";
+  static final Integer BROKER_ID_PLACEHOLDER = 0;
+  static final long EXECUTION_ID_PLACEHOLDER = 0;
+  static final long REMOVAL_HISTORY_RETENTION_TIME_MS = TimeUnit.HOURS.toMillis(12);
+  static final long DEMOTION_HISTORY_RETENTION_TIME_MS = TimeUnit.DAYS.toMillis(1);
+  static final long PRODUCE_SIZE_IN_BYTES = 10000L;
+  static final long EXECUTION_DEADLINE_MS = TimeUnit.SECONDS.toMillis(30);
+  static final long EXECUTION_SHORT_CHECK_MS = 10L;
+  static final long EXECUTION_REGULAR_CHECK_MS = 100L;
+  static final long LIST_PARTITION_REASSIGNMENTS_TIMEOUT_MS = 1000L;
+  static final int LIST_PARTITION_REASSIGNMENTS_MAX_ATTEMPTS = 1;
+  static final long EXECUTION_ALERTING_THRESHOLD_MS = 100L;
+
+  private ExecutorTestUtils() {
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
@@ -26,10 +26,10 @@ import java.util.Set;
 
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC0;
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC1;
+import static com.linkedin.kafka.cruisecontrol.executor.ExecutorTestUtils.*;
 import static org.junit.Assert.assertEquals;
 
 public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness {
-  private static final long TASK_EXECUTION_ALERTING_THRESHOLD_MS = 100L;
 
   @Override
   public int clusterSize() {
@@ -69,7 +69,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
   }
 
   private ExecutionTask inProgressTaskForProposal(long id, ExecutionProposal proposal) {
-    ExecutionTask task = new ExecutionTask(id, proposal, ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION, TASK_EXECUTION_ALERTING_THRESHOLD_MS);
+    ExecutionTask task = new ExecutionTask(id, proposal, ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION, EXECUTION_ALERTING_THRESHOLD_MS);
     task.inProgress(0);
     return task;
   }


### PR DESCRIPTION
This PR resolves #1824 

Today, CruiseControl re-executes the inter-broker partition movement tasks in a batch if any task has partitions that's not being moved. The logic can cause unnecessary re-execution of partition movement.

 For example:

There is a list of under-execution tasks: [task1, task2, task3, ...]. Task1 is to move partition1, and task2 is to move partition2, etc.

If partition1 is not being moved, while all of the partition2, 3, ..., are already being moved in the kafka cluster, cruise-control will re-execute all tasks. 

This is not necessary, as ideally cruise-control should only re-execute task1. This PR is to address this issue and only re-execute the task that doesn't have in-movement partition.