### PR TITLE
[Refactor] Consolidate default Goal#name implementation

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -134,8 +134,14 @@ public abstract class AbstractGoal implements Goal {
     }
   }
 
+  /**
+   * A default implementation
+   * @return Dynamically obtained simple name of the class.  Works even with sub-classing
+   */
   @Override
-  public abstract String name();
+  public String name() {
+    return this.getClass().getSimpleName();
+  }
 
   @Override
   public void finish() {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/BrokerSetAwareGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/BrokerSetAwareGoal.java
@@ -100,11 +100,6 @@ public class BrokerSetAwareGoal extends AbstractGoal {
   }
 
   @Override
-  public String name() {
-    return BrokerSetAwareGoal.class.getSimpleName();
-  }
-
-  @Override
   public boolean isHardGoal() {
     return true;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CapacityGoal.java
@@ -112,9 +112,6 @@ public abstract class CapacityGoal extends AbstractGoal {
     return new ModelCompletenessRequirements(MIN_NUM_VALID_WINDOWS_FOR_SELF_HEALING, _minMonitoredPartitionPercentage, true);
   }
 
-  @Override
-  public abstract String name();
-
   /**
    * This is a hard goal; hence, the proposals are not limited to broken broker replicas in case of self-healing.
    * Check if requirements of this goal are not violated if this action is applied to the given cluster state,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CpuCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CpuCapacityGoal.java
@@ -30,8 +30,4 @@ public class CpuCapacityGoal extends CapacityGoal {
     return Resource.CPU;
   }
 
-  @Override
-  public String name() {
-    return CpuCapacityGoal.class.getSimpleName();
-  }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CpuUsageDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/CpuUsageDistributionGoal.java
@@ -30,8 +30,4 @@ public class CpuUsageDistributionGoal extends ResourceDistributionGoal {
     return Resource.CPU;
   }
 
-  @Override
-  public String name() {
-    return CpuUsageDistributionGoal.class.getSimpleName();
-  }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/DiskCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/DiskCapacityGoal.java
@@ -42,8 +42,4 @@ public class DiskCapacityGoal extends CapacityGoal {
     return action.balancingAction() == ActionType.LEADERSHIP_MOVEMENT ? ACCEPT : super.actionAcceptance(action, clusterModel);
   }
 
-  @Override
-  public String name() {
-    return DiskCapacityGoal.class.getSimpleName();
-  }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/DiskUsageDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/DiskUsageDistributionGoal.java
@@ -45,11 +45,6 @@ public class DiskUsageDistributionGoal extends ResourceDistributionGoal {
   }
 
   @Override
-  public String name() {
-    return DiskUsageDistributionGoal.class.getSimpleName();
-  }
-
-  @Override
   public ModelCompletenessRequirements clusterModelCompletenessRequirements() {
     return new ModelCompletenessRequirements(MIN_NUM_VALID_WINDOWS_FOR_SELF_HEALING, _minMonitoredPartitionPercentage, true);
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskCapacityGoal.java
@@ -237,11 +237,6 @@ public class IntraBrokerDiskCapacityGoal extends AbstractGoal {
     return new ModelCompletenessRequirements(MIN_NUM_VALID_WINDOWS, _minMonitoredPartitionPercentage, true);
   }
 
-  @Override
-  public String name() {
-    return this.getClass().getSimpleName();
-  }
-
   /**
    * Check whether the combined replica utilization is above the given disk capacity limits.
    *

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskUsageDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/IntraBrokerDiskUsageDistributionGoal.java
@@ -506,9 +506,4 @@ public class IntraBrokerDiskUsageDistributionGoal extends AbstractGoal {
   public ModelCompletenessRequirements clusterModelCompletenessRequirements() {
     return new ModelCompletenessRequirements(_numWindows, _minMonitoredPartitionPercentage, false);
   }
-
-  @Override
-  public String name() {
-    return this.getClass().getSimpleName();
-  }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderBytesInDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderBytesInDistributionGoal.java
@@ -140,11 +140,6 @@ public class LeaderBytesInDistributionGoal extends AbstractGoal {
   }
 
   @Override
-  public String name() {
-    return LeaderBytesInDistributionGoal.class.getSimpleName();
-  }
-
-  @Override
   public boolean isHardGoal() {
     return false;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderReplicaDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LeaderReplicaDistributionGoal.java
@@ -125,11 +125,6 @@ public class LeaderReplicaDistributionGoal extends ReplicaDistributionAbstractGo
     return new LeaderReplicaDistributionGoalStatsComparator();
   }
 
-  @Override
-  public String name() {
-    return LeaderReplicaDistributionGoal.class.getSimpleName();
-  }
-
   /**
    * Rebalance the given broker without violating the constraints of the current goal and optimized goals.
    *

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/MinTopicLeadersPerBrokerGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/MinTopicLeadersPerBrokerGoal.java
@@ -80,11 +80,6 @@ public class MinTopicLeadersPerBrokerGoal extends AbstractGoal {
   }
 
   @Override
-  public String name() {
-    return MinTopicLeadersPerBrokerGoal.class.getSimpleName();
-  }
-
-  @Override
   public boolean isHardGoal() {
     return true;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/NetworkInboundCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/NetworkInboundCapacityGoal.java
@@ -41,9 +41,4 @@ public class NetworkInboundCapacityGoal extends CapacityGoal {
     // Leadership movement won't cause inbound network utilization change.
     return action.balancingAction() == ActionType.LEADERSHIP_MOVEMENT ? ACCEPT : super.actionAcceptance(action, clusterModel);
   }
-
-  @Override
-  public String name() {
-    return NetworkInboundCapacityGoal.class.getSimpleName();
-  }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/NetworkInboundUsageDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/NetworkInboundUsageDistributionGoal.java
@@ -42,9 +42,4 @@ public class NetworkInboundUsageDistributionGoal extends ResourceDistributionGoa
     return action.balancingAction() == ActionType.LEADERSHIP_MOVEMENT ? ACCEPT : super.actionAcceptance(action, clusterModel);
   }
 
-  @Override
-  public String name() {
-    return NetworkInboundUsageDistributionGoal.class.getSimpleName();
-  }
-
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/NetworkOutboundCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/NetworkOutboundCapacityGoal.java
@@ -30,8 +30,4 @@ public class NetworkOutboundCapacityGoal extends CapacityGoal {
     return Resource.NW_OUT;
   }
 
-  @Override
-  public String name() {
-    return NetworkOutboundCapacityGoal.class.getSimpleName();
-  }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/NetworkOutboundUsageDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/NetworkOutboundUsageDistributionGoal.java
@@ -30,8 +30,4 @@ public class NetworkOutboundUsageDistributionGoal extends ResourceDistributionGo
     return Resource.NW_OUT;
   }
 
-  @Override
-  public String name() {
-    return NetworkOutboundUsageDistributionGoal.class.getSimpleName();
-  }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/PotentialNwOutGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/PotentialNwOutGoal.java
@@ -141,11 +141,6 @@ public class PotentialNwOutGoal extends AbstractGoal {
   }
 
   @Override
-  public String name() {
-    return PotentialNwOutGoal.class.getSimpleName();
-  }
-
-  @Override
   public boolean isHardGoal() {
     return false;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareDistributionGoal.java
@@ -118,11 +118,6 @@ public class RackAwareDistributionGoal extends AbstractRackAwareGoal {
     return numPartitionReplicasByRackId;
   }
 
-  @Override
-  public String name() {
-    return RackAwareDistributionGoal.class.getSimpleName();
-  }
-
   /**
    * Check whether the given broker is excluded for replica moves.
    * Such a broker cannot receive replicas, but can give them away.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/RackAwareGoal.java
@@ -60,11 +60,6 @@ public class RackAwareGoal extends AbstractRackAwareGoal {
                            .anyMatch(mappedRackIdOf(destinationBroker)::equals);
   }
 
-  @Override
-  public String name() {
-    return RackAwareGoal.class.getSimpleName();
-  }
-
   /**
    * This is a hard goal; hence, the proposals are not limited to dead broker replicas in case of self-healing.
    * Sanity Check: There exists sufficient number of racks for achieving rack-awareness.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaCapacityGoal.java
@@ -92,11 +92,6 @@ public class ReplicaCapacityGoal extends AbstractGoal {
   }
 
   @Override
-  public String name() {
-    return ReplicaCapacityGoal.class.getSimpleName();
-  }
-
-  @Override
   public boolean isHardGoal() {
     return true;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ReplicaDistributionGoal.java
@@ -142,11 +142,6 @@ public class ReplicaDistributionGoal extends ReplicaDistributionAbstractGoal {
     return new ReplicaDistributionGoalStatsComparator();
   }
 
-  @Override
-  public String name() {
-    return ReplicaDistributionGoal.class.getSimpleName();
-  }
-
   /**
    * Initiates replica distribution goal.
    *

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ResourceDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/ResourceDistributionGoal.java
@@ -168,9 +168,6 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
   }
 
   @Override
-  public abstract String name();
-
-  @Override
   public boolean isHardGoal() {
     return false;
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicReplicaDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicReplicaDistributionGoal.java
@@ -235,11 +235,6 @@ public class TopicReplicaDistributionGoal extends AbstractGoal {
   }
 
   @Override
-  public String name() {
-    return TopicReplicaDistributionGoal.class.getSimpleName();
-  }
-
-  @Override
   public boolean isHardGoal() {
     return false;
   }


### PR DESCRIPTION
Moved all implementations that are equivalent to `XXX.class.getSimpleName()` into `AbstractGoal#name()` with a dynamic `this.getClass().getSimpleName()`. This should avoid confusion for sub-classing.
