### PR TITLE
Bump scala version to 2.13.10 (CVE-2022-36944)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 org.gradle.parallel=false
 org.gradle.jvmargs=-Xms512m -Xmx512m
-scalaVersion=2.13.6
+scalaVersion=2.13.10
 kafkaVersion=3.1.0
 zookeeperVersion=3.6.3
 nettyVersion=4.1.77.Final


### PR DESCRIPTION
This PR resolves #1929.
