### PR TITLE
Bump up SpotBugs to resolve false positives with RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id "idea"
   id "jacoco" // Java Code Coverage plugin
   id "com.github.ben-manes.versions" version "0.42.0"
-  id "com.github.spotbugs" version "5.0.6" apply false
+  id "com.github.spotbugs" version "5.0.9" apply false
   id "checkstyle"
 }
 
@@ -103,7 +103,7 @@ subprojects {
   }
 
   spotbugs {
-    toolVersion = '4.6.0'
+    toolVersion = '4.7.1'
     excludeFilter = file("$rootDir/gradle/findbugs-exclude.xml")
     ignoreFailures = false
     jvmArgs = [ '-Xms512m' ]

--- a/gradle/findbugs-exclude.xml
+++ b/gradle/findbugs-exclude.xml
@@ -60,11 +60,6 @@
     <Bug pattern="SE_BAD_FIELD"/>
   </Match>
 
-  <!-- False positive in Java 11 with spotbugs 4.4.0, see https://github.com/spotbugs/spotbugs/issues/1338 -->
-  <Match>
-    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
-  </Match>
-
   <Match>
     <Or>
       <Bug pattern="EI_EXPOSE_REP"/>


### PR DESCRIPTION
This PR resolves #1868.

-- I verified the fix. Before the fix I was getting the following warning in the SpotBugs report:
```
RCN | Nullcheck of response at line 78 of value previously dereferenced in com.linkedin.kafka.cruisecontrol.monitor.sampling.prometheus.PrometheusAdapter.queryMetric(String, long, long)
```