### PR TITLE
Fix the BrokerFailureDetector bug

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AbstractBrokerFailureDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AbstractBrokerFailureDetector.java
@@ -30,7 +30,7 @@ import static org.apache.commons.io.FileUtils.writeStringToFile;
  * This class detects broker failures.
  */
 public abstract class AbstractBrokerFailureDetector extends AbstractAnomalyDetector implements Runnable {
-  
+
   protected static final Logger LOG = LoggerFactory.getLogger(AbstractBrokerFailureDetector.class);
   public static final String FAILED_BROKERS_OBJECT_CONFIG = "failed.brokers.object";
   // Config to indicate whether detected broker failures are fixable or not.
@@ -71,7 +71,7 @@ public abstract class AbstractBrokerFailureDetector extends AbstractAnomalyDetec
         // Report the failures to anomaly detector to handle.
         reportBrokerFailures();
       }
-    } catch (Exception e) {
+    } catch (Throwable e) {
       LOG.warn("Broker failure detector received exception: ", e);
     } finally {
       LOG.debug("Broker failure detection finished.");

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ZKBrokerFailureDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ZKBrokerFailureDetector.java
@@ -21,7 +21,7 @@ import kafka.zk.BrokerIdsZNode;
 import kafka.zk.KafkaZkClient;
 import org.apache.zookeeper.client.ZKClientConfig;
 import kafka.zookeeper.ZNodeChildChangeHandler;
-import scala.jdk.javaapi.CollectionConverters;
+import scala.collection.JavaConverters;
 
 import static java.util.stream.Collectors.toSet;
 
@@ -90,7 +90,7 @@ public class ZKBrokerFailureDetector extends AbstractBrokerFailureDetector {
   @Override
   Set<Integer> aliveBrokers() {
     // We get the alive brokers from ZK directly.
-    return CollectionConverters.asJava(_kafkaZkClient.getAllBrokersInCluster()).stream().map(Broker::id).collect(toSet());
+    return JavaConverters.asJavaCollection(_kafkaZkClient.getAllBrokersInCluster()).stream().map(Broker::id).collect(toSet());
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ZKBrokerFailureDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ZKBrokerFailureDetector.java
@@ -90,6 +90,8 @@ public class ZKBrokerFailureDetector extends AbstractBrokerFailureDetector {
   @Override
   Set<Integer> aliveBrokers() {
     // We get the alive brokers from ZK directly.
+    // The JavaConverters API is deprecated in scala 2.13.0, and the new API is CollectionConverter. However, LinkedIn is still using
+    //  scala 2.12, which will cause it fail if it uses CollectionConverter.
     return JavaConverters.asJavaCollection(_kafkaZkClient.getAllBrokersInCluster()).stream().map(Broker::id).collect(toSet());
   }
 


### PR DESCRIPTION
This PR resolves #1876 .

**Description:**

In a previous PR, someone bumped the scala version from 2.12 to 2.13, and updated a bunch of APIs. For open source code, it doesn't have any issues. However, LinkedIn today still only supports scala 2.12. The API CollectionConverter that is supported by scala 2.13, is throwing exception in LinkedIn internal runtime.

This PR revert the API back to JavaConverter as a workaround. JavaConverter is an API in scala 2.12 and deprecated in scala 2.13 (still working though). With this change, it should fix the issue that LinkedIn is facing internally. For open source users, this PR shouldn't lead to any functional changes.