### PR TITLE
Display the brokerSet id in kafka_cluster_state endpoint.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -15,6 +15,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.GoalOptimizer;
 import com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress;
 import com.linkedin.kafka.cruisecontrol.common.KafkaCruiseControlThreadFactory;
 import com.linkedin.kafka.cruisecontrol.common.MetadataClient;
+import com.linkedin.kafka.cruisecontrol.config.BrokerSetResolver;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.config.TopicConfigProvider;
 import com.linkedin.kafka.cruisecontrol.config.constants.AnomalyDetectorConfig;
@@ -866,6 +867,13 @@ public class KafkaCruiseControl {
    */
   public TopicConfigProvider topicConfigProvider() {
     return _loadMonitor.topicConfigProvider();
+  }
+
+  /**
+   * @return The broker set resolver
+   */
+  public BrokerSetResolver brokerSetResolver() {
+    return _goalOptimizer.brokerSetResolver();
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
@@ -8,6 +8,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.linkedin.kafka.cruisecontrol.common.Utils;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
+import com.linkedin.kafka.cruisecontrol.config.BrokerSetResolver;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.common.KafkaCruiseControlThreadFactory;
 import com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig;
@@ -504,6 +505,14 @@ public class GoalOptimizer implements Runnable {
   public Set<String> excludedTopics(ClusterModel clusterModel, Pattern requestedExcludedTopics) {
     Pattern topicsToExclude = requestedExcludedTopics != null ? requestedExcludedTopics : _defaultExcludedTopics;
     return Utils.getTopicNamesMatchedWithPattern(topicsToExclude, clusterModel::topics);
+  }
+
+  /**
+   * Get the broker set resolver
+   * @return the configured BrokerSetResolver instance
+   */
+  public BrokerSetResolver brokerSetResolver() {
+    return _balancingConstraint.brokerSetResolver();
   }
 
   private OptimizerResult updateCachedProposals(OptimizerResult result) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerSetAssignmentPolicy.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerSetAssignmentPolicy.java
@@ -23,7 +23,20 @@ public interface BrokerSetAssignmentPolicy {
    * @param clusterModel cluster model object
    * @param existingBrokerSetMapping existing mapping of broker sets to broker ids
    * @return A map of broker Ids by their broker set Id
+   * @deprecated This method will be replaced by {@link #assignBrokerSetsForUnresolvedBrokers(Map, Map)}
    */
+  @Deprecated
   Map<String, Set<Integer>> assignBrokerSetsForUnresolvedBrokers(ClusterModel clusterModel, Map<String, Set<Integer>> existingBrokerSetMapping)
+      throws BrokerSetResolutionException;
+
+  /**
+   * Assigns broker sets to the brokers that do not have broker sets assigned
+   *
+   * @param rackIdToBrokerId a map of broker ids to rack ids in the cluster
+   * @param existingBrokerSetMapping existing mapping of broker sets to broker ids
+   * @return A map of broker Ids by their broker set Id
+   */
+  Map<String, Set<Integer>> assignBrokerSetsForUnresolvedBrokers(Map<Integer, String> rackIdToBrokerId,
+                                                                 Map<String, Set<Integer>> existingBrokerSetMapping)
       throws BrokerSetResolutionException;
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerSetAssignmentPolicy.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerSetAssignmentPolicy.java
@@ -23,7 +23,7 @@ public interface BrokerSetAssignmentPolicy {
    * @param clusterModel cluster model object
    * @param existingBrokerSetMapping existing mapping of broker sets to broker ids
    * @return A map of broker Ids by their broker set Id
-   * @deprecated This method will be replaced by {@link #assignBrokerSetsForUnresolvedBrokers(Map, Map)}
+   * @deprecated This method will be replaced by {@link #assignBrokerSetsForUnresolvedBrokers(Map, Map)} TODO: this method should be removed soon
    */
   @Deprecated
   Map<String, Set<Integer>> assignBrokerSetsForUnresolvedBrokers(ClusterModel clusterModel, Map<String, Set<Integer>> existingBrokerSetMapping)

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerSetFileResolver.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerSetFileResolver.java
@@ -59,10 +59,23 @@ public class BrokerSetFileResolver implements BrokerSetResolver {
     try {
       brokerIdsByBrokerSetId = loadBrokerSetData();
     } catch (IOException e) {
-      throw new IllegalArgumentException(e);
+      throw new BrokerSetResolutionException(e.getMessage());
     }
 
     return _brokerSetAssignmentPolicy.assignBrokerSetsForUnresolvedBrokers(clusterModel, brokerIdsByBrokerSetId);
+  }
+
+  @Override
+  public Map<String, Set<Integer>> brokerIdsByBrokerSetId(Map<Integer, String> rackIdByBrokerId)
+      throws BrokerSetResolutionException {
+    Map<String, Set<Integer>> brokerIdsByBrokerSetId;
+    try {
+      brokerIdsByBrokerSetId = loadBrokerSetData();
+    } catch (IOException e) {
+      throw new BrokerSetResolutionException(e.getMessage());
+    }
+
+    return _brokerSetAssignmentPolicy.assignBrokerSetsForUnresolvedBrokers(rackIdByBrokerId, brokerIdsByBrokerSetId);
   }
 
   private Map<String, Set<Integer>> loadBrokerSetData() throws IOException {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerSetResolutionHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerSetResolutionHelper.java
@@ -5,73 +5,96 @@
 package com.linkedin.kafka.cruisecontrol.config;
 
 import com.linkedin.kafka.cruisecontrol.exception.BrokerSetResolutionException;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
-import com.linkedin.kafka.cruisecontrol.model.Broker;
-import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
-
+import org.apache.kafka.common.Cluster;
 
 /**
  * This is a helper class to contain helper functions to get brokerSet mappings and reverse mappings
  */
 public class BrokerSetResolutionHelper {
-  private Map<String, Set<Broker>> _brokersByBrokerSetId;
+  private Map<String, Set<Integer>> _brokersByBrokerSetId;
   private Map<Integer, String> _brokerSetIdByBrokerId;
 
+  public BrokerSetResolutionHelper(Cluster cluster, BrokerSetResolver brokerSetResolver) throws BrokerSetResolutionException {
+    initializeBrokerSetMappings(getRackIdByBrokerIdMapping(cluster), brokerSetResolver);
+  }
+
   public BrokerSetResolutionHelper(ClusterModel clusterModel, BrokerSetResolver brokerSetResolver) throws BrokerSetResolutionException {
-    initializeBrokerSetMappings(clusterModel, brokerSetResolver);
+    initializeBrokerSetMappings(getRackIdByBrokerIdMapping(clusterModel), brokerSetResolver);
   }
 
   /**
    * Init method to initialize the broker set to broker mapping and reverse mapping
    *
-   * @param clusterModel cluster model
+   * @param rackIdByBrokerId a map of broker ids to rack ids in the cluster
    * @param brokerSetResolver broker set resolver object
-   * @throws BrokerSetResolutionException
    */
-  private void initializeBrokerSetMappings(ClusterModel clusterModel, BrokerSetResolver brokerSetResolver)
+  private void initializeBrokerSetMappings(Map<Integer, String> rackIdByBrokerId, BrokerSetResolver brokerSetResolver)
       throws BrokerSetResolutionException {
-    _brokersByBrokerSetId = brokerSetResolver.brokerIdsByBrokerSetId(clusterModel)
-                                             .entrySet()
-                                             .stream()
-                                             .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue()
-                                                                                                .stream()
-                                                                                                .map(id -> clusterModel.broker(id))
-                                                                                                .filter(Objects::nonNull)
-                                                                                                .collect(Collectors.toSet())));
-
+    _brokersByBrokerSetId = brokerSetResolver.brokerIdsByBrokerSetId(rackIdByBrokerId);
     _brokerSetIdByBrokerId = new HashMap<>();
 
     _brokersByBrokerSetId.forEach((brokerSet, brokers) -> {
-      brokers.forEach(broker -> _brokerSetIdByBrokerId.put(broker.id(), brokerSet));
+      brokers.forEach(broker -> _brokerSetIdByBrokerId.put(broker, brokerSet));
     });
   }
 
   /**
-   * Helper function to get Broker to BrokerSet mapping
+   * Helper function to get Broker by BrokerSet mapping
    *
    * @return broker by broker set id Mapping
    */
-  public Map<String, Set<Broker>> brokersByBrokerSetId() {
+  public Map<String, Set<Integer>> brokersByBrokerSetId() {
     return _brokersByBrokerSetId;
+  }
+
+  /**
+   * Helper function to get BrokerSet by Broker mapping
+   *
+   * @return broker set id by broker id Mapping
+   */
+  public Map<Integer, String> brokerSetIdByBrokerId() {
+    return _brokerSetIdByBrokerId;
   }
 
   /**
    * Helper function to get brokerSet for a broker
    *
-   * @param broker broker object
+   * @param brokerId broker object
    * @return broker set id
    */
-  public String brokerSetId(Broker broker) throws BrokerSetResolutionException {
-    String brokerSetId = _brokerSetIdByBrokerId.get(broker.id());
+  public String brokerSetId(Integer brokerId) throws BrokerSetResolutionException {
+    String brokerSetId = _brokerSetIdByBrokerId.get(brokerId);
 
     if (brokerSetId != null) {
       return brokerSetId;
     }
 
-    throw new BrokerSetResolutionException(String.format("Failed to resolve BrokerSet for Broker %s", broker));
+    throw new BrokerSetResolutionException(String.format("Failed to resolve BrokerSet for Broker %s", brokerId));
+  }
+
+  /**
+   * Get the broker to rack mapping from cluster
+   * @param cluster the kafka cluster
+   * @return the map of broker id to rack id
+   */
+  public static Map<Integer, String> getRackIdByBrokerIdMapping(Cluster cluster) {
+    Map<Integer, String> rackIdByBrokerId = new HashMap<>();
+    cluster.nodes().forEach(node -> rackIdByBrokerId.put(node.id(), node.rack()));
+    return rackIdByBrokerId;
+  }
+
+  /**
+   * Get the broker to rack mapping from cluster model
+   * @param clusterModel the cluster model
+   * @return the map of broker id to rack id
+   */
+  public static Map<Integer, String> getRackIdByBrokerIdMapping(ClusterModel clusterModel) {
+    Map<Integer, String> rackIdByBrokerId = new HashMap<>();
+    clusterModel.brokers().forEach(broker -> rackIdByBrokerId.put(broker.id(), broker.rack().id()));
+    return rackIdByBrokerId;
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerSetResolver.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerSetResolver.java
@@ -23,7 +23,7 @@ public interface BrokerSetResolver extends CruiseControlConfigurable {
    *
    * @param clusterModel cluster model object
    * @return A map of broker Ids by their broker set Id
-   * @deprecated This method will be replaced by {@link #brokerIdsByBrokerSetId(Map)}
+   * @deprecated This method will be replaced by {@link #brokerIdsByBrokerSetId(Map)}. TODO: this method should be removed soon
    */
   @Deprecated
   Map<String, Set<Integer>> brokerIdsByBrokerSetId(ClusterModel clusterModel) throws BrokerSetResolutionException;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerSetResolver.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerSetResolver.java
@@ -23,6 +23,16 @@ public interface BrokerSetResolver extends CruiseControlConfigurable {
    *
    * @param clusterModel cluster model object
    * @return A map of broker Ids by their broker set Id
+   * @deprecated This method will be replaced by {@link #brokerIdsByBrokerSetId(Map)}
    */
+  @Deprecated
   Map<String, Set<Integer>> brokerIdsByBrokerSetId(ClusterModel clusterModel) throws BrokerSetResolutionException;
+
+  /**
+   * Get all broker sets of a cluster.
+   *
+   * @param rackIdByBrokerId a map of broker ids to rack ids in the cluster
+   * @return A map of broker Ids by their broker set Id
+   */
+  Map<String, Set<Integer>> brokerIdsByBrokerSetId(Map<Integer, String> rackIdByBrokerId) throws BrokerSetResolutionException;
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/ReplicaToOriginalBrokerSetMappingPolicy.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/ReplicaToOriginalBrokerSetMappingPolicy.java
@@ -27,6 +27,6 @@ public class ReplicaToOriginalBrokerSetMappingPolicy implements ReplicaToBrokerS
   public String brokerSetIdForReplica(final Replica replica, final ClusterModel clusterModel,
                                       final BrokerSetResolutionHelper brokerSetResolutionHelper) throws BrokerSetResolutionException {
     Broker originalBroker = replica.originalBroker();
-    return brokerSetResolutionHelper.brokerSetId(originalBroker);
+    return brokerSetResolutionHelper.brokerSetId(originalBroker.id());
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/TopicNameHashBrokerSetMappingPolicy.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/TopicNameHashBrokerSetMappingPolicy.java
@@ -5,7 +5,6 @@
 package com.linkedin.kafka.cruisecontrol.config;
 
 import com.linkedin.kafka.cruisecontrol.exception.ReplicaToBrokerSetMappingException;
-import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import com.linkedin.kafka.cruisecontrol.model.Replica;
 import java.nio.charset.StandardCharsets;
@@ -53,7 +52,7 @@ public class TopicNameHashBrokerSetMappingPolicy implements ReplicaToBrokerSetMa
                                       final BrokerSetResolutionHelper brokerSetResolutionHelper) throws ReplicaToBrokerSetMappingException {
     String topicName = replica.topicPartition().topic();
 
-    Map<String, Set<Broker>> brokersByBrokerSetId = brokerSetResolutionHelper.brokersByBrokerSetId();
+    Map<String, Set<Integer>> brokersByBrokerSetId = brokerSetResolutionHelper.brokersByBrokerSetId();
     int numBrokerSets = brokersByBrokerSetId.size();
 
     if (numBrokerSets == 0) {
@@ -84,7 +83,7 @@ public class TopicNameHashBrokerSetMappingPolicy implements ReplicaToBrokerSetMa
    * @param brokersByBrokerSetId broker set id to broker ids mapping
    * @return broker set id
    */
-  private String brokerSetIdForTopic(String topicName, Map<String, Set<Broker>> brokersByBrokerSetId) {
+  private String brokerSetIdForTopic(String topicName, Map<String, Set<Integer>> brokersByBrokerSetId) {
     // If sorted broker set id list is not cached, then cache or else avoid sorting each time
     if (_sortedBrokerSetIdsCache.isEmpty()) {
       // Sorting to make the ordering work with consistent hashing

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/sync/KafkaClusterStateRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/sync/KafkaClusterStateRequest.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.servlet.handler.sync;
 
+import com.linkedin.kafka.cruisecontrol.config.BrokerSetResolver;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.config.TopicConfigProvider;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.KafkaClusterStateParameters;
@@ -22,6 +23,7 @@ public class KafkaClusterStateRequest extends AbstractSyncRequest {
   protected KafkaClusterStateParameters _parameters;
   protected TopicConfigProvider _topicConfigProvider;
   protected AdminClient _adminClient;
+  protected BrokerSetResolver _brokerSetResolver;
 
   public KafkaClusterStateRequest() {
     super();
@@ -29,7 +31,7 @@ public class KafkaClusterStateRequest extends AbstractSyncRequest {
 
   @Override
   protected KafkaClusterState handle() {
-    return new KafkaClusterState(_kafkaCluster, _topicConfigProvider, _adminClient, _config);
+    return new KafkaClusterState(_kafkaCluster, _topicConfigProvider, _adminClient, _config, _brokerSetResolver);
   }
 
   @Override
@@ -49,6 +51,7 @@ public class KafkaClusterStateRequest extends AbstractSyncRequest {
     _topicConfigProvider = _servlet.asyncKafkaCruiseControl().topicConfigProvider();
     _config = _servlet.asyncKafkaCruiseControl().config();
     _adminClient = _servlet.asyncKafkaCruiseControl().adminClient();
+    _brokerSetResolver = _servlet.asyncKafkaCruiseControl().brokerSetResolver();
     _parameters = (KafkaClusterStateParameters) validateNotNull(configs.get(KAFKA_CLUSTER_STATE_PARAMETER_OBJECT_CONFIG),
             "Parameter configuration is missing from the request.");
   }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/BrokerSetResolutionHelperTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/BrokerSetResolutionHelperTest.java
@@ -6,11 +6,9 @@ package com.linkedin.kafka.cruisecontrol.config;
 
 import com.linkedin.kafka.cruisecontrol.common.DeterministicCluster;
 import com.linkedin.kafka.cruisecontrol.exception.BrokerSetResolutionException;
-import com.linkedin.kafka.cruisecontrol.model.Broker;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.easymock.EasyMock;
 import org.junit.Test;
 
@@ -33,29 +31,18 @@ public class BrokerSetResolutionHelperTest {
     Map<String, Set<Integer>> testBrokerSetMapping = Map.of("BS1", Set.of(0), "BS2", Set.of(1, 2), "BS3", Set.of(3, 4), "BS4", Set.of(5));
 
     BrokerSetResolver brokerSetResolver = EasyMock.createNiceMock(BrokerSetResolver.class);
-    EasyMock.expect(brokerSetResolver.brokerIdsByBrokerSetId(clusterModel)).andReturn(testBrokerSetMapping);
+    EasyMock.expect(brokerSetResolver.brokerIdsByBrokerSetId(BrokerSetResolutionHelper.getRackIdByBrokerIdMapping(clusterModel)))
+            .andReturn(testBrokerSetMapping);
     EasyMock.replay(brokerSetResolver);
 
     BrokerSetResolutionHelper brokerSetResolutionHelper = new BrokerSetResolutionHelper(clusterModel, brokerSetResolver);
 
-    assertEquals("BS1", brokerSetResolutionHelper.brokerSetId(clusterModel.broker(0)));
-    assertEquals("BS2", brokerSetResolutionHelper.brokerSetId(clusterModel.broker(1)));
-    assertEquals("BS2", brokerSetResolutionHelper.brokerSetId(clusterModel.broker(2)));
-    assertEquals("BS3", brokerSetResolutionHelper.brokerSetId(clusterModel.broker(3)));
-    assertEquals("BS3", brokerSetResolutionHelper.brokerSetId(clusterModel.broker(4)));
-    assertEquals("BS4", brokerSetResolutionHelper.brokerSetId(clusterModel.broker(5)));
-
-    Map<String, Set<Broker>> expectedMapping = testBrokerSetMapping.entrySet()
-                                                                   .stream()
-                                                                   .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue()
-                                                                                                                      .stream()
-                                                                                                                      .map(
-                                                                                                                          id -> clusterModel.broker(
-                                                                                                                              id))
-                                                                                                                      .collect(
-                                                                                                                          Collectors.toSet())));
-
-    assertEquals(expectedMapping, brokerSetResolutionHelper.brokersByBrokerSetId());
+    assertEquals("BS1", brokerSetResolutionHelper.brokerSetId(0));
+    assertEquals("BS2", brokerSetResolutionHelper.brokerSetId(1));
+    assertEquals("BS2", brokerSetResolutionHelper.brokerSetId(2));
+    assertEquals("BS3", brokerSetResolutionHelper.brokerSetId(3));
+    assertEquals("BS3", brokerSetResolutionHelper.brokerSetId(4));
+    assertEquals("BS4", brokerSetResolutionHelper.brokerSetId(5));
   }
 
   /**
@@ -68,29 +55,18 @@ public class BrokerSetResolutionHelperTest {
     Map<String, Set<Integer>> testBrokerSetMapping = Map.of("BS1", Set.of(0), "BS2", Set.of(1, 2), "BS3", Set.of(3, 4));
 
     BrokerSetResolver brokerSetResolver = EasyMock.createNiceMock(BrokerSetResolver.class);
-    EasyMock.expect(brokerSetResolver.brokerIdsByBrokerSetId(clusterModel)).andReturn(testBrokerSetMapping);
+    EasyMock.expect(brokerSetResolver.brokerIdsByBrokerSetId(BrokerSetResolutionHelper.getRackIdByBrokerIdMapping(clusterModel)))
+            .andReturn(testBrokerSetMapping);
     EasyMock.replay(brokerSetResolver);
 
     BrokerSetResolutionHelper brokerSetResolutionHelper = new BrokerSetResolutionHelper(clusterModel, brokerSetResolver);
 
-    assertEquals("BS1", brokerSetResolutionHelper.brokerSetId(clusterModel.broker(0)));
-    assertEquals("BS2", brokerSetResolutionHelper.brokerSetId(clusterModel.broker(1)));
-    assertEquals("BS2", brokerSetResolutionHelper.brokerSetId(clusterModel.broker(2)));
-    assertEquals("BS3", brokerSetResolutionHelper.brokerSetId(clusterModel.broker(3)));
-    assertEquals("BS3", brokerSetResolutionHelper.brokerSetId(clusterModel.broker(4)));
-    assertThrows(BrokerSetResolutionException.class, () -> brokerSetResolutionHelper.brokerSetId(clusterModel.broker(5)));
-
-    Map<String, Set<Broker>> expectedMapping = testBrokerSetMapping.entrySet()
-                                                                   .stream()
-                                                                   .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue()
-                                                                                                                      .stream()
-                                                                                                                      .map(
-                                                                                                                          id -> clusterModel.broker(
-                                                                                                                              id))
-                                                                                                                      .collect(
-                                                                                                                          Collectors.toSet())));
-
-    assertEquals(expectedMapping, brokerSetResolutionHelper.brokersByBrokerSetId());
+    assertEquals("BS1", brokerSetResolutionHelper.brokerSetId(0));
+    assertEquals("BS2", brokerSetResolutionHelper.brokerSetId(1));
+    assertEquals("BS2", brokerSetResolutionHelper.brokerSetId(2));
+    assertEquals("BS3", brokerSetResolutionHelper.brokerSetId(3));
+    assertEquals("BS3", brokerSetResolutionHelper.brokerSetId(4));
+    assertThrows(BrokerSetResolutionException.class, () -> brokerSetResolutionHelper.brokerSetId(5));
   }
 }
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/ModuloBasedBrokerSetAssignmentPolicyTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/ModuloBasedBrokerSetAssignmentPolicyTest.java
@@ -4,8 +4,6 @@
 
 package com.linkedin.kafka.cruisecontrol.config;
 
-import com.linkedin.kafka.cruisecontrol.common.DeterministicCluster;
-import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -29,13 +27,13 @@ public class ModuloBasedBrokerSetAssignmentPolicyTest {
   @Test
   public void testBrokerSetAssignment() {
     // The cluster model has 6 brokers - 0,1,2,3,4,5
-    final ClusterModel clusterModel = DeterministicCluster.brokerSetSatisfiable1();
+    Map<Integer, String> brokers = Map.of(0, "", 1, "", 2, "", 3, "", 4, "", 5, "");
     Map<String, Set<Integer>> mappedBrokers = new HashMap<>();
     mappedBrokers.put("bs1", new HashSet<>(Arrays.asList(0)));
     mappedBrokers.put("bs2", new HashSet<>(Arrays.asList(1)));
 
     Map<String, Set<Integer>> mappedBrokersAfterAssignment =
-        MODULO_BASED_BROKER_SET_ASSIGNMENT_POLICY.assignBrokerSetsForUnresolvedBrokers(clusterModel, mappedBrokers);
+        MODULO_BASED_BROKER_SET_ASSIGNMENT_POLICY.assignBrokerSetsForUnresolvedBrokers(brokers, mappedBrokers);
 
     assertNotNull(mappedBrokersAfterAssignment);
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/NoOpBrokerSetAssignmentPolicyTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/NoOpBrokerSetAssignmentPolicyTest.java
@@ -4,16 +4,13 @@
 
 package com.linkedin.kafka.cruisecontrol.config;
 
-import com.linkedin.kafka.cruisecontrol.common.DeterministicCluster;
-import com.linkedin.kafka.cruisecontrol.exception.BrokerSetResolutionException;
-import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
 
 
 /**
@@ -26,11 +23,11 @@ public class NoOpBrokerSetAssignmentPolicyTest {
    * Tests if no op policy does not make any assignment to missing brokers
    */
   @Test
-  public void testBrokerSetAssignment() throws BrokerSetResolutionException {
-    final ClusterModel clusterModel = DeterministicCluster.brokerSetSatisfiable1();
+  public void testBrokerSetAssignment() {
+    Map<Integer, String> brokers = Map.of(0, "", 1, "", 2, "", 3, "", 4, "", 5, "");
     Map<String, Set<Integer>> mappedBrokers = Map.of("bs1", Set.of(0, 1, 2, 3, 4), "bs2", Set.of(5));
     Map<String, Set<Integer>> mappedBrokersAfterAssignment =
-        NO_OP_BROKER_SET_ASSIGNMENT_POLICY.assignBrokerSetsForUnresolvedBrokers(clusterModel, mappedBrokers);
+        NO_OP_BROKER_SET_ASSIGNMENT_POLICY.assignBrokerSetsForUnresolvedBrokers(brokers, mappedBrokers);
 
     assertNotNull(mappedBrokersAfterAssignment);
 
@@ -41,10 +38,12 @@ public class NoOpBrokerSetAssignmentPolicyTest {
    * Tests if no op policy throws resolution exception when unassigned
    */
   @Test
-  public void testBrokerSetAssignmentThrowsResolutionException() {
-    final ClusterModel clusterModel = DeterministicCluster.brokerSetSatisfiable1();
-    Map<String, Set<Integer>> mappedBrokers = Map.of("bs1", Set.of(0, 1, 2), "bs2", Set.of(5));
-    assertThrows(BrokerSetResolutionException.class,
-                 () -> NO_OP_BROKER_SET_ASSIGNMENT_POLICY.assignBrokerSetsForUnresolvedBrokers(clusterModel, mappedBrokers));
+  public void testBrokerSetAssignmentForUnmappedBrokers() {
+    Map<Integer, String> brokers = Map.of(0, "", 1, "", 2, "", 3, "", 4, "", 5, "");
+    Map<String, Set<Integer>> mappedBrokers = new HashMap<>();
+    mappedBrokers.put("bs1", Set.of(0, 1, 2));
+    mappedBrokers.put("bs2", Set.of(5));
+    NO_OP_BROKER_SET_ASSIGNMENT_POLICY.assignBrokerSetsForUnresolvedBrokers(brokers, mappedBrokers);
+    assertEquals(mappedBrokers.get(NoOpBrokerSetAssignmentPolicy.UNMAPPED_BROKER_SET_ID).size(), 2);
   }
 }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/TopicNameHashBrokerSetMappingPolicyTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/config/TopicNameHashBrokerSetMappingPolicyTest.java
@@ -39,7 +39,8 @@ public class TopicNameHashBrokerSetMappingPolicyTest {
     Map<String, Set<Integer>> testSingleBrokerSetMapping = Collections.singletonMap("BS1", Set.of(0, 1, 2, 3, 4, 5));
 
     BrokerSetResolver brokerSetResolver = EasyMock.createNiceMock(BrokerSetResolver.class);
-    EasyMock.expect(brokerSetResolver.brokerIdsByBrokerSetId(clusterModel)).andReturn(testSingleBrokerSetMapping);
+    EasyMock.expect(brokerSetResolver.brokerIdsByBrokerSetId(BrokerSetResolutionHelper.getRackIdByBrokerIdMapping(clusterModel)))
+            .andReturn(testSingleBrokerSetMapping);
     EasyMock.replay(brokerSetResolver);
 
     BrokerSetResolutionHelper brokerSetResolutionHelper = new BrokerSetResolutionHelper(clusterModel, brokerSetResolver);
@@ -60,7 +61,8 @@ public class TopicNameHashBrokerSetMappingPolicyTest {
     Map<String, Set<Integer>> testBrokerSetMapping = Map.of("BS1", Set.of(0), "BS2", Set.of(1, 2));
 
     BrokerSetResolver brokerSetResolver = EasyMock.createNiceMock(BrokerSetResolver.class);
-    EasyMock.expect(brokerSetResolver.brokerIdsByBrokerSetId(clusterModel)).andReturn(testBrokerSetMapping);
+    EasyMock.expect(brokerSetResolver.brokerIdsByBrokerSetId(BrokerSetResolutionHelper.getRackIdByBrokerIdMapping(clusterModel)))
+            .andReturn(testBrokerSetMapping);
     EasyMock.replay(brokerSetResolver);
 
     BrokerSetResolutionHelper brokerSetResolutionHelper = new BrokerSetResolutionHelper(clusterModel, brokerSetResolver);
@@ -104,7 +106,8 @@ public class TopicNameHashBrokerSetMappingPolicyTest {
     Map<String, Set<Integer>> testBrokerSetMapping = Map.of("BS1", Set.of(0), "BS2", Set.of(1), "BS3", Set.of(2));
 
     BrokerSetResolver brokerSetResolver = EasyMock.createNiceMock(BrokerSetResolver.class);
-    EasyMock.expect(brokerSetResolver.brokerIdsByBrokerSetId(clusterModel)).andReturn(testBrokerSetMapping);
+    EasyMock.expect(brokerSetResolver.brokerIdsByBrokerSetId(BrokerSetResolutionHelper.getRackIdByBrokerIdMapping(clusterModel)))
+            .andReturn(testBrokerSetMapping);
     EasyMock.replay(brokerSetResolver);
 
     BrokerSetResolutionHelper brokerSetResolutionHelper = new BrokerSetResolutionHelper(clusterModel, brokerSetResolver);


### PR DESCRIPTION
This PR resolves #1860.

**Description**:

This PR pass the BrokerSetResolver instance to KafkaClusterStateRequest, so that calling kafka_cluster_state endpoint would display the brokerSet information for each broker. E.g.

![Screen Shot 2022-08-24 at 2 54 09 PM](https://user-images.githubusercontent.com/38366317/186530404-020f6c7b-5c2a-4b4e-b88f-e3440ab0b48f.png)


Along with that change, this PR deprecates several BrokerSetAwareGoal related APIs and creates replacements. Reasons:

- BrokerSetResolver is now used in both BrokerSetAwareGoal and KafkaClusterStateRequest. The available/accessible info is different in those 2 classes.
- BrokerSetAwareGoal has access to ClusterModel object.
- KafkaClusterStateRequest has access to Cluster object.
- In order to make BrokerSetResolver usable for both places, we have to expose an interface that has input param of commonly available info. In our case, it's the "rackIdByBrokerId" map. The map contains all broker ids and their racks. which is available from both clusterModel and cluster.


Besides, there are multiple side-notes:
- Most importantly: BrokerSetResolver will be the single source of truth of broker-set assignment. There will be only one single instance of BrokerSetResolver exists in CC. In contrast, BrokerSetResolutionHelper is a wrapper on top of BrokerSetResolver, and there could be multiple instances of BrokerSetResolutionHelper.
- We use BrokerSetResolutionHelper as a facade, to convert ClusterModel or Cluster to the "rackIdByBrokerId" map.
- If the broker is not assigned with an BrokerSet, or the BrokerSetResolver fails, the kafka_cluster_state will show the BROKER_SET of the broker as "null".

