### PR TITLE
Add create CircleCI account as a tip in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,12 @@ existing and new unit tests.
 2. Bug fixes must include a test case demonstrating the error that it fixes.
 3. Open an issue first and seek advice for your change before submitting a PR. Large features which have never been 
 discussed are unlikely to be accepted.
-4. Do not create a PR with "work-in-progress" (WIP) changes.
-5. Use clear and concise titles for submitted PRs and issues.
-6. Each PR should be linked to an existing issue corresponding to the PR 
+4. New contributors should create an account in CircleCI first before raising the PR. 
+5. Do not create a PR with "work-in-progress" (WIP) changes.
+6. Use clear and concise titles for submitted PRs and issues.
+7. Each PR should be linked to an existing issue corresponding to the PR 
 (see [PR template](https://github.com/linkedin/cruise-control/blob/migrate_to_kafka_2_4/docs/pull_request_template.md)).
-7. If there are no existing issues about a PR, create one before submitting the PR.
-8. We strongly encourage the use of recommended code-style for the project 
+8. If there are no existing issues about a PR, create one before submitting the PR.
+9. We strongly encourage the use of recommended code-style for the project 
 (see [code-style.xml](https://github.com/linkedin/cruise-control/blob/migrate_to_kafka_2_4/docs/code-style.xml)).
-9. A pre-commit CheckStyle hook can be run by adding `./checkstyle/checkstyle-pre-commit` to your `.git/hooks/pre-commit` script.
+10. A pre-commit CheckStyle hook can be run by adding `./checkstyle/checkstyle-pre-commit` to your `.git/hooks/pre-commit` script.


### PR DESCRIPTION
This PR resolves the comment in #1928.

Without a CircleCI account, the PR will fail to trigger the test pipelines. This is a required step for new contributors to create PRs for crusie-control.
