### PR TITLE
Compare exact member of ISR with RS when deciding whether the partition is URP

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionState.java
@@ -15,10 +15,12 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import java.util.Arrays;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.Node;
+
 
 
 @JsonResponseClass
@@ -118,7 +120,7 @@ public class ClusterPartitionState {
           int numReplicas = partitionInfo.replicas().length;
           Node[] replicas = Arrays.copyOf(partitionInfo.replicas(), numReplicas);
           Arrays.sort(replicas);
-          boolean isURP = !(replicas == inSyncReplicas);
+          boolean isURP = !(Arrays.equals(replicas, inSyncReplicas));
           if (numInsyncReplicas < minInsyncReplicas) {
             underMinIsrPartitions.add(partitionInfo);
           }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionState.java
@@ -112,7 +112,7 @@ public class ClusterPartitionState {
         }
         for (PartitionInfo partitionInfo : _kafkaCluster.partitionsForTopic(topic)) {
           int numInsyncReplicas = partitionInfo.inSyncReplicas().length;
-          boolean isURP = numInsyncReplicas != partitionInfo.replicas().length;
+          boolean isURP = !(partitionInfo.inSyncReplicas() == partitionInfo.replicas());
           if (numInsyncReplicas < minInsyncReplicas) {
             underMinIsrPartitions.add(partitionInfo);
           }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionState.java
@@ -93,8 +93,7 @@ public class ClusterPartitionState {
    * @param partitionInfo the {@link PartitionInfo} object that contains partition info.
    * @return the effective boolean under replicated status of a partition.
    */
-  protected boolean isURP(PartitionInfo partitionInfo)
-  {
+  protected boolean isURP(PartitionInfo partitionInfo) {
     int numInsyncReplicas = partitionInfo.inSyncReplicas().length;
     Node[] inSyncReplicas = Arrays.copyOf(partitionInfo.inSyncReplicas(), numInsyncReplicas);
     Arrays.sort(inSyncReplicas);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionState.java
@@ -100,7 +100,7 @@ public class ClusterPartitionState {
     int numReplicas = partitionInfo.replicas().length;
     Node[] replicas = Arrays.copyOf(partitionInfo.replicas(), numReplicas);
     Arrays.sort(replicas);
-    boolean isURP = !(Arrays.equals(replicas, inSyncReplicas));
+    boolean isURP = !Arrays.equals(replicas, inSyncReplicas);
     return isURP;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionState.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.Node;
 
 
 @JsonResponseClass
@@ -112,7 +113,12 @@ public class ClusterPartitionState {
         }
         for (PartitionInfo partitionInfo : _kafkaCluster.partitionsForTopic(topic)) {
           int numInsyncReplicas = partitionInfo.inSyncReplicas().length;
-          boolean isURP = !(partitionInfo.inSyncReplicas() == partitionInfo.replicas());
+          Node[] inSyncReplicas = Arrays.copyOf(partitionInfo.inSyncReplicas(), numInsyncReplicas);
+          Arrays.sort(inSyncReplicas);
+          int numReplicas = partitionInfo.replicas().length;
+          Node[] replicas = Arrays.copyOf(partitionInfo.replicas(), numReplicas);
+          Arrays.sort(replicas);
+          boolean isURP = !(replicas == inSyncReplicas);
           if (numInsyncReplicas < minInsyncReplicas) {
             underMinIsrPartitions.add(partitionInfo);
           }


### PR DESCRIPTION
This PR resolves [#1905 ](https://github.com/linkedin/cruise-control/issues/1905)

Today, the way we determine a partition is an URP (Under Replicated Partition) based on the size of ISR and RS. E.g. if ISR = [A, B], and RS = [A, B, C], then the partition is treated as URP by CC.

However, in certain cases (usually because kafka is in a bad/inconsistent state), the ISR can be diverged from RS. E.g. ISR = [A, B, B], while RS = [D, E, F]. In this case, we still want CC to report this replica as URP, since the partition is not in a good state.

The proposal is, instead of comparing the size of ISR and RS, we should comparing the members in ISR and RS. If ISR != RS, CC should report it as URP.