### PR TITLE
Add endpoint to move all replicas from a disk to other disks of the same broker

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskCapacityGoal.java
@@ -264,11 +264,10 @@ public class IntraBrokerDiskCapacityGoal extends AbstractGoal {
    * @return {@code true} if utilization is over the limit, {@code false} otherwise.
    */
   private boolean isUtilizationOverLimit(Disk disk) {
-    boolean diskUtilizationValid = true;
-    if (_shouldEmptyZeroCapacityDisks) {
-      diskUtilizationValid = disk.utilization() > 0;
+    if (_shouldEmptyZeroCapacityDisks && disk.capacity() == 0) {
+      return disk.utilization() > 0 || disk.replicas().size() > 0;
     }
-    return diskUtilizationValid && disk.utilization() > disk.capacity() * _balancingConstraint.capacityThreshold(RESOURCE);
+    return disk.utilization() > disk.capacity() * _balancingConstraint.capacityThreshold(RESOURCE);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskCapacityGoal.java
@@ -43,13 +43,13 @@ public class IntraBrokerDiskCapacityGoal extends AbstractGoal {
   private static final Logger LOG = LoggerFactory.getLogger(IntraBrokerDiskCapacityGoal.class);
   private static final int MIN_NUM_VALID_WINDOWS = 1;
   private static final Resource RESOURCE = Resource.DISK;
-  private boolean _shouldEmptyZeroCapacityDisks = false;
+  private final boolean _shouldEmptyZeroCapacityDisks;
 
   /**
    * Constructor for Capacity Goal.
    */
   public IntraBrokerDiskCapacityGoal() {
-
+    _shouldEmptyZeroCapacityDisks = false;
   }
 
   /**
@@ -66,6 +66,7 @@ public class IntraBrokerDiskCapacityGoal extends AbstractGoal {
    */
   IntraBrokerDiskCapacityGoal(BalancingConstraint constraint) {
     _balancingConstraint = constraint;
+    _shouldEmptyZeroCapacityDisks = false;
   }
 
   @Override
@@ -257,7 +258,7 @@ public class IntraBrokerDiskCapacityGoal extends AbstractGoal {
 
   /**
    * Check whether the combined replica utilization is above the given disk capacity limits.
-   * If _shouldEmptyZeroCapacityDisks is true, the disk utilization is over limit only if it greater than 0.
+   * If _shouldEmptyZeroCapacityDisks is true, the disk utilization is over limit only if it is greater than 0.
    *
    * @param disk Disk to be checked for capacity limit violation.
    * @return {@code true} if utilization is over the limit, {@code false} otherwise.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/CruiseControlParametersConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/CruiseControlParametersConfig.java
@@ -4,26 +4,27 @@
 
 package com.linkedin.kafka.cruisecontrol.config.constants;
 
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.AddBrokerParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.AdminParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.BootstrapParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.ClusterLoadParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.CruiseControlStateParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.DemoteBrokerParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.FixOfflineReplicasParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.KafkaClusterStateParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.PartitionLoadParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RemoveDisksParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.PauseResumeParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.StopProposalParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.TrainParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.ClusterLoadParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.PartitionLoadParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.BootstrapParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.ProposalsParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.RebalanceParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.RemoveBrokerParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.CruiseControlStateParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.KafkaClusterStateParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.UserTasksParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.ReviewBoardParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.ReviewParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.RightsizeParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.StopProposalParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.AddBrokerParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RemoveBrokerParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.FixOfflineReplicasParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.DemoteBrokerParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RebalanceParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.AdminParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.TopicConfigurationParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.TrainParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.UserTasksParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RightsizeParameters;
 import org.apache.kafka.common.config.ConfigDef;
 
 
@@ -179,6 +180,13 @@ public final class CruiseControlParametersConfig {
   public static final String DEFAULT_RIGHTSIZE_PARAMETERS_CLASS = RightsizeParameters.class.getName();
   public static final String RIGHTSIZE_PARAMETERS_CLASS_DOC = "The class for parameters of a provision rightsize request.";
 
+  /**
+   * <code>remove.disks.parameters.class</code>
+   */
+  public static final String REMOVE_DISKS_PARAMETERS_CLASS_CONFIG = "remove.disks.parameters.class";
+  public static final String DEFAULT_REMOVE_DISKS_PARAMETERS_CLASS = RemoveDisksParameters.class.getName();
+  public static final String REMOVE_DISKS_PARAMETERS_CLASS_DOC = "The class for parameters of a disks removal request.";
+
   private CruiseControlParametersConfig() {
   }
 
@@ -293,6 +301,11 @@ public final class CruiseControlParametersConfig {
                             ConfigDef.Type.CLASS,
                             DEFAULT_RIGHTSIZE_PARAMETERS_CLASS,
                             ConfigDef.Importance.MEDIUM,
-                            RIGHTSIZE_PARAMETERS_CLASS_DOC);
+                            RIGHTSIZE_PARAMETERS_CLASS_DOC)
+                    .define(REMOVE_DISKS_PARAMETERS_CLASS_CONFIG,
+                            ConfigDef.Type.CLASS,
+                            DEFAULT_REMOVE_DISKS_PARAMETERS_CLASS,
+                            ConfigDef.Importance.MEDIUM,
+                            REMOVE_DISKS_PARAMETERS_CLASS_DOC);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/CruiseControlRequestConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/CruiseControlRequestConfig.java
@@ -4,17 +4,18 @@
 
 package com.linkedin.kafka.cruisecontrol.config.constants;
 
-import com.linkedin.kafka.cruisecontrol.servlet.handler.async.AddBrokerRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.async.ClusterLoadRequest;
-import com.linkedin.kafka.cruisecontrol.servlet.handler.async.CruiseControlStateRequest;
-import com.linkedin.kafka.cruisecontrol.servlet.handler.async.DemoteRequest;
-import com.linkedin.kafka.cruisecontrol.servlet.handler.async.FixOfflineReplicasRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.async.PartitionLoadRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.async.ProposalsRequest;
-import com.linkedin.kafka.cruisecontrol.servlet.handler.async.RebalanceRequest;
-import com.linkedin.kafka.cruisecontrol.servlet.handler.async.RemoveBrokerRequest;
-import com.linkedin.kafka.cruisecontrol.servlet.handler.sync.RightsizeRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.CruiseControlStateRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.async.TopicConfigurationRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.AddBrokerRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.RemoveBrokerRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.RemoveDisksRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.DemoteRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.RebalanceRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.FixOfflineReplicasRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.sync.RightsizeRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.sync.AdminRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.sync.BootstrapRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.sync.KafkaClusterStateRequest;
@@ -181,6 +182,13 @@ public final class CruiseControlRequestConfig {
   public static final String DEFAULT_RIGHTSIZE_REQUEST_CLASS = RightsizeRequest.class.getName();
   public static final String RIGHTSIZE_REQUEST_CLASS_DOC = "The class to handle a provision rightsize request.";
 
+  /**
+   * <code>remove.disks.request.class</code>
+   */
+  public static final String REMOVE_DISKS_REQUEST_CLASS_CONFIG = "remove.disks.request.class";
+  public static final String DEFAULT_REMOVE_DISKS_REQUEST_CLASS = RemoveDisksRequest.class.getName();
+  public static final String REMOVE_DISKS_REQUEST_CLASS_DOC = "The class to handle a disks removal request.";
+
   private CruiseControlRequestConfig() {
   }
 
@@ -295,6 +303,11 @@ public final class CruiseControlRequestConfig {
                             ConfigDef.Type.CLASS,
                             DEFAULT_RIGHTSIZE_REQUEST_CLASS,
                             ConfigDef.Importance.MEDIUM,
-                            RIGHTSIZE_REQUEST_CLASS_DOC);
+                            RIGHTSIZE_REQUEST_CLASS_DOC)
+                    .define(REMOVE_DISKS_REQUEST_CLASS_CONFIG,
+                            ConfigDef.Type.CLASS,
+                            DEFAULT_REMOVE_DISKS_REQUEST_CLASS,
+                            ConfigDef.Importance.MEDIUM,
+                            REMOVE_DISKS_REQUEST_CLASS_DOC);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Disk.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Disk.java
@@ -111,6 +111,13 @@ public class Disk implements Comparable<Disk> {
   }
 
   /**
+   * Set disk capacity to 0 to mark it for removal.
+   */
+  public void markDiskForRemoval() {
+    _capacity = 0;
+  }
+
+  /**
    * Add replica to the disk.
    *
    * @param replica Replica to be added to the current disk.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/CruiseControlEndPoint.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/CruiseControlEndPoint.java
@@ -34,7 +34,8 @@ public enum CruiseControlEndPoint implements EndPoint {
   ADMIN(CRUISE_CONTROL_ADMIN),
   REVIEW(CRUISE_CONTROL_ADMIN),
   TOPIC_CONFIGURATION(KAFKA_ADMIN),
-  RIGHTSIZE(KAFKA_ADMIN);
+  RIGHTSIZE(KAFKA_ADMIN),
+  REMOVE_DISKS(KAFKA_ADMIN);
 
   private static final List<CruiseControlEndPoint> CACHED_VALUES = List.of(values());
   private static final List<CruiseControlEndPoint> GET_ENDPOINTS = Arrays.asList(BOOTSTRAP,
@@ -57,7 +58,8 @@ public enum CruiseControlEndPoint implements EndPoint {
                                                                                   ADMIN,
                                                                                   REVIEW,
                                                                                   TOPIC_CONFIGURATION,
-                                                                                  RIGHTSIZE);
+                                                                                  RIGHTSIZE,
+                                                                                  REMOVE_DISKS);
 
   private final EndpointType _endpointType;
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
@@ -116,6 +116,9 @@ public final class KafkaCruiseControlServletUtils {
     RequestParameterWrapper rightsize = new RequestParameterWrapper(RIGHTSIZE_PARAMETERS_CLASS_CONFIG,
                                                                     RIGHTSIZE_PARAMETER_OBJECT_CONFIG,
                                                                     RIGHTSIZE_REQUEST_CLASS_CONFIG);
+    RequestParameterWrapper removeDisks = new RequestParameterWrapper(REMOVE_DISKS_PARAMETERS_CLASS_CONFIG,
+                                                                      REMOVE_DISKS_PARAMETER_OBJECT_CONFIG,
+                                                                      REMOVE_DISKS_REQUEST_CLASS_CONFIG);
 
     requestParameterConfigs.put(BOOTSTRAP, bootstrap);
     requestParameterConfigs.put(TRAIN, train);
@@ -138,6 +141,7 @@ public final class KafkaCruiseControlServletUtils {
     requestParameterConfigs.put(REVIEW_BOARD, reviewBoard);
     requestParameterConfigs.put(TOPIC_CONFIGURATION, topicConfiguration);
     requestParameterConfigs.put(RIGHTSIZE, rightsize);
+    requestParameterConfigs.put(REMOVE_DISKS, removeDisks);
 
     REQUEST_PARAMETER_CONFIGS = Collections.unmodifiableMap(requestParameterConfigs);
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/RemoveDisksRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/RemoveDisksRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.handler.async;
+
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.OperationFuture;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.RemoveDisksRunnable;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RemoveDisksParameters;
+import java.util.Map;
+
+import static com.linkedin.cruisecontrol.common.utils.Utils.validateNotNull;
+import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.REMOVE_DISKS_PARAMETER_OBJECT_CONFIG;
+
+public class RemoveDisksRequest extends AbstractAsyncRequest {
+    protected RemoveDisksParameters _parameters;
+
+    public RemoveDisksRequest() {
+        super();
+    }
+
+    @Override
+    protected OperationFuture handle(String uuid) {
+        OperationFuture future = new OperationFuture("Remove disks");
+        pending(future.operationProgress());
+        _asyncKafkaCruiseControl.sessionExecutor().submit(new RemoveDisksRunnable(_asyncKafkaCruiseControl, future, _parameters, uuid));
+        return future;
+    }
+
+    @Override
+    public RemoveDisksParameters parameters() {
+        return _parameters;
+    }
+
+    @Override
+    public String name() {
+        return RemoveDisksRequest.class.getSimpleName();
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        super.configure(configs);
+        _parameters = (RemoveDisksParameters) validateNotNull(configs.get(REMOVE_DISKS_PARAMETER_OBJECT_CONFIG),
+                "Parameter configuration is missing from the request.");
+    }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RemoveDisksRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RemoveDisksRunnable.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2022 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable;
+
+import com.linkedin.cruisecontrol.exception.NotEnoughValidWindowsException;
+import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
+import com.linkedin.kafka.cruisecontrol.analyzer.BalancingConstraint;
+import com.linkedin.kafka.cruisecontrol.analyzer.OptimizationOptions;
+import com.linkedin.kafka.cruisecontrol.analyzer.OptimizerResult;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.IntraBrokerDiskCapacityGoal;
+import com.linkedin.kafka.cruisecontrol.common.Resource;
+import com.linkedin.kafka.cruisecontrol.config.constants.ExecutorConfig;
+import com.linkedin.kafka.cruisecontrol.exception.KafkaCruiseControlException;
+import com.linkedin.kafka.cruisecontrol.model.Broker;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import com.linkedin.kafka.cruisecontrol.model.Disk;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RemoveDisksParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.response.OptimizationResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.Set;
+import java.util.Map;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+import static com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.RunnableUtils.maybeStopOngoingExecutionToModifyAndWait;
+import static com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.RunnableUtils.computeOptimizationOptions;
+import static com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.RunnableUtils.isKafkaAssignerMode;
+import static com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.RunnableUtils.SELF_HEALING_EXECUTION_PROGRESS_CHECK_INTERVAL_MS;
+import static com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.RunnableUtils.SELF_HEALING_REPLICA_MOVEMENT_STRATEGY;
+import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.DEFAULT_START_TIME_FOR_CLUSTER_MODEL;
+
+public class RemoveDisksRunnable extends GoalBasedOperationRunnable {
+    private static final Logger LOG = LoggerFactory.getLogger(RemoveDisksRunnable.class);
+    private static final int CONCURRENT_INTER_BROKER_PARTITION_MOVEMENTS = 0;
+    private static final int MAX_INTER_BROKER_PARTITION_MOVEMENTS = 0;
+    private static final int CONCURRENT_INTRA_BROKER_PARTITION_MOVEMENTS = 1;
+    private static final int CONCURRENT_LEADER_MOVEMENTS = 1;
+    private final Map<Integer, Set<String>> _brokerIdAndLogdirs;
+
+    public RemoveDisksRunnable(KafkaCruiseControl kafkaCruiseControl,
+                               OperationFuture future,
+                               RemoveDisksParameters parameters,
+                               String uuid) {
+        super(kafkaCruiseControl, future, parameters, parameters.dryRun(), parameters.stopOngoingExecution(), false,
+                uuid, parameters::reason);
+        _brokerIdAndLogdirs = parameters.brokerIdAndLogdirs();
+    }
+
+    @Override
+    protected OptimizationResult getResult() throws Exception {
+        return new OptimizationResult(computeResult(), _kafkaCruiseControl.config());
+    }
+
+    @Override
+    protected void init() {
+        _kafkaCruiseControl.sanityCheckDryRun(_dryRun, _stopOngoingExecution);
+        _goalsByPriority = new ArrayList<>(1);
+        Goal intraBrokerDiskCapacityGoal = new IntraBrokerDiskCapacityGoal(true);
+        intraBrokerDiskCapacityGoal.configure(_kafkaCruiseControl.config().mergedConfigValues());
+        _goalsByPriority.add(intraBrokerDiskCapacityGoal);
+
+        _operationProgress = _future.operationProgress();
+        if (_stopOngoingExecution) {
+            maybeStopOngoingExecutionToModifyAndWait(_kafkaCruiseControl, _operationProgress);
+        }
+        _combinedCompletenessRequirements = _goalsByPriority.get(0).clusterModelCompletenessRequirements();
+    }
+
+    @Override
+    protected OptimizerResult workWithClusterModel() throws KafkaCruiseControlException, NotEnoughValidWindowsException, TimeoutException {
+        Set<Integer> brokersToCheckPresence = new HashSet<>(_brokerIdAndLogdirs.keySet());
+        _kafkaCruiseControl.sanityCheckBrokerPresence(brokersToCheckPresence);
+        ClusterModel clusterModel = _kafkaCruiseControl.clusterModel(
+                DEFAULT_START_TIME_FOR_CLUSTER_MODEL,
+                _kafkaCruiseControl.timeMs(),
+                _combinedCompletenessRequirements,
+                true,
+                _allowCapacityEstimation,
+                _operationProgress
+        );
+
+        checkCanRemoveDisks(_brokerIdAndLogdirs, clusterModel);
+
+        _brokerIdAndLogdirs.forEach((brokerId, logDirsToRemove) ->
+                logDirsToRemove.forEach(logDir -> clusterModel.broker(brokerId).disk(logDir).markDiskForRemoval())
+        );
+
+        OptimizationOptions optimizationOptions = computeOptimizationOptions(clusterModel,
+                false,
+                _kafkaCruiseControl,
+                Collections.emptySet(),
+                _dryRun,
+                _excludeRecentlyDemotedBrokers,
+                _excludeRecentlyRemovedBrokers,
+                _excludedTopics,
+                Collections.emptySet(),
+                false,
+                _fastMode
+        );
+
+        OptimizerResult result = _kafkaCruiseControl.optimizations(clusterModel, _goalsByPriority, _operationProgress, null, optimizationOptions);
+        if (!_dryRun) {
+            _kafkaCruiseControl.executeProposals(
+                    result.goalProposals(),
+                    Collections.emptySet(),
+                    isKafkaAssignerMode(_goals),
+                    CONCURRENT_INTER_BROKER_PARTITION_MOVEMENTS,
+                    MAX_INTER_BROKER_PARTITION_MOVEMENTS,
+                    CONCURRENT_INTRA_BROKER_PARTITION_MOVEMENTS,
+                    CONCURRENT_LEADER_MOVEMENTS,
+                    SELF_HEALING_EXECUTION_PROGRESS_CHECK_INTERVAL_MS,
+                    SELF_HEALING_REPLICA_MOVEMENT_STRATEGY,
+                    _kafkaCruiseControl.config().getLong(ExecutorConfig.DEFAULT_REPLICATION_THROTTLE_CONFIG),
+                    _isTriggeredByUserRequest,
+                    _uuid,
+                    false
+            );
+        }
+
+        return result;
+    }
+
+    private void checkCanRemoveDisks(Map<Integer, Set<String>> brokerIdAndLogdirs, ClusterModel clusterModel) {
+        BalancingConstraint balancingConstraint = new BalancingConstraint(_kafkaCruiseControl.config());
+        double capacityThreshold = balancingConstraint.capacityThreshold(Resource.DISK);
+        for (Map.Entry<Integer, Set<String>> entry : brokerIdAndLogdirs.entrySet()) {
+            Integer brokerId = entry.getKey();
+            Set<String> logDirsToRemove = entry.getValue();
+            Broker broker = clusterModel.broker(brokerId);
+            Set<String> brokerLogDirs = broker.disks().stream().map(Disk::logDir).collect(Collectors.toSet());
+            if (!brokerLogDirs.containsAll(logDirsToRemove)) {
+                throw new IllegalArgumentException(String.format("Invalid log dirs provided for broker %d.", brokerId));
+            }
+            if (broker.disks().size() == logDirsToRemove.size()) {
+                throw new IllegalArgumentException(String.format("No log dir remaining to move replicas to for broker %d.", brokerId));
+            }
+
+            double futureUsage = 0.0;
+            double remainingCapacity = 0.0;
+            for (Disk disk : broker.disks()) {
+                futureUsage += disk.utilization();
+                if (!logDirsToRemove.contains(disk.logDir())) {
+                    remainingCapacity += disk.capacity();
+                }
+            }
+            if (futureUsage / remainingCapacity > capacityThreshold) {
+                throw new IllegalArgumentException("Not enough remaining capacity to move replicas to.");
+            }
+        }
+    }
+
+    @Override
+    protected boolean shouldWorkWithClusterModel() {
+        return true;
+    }
+
+    @Override
+    protected OptimizerResult workWithoutClusterModel() {
+        return null;
+    }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
@@ -160,6 +160,7 @@ public final class ParameterUtils {
   public static final String REVIEW_PARAMETER_OBJECT_CONFIG = "review.parameter.object";
   public static final String TOPIC_CONFIGURATION_PARAMETER_OBJECT_CONFIG = "topic.configuration.parameter.object";
   public static final String RIGHTSIZE_PARAMETER_OBJECT_CONFIG = "rightsize.parameter.object";
+  public static final String REMOVE_DISKS_PARAMETER_OBJECT_CONFIG = "remove.disks.parameter.object";
 
   private ParameterUtils() {
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RemoveDisksParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RemoveDisksParameters.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.parameters;
+
+import com.linkedin.kafka.cruisecontrol.config.constants.ExecutorConfig;
+import com.linkedin.kafka.cruisecontrol.servlet.UserRequestException;
+import java.io.UnsupportedEncodingException;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.Collections;
+import java.util.Set;
+import java.util.Map;
+
+import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.BROKER_ID_AND_LOGDIRS_PARAM;
+import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.DRY_RUN_PARAM;
+import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.REASON_PARAM;
+import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.STOP_ONGOING_EXECUTION_PARAM;
+import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.JSON_PARAM;
+
+public class RemoveDisksParameters extends GoalBasedOptimizationParameters {
+    protected static final SortedSet<String> CASE_INSENSITIVE_PARAMETER_NAMES;
+    static {
+        SortedSet<String> validParameterNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        validParameterNames.add(BROKER_ID_AND_LOGDIRS_PARAM);
+        validParameterNames.add(DRY_RUN_PARAM);
+        validParameterNames.add(REASON_PARAM);
+        validParameterNames.add(STOP_ONGOING_EXECUTION_PARAM);
+        validParameterNames.add(JSON_PARAM);
+        CASE_INSENSITIVE_PARAMETER_NAMES = Collections.unmodifiableSortedSet(validParameterNames);
+    }
+    private boolean _dryRun;
+    private String _reason;
+    private boolean _stopOngoingExecution;
+    private Map<Integer, Set<String>> _logdirByBrokerId;
+
+    public RemoveDisksParameters() {
+        super();
+    }
+
+    @Override
+    protected void initParameters() throws UnsupportedEncodingException {
+        super.initParameters();
+        _logdirByBrokerId = ParameterUtils.brokerIdAndLogdirs(_requestContext);
+        _dryRun = ParameterUtils.getDryRun(_requestContext);
+        boolean requestReasonRequired = _config.getBoolean(ExecutorConfig.REQUEST_REASON_REQUIRED_CONFIG);
+        _reason = ParameterUtils.reason(_requestContext, requestReasonRequired && !_dryRun);
+        _stopOngoingExecution = ParameterUtils.stopOngoingExecution(_requestContext);
+        if (_stopOngoingExecution && _dryRun) {
+            throw new UserRequestException(String.format("%s and %s cannot both be set to true.", STOP_ONGOING_EXECUTION_PARAM, DRY_RUN_PARAM));
+        }
+    }
+
+    public Map<Integer, Set<String>> brokerIdAndLogdirs() {
+        return _logdirByBrokerId;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        super.configure(configs);
+    }
+
+    @Override
+    public SortedSet<String> caseInsensitiveParameterNames() {
+        return CASE_INSENSITIVE_PARAMETER_NAMES;
+    }
+    public String reason() {
+        return _reason;
+    }
+    public boolean dryRun() {
+        return _dryRun;
+    }
+    public boolean stopOngoingExecution() {
+        return _stopOngoingExecution;
+    }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/OptimizationResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/OptimizationResult.java
@@ -6,15 +6,16 @@ package com.linkedin.kafka.cruisecontrol.servlet.response;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.linkedin.cruisecontrol.servlet.parameters.CruiseControlParameters;
 import com.linkedin.kafka.cruisecontrol.analyzer.OptimizerResult;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.executor.ExecutionProposal;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
 import com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.AddedOrRemovedBrokerParameters;
-import com.linkedin.cruisecontrol.servlet.parameters.CruiseControlParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.DemoteBrokerParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.KafkaOptimizationParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RemoveDisksParameters;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -85,6 +86,8 @@ public class OptimizationResult extends AbstractCruiseControlResponse {
       case TOPIC_CONFIGURATION:
         return String.format("%n%nCluster load after updating replication factor of topics %s%n",
                              _optimizerResult.topicsWithReplicationFactorChange());
+      case REMOVE_DISKS:
+        return String.format("%n%nCluster load after removing disks %s:%n", ((RemoveDisksParameters) parameters).brokerIdAndLogdirs());
       default:
         LOG.error("Unrecognized endpoint.");
         return "Unrecognized endpoint.";

--- a/cruise-control/src/main/resources/yaml/base.yaml
+++ b/cruise-control/src/main/resources/yaml/base.yaml
@@ -52,3 +52,5 @@ paths:
     $ref: 'endpoints/train.yaml#/TrainEndpoint'
   /user_tasks:
     $ref: 'endpoints/userTasks.yaml#/UserTasksEndpoint'
+  /remove_disks:
+    $ref: 'endpoints/removeDisks.yaml#/RemoveDisksEndpoint'

--- a/cruise-control/src/main/resources/yaml/endpoints/removeDisks.yaml
+++ b/cruise-control/src/main/resources/yaml/endpoints/removeDisks.yaml
@@ -1,0 +1,69 @@
+RemoveDisksEndpoint:
+  post:
+    operationId: removeDisks
+    summary: Move all replicas from the specified disk to other disks of the same broker.
+    parameters:
+      - name: dryrun
+        in: query
+        description: Whether to dry-run the request or not.
+        schema:
+          type: boolean
+          default: true
+      - name: stop_ongoing_execution
+        in: query
+        description: Whether to stop the ongoing execution (if any) and start executing the given request.
+        schema:
+          type: boolean
+          default: false
+      - name: reason
+        in: query
+        description: Reason for request.
+        schema:
+          type: string
+        example: "Balance disk utilization across all brokers in the cluster."
+      - name: brokerid_and_logdirs
+        in: query
+        description: List of broker id and logdir pair to be demoted in the cluster.
+        schema:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        required: true
+        example: 101-/tmp/kafka-logs-1,101-/tmp/kafka-logs-2
+      - name: json
+        in: query
+        description: Whether to return in JSON format or not.
+        schema:
+          type: boolean
+          default: false
+    responses:
+      '200':
+        description: Successful removed disks response.
+        content:
+          application/json:
+            schema:
+              $ref: '../responses/optimizationResult.yaml#/OptimizationResult'
+          text/plain:
+            schema:
+              type: string
+      '202':
+        description: Remove disks in progress.
+        content:
+          application/json:
+            schema:
+              $ref: '../responses/progressResult.yaml#/ProgressResult'
+          text/plain:
+            schema:
+              type: string
+      # Response for all errors
+      default:
+        description: Error response.
+        content:
+          application/json:
+            schema:
+              $ref: '../responses/errorResponse.yaml#/ErrorResponse'
+          text/plain:
+            schema:
+              type: string

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RemoveDisksTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RemoveDisksTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2023 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer;
+
+import com.codahale.metrics.MetricRegistry;
+import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUnitTestUtils;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.IntraBrokerDiskCapacityGoal;
+import com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress;
+import com.linkedin.kafka.cruisecontrol.common.Resource;
+import com.linkedin.kafka.cruisecontrol.common.TestConstants;
+import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
+import com.linkedin.kafka.cruisecontrol.exception.KafkaCruiseControlException;
+import com.linkedin.kafka.cruisecontrol.exception.OptimizationFailureException;
+import com.linkedin.kafka.cruisecontrol.executor.ExecutionProposal;
+import com.linkedin.kafka.cruisecontrol.executor.Executor;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import com.linkedin.kafka.cruisecontrol.monitor.ModelGeneration;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.SystemTime;
+import org.easymock.EasyMock;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUnitTestUtils.getAggregatedMetricValues;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+@RunWith(Parameterized.class)
+public class RemoveDisksTest {
+    private final Goal _goalToTest;
+    private final ClusterModel _clusterModel;
+    private final boolean _expectedToOptimize;
+    private final KafkaCruiseControlConfig _kafkaCruiseControlConfig;
+
+    public RemoveDisksTest(Goal goal, ClusterModel clusterModel, KafkaCruiseControlConfig config, boolean expectedToOptimize) {
+        _goalToTest = goal;
+        _clusterModel = clusterModel;
+        _expectedToOptimize = expectedToOptimize;
+        _kafkaCruiseControlConfig = config;
+    }
+
+    /**
+     * Populate parameters for the {@link OptimizationVerifier}.
+     *
+     * @return Parameters for the {@link OptimizationVerifier}.
+     */
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> buildParameters() {
+        List<Object[]> parameters = new ArrayList<>();
+
+        final Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
+        final KafkaCruiseControlConfig kafkaCruiseControlConfig = new KafkaCruiseControlConfig(props);
+        final BalancingConstraint balancingConstraint = new BalancingConstraint(kafkaCruiseControlConfig);
+
+        // running 3 tests: one for medium utilization, one for 0 utilization, and one for max utilization.
+        // max utilization should not be moved by the intra-broker disk capacity goal.
+        List<Double> replicaLoadList = Arrays.asList(
+                TestConstants.LARGE_BROKER_CAPACITY / 4,
+                0.0,
+                TestConstants.LARGE_BROKER_CAPACITY / 2 * balancingConstraint.capacityThreshold(Resource.DISK)
+        );
+        for (Double replicaLoad : replicaLoadList) {
+            final Map<Integer, String> brokerToRack = Map.of(0, "A::0",
+                    1, "B::0",
+                    2, "C::1");
+            final ClusterModel cluster = new ClusterModel(new ModelGeneration(0, 0L), 1.0);
+            BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY, TestConstants.DISK_CAPACITY);
+            brokerToRack.values().stream().distinct().forEach(cluster::createRack);
+            brokerToRack.forEach((broker, rack) -> cluster.createBroker(
+                    rack, Integer.toString(broker), broker,
+                    commonBrokerCapacityInfo,
+                    commonBrokerCapacityInfo.diskCapacityByLogDir() != null
+            ));
+
+            // populate the cluster with a set of replicas
+            TopicPartition tp = new TopicPartition("topic", 0);
+            cluster.createReplica(brokerToRack.get(0), 0, tp, 0, true, false, TestConstants.LOGDIR0, false);
+
+            // create snapshots and push them to the cluster.
+            List<Long> windows = Collections.singletonList(1L);
+            cluster.setReplicaLoad(brokerToRack.get(0), 0, tp, getAggregatedMetricValues(40.0, 100.0, 130.0, replicaLoad), windows);
+
+            parameters.add(new Object[]{
+                    new IntraBrokerDiskCapacityGoal(true),
+                    cluster,
+                    kafkaCruiseControlConfig,
+                    replicaLoad != TestConstants.LARGE_BROKER_CAPACITY / 2 * balancingConstraint.capacityThreshold(Resource.DISK)
+            });
+        }
+
+        return parameters;
+    }
+
+    @Test
+    public void testRemoveDisks() throws KafkaCruiseControlException {
+        // mark disk 0 of broker 0 for removal
+        _clusterModel.broker(0).disk(TestConstants.LOGDIR0).markDiskForRemoval();
+
+        List<Goal> goalsByPriority = Collections.singletonList(_goalToTest);
+        _goalToTest.configure(_kafkaCruiseControlConfig.mergedConfigValues());
+        GoalOptimizer goalOptimizer = new GoalOptimizer(_kafkaCruiseControlConfig,
+                null,
+                new SystemTime(),
+                new MetricRegistry(),
+                EasyMock.mock(Executor.class),
+                EasyMock.mock(AdminClient.class));
+
+        if (_expectedToOptimize) {
+            final Set<ExecutionProposal> proposals =
+                    goalOptimizer.optimizations(_clusterModel, goalsByPriority, new OperationProgress()).goalProposals();
+            assertEquals(1, proposals.size());
+            assertEquals(1, proposals.iterator().next().replicasToMoveBetweenDisksByBroker().size());
+            assertEquals(0, proposals.iterator().next().replicasToMoveBetweenDisksByBroker().get(0).brokerId().intValue());
+            assertEquals(TestConstants.LOGDIR1, proposals.iterator().next().replicasToMoveBetweenDisksByBroker().get(0).logdir());
+        } else {
+            assertThrows(OptimizationFailureException.class,
+                    () -> goalOptimizer.optimizations(_clusterModel, goalsByPriority, new OperationProgress()));
+        }
+    }
+}


### PR DESCRIPTION
This PR resolves #1907 .

This PR introduces a new endpoint that moves replicas from a specified disk to other disks of the same broker. This will allow the removal of the disk without the loss of data.

The replicas are moved in a round-robin manner to the remaining disks, from the largest to the smallest, while checking the following constraint:
```
1 - (remainingUsageAfterRemoval / remainingCapacity) > errorMargin
```
where
```
remainingUsageAfterRemoval = current usage for remaining disks + additional usage from removed disks
remainingCapacity = sum of capacities of the remaining disks
errorMargin = configurable property (default 0.1); it makes sure that a disk percentage is always free when moving replicas
```

## What is new
The new endpoint is available as follows:
```
POST /remove_disks?brokerid_and_logdirs=[brokerid1-logdir1,brokerid2-logdir2...]
```

## What is missing
After all replicas are moved from the specified disk, the disk may still be used by CC during rebalances and Kafka can still use it when creating topics.