### PR TITLE
Remove initialized check when get concurrency summary

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/concurrency/ExecutionConcurrencyManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/concurrency/ExecutionConcurrencyManager.java
@@ -280,9 +280,6 @@ public class ExecutionConcurrencyManager {
    * @return the execution concurrency summary
    */
   public synchronized ExecutionConcurrencySummary getExecutionConcurrencySummary() {
-    if (!_initialized) {
-      throw new IllegalArgumentException("The execution manager has not been initialized.");
-    }
     return _executionConcurrencySummary;
   }
 


### PR DESCRIPTION
This is to avoid errors when execution not starts.
