### PR TITLE
Set offline partitions as true if leader is null

### DIFF
--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionStateTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/response/ClusterPartitionStateTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.response;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ClusterPartitionStateTest {
+  private static final String TOPIC = "sample-topic";
+  private static final int PARTITION = 0;
+  private static final boolean VERBOSE = true;
+  private static final Pattern TOPIC_PATTERN = null;
+  private static final Map<String, Properties> ALL_TOPIC_CONFIGS = new HashMap<>();
+  private static final Properties CLUSTER_CONFIGS = new Properties();
+  private static final Node[] OFFLINE_REPLICAS = { };
+
+  @Test
+  public void testPopulateKafkaPartitionStateWithNoOfflinePartitions() {
+    Node leader = new Node(0, "localhost", 9092);
+    Node[] replicas = new Node[] { leader, new Node(1, "localhost", 9092)};
+    Node[] inSyncReplicas = { replicas[0], replicas[1] };
+
+    PartitionInfo partitionInfo = new PartitionInfo(TOPIC, PARTITION, leader, replicas, inSyncReplicas, OFFLINE_REPLICAS);
+
+    Cluster kafkaCluster = new Cluster(
+      "clusterId", Arrays.asList(replicas), Arrays.asList(partitionInfo), Collections.emptySet(), Collections.emptySet()
+      );
+
+    ClusterPartitionState clusterPartitionState = new ClusterPartitionState(VERBOSE, TOPIC_PATTERN, kafkaCluster, ALL_TOPIC_CONFIGS, CLUSTER_CONFIGS);
+
+    assertTrue(clusterPartitionState._offlinePartitions.isEmpty());
+  }
+
+  @Test
+  public void testPopulateKafkaPartitionStateWithOfflinePartitions() {
+    Node leader = null;
+    Node[] replicas = { };
+    Node[] inSyncReplicas = { };
+
+    PartitionInfo partitionInfo = new PartitionInfo(TOPIC, PARTITION, leader, replicas, inSyncReplicas, OFFLINE_REPLICAS);
+
+    Cluster kafkaCluster = new Cluster(
+      "clusterId", Arrays.asList(replicas), Arrays.asList(partitionInfo), Collections.emptySet(), Collections.emptySet()
+      );
+
+    Comparator<PartitionInfo> comparator = Comparator.comparing(PartitionInfo::topic).thenComparingInt(PartitionInfo::partition);
+    Set<PartitionInfo> offlinePartitions = new TreeSet<>(comparator);
+    offlinePartitions.add(partitionInfo);
+
+    ClusterPartitionState clusterPartitionState = new ClusterPartitionState(VERBOSE, TOPIC_PATTERN, kafkaCluster, ALL_TOPIC_CONFIGS, CLUSTER_CONFIGS);
+    assertEquals(offlinePartitions, clusterPartitionState._offlinePartitions);
+  }
+}


### PR DESCRIPTION
**🌊 This PR resolves https://github.com/linkedin/cruise-control/issues/1828.** 

## What does this PR accomplish?
Currently, cruise-control detects offline partitions if the number of in-sync replicas is zero, and only performs this check if the partition is under-replicated. This definition of offline partitions is not comprehensive nor completely correct.

This PR corrects the detection of offline partitions by using the **status of a partition's leader** to determine whether a partition is offline. It also cleans up the conditional logic that determines whether a partition's status is checked to begin with.

<img width="536" alt="Screenshot 2023-04-18 at 12 07 55 PM" src="https://user-images.githubusercontent.com/41079854/232837507-d40bb184-9e51-46ca-a620-aedfa00336ba.png">

## How was it tested?
1. Removed brokers in a test cluster to create offline partitions. Confirmed that offline partitions are listed on the cruise-control UI (screenshot above). Confirmed that values close to my change (eg. URPs, offline replicas) do not seem affected. 

Checked http://localhost:9090/kafkacruisecontrol/kafka_cluster_state endpoint to confirm values matched UI:
<img width="1189" alt="Screenshot 2023-04-18 at 3 13 20 PM" src="https://user-images.githubusercontent.com/41079854/232881449-089c3d58-edef-47b7-81ba-52dae3c1456f.png">

2. Added a test for updated functionality
3. Deployed to Shopify's production environment