### PR TITLE
Bumped swagger-parser-v3 version to 2.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -282,7 +282,7 @@ project(':cruise-control') {
     implementation "org.eclipse.jetty:jetty-server:${jettyVersion}"
     implementation 'io.dropwizard.metrics:metrics-jmx:4.2.9'
     implementation 'com.nimbusds:nimbus-jose-jwt:9.21'
-    implementation 'io.swagger.parser.v3:swagger-parser-v3:2.0.30'
+    implementation 'io.swagger.parser.v3:swagger-parser-v3:2.1.3'
     implementation 'io.github.classgraph:classgraph:4.8.141'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'com.google.guava:guava:31.1-jre'


### PR DESCRIPTION
2.1.3 is the latest version as of today on https://mvnrepository.com/artifact/io.swagger.parser.v3/swagger-parser-v3

This PR resolves #1924.
