### PR TITLE
Downgrade netty and jetty dependencies to a safer version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ org.gradle.jvmargs=-Xms512m -Xmx512m
 scalaVersion=2.12.10
 kafkaVersion=2.4.1
 zookeeperVersion=3.5.8
-nettyVersion=4.1.78.Final
-jettyVersion=9.4.48.v20220622
+nettyVersion=4.1.77.Final
+jettyVersion=9.4.47.v20220610


### PR DESCRIPTION
The previous PR https://github.com/linkedin/cruise-control/pull/1855 may introduce some potential risks. (The versions didn't pass our ELR check)

This PR is going to downgrade the versions back to a safer version.
