### PR TITLE
Future-proof against Kafka 3.5 breaking changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -278,6 +278,8 @@ project(':cruise-control') {
     implementation "io.netty:netty-transport-native-epoll:${nettyVersion}"
     api "org.apache.kafka:kafka_$scalaBinaryVersion:$kafkaVersion"
     api "org.apache.kafka:kafka-clients:$kafkaVersion"
+    // Add following dependency when upgrading to Kafka 3.5
+    //api "org.apache.kafka:kafka-storage:$kafkaVersion"
     implementation "org.scala-lang:scala-library:$scalaVersion"
     implementation 'org.apache.commons:commons-math3:3.6.1'
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import kafka.log.LogConfig;
 import kafka.server.KafkaConfig;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
@@ -284,9 +283,9 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
     NewTopic newTopic = new NewTopic(cruiseControlMetricsTopic, cruiseControlMetricsTopicNumPartition, cruiseControlMetricsTopicReplicaFactor);
 
     Map<String, String> config = new HashMap<>();
-    config.put(LogConfig.RetentionMsProp(),
+    config.put(TopicConfig.RETENTION_MS_CONFIG,
                Long.toString(reporterConfig.getLong(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_RETENTION_MS_CONFIG)));
-    config.put(LogConfig.CleanupPolicyProp(), CRUISE_CONTROL_METRICS_TOPIC_CLEAN_UP_POLICY);
+    config.put(TopicConfig.CLEANUP_POLICY_CONFIG, CRUISE_CONTROL_METRICS_TOPIC_CLEAN_UP_POLICY);
     if (cruiseControlMetricsTopicMinInsyncReplicas > 0) {
       // If the user has set the minISR for the metrics topic we need to check that the replication factor is set to a level that allows the
       // minISR to be met.
@@ -358,8 +357,8 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
       Config topicConfig = describeConfigsResult.values().get(topicResource).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
       Set<AlterConfigOp> alterConfigOps = new HashSet<>();
       Map<String, String> configsToSet = new HashMap<>();
-      configsToSet.put(LogConfig.RetentionMsProp(), _metricsTopic.configs().get(LogConfig.RetentionMsProp()));
-      configsToSet.put(LogConfig.CleanupPolicyProp(), _metricsTopic.configs().get(LogConfig.CleanupPolicyProp()));
+      configsToSet.put(TopicConfig.RETENTION_MS_CONFIG, _metricsTopic.configs().get(TopicConfig.RETENTION_MS_CONFIG));
+      configsToSet.put(TopicConfig.CLEANUP_POLICY_CONFIG, _metricsTopic.configs().get(TopicConfig.CLEANUP_POLICY_CONFIG));
       maybeUpdateConfig(alterConfigOps, configsToSet, topicConfig);
       if (!alterConfigOps.isEmpty()) {
         AlterConfigsResult alterConfigsResult = _adminClient.incrementalAlterConfigs(Collections.singletonMap(topicResource, alterConfigOps));

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -43,6 +43,7 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.ReassignmentInProgressException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.message.MetadataResponseData;
@@ -80,8 +81,6 @@ import scala.Option;
 
 import static com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig.RECONNECT_BACKOFF_MS_CONFIG;
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.SKIP_HARD_GOAL_CHECK_PARAM;
-import static kafka.log.LogConfig.CleanupPolicyProp;
-import static kafka.log.LogConfig.RetentionMsProp;
 
 
 /**
@@ -243,8 +242,8 @@ public final class KafkaCruiseControlUtils {
 
     NewTopic newTopic = new NewTopic(topic, partitionCount, replicationFactor);
     Map<String, String> config = new HashMap<>();
-    config.put(RetentionMsProp(), Long.toString(retentionMs));
-    config.put(CleanupPolicyProp(), DEFAULT_CLEANUP_POLICY);
+    config.put(TopicConfig.RETENTION_MS_CONFIG, Long.toString(retentionMs));
+    config.put(TopicConfig.CLEANUP_POLICY_CONFIG, DEFAULT_CLEANUP_POLICY);
     newTopic.configs(config);
 
     return newTopic;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
@@ -424,40 +424,36 @@ class ReplicationThrottleHelper {
       // First we try to get the LogConfig class for Kafka 3.5+
       logConfigClass = Class.forName(LOG_CONFIG_IN_KAFKA_3_5_AND_LATER);
       LOG.info("Found class {} for Kafka 3.5 and newer.", LOG_CONFIG_IN_KAFKA_3_5_AND_LATER);
+      try {
+        Field field = logConfigClass.getDeclaredField(config.toString());
+        return field.get(null).toString();
+      } catch (NoSuchFieldException | IllegalAccessException e) {
+        LOG.info("Field {} not found. We are probably on Kafka 3.4 or older.", config);
+      }
     } catch (ClassNotFoundException e) {
       LOG.info("Class {} not found. We are probably on Kafka 3.4 or older.", LOG_CONFIG_IN_KAFKA_3_5_AND_LATER);
+    }
 
-      // We did not find the LogConfig class from Kafka 3.5+.
-      // So we are probably on older Kafka version => we will try the older class for Kafka 3.4-.
+    // We did not find the LogConfig class or field from Kafka 3.5+.
+    // So we are probably on older Kafka version => we will try the older class for Kafka 3.4-.
+    try {
+      logConfigClass = Class.forName(LOG_CONFIG_IN_KAFKA_3_4_AND_EARLIER);
+      LOG.info("Found class {} for Kafka 3.4 and earlier.", LOG_CONFIG_IN_KAFKA_3_4_AND_EARLIER);
       try {
-        logConfigClass = Class.forName(LOG_CONFIG_IN_KAFKA_3_4_AND_EARLIER);
-        LOG.info("Found class {} for Kafka 3.4 and earlier.", LOG_CONFIG_IN_KAFKA_3_4_AND_EARLIER);
-      } catch (ClassNotFoundException ee) {
-          // No class was found for any Kafka version => we should fail
-          throw new RuntimeException("Failed to find LogConfig class", ee);
+        String nameOfMethod = "";
+        if (config == LogConfig.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG) {
+          nameOfMethod = "LeaderReplicationThrottledReplicasProp";
+        } else if (config == LogConfig.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG) {
+          nameOfMethod = "FollowerReplicationThrottledReplicasProp";
         }
-    }
-
-    try {
-      Field field = logConfigClass.getDeclaredField(config.toString());
-      return field.get(null).toString();
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      LOG.info("Field {} not found. We are probably on Kafka 3.4 or older.", config);
-
-      // We did not find the LogConfig class field from Kafka 3.5+ LogConfig class.
-      // So we are probably on older Kafka version => we will try the older class for Kafka 3.4-.
-    }
-    try {
-      String nameOfMethod = "";
-      if (config == LogConfig.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG) {
-        nameOfMethod = "LeaderReplicationThrottledReplicasProp";
-      } else if (config == LogConfig.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG) {
-        nameOfMethod = "FollowerReplicationThrottledReplicasProp";
+        Method method = logConfigClass.getMethod(nameOfMethod);
+        return method.invoke(null).toString();
+      } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+        throw new RuntimeException("Failed to get configuration", e);
       }
-      Method method = logConfigClass.getMethod(nameOfMethod);
-      return method.invoke(null).toString();
-    } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
-      throw new RuntimeException("Failed to get configuration", e);
+    } catch (ClassNotFoundException e) {
+      // No class was found for any Kafka version => we should fail
+      throw new RuntimeException("Failed to find LogConfig class", e);
     }
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
@@ -6,7 +6,6 @@ package com.linkedin.kafka.cruisecontrol.executor;
 
 import com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsUtils;
 import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
-import kafka.log.LogConfig;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.Config;
@@ -39,8 +38,10 @@ class ReplicationThrottleHelper {
   static final String WILDCARD_ASTERISK = "*";
   static final String LEADER_THROTTLED_RATE = "leader.replication.throttled.rate";
   static final String FOLLOWER_THROTTLED_RATE = "follower.replication.throttled.rate";
-  static final String LEADER_THROTTLED_REPLICAS = LogConfig.LeaderReplicationThrottledReplicasProp();
-  static final String FOLLOWER_THROTTLED_REPLICAS = LogConfig.FollowerReplicationThrottledReplicasProp();
+  // TODO: Update to LogConfig.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG for upgrade to Kafka 3.5
+  static final String LEADER_THROTTLED_REPLICAS = "leader.replication.throttled.replicas";
+  // TODO: Update to LogConfig.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG for upgrade to Kafka 3.5
+  static final String FOLLOWER_THROTTLED_REPLICAS = "follower.replication.throttled.replicas";
   public static final long CLIENT_REQUEST_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
   static final int RETRIES = 30;
 


### PR DESCRIPTION
This PR resolves #2018.

This PR future proofs Cruise Control against breaking changes coming with Kafka 3.5. Tested against a Kafka 3.5 cluster and a Kafka 3.4 cluster 

Let me know if it is preferable to submit this against a new  `migrate_to_kafka_3_5` branch. 

Let me know what you think!
