### PR TITLE
bug fix on dot-handled topic names

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/holder/BrokerLoad.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/holder/BrokerLoad.java
@@ -70,14 +70,14 @@ public class BrokerLoad {
         break;
       case TOPIC:
         TopicMetric tm = (TopicMetric) ccm;
-        _dotHandledTopicMetrics.computeIfAbsent(tm.topic(), t -> new RawMetricsHolder())
+        _dotHandledTopicMetrics.computeIfAbsent(replaceDotsWithUnderscores(tm.topic()), t -> new RawMetricsHolder())
                                .recordCruiseControlMetric(ccm);
         break;
       case PARTITION:
         PartitionMetric pm = (PartitionMetric) ccm;
-        _dotHandledPartitionMetrics.computeIfAbsent(new TopicPartition(pm.topic(), pm.partition()), tp -> new RawMetricsHolder())
+        _dotHandledPartitionMetrics.computeIfAbsent(new TopicPartition(replaceDotsWithUnderscores(pm.topic()), pm.partition()), tp -> new RawMetricsHolder())
                                    .recordCruiseControlMetric(ccm);
-        _dotHandledTopicsWithPartitionSizeReported.add(pm.topic());
+        _dotHandledTopicsWithPartitionSizeReported.add(replaceDotsWithUnderscores(pm.topic()));
         break;
       default:
         throw new IllegalStateException(String.format("Should never be here. Unrecognized metric scope %s",


### PR DESCRIPTION
We have seen TopicMetrics ccm returned from `PrometheusMetricSampler` are not `dot-handled`, which causes "missing topic metrics" on topics with dots in their names, in turn, that blocks CC from generating rebalancing proposals.

This PR is going to fix the above problem related to `PrometheusMetricSampler`. The change should have not effect on already dot-handled topics.

Thank you

Xinyu Liu