### PR TITLE
Change default doLog to false to avoid verbose logs during init CC config.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/AbstractGoal.java
@@ -67,7 +67,7 @@ public abstract class AbstractGoal implements Goal {
 
   @Override
   public void configure(Map<String, ?> configs) {
-    KafkaCruiseControlConfig parsedConfig = new KafkaCruiseControlConfig(configs, false);
+    KafkaCruiseControlConfig parsedConfig = new KafkaCruiseControlConfig(configs);
     _balancingConstraint = new BalancingConstraint(parsedConfig);
     _numWindows = parsedConfig.getInt(MonitorConfig.NUM_PARTITION_METRICS_WINDOWS_CONFIG);
     _minMonitoredPartitionPercentage = parsedConfig.getDouble(MonitorConfig.MIN_VALID_PARTITION_RATIO_CONFIG);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoal.java
@@ -93,7 +93,7 @@ public class KafkaAssignerDiskUsageDistributionGoal implements Goal {
 
   @Override
   public void configure(Map<String, ?> configs) {
-    KafkaCruiseControlConfig parsedConfig = new KafkaCruiseControlConfig(configs, false);
+    KafkaCruiseControlConfig parsedConfig = new KafkaCruiseControlConfig(configs);
     _balancingConstraint = new BalancingConstraint(parsedConfig);
     _minMonitoredPartitionPercentage = parsedConfig.getDouble(MonitorConfig.MIN_VALID_PARTITION_RATIO_CONFIG);
     _rackIdMapper = GoalUtils.getRackAwareGoalRackIdMapper(configs);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -44,7 +44,7 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
   }
 
   public KafkaCruiseControlConfig(Map<?, ?> originals) {
-    this(originals, true);
+    this(originals, false);
   }
 
   public KafkaCruiseControlConfig(Map<?, ?> originals, boolean doLog) {
@@ -250,7 +250,7 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
    */
   void sanityCheckConcurrency() {
     int maxClusterMovementConcurrency = getInt(ExecutorConfig.MAX_NUM_CLUSTER_MOVEMENTS_CONFIG);
-    
+
     int maxPartitionMovementsInCluster = getInt(ExecutorConfig.MAX_NUM_CLUSTER_PARTITION_MOVEMENTS_CONFIG);
     if (maxPartitionMovementsInCluster > maxClusterMovementConcurrency) {
       throw new ConfigException(String.format("Maximum Inter-broker partition movement [%d] cannot be greater than the "

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaTopicConfigProvider.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaTopicConfigProvider.java
@@ -109,7 +109,7 @@ public class KafkaTopicConfigProvider extends JsonFileTopicConfigProvider {
   public void configure(Map<String, ?> configs) {
     _connectString = (String) configs.get(ExecutorConfig.ZOOKEEPER_CONNECT_CONFIG);
     _zkSecurityEnabled = (Boolean) configs.get(ExecutorConfig.ZOOKEEPER_SECURITY_ENABLED_CONFIG);
-    _zkClientConfig = ZKConfigUtils.zkClientConfigFromKafkaConfig(new KafkaCruiseControlConfig(configs));
+    _zkClientConfig = ZKConfigUtils.zkClientConfigFromKafkaConfig(new KafkaCruiseControlConfig(configs, true));
     _clusterConfigs = loadClusterConfigs(configs);
   }
 


### PR DESCRIPTION
This PR resolves #2004 .

KafkaCruiseControlConfig is initialized with doLogs set to true by default, which could generate lots of verbose logs. Recently we have seen another one of those incidents that someone init the KafkaCruiseControlConfig class without setting doLog to false. Since it is not the first time, and we don't see much values from the verbose config value logs, we updated the default doLog to false in this PR.
