### PR TITLE
Port BrokerSetResolver to KafkaClusterState

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -15,6 +15,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.GoalOptimizer;
 import com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress;
 import com.linkedin.kafka.cruisecontrol.common.KafkaCruiseControlThreadFactory;
 import com.linkedin.kafka.cruisecontrol.common.MetadataClient;
+import com.linkedin.kafka.cruisecontrol.config.BrokerSetResolver;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.config.TopicConfigProvider;
 import com.linkedin.kafka.cruisecontrol.config.constants.AnomalyDetectorConfig;
@@ -866,6 +867,13 @@ public class KafkaCruiseControl {
    */
   public TopicConfigProvider topicConfigProvider() {
     return _loadMonitor.topicConfigProvider();
+  }
+
+  /**
+   * @return The broker set resolver
+   */
+  public BrokerSetResolver brokerSetResolver() {
+    return _goalOptimizer.brokerSetResolver();
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
@@ -8,6 +8,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.linkedin.kafka.cruisecontrol.common.Utils;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
+import com.linkedin.kafka.cruisecontrol.config.BrokerSetResolver;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.common.KafkaCruiseControlThreadFactory;
 import com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig;
@@ -504,6 +505,14 @@ public class GoalOptimizer implements Runnable {
   public Set<String> excludedTopics(ClusterModel clusterModel, Pattern requestedExcludedTopics) {
     Pattern topicsToExclude = requestedExcludedTopics != null ? requestedExcludedTopics : _defaultExcludedTopics;
     return Utils.getTopicNamesMatchedWithPattern(topicsToExclude, clusterModel::topics);
+  }
+
+  /**
+   * Get the broker set resolver
+   * @return the configured BrokerSetResolver instance
+   */
+  public BrokerSetResolver brokerSetResolver() {
+    return _balancingConstraint.brokerSetResolver();
   }
 
   private OptimizerResult updateCachedProposals(OptimizerResult result) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/sync/KafkaClusterStateRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/sync/KafkaClusterStateRequest.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.handler.sync;
 
+import com.linkedin.kafka.cruisecontrol.config.BrokerSetResolver;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.config.TopicConfigProvider;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.KafkaClusterStateParameters;
@@ -22,6 +23,7 @@ public class KafkaClusterStateRequest extends AbstractSyncRequest {
   protected KafkaClusterStateParameters _parameters;
   protected TopicConfigProvider _topicConfigProvider;
   protected AdminClient _adminClient;
+  protected BrokerSetResolver _brokerSetResolver;
 
   public KafkaClusterStateRequest() {
     super();
@@ -29,7 +31,7 @@ public class KafkaClusterStateRequest extends AbstractSyncRequest {
 
   @Override
   protected KafkaClusterState handle() {
-    return new KafkaClusterState(_kafkaCluster, _topicConfigProvider, _adminClient, _config);
+    return new KafkaClusterState(_kafkaCluster, _topicConfigProvider, _adminClient, _config, _brokerSetResolver);
   }
 
   @Override
@@ -49,6 +51,7 @@ public class KafkaClusterStateRequest extends AbstractSyncRequest {
     _topicConfigProvider = _servlet.asyncKafkaCruiseControl().topicConfigProvider();
     _config = _servlet.asyncKafkaCruiseControl().config();
     _adminClient = _servlet.asyncKafkaCruiseControl().adminClient();
+    _brokerSetResolver = _servlet.asyncKafkaCruiseControl().brokerSetResolver();
     _parameters = (KafkaClusterStateParameters) validateNotNull(configs.get(KAFKA_CLUSTER_STATE_PARAMETER_OBJECT_CONFIG),
             "Parameter configuration is missing from the request.");
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/KafkaClusterState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/KafkaClusterState.java
@@ -5,6 +5,7 @@
 package com.linkedin.kafka.cruisecontrol.servlet.response;
 
 import com.google.gson.Gson;
+import com.linkedin.kafka.cruisecontrol.config.BrokerSetResolver;
 import com.linkedin.kafka.cruisecontrol.config.TopicConfigProvider;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.cruisecontrol.servlet.parameters.CruiseControlParameters;
@@ -29,17 +30,20 @@ public class KafkaClusterState extends AbstractCruiseControlResponse {
   protected final Map<String, Properties> _allTopicConfigs;
   protected final Properties _clusterConfigs;
   protected final AdminClient _adminClient;
+  protected final BrokerSetResolver _brokerSetResolver;
   protected Cluster _kafkaCluster;
 
   public KafkaClusterState(Cluster kafkaCluster,
                            TopicConfigProvider topicConfigProvider,
                            AdminClient adminClient,
-                           KafkaCruiseControlConfig config) {
+                           KafkaCruiseControlConfig config,
+                           BrokerSetResolver brokerSetResolver) {
     super(config);
     _kafkaCluster = kafkaCluster;
     _allTopicConfigs = topicConfigProvider.topicConfigs(_kafkaCluster.topics());
     _clusterConfigs = topicConfigProvider.clusterConfigs();
     _adminClient = adminClient;
+    _brokerSetResolver = brokerSetResolver;
   }
 
   protected String getJsonString(CruiseControlParameters parameters) {


### PR DESCRIPTION
This PR resolves #1887.

This is the first step of visualizing broker set info in kafka_cluster_state endpoint. The BrokerSetResolver will be regarded as single source of truth to get the broker set info.