### PR TITLE
Handle the inconsistency between clusterModel and kafka metadata during update topic configuration

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -38,7 +38,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.linkedin.kafka.cruisecontrol.model.ModelUtils.*;
 import static com.linkedin.kafka.cruisecontrol.monitor.MonitorUtils.EMPTY_BROKER_CAPACITY;
 
 /**
@@ -992,7 +991,7 @@ public class ClusterModel implements Serializable {
 
           TopicPartition tp = new TopicPartition(topic, partitionInfo.partition());
           Partition partition = partition(tp);
-          if (!hasSameReplicasFor(partition, partitionInfo)) {
+          if (!ModelUtils.hasSameReplicasFor(partition, partitionInfo)) {
             LOG.warn("Detected partition info inconsistent with clusterModel: PartitionInfo: {}, Partition in ClusterModel: {}. "
                      + " Skip creating or deleting replicas for this partition.", partitionInfo, partition);
             continue;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -977,7 +977,6 @@ public class ClusterModel implements Serializable {
                                      Cluster cluster) {
     // After replica deletion of some topic partitions, the cluster's maximal replication factor may decrease.
     boolean needToRefreshClusterMaxReplicationFactor = false;
-    Set<Integer> brokerIds = _brokers.stream().map(Broker::id).collect(Collectors.toSet());
 
     for (Map.Entry<Short, Set<String>> entry : topicsByReplicationFactor.entrySet()) {
       short replicationFactor = entry.getKey();
@@ -1028,11 +1027,6 @@ public class ClusterModel implements Serializable {
             // Make sure the leader replica is in new replica list.
             newAssignedReplica.add(partitionInfo.leader().id());
             for (Node node : partitionInfo.replicas()) {
-              // Current clusterModel may have inconsistency with the partitionInfo. In that case, we skip the replica.
-              if (!brokerIds.contains(node.id())) {
-                continue;
-              }
-
               if (node.id() != newAssignedReplica.get(0)) {
                 if (newAssignedReplica.size() < replicationFactor) {
                   newAssignedReplica.add(node.id());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -972,6 +972,7 @@ public class ClusterModel implements Serializable {
                                      Cluster cluster) {
     // After replica deletion of some topic partitions, the cluster's maximal replication factor may decrease.
     boolean needToRefreshClusterMaxReplicationFactor = false;
+    Set<Integer> brokerIds = _brokers.stream().map(Broker::id).collect(Collectors.toSet());
 
     for (Map.Entry<Short, Set<String>> entry : topicsByReplicationFactor.entrySet()) {
       short replicationFactor = entry.getKey();
@@ -1015,6 +1016,11 @@ public class ClusterModel implements Serializable {
             // Make sure the leader replica is in new replica list.
             newAssignedReplica.add(partitionInfo.leader().id());
             for (Node node : partitionInfo.replicas()) {
+              // Current clusterModel may have inconsistency with the partitionInfo. In that case, we skip the replica.
+              if (!brokerIds.contains(node.id())) {
+                continue;
+              }
+
               if (node.id() != newAssignedReplica.get(0)) {
                 if (newAssignedReplica.size() < replicationFactor) {
                   newAssignedReplica.add(node.id());

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ModelUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ModelUtils.java
@@ -11,6 +11,9 @@ import com.linkedin.kafka.cruisecontrol.common.Resource;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
 import com.linkedin.kafka.cruisecontrol.monitor.metricdefinition.KafkaMetricDef;
+import java.util.List;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -165,5 +168,31 @@ public final class ModelUtils {
       result += resource == Resource.DISK ? valuesForId.latest() : valuesForId.avg();
     }
     return max(result, 0.0);
+  }
+
+  /**
+   * Check the consistency between a Partition object and a PartitionInfo object
+   * @param partition the Partition object that contains partition info
+   * @param partitionInfo the PartitionInfo object that contains partition info
+   * @return true if both objects contains the same partition info
+   */
+  public static boolean hasSameReplicasFor(Partition partition, PartitionInfo partitionInfo) {
+    if (partition == null) {
+      return false;
+    }
+
+    List<Replica> replicasFromPartition = partition.replicas();
+    Node[] replicasFromPartitionInfo = partitionInfo.replicas();
+    if (replicasFromPartition.size() != replicasFromPartitionInfo.length) {
+      return false;
+    }
+
+    for (int i = 0; i < replicasFromPartitionInfo.length; i++) {
+      if (replicasFromPartitionInfo[i].id() != replicasFromPartition.get(i).broker().id()) {
+        return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ModelUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ModelUtils.java
@@ -172,9 +172,9 @@ public final class ModelUtils {
 
   /**
    * Check the consistency between a Partition object and a PartitionInfo object
-   * @param partition the Partition object that contains partition info
-   * @param partitionInfo the PartitionInfo object that contains partition info
-   * @return true if both objects contains the same partition info
+   * @param partition the {@link Partition} object that contains partition info
+   * @param partitionInfo the {@link PartitionInfo} object that contains partition info
+   * @return {@code true} if both objects contains the same partition info
    */
   public static boolean hasSameReplicasFor(Partition partition, PartitionInfo partitionInfo) {
     if (partition == null) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/UpdateTopicConfigurationRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/UpdateTopicConfigurationRunnable.java
@@ -65,6 +65,10 @@ import static com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.Ru
  *
  * If the current replication factor of partition is larger than target replication factor, remove one or more follower
  * replicas from the partition. Replicas are removed following the reverse order of position in replica list of partition.
+ *
+ * For a partition, the PartitionInfo can be inconsistent with clusterModel. E.g.
+ * In the PartitionInfo, a partition has replicas [A, B, C, D]. In clusterModel, the same partition only has replicas [A, B, C].
+ * In the above case, the replication factor update for that partition will be skipped.
  */
 public class UpdateTopicConfigurationRunnable extends GoalBasedOperationRunnable {
   protected final Map<Short, Pattern> _topicPatternByReplicationFactor;

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/CreateOrDeleteReplicasTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/CreateOrDeleteReplicasTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.model;
+
+import com.linkedin.kafka.cruisecontrol.common.DeterministicCluster;
+import com.linkedin.kafka.cruisecontrol.common.TestConstants;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CreateOrDeleteReplicasTest {
+  @Test
+  public void testCreateOrDeleteReplicasSkippedOnModelInconsistency() {
+    ClusterModel clusterModel = DeterministicCluster.smallClusterModel(TestConstants.BROKER_CAPACITY);
+    Cluster clusterFromClusterModel = DeterministicCluster.generateClusterFromClusterModel(clusterModel);
+
+    Map<Short, Set<String>> topicsByRF = new HashMap<>();
+    topicsByRF.put((short) 1, Set.of(DeterministicCluster.T1));
+    clusterModel.createOrDeleteReplicas(topicsByRF, Collections.emptyMap(), Collections.emptyMap(), clusterFromClusterModel);
+
+    // Verify the delete replica works when the cluster is consistent with cluster model
+    Assert.assertEquals(1, clusterModel.partition(new TopicPartition(DeterministicCluster.T1, 0)).replicas().size());
+
+    Cluster updatedCluster = DeterministicCluster.generateClusterFromClusterModel(clusterModel);
+    clusterModel = DeterministicCluster.smallClusterModel(TestConstants.BROKER_CAPACITY);
+    clusterModel.createOrDeleteReplicas(topicsByRF, Collections.emptyMap(), Collections.emptyMap(),
+                                        updatedCluster);
+    // Verify the delete replica is skipped when the cluster is inconsistent with cluster model
+    Assert.assertEquals(2, clusterModel.partition(new TopicPartition(DeterministicCluster.T1, 0)).replicas().size());
+  }
+}


### PR DESCRIPTION
This PR resolves #1878 .

**Description:**

CruiseControl holds 2 versions of kafka cluster metadata:
1. ClusterModel: comes from the load monitor and may have fresher information
2. Cluster: comes from the metadata response from a kafka bootstrap server. 

The Cluster object may contain stale data if the kafka server has the stale metadata (which is possible because it takes time for kafka controller to send out the latest metadata to all brokers).

In that case, the data in Cluster may differ from the data in ClusterModel. E.g. a broker A can exist in Cluster but not in ClusterModel.

This PR is to take care of the above inconsistency during topic configuration change.