### PR TITLE
Add initialized state to concurrency adjuster and avoid null for the metric value

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -438,8 +438,8 @@ public class Executor {
      * Concurrency should be reset after each execution is done.
      */
     public synchronized void clearAdjustment() {
-      _executionConcurrencyManager.reset();
       _started = false;
+      _executionConcurrencyManager.reset();
     }
 
     /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/concurrency/ExecutionConcurrencySummary.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/concurrency/ExecutionConcurrencySummary.java
@@ -17,10 +17,13 @@ public class ExecutionConcurrencySummary {
   private final Map<Integer, Integer> _interBrokerPartitionMovementConcurrency;
   private final Map<Integer, Integer> _intraBrokerPartitionMovementConcurrency;
   private final Map<Integer, Integer> _leadershipMovementConcurrency;
+  private final boolean _initialized;
 
-  public ExecutionConcurrencySummary(Map<Integer, Integer> interBrokerPartitionMovementConcurrency,
+  public ExecutionConcurrencySummary(boolean initialized,
+                                     Map<Integer, Integer> interBrokerPartitionMovementConcurrency,
                                      Map<Integer, Integer> intraBrokerPartitionMovementConcurrency,
                                      Map<Integer, Integer> leadershipMovementConcurrency) {
+    _initialized = initialized;
     _interBrokerPartitionMovementConcurrency = new HashMap<>(interBrokerPartitionMovementConcurrency);
     _intraBrokerPartitionMovementConcurrency = new HashMap<>(intraBrokerPartitionMovementConcurrency);
     _leadershipMovementConcurrency = new HashMap<>(leadershipMovementConcurrency);
@@ -29,9 +32,13 @@ public class ExecutionConcurrencySummary {
   /**
    * Get the min broker execution concurrency of the cluster
    * @param concurrencyType the concurrency type of the min execution concurrency
-   * @return the min broker execution concurrency of the cluster
+   * @return the min broker execution concurrency of the cluster. If not initialized, return 0.
    */
   public synchronized int getMinExecutionConcurrency(ConcurrencyType concurrencyType) {
+    if (!_initialized) {
+      return 0;
+    }
+
     sanityCheckValidity();
     switch (concurrencyType) {
       case INTER_BROKER_REPLICA:
@@ -48,9 +55,13 @@ public class ExecutionConcurrencySummary {
   /**
    * Get the max broker execution concurrency of the cluster
    * @param concurrencyType the concurrency type of the max execution concurrency
-   * @return the max broker execution concurrency of the cluster
+   * @return the max broker execution concurrency of the cluster. If not initialized, return 0.
    */
   public synchronized int getMaxExecutionConcurrency(ConcurrencyType concurrencyType) {
+    if (!_initialized) {
+      return 0;
+    }
+
     sanityCheckValidity();
     switch (concurrencyType) {
       case INTER_BROKER_REPLICA:
@@ -67,9 +78,13 @@ public class ExecutionConcurrencySummary {
   /**
    * Get the avg broker execution concurrency of the cluster
    * @param concurrencyType the concurrency type of the avg execution concurrency
-   * @return the avg broker execution concurrency of the cluster
+   * @return the avg broker execution concurrency of the cluster. If not initialized, return 0.
    */
   public synchronized double getAvgExecutionConcurrency(ConcurrencyType concurrencyType) {
+    if (!_initialized) {
+      return 0;
+    }
+
     sanityCheckValidity();
     switch (concurrencyType) {
       case INTER_BROKER_REPLICA:

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionConcurrencySummaryTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionConcurrencySummaryTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.executor;
+
+import com.linkedin.kafka.cruisecontrol.executor.concurrency.ExecutionConcurrencySummary;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ExecutionConcurrencySummaryTest {
+  private final Map<Integer, Integer> _interBrokerConcurrencyMap = Map.of(0, 5, 1, 6, 2, 7);
+  private final Map<Integer, Integer> _intraBrokerConcurrencyMap = Map.of(0, 10, 1, 11, 2, 12);
+  private final Map<Integer, Integer> _leadershipBrokerConcurrencyMap = Map.of(0, 100, 1, 200, 2, 300);
+
+  @Test
+  public void testInterBrokerMinMaxAvgConcurrency() {
+    ExecutionConcurrencySummary summary = new ExecutionConcurrencySummary(
+        true, _interBrokerConcurrencyMap, _intraBrokerConcurrencyMap, _leadershipBrokerConcurrencyMap);
+
+    assertEquals(summary.getMaxExecutionConcurrency(ConcurrencyType.INTER_BROKER_REPLICA), 7);
+    assertEquals(summary.getMinExecutionConcurrency(ConcurrencyType.INTER_BROKER_REPLICA), 5);
+    assertEquals(summary.getAvgExecutionConcurrency(ConcurrencyType.INTER_BROKER_REPLICA), 6, 0.01);
+  }
+
+  @Test
+  public void testIntraBrokerMinMaxAvgConcurrency() {
+    ExecutionConcurrencySummary summary = new ExecutionConcurrencySummary(
+        true, _interBrokerConcurrencyMap, _intraBrokerConcurrencyMap, _leadershipBrokerConcurrencyMap);
+
+    assertEquals(summary.getMaxExecutionConcurrency(ConcurrencyType.INTRA_BROKER_REPLICA), 12);
+    assertEquals(summary.getMinExecutionConcurrency(ConcurrencyType.INTRA_BROKER_REPLICA), 10);
+    assertEquals(summary.getAvgExecutionConcurrency(ConcurrencyType.INTRA_BROKER_REPLICA), 11, 0.01);
+  }
+
+  @Test
+  public void testLeadershipMinMaxAvgConcurrency() {
+    ExecutionConcurrencySummary summary = new ExecutionConcurrencySummary(
+        true, _interBrokerConcurrencyMap, _intraBrokerConcurrencyMap, _leadershipBrokerConcurrencyMap);
+
+    assertEquals(summary.getMaxExecutionConcurrency(ConcurrencyType.LEADERSHIP), 300);
+    assertEquals(summary.getMinExecutionConcurrency(ConcurrencyType.LEADERSHIP), 100);
+    assertEquals(summary.getAvgExecutionConcurrency(ConcurrencyType.LEADERSHIP), 200, 0.01);
+  }
+
+  @Test
+  public void testInvalidConcurrencySummaryShouldReturnZeroForMinMaxAvg() {
+    ExecutionConcurrencySummary summary = new ExecutionConcurrencySummary(
+        false, _interBrokerConcurrencyMap, _intraBrokerConcurrencyMap, _leadershipBrokerConcurrencyMap);
+
+    assertEquals(summary.getMaxExecutionConcurrency(ConcurrencyType.INTER_BROKER_REPLICA), 0);
+    assertEquals(summary.getMinExecutionConcurrency(ConcurrencyType.INTER_BROKER_REPLICA), 0);
+    assertEquals(summary.getAvgExecutionConcurrency(ConcurrencyType.INTER_BROKER_REPLICA), 0, 0.01);
+    assertEquals(summary.getMaxExecutionConcurrency(ConcurrencyType.INTRA_BROKER_REPLICA), 0);
+    assertEquals(summary.getMinExecutionConcurrency(ConcurrencyType.INTRA_BROKER_REPLICA), 0);
+    assertEquals(summary.getAvgExecutionConcurrency(ConcurrencyType.INTRA_BROKER_REPLICA), 0, 0.01);
+    assertEquals(summary.getMaxExecutionConcurrency(ConcurrencyType.LEADERSHIP), 0);
+    assertEquals(summary.getMinExecutionConcurrency(ConcurrencyType.LEADERSHIP), 0);
+    assertEquals(summary.getAvgExecutionConcurrency(ConcurrencyType.LEADERSHIP), 0, 0.01);
+  }
+
+  @Test
+  public void testShouldThrowExceptionIfConcurrencyMapNotFullyPopulated() {
+    ExecutionConcurrencySummary summary = new ExecutionConcurrencySummary(
+        true, Collections.emptyMap(), _intraBrokerConcurrencyMap, _leadershipBrokerConcurrencyMap);
+    assertThrows(IllegalArgumentException.class, () -> summary.getMaxExecutionConcurrency(ConcurrencyType.INTER_BROKER_REPLICA));
+    assertThrows(IllegalArgumentException.class, () -> summary.getMinExecutionConcurrency(ConcurrencyType.INTER_BROKER_REPLICA));
+    assertThrows(IllegalArgumentException.class, () -> summary.getAvgExecutionConcurrency(ConcurrencyType.INTER_BROKER_REPLICA));
+    assertThrows(IllegalArgumentException.class, () -> summary.getMaxExecutionConcurrency(ConcurrencyType.INTRA_BROKER_REPLICA));
+    assertThrows(IllegalArgumentException.class, () -> summary.getMinExecutionConcurrency(ConcurrencyType.INTRA_BROKER_REPLICA));
+    assertThrows(IllegalArgumentException.class, () -> summary.getAvgExecutionConcurrency(ConcurrencyType.INTRA_BROKER_REPLICA));
+    assertThrows(IllegalArgumentException.class, () -> summary.getMaxExecutionConcurrency(ConcurrencyType.LEADERSHIP));
+    assertThrows(IllegalArgumentException.class, () -> summary.getMinExecutionConcurrency(ConcurrencyType.LEADERSHIP));
+    assertThrows(IllegalArgumentException.class, () -> summary.getAvgExecutionConcurrency(ConcurrencyType.LEADERSHIP));
+  }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -729,6 +729,8 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
 
     if (verifyProgress) {
       verifyOngoingPartitionReassignments(Collections.singleton(TP0));
+      assertTrue("Concurrency adjuster is not started during execution", executor.isConcurrencyAdjusterStarted());
+      assertTrue("Concurrency manager is not initialized during execution", executor.isConcurrencyManagerInitialized());
     }
 
     waitUntilTrue(() -> (!executor.hasOngoingExecution() && executor.state().state() == ExecutorState.State.NO_TASK_IN_PROGRESS),
@@ -767,6 +769,8 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
     assertNotNull(metricRegistry.meter("Executor.partition-data-movement-rate-MB"));
     assertNotNull(metricRegistry.gauge("Executor.partition-movement-count-per-second"));
     assertNotNull(metricRegistry.gauge("Executor.partition-movement-MB-per-second"));
+    assertFalse("Concurrency adjuster is not shutdown after execution", executor.isConcurrencyAdjusterStarted());
+    assertFalse("Concurrency manager is not reset after execution", executor.isConcurrencyManagerInitialized());
   }
 
   private Properties getExecutorProperties() {


### PR DESCRIPTION
This PR resolves #1982.

This PR includes:
1. Avoid returning null for max/min/avg concurrencies if no ongoing execution. It will simply returns 0.
2. Add running state for ConcurrencyAdjuster and ConcurrencyManager. Only set state to running during execution.
3. Reseting the concurrency adjuster, manager and all concurrency values after execution. 
4. Add unit tests for the above 3 changes.
