### PR TITLE
Generate jacoco coverage as html

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,6 +144,15 @@ subprojects {
     if (!project.hasProperty("maxParallelForks")) {
       maxParallelForks = Runtime.runtime.availableProcessors()
     }
+    finalizedBy jacocoTestReport
+  }
+
+  jacocoTestReport {
+    reports {
+      xml.required = false
+      csv.required = false
+      html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+    }
   }
 }
 


### PR DESCRIPTION
This PR resolves #1833.

The coverage HTML is generated <module>/build/jacocoHtml folder.
