### PR TITLE
Generate Multi-Release fat JAR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -351,6 +351,9 @@ project(':cruise-control') {
     archiveBaseName = project.name + '-all'
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
+    manifest {
+      attributes("Multi-Release": true)
+    }
     with jar
   }
 


### PR DESCRIPTION
This PR resolves #1996.

Tested on Java 11. The only difference in generated JAR file is single MANIFEST.MF entry. With this change warning from linked issue disappears.