### PR TITLE
Add more logging to SlowBrokerFinder

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/SlowBrokerFinder.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/SlowBrokerFinder.java
@@ -193,6 +193,7 @@ public class SlowBrokerFinder implements MetricAnomalyFinder<BrokerEntity> {
     Set<BrokerEntity> detectedMetricAnomalies = getMetricAnomalies(historicalLogFlushTimeMetricValues, currentLogFlushTimeMetricValues);
     detectedMetricAnomalies.retainAll(getMetricAnomalies(historicalPerByteLogFlushTimeMetricValues, currentPerByteLogFlushTimeMetricValues));
     detectedMetricAnomalies.retainAll(getLogFlushTimeMetricAnomaliesFromValue(currentLogFlushTimeMetricValues));
+    LOG.info("Suspected Slow Brokers: {}", detectedMetricAnomalies);
     return detectedMetricAnomalies;
   }
 
@@ -312,8 +313,10 @@ public class SlowBrokerFinder implements MetricAnomalyFinder<BrokerEntity> {
   }
 
   private SlowBrokers createSlowBrokersAnomaly(Map<BrokerEntity, Long> detectedBrokers, boolean fixable, boolean removeSlowBroker) {
+    String slowBrokerDescription = getSlowBrokerDescription(detectedBrokers);
+    LOG.info(slowBrokerDescription);
     Map<String, Object> parameterConfigOverrides = Map.of(KAFKA_CRUISE_CONTROL_OBJECT_CONFIG, _kafkaCruiseControl,
-                                                          METRIC_ANOMALY_DESCRIPTION_OBJECT_CONFIG, getSlowBrokerDescription(detectedBrokers),
+                                                          METRIC_ANOMALY_DESCRIPTION_OBJECT_CONFIG, slowBrokerDescription,
                                                           METRIC_ANOMALY_BROKER_ENTITIES_OBJECT_CONFIG, detectedBrokers,
                                                           REMOVE_SLOW_BROKER_CONFIG, removeSlowBroker,
                                                           ANOMALY_DETECTION_TIME_MS_OBJECT_CONFIG, _kafkaCruiseControl.timeMs(),


### PR DESCRIPTION
This PR resolves #1896 

Example logs :

```
[2022-08-29 17:42:39,211] INFO Suspected Slow Brokers: [brokerId=14,host=b-14.XXXXXXXXX.c3.kafka.us-east-1.amazonaws.com] (com.linkedin.kafka.cruisecontrol.detector.SlowBrokerFinder)
32-07:00
[2022-08-29 17:42:39,231] INFO Slow Brokers Detected, description: {14 is slow (score: 50/50) since 2022-08-25T23:57:39Z} (com.linkedin.kafka.cruisecontrol.detector.SlowBrokerFinder)
```
