### PR TITLE
Add basic auth for Prometheus adapter

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusMetricSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusMetricSampler.java
@@ -111,9 +111,6 @@ public class PrometheusMetricSampler extends AbstractMetricSampler {
 
         try {
             HttpHost host = HttpHost.create(endpoint);
-            if (host.getPort() < 0) {
-                throw new IllegalArgumentException();
-            }
             _httpClient = HttpClients.createDefault();
             _prometheusAdapter = new PrometheusAdapter(_httpClient, host, basicAuth, _samplingIntervalMs);
         } catch (IllegalArgumentException ex) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusMetricSamplerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusMetricSamplerTest.java
@@ -80,22 +80,6 @@ public class PrometheusMetricSamplerTest {
         _prometheusQueryMap = prometheusQuerySupplier.get();
     }
 
-    @Test(expected = ConfigException.class)
-    public void testConfigureWithPrometheusEndpointNoPortFails() throws Exception {
-        Map<String, Object> config = new HashMap<>();
-        config.put(PROMETHEUS_SERVER_ENDPOINT_CONFIG, "http://kafka-cluster-1.org");
-        addCapacityConfig(config);
-        _prometheusMetricSampler.configure(config);
-    }
-
-    @Test(expected = ConfigException.class)
-    public void testConfigureWithPrometheusEndpointNegativePortFails() throws Exception {
-        Map<String, Object> config = new HashMap<>();
-        config.put(PROMETHEUS_SERVER_ENDPOINT_CONFIG, "http://kafka-cluster-1.org:-20");
-        addCapacityConfig(config);
-        _prometheusMetricSampler.configure(config);
-    }
-
     @Test
     public void testConfigureWithPrometheusEndpointNoSchemaDoesNotFail() throws Exception {
         Map<String, Object> config = new HashMap<>();


### PR DESCRIPTION
This PR resolves https://github.com/linkedin/cruise-control/issues/2037.

This PR adds the ability to handle basic auth to the Prometheus adapter.

To use it, set the `prometheus.server.endpoint.auth.basic` configuration value in `cruisecontrol.properties` to your `user:password` (similar to how the `-u` flag of `curl` expects it). It is probably a good idea to inject the environment variable into the config instead of directly setting like detailed in https://github.com/linkedin/cruise-control/issues/1197.

This PR also removes the check for negative ports in `PrometheusMetricSampler.java`. If you're routing requests to your Prometheus instance based on incoming host, you're not always able to specify the port.