### PR TITLE
Update to Kafka 3.2.1 + bump dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,14 @@ Cruise Control for Apache Kafka
     * Adjust replication factor
 
 ### Environment Requirements ###
-* The `migrate_to_kafka_2_5` branch of Cruise Control is compatible with Apache Kafka `2.5` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.*`),
-  `2.6` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.11+`), `2.7` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.36+`),
-  `2.8` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.66+`), `3.0` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.85+`),
-  and `3.1` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.85+`).
+* The `migrate_to_kafka_2_5` branch of Cruise Control is compatible with the versions of Apache Kafka, from 2.5 onwards, as below: 
+  * `2.5` -> `2.5.*`
+  * `2.6` -> `2.5.11+`
+  * `2.7` -> `2.5.36+`
+  * `2.8` -> `2.5.66+`
+  * `3.0` -> `2.5.85+` 
+  * `3.1` -> `2.5.85+`
+  * `3.2` -> `2.5.85+`
 * The `migrate_to_kafka_2_4` branch of Cruise Control is compatible with Apache Kafka `2.4` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.4.*`).
 * The `kafka_2_0_to_2_3` branch (deprecated) of Cruise Control is compatible with Apache Kafka `2.0`, `2.1`, `2.2`, and `2.3` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.0.*`).
 * The `kafka_0_11_and_1_0` branch (deprecated) of Cruise Control is compatible with Apache Kafka `0.11.0.0`, `1.0`, and `1.1` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `0.1.*`).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 org.gradle.daemon=false
 org.gradle.parallel=false
 org.gradle.jvmargs=-Xms512m -Xmx512m
-scalaVersion=2.13.6
-kafkaVersion=3.1.0
+scalaVersion=2.13.8
+kafkaVersion=3.2.1
 zookeeperVersion=3.6.3
-nettyVersion=4.1.77.Final
-jettyVersion=9.4.47.v20220610
+nettyVersion=4.1.79.Final
+jettyVersion=9.4.48.v20220622

--- a/kafka-cruise-control-start.sh
+++ b/kafka-cruise-control-start.sh
@@ -30,7 +30,7 @@ copyJars() {
 base_dir=$(dirname $0)
 
 if [ -z "$SCALA_VERSION" ]; then
-  SCALA_VERSION=2.13.6
+  SCALA_VERSION=2.13.8
 fi
 
 if [ -z "$SCALA_BINARY_VERSION" ]; then


### PR DESCRIPTION
This PR updates to Kafka 3.2.1 and also upgrades the Scala version to match the one used in Kafka (2.13.8). It also bumps netty and jetty for completeness.
