### PR TITLE
Add option to add preamble text to all slack notifications

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SlackSelfHealingNotifier.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/notifier/SlackSelfHealingNotifier.java
@@ -21,14 +21,17 @@ public class SlackSelfHealingNotifier extends SelfHealingNotifier {
     public static final String SLACK_SELF_HEALING_NOTIFIER_ICON = "slack.self.healing.notifier.icon";
     public static final String SLACK_SELF_HEALING_NOTIFIER_USER = "slack.self.healing.notifier.user";
     public static final String SLACK_SELF_HEALING_NOTIFIER_CHANNEL = "slack.self.healing.notifier.channel";
+    public static final String SLACK_SELF_HEALING_NOTIFIER_PREAMBLE = "slack.self.healing.notifier.preamble";
 
     public static final String DEFAULT_SLACK_SELF_HEALING_NOTIFIER_ICON = ":information_source:";
     public static final String DEFAULT_SLACK_SELF_HEALING_NOTIFIER_USER = "Cruise Control";
+    public static final String DEFAULT_SLACK_SELF_HEALING_NOTIFIER_PREAMBLE = "";
 
     protected String _slackWebhook;
     protected String _slackIcon;
     protected String _slackChannel;
     protected String _slackUser;
+    protected String _slackPreamble;
 
     public SlackSelfHealingNotifier() {
     }
@@ -44,8 +47,10 @@ public class SlackSelfHealingNotifier extends SelfHealingNotifier {
         _slackIcon = (String) config.get(SLACK_SELF_HEALING_NOTIFIER_ICON);
         _slackChannel = (String) config.get(SLACK_SELF_HEALING_NOTIFIER_CHANNEL);
         _slackUser = (String) config.get(SLACK_SELF_HEALING_NOTIFIER_USER);
+        _slackPreamble = (String) config.get(SLACK_SELF_HEALING_NOTIFIER_PREAMBLE);
         _slackIcon = _slackIcon == null ? DEFAULT_SLACK_SELF_HEALING_NOTIFIER_ICON : _slackIcon;
         _slackUser = _slackUser == null ? DEFAULT_SLACK_SELF_HEALING_NOTIFIER_USER : _slackUser;
+        _slackPreamble = _slackPreamble == null ? DEFAULT_SLACK_SELF_HEALING_NOTIFIER_PREAMBLE : _slackPreamble;
     }
 
     @Override
@@ -62,7 +67,7 @@ public class SlackSelfHealingNotifier extends SelfHealingNotifier {
             return;
         }
 
-        String text = String.format("%s detected %s. Self healing %s.%s", anomalyType, anomaly,
+        String text = String.format("%s%s detected %s. Self healing %s.%s", _slackPreamble, anomalyType, anomaly,
                 _selfHealingEnabled.get(anomalyType) ? String.format("start time %s", utcDateFor(selfHealingStartTime))
                         : "is disabled",
                 autoFixTriggered ? "%nSelf-healing has been triggered." : "");

--- a/docs/wiki/User Guide/Configure-notifications.md
+++ b/docs/wiki/User Guide/Configure-notifications.md
@@ -18,6 +18,8 @@
 User name to display in the slack notification message. (default: Cruise Control)
 `slack.self.healing.notifier.icon` (Optional)
 Icon to display in the slack notification message. (default: `information_source` )
+`slack.self.healing.notifier.preamble` (Optional)
+Preamble string that will be added (verbatim) to the front of **all** slack notification messages. (default: empty string)
 To enable Slack notification, set `anomaly.notifier.class=com.linkedin.kafka.cruisecontrol.detector.notifier.SlackSelfHealingNotifier`
 
 ## MS Teams


### PR DESCRIPTION
We use a single slack channel to receive notifications from multiple Cruise Control instances. The current slack notifier does not provided any uniquely identifiable information in its text so it is not possible to know from what instance a particular alert came from.

The notifier does let you customise the username and icon, which could allow us distinguish the alerts. However, as per that Slack webhook [docs](https://api.slack.com/messaging/webhooks#advanced_message_formatting):

> You cannot override the default channel (chosen by the user who installed your app), username, or icon when you're using Incoming Webhooks to post messages. Instead, these values will always inherit from the associated Slack app configuration.

This PR provides a simple solution by allowing a preamble string to added to every slack alert. This is set per instance and so users can easily provide unique identifiers.
 