### PR TITLE
Bump swagger parser for CVE-2020-36518

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -259,6 +259,8 @@ project(':cruise-control') {
     api 'com.101tec:zkclient:0.11'
     api 'io.swagger.parser.v3:swagger-parser-v3:2.0.28'
     api 'io.github.classgraph:classgraph:4.8.117'
+    // Temporary pin for vulnerability
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.6.1'
 
     testImplementation project(path: ':cruise-control-metrics-reporter', configuration: 'testOutput')
     testImplementation project(path: ':cruise-control-core', configuration: 'testOutput')


### PR DESCRIPTION
Same change as (https://github.com/linkedin/cruise-control/pull/1815) for kafka_2_0_to_2_3 branch

This PR resolves vuln: CVE-2020-36518
