### PR TITLE
Upgrade Netty and Jetty dependencies for CVE fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ org.gradle.jvmargs=-Xms512m -Xmx512m
 scalaVersion=2.13.6
 kafkaVersion=3.1.0
 zookeeperVersion=3.6.3
-nettyVersion=4.1.75.Final
-jettyVersion=9.4.45.v20220203
+nettyVersion=4.1.78.Final
+jettyVersion=9.4.48.v20220622


### PR DESCRIPTION
Upgrade Netty and Jetty for CVE fixes.

Netty: [CVE-2022-24823](https://nvd.nist.gov/vuln/detail/CVE-2022-24823) - Fixed by upgrading to 4.1.78
Jetty: [CVE-2022-2047](https://nvd.nist.gov/vuln/detail/CVE-2022-2047) - fixed by upgrading to 9.4.48.v20220622

