### PR TITLE
Use ExecutorService.execute where return value is unnecessary to make uncaught exception handler works fixes #2052

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -222,7 +222,7 @@ public class KafkaCruiseControl {
     LOG.info("Starting Kafka Cruise Control...");
     _loadMonitor.startUp();
     _anomalyDetectorManager.startDetection();
-    _goalOptimizerExecutor.submit(_goalOptimizer);
+    _goalOptimizerExecutor.execute(_goalOptimizer);
     LOG.info("Kafka Cruise Control started.");
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
@@ -328,7 +328,7 @@ public class GoalOptimizer implements Runnable {
             } else if (!_hasOngoingExplicitPrecomputation) {
               // Submit background computation if there is no ongoing explicit precomputation and wait for the cache update.
               _hasOngoingExplicitPrecomputation = true;
-              _proposalPrecomputingExecutor.submit(() -> computeCachedProposal(allowCapacityEstimation));
+              _proposalPrecomputingExecutor.execute(() -> computeCachedProposal(allowCapacityEstimation));
             }
             operationProgress.refer(_proposalPrecomputingProgress);
             _cacheLock.wait();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorManager.java
@@ -239,9 +239,9 @@ public class AnomalyDetectorManager {
     scheduleDetectorAtFixedRate(DISK_FAILURE, _diskFailureDetector);
     scheduleDetectorAtFixedRate(BROKER_FAILURE, _brokerFailureDetector);
     LOG.debug("Starting {} detector.", MAINTENANCE_EVENT);
-    _detectorScheduler.submit(_maintenanceEventDetector);
+    _detectorScheduler.execute(_maintenanceEventDetector);
     LOG.debug("Starting anomaly handler.");
-    _detectorScheduler.submit(new AnomalyHandlerTask());
+    _detectorScheduler.execute(new AnomalyHandlerTask());
   }
 
   /**
@@ -551,10 +551,10 @@ public class AnomalyDetectorManager {
               }
               LOG.info("{} the anomaly {}.", fixStarted ? "Fixing" : "Cannot fix", _anomalyInProgress);
               String optimizationResult = fixStarted ? _anomalyInProgress.optimizationResult(false) : null;
-              _anomalyLoggerExecutor.submit(() -> logSelfHealingOperation(anomalyId, null, optimizationResult));
+              _anomalyLoggerExecutor.execute(() -> logSelfHealingOperation(anomalyId, null, optimizationResult));
             }
           } catch (OptimizationFailureException ofe) {
-            _anomalyLoggerExecutor.submit(() -> logSelfHealingOperation(anomalyId, ofe, null));
+            _anomalyLoggerExecutor.execute(() -> logSelfHealingOperation(anomalyId, ofe, null));
             skipReportingIfNotUpdated = anomalyType == KafkaAnomalyType.BROKER_FAILURE;
             throw ofe;
           } finally {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ZKBrokerFailureDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ZKBrokerFailureDetector.java
@@ -110,7 +110,7 @@ public class ZKBrokerFailureDetector extends AbstractBrokerFailureDetector {
       // Ensure that broker failures are not reported if there are no updates in already known failed brokers.
       // Anomaly Detector guarantees that a broker failure detection will not be lost. Skipping reporting if not updated
       // ensures that the broker failure detector will not report superfluous broker failures due to flaky zNode.
-      _detectionExecutor.submit(() -> detectBrokerFailures(true));
+      _detectionExecutor.execute(() -> detectBrokerFailures(true));
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -955,7 +955,7 @@ public class Executor {
     } else {
       _numExecutionStartedInNonKafkaAssignerMode.incrementAndGet();
     }
-    _proposalExecutor.submit(
+    _proposalExecutor.execute(
         new ProposalExecutionRunnable(loadMonitor, demotedBrokers, removedBrokers, replicationThrottle, isTriggeredByUserRequest));
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
@@ -212,7 +212,7 @@ public class KafkaSampleStore extends AbstractKafkaSampleStore {
       prepareConsumers();
 
       for (Consumer<byte[], byte[]> consumer : _consumers) {
-        _metricProcessorExecutor.submit(
+        _metricProcessorExecutor.execute(
             new MetricLoader(consumer, sampleLoader, numLoadedSamples, numPartitionMetricSamples, numBrokerMetricSamples,
                              totalSamples));
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/task/LoadMonitorTaskRunner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/task/LoadMonitorTaskRunner.java
@@ -137,7 +137,7 @@ public class LoadMonitorTaskRunner {
   public void bootstrap(long startMs, long endMs, boolean clearMetrics) {
 
     if (_state.compareAndSet(RUNNING, BOOTSTRAPPING)) {
-      _samplingScheduler.submit(new BootstrapTask(startMs, endMs, clearMetrics, _metadataClient,
+      _samplingScheduler.execute(new BootstrapTask(startMs, endMs, clearMetrics, _metadataClient,
           _partitionMetricSampleAggregator,
                                                   this, _metricFetcherManager, _sampleStore, _configuredNumWindows,
                                                   _configuredWindowMs, _samplingIntervalMs, _time));
@@ -156,7 +156,7 @@ public class LoadMonitorTaskRunner {
   public void bootstrap(long startMs, boolean clearMetrics) {
 
     if (_state.compareAndSet(RUNNING, BOOTSTRAPPING)) {
-      _samplingScheduler.submit(new BootstrapTask(startMs, clearMetrics, _metadataClient,
+      _samplingScheduler.execute(new BootstrapTask(startMs, clearMetrics, _metadataClient,
           _partitionMetricSampleAggregator,
                                                   this, _metricFetcherManager, _sampleStore, _configuredNumWindows,
                                                   _configuredWindowMs, _samplingIntervalMs, _time));
@@ -173,7 +173,7 @@ public class LoadMonitorTaskRunner {
    */
   public void bootstrap(boolean clearMetrics) {
     if (_state.compareAndSet(RUNNING, BOOTSTRAPPING)) {
-      _samplingScheduler.submit(new BootstrapTask(clearMetrics, _metadataClient, _partitionMetricSampleAggregator,
+      _samplingScheduler.execute(new BootstrapTask(clearMetrics, _metadataClient, _partitionMetricSampleAggregator,
                                                   this, _metricFetcherManager, _sampleStore, _configuredNumWindows,
                                                   _configuredWindowMs, _samplingIntervalMs, _time));
     } else {
@@ -193,7 +193,7 @@ public class LoadMonitorTaskRunner {
    */
   private void loadSamples() {
     if (_state.compareAndSet(RUNNING, LOADING)) {
-      _samplingScheduler.submit(new SampleLoadingTask(_sampleStore,
+      _samplingScheduler.execute(new SampleLoadingTask(_sampleStore,
                                                       _partitionMetricSampleAggregator,
                                                       _brokerMetricSampleAggregator,
                                                       this));
@@ -214,7 +214,7 @@ public class LoadMonitorTaskRunner {
    */
   public void train(long startMs, long endMs) {
     if (_state.compareAndSet(RUNNING, TRAINING)) {
-      _samplingScheduler.submit(new TrainingTask(_time, this, _metricFetcherManager, _sampleStore,
+      _samplingScheduler.execute(new TrainingTask(_time, this, _metricFetcherManager, _sampleStore,
                                                  _configuredWindowMs, _samplingIntervalMs, startMs, endMs));
     } else {
       throw new IllegalStateException("Cannot start model training because the load monitor is in "

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
@@ -344,14 +344,14 @@ public class UserTaskManager implements Closeable {
         _uuidToCompletedUserTaskInfoMap.get(entry.getValue().endPoint().endpointType())
                                        .put(entry.getKey(), entry.getValue().setState(TaskState.COMPLETED_WITH_ERROR));
         iter.remove();
-        _userTaskLoggerExecutor.submit(() -> entry.getValue().logOperation());
+        _userTaskLoggerExecutor.execute(() -> entry.getValue().logOperation());
       } else if (entry.getValue().isUserTaskDone()) {
         LOG.info("UserTask {} is completed and removed from active tasks list", entry.getKey());
         _successfulRequestExecutionTimer.get(entry.getValue().endPoint()).update(entry.getValue().executionTimeNs(), TimeUnit.NANOSECONDS);
         _uuidToCompletedUserTaskInfoMap.get(entry.getValue().endPoint().endpointType())
                                        .put(entry.getKey(), entry.getValue().setState(TaskState.COMPLETED));
         iter.remove();
-        _userTaskLoggerExecutor.submit(() -> entry.getValue().logOperation());
+        _userTaskLoggerExecutor.execute(() -> entry.getValue().logOperation());
       }
     }
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/AddBrokerRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/AddBrokerRequest.java
@@ -24,7 +24,7 @@ public class AddBrokerRequest extends AbstractAsyncRequest {
   protected OperationFuture handle(String uuid) {
     OperationFuture future = new OperationFuture("Add brokers");
     pending(future.operationProgress());
-    _asyncKafkaCruiseControl.sessionExecutor().submit(new AddBrokersRunnable(_asyncKafkaCruiseControl, future, _parameters, uuid));
+    _asyncKafkaCruiseControl.sessionExecutor().execute(new AddBrokersRunnable(_asyncKafkaCruiseControl, future, _parameters, uuid));
     return future;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/ClusterLoadRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/ClusterLoadRequest.java
@@ -24,7 +24,7 @@ public class ClusterLoadRequest extends AbstractAsyncRequest {
   protected OperationFuture handle(String uuid) {
     OperationFuture future = new OperationFuture("Get broker stats");
     pending(future.operationProgress());
-    _asyncKafkaCruiseControl.sessionExecutor().submit(new LoadRunnable(_asyncKafkaCruiseControl, future, _parameters));
+    _asyncKafkaCruiseControl.sessionExecutor().execute(new LoadRunnable(_asyncKafkaCruiseControl, future, _parameters));
     return future;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/CruiseControlStateRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/CruiseControlStateRequest.java
@@ -24,7 +24,7 @@ public class CruiseControlStateRequest extends AbstractAsyncRequest {
   protected OperationFuture handle(String uuid) {
     OperationFuture future = new OperationFuture("Get state");
     pending(future.operationProgress());
-    _asyncKafkaCruiseControl.sessionExecutor().submit(new GetStateRunnable(_asyncKafkaCruiseControl, future, _parameters));
+    _asyncKafkaCruiseControl.sessionExecutor().execute(new GetStateRunnable(_asyncKafkaCruiseControl, future, _parameters));
     return future;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/DemoteRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/DemoteRequest.java
@@ -24,7 +24,7 @@ public class DemoteRequest extends AbstractAsyncRequest {
   protected OperationFuture handle(String uuid) {
     OperationFuture future = new OperationFuture("Demote");
     pending(future.operationProgress());
-    _asyncKafkaCruiseControl.sessionExecutor().submit(new DemoteBrokerRunnable(_asyncKafkaCruiseControl, future, uuid, _parameters));
+    _asyncKafkaCruiseControl.sessionExecutor().execute(new DemoteBrokerRunnable(_asyncKafkaCruiseControl, future, uuid, _parameters));
     return future;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/FixOfflineReplicasRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/FixOfflineReplicasRequest.java
@@ -24,7 +24,7 @@ public class FixOfflineReplicasRequest extends AbstractAsyncRequest {
   protected OperationFuture handle(String uuid) {
     OperationFuture future = new OperationFuture("Fix offline replicas");
     pending(future.operationProgress());
-    _asyncKafkaCruiseControl.sessionExecutor().submit(new FixOfflineReplicasRunnable(_asyncKafkaCruiseControl, future, _parameters, uuid));
+    _asyncKafkaCruiseControl.sessionExecutor().execute(new FixOfflineReplicasRunnable(_asyncKafkaCruiseControl, future, _parameters, uuid));
     return future;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/PartitionLoadRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/PartitionLoadRequest.java
@@ -24,7 +24,7 @@ public class PartitionLoadRequest extends AbstractAsyncRequest {
   protected OperationFuture handle(String uuid) {
     OperationFuture future = new OperationFuture(String.format("Get partition load from %d to %d", _parameters.startMs(), _parameters.endMs()));
     pending(future.operationProgress());
-    _asyncKafkaCruiseControl.sessionExecutor().submit(new PartitionLoadRunnable(_asyncKafkaCruiseControl, future, _parameters));
+    _asyncKafkaCruiseControl.sessionExecutor().execute(new PartitionLoadRunnable(_asyncKafkaCruiseControl, future, _parameters));
     return future;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/ProposalsRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/ProposalsRequest.java
@@ -24,7 +24,7 @@ public class ProposalsRequest extends AbstractAsyncRequest {
   protected OperationFuture handle(String uuid) {
     OperationFuture future = new OperationFuture("Get customized proposals");
     pending(future.operationProgress());
-    _asyncKafkaCruiseControl.sessionExecutor().submit(new ProposalsRunnable(_asyncKafkaCruiseControl, future, _parameters));
+    _asyncKafkaCruiseControl.sessionExecutor().execute(new ProposalsRunnable(_asyncKafkaCruiseControl, future, _parameters));
     return future;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/RebalanceRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/RebalanceRequest.java
@@ -29,7 +29,7 @@ public class RebalanceRequest extends AbstractAsyncRequest {
     OperationFuture future = new OperationFuture("Rebalance");
     pending(future.operationProgress());
     _runnable = new RebalanceRunnable(_asyncKafkaCruiseControl, future, _parameters, uuid);
-    _asyncKafkaCruiseControl.sessionExecutor().submit(_runnable);
+    _asyncKafkaCruiseControl.sessionExecutor().execute(_runnable);
     return future;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/RemoveBrokerRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/RemoveBrokerRequest.java
@@ -24,7 +24,7 @@ public class RemoveBrokerRequest extends AbstractAsyncRequest {
   protected OperationFuture handle(String uuid) {
     OperationFuture future = new OperationFuture("Remove brokers");
     pending(future.operationProgress());
-    _asyncKafkaCruiseControl.sessionExecutor().submit(new RemoveBrokersRunnable(_asyncKafkaCruiseControl, future, _parameters, uuid));
+    _asyncKafkaCruiseControl.sessionExecutor().execute(new RemoveBrokersRunnable(_asyncKafkaCruiseControl, future, _parameters, uuid));
     return future;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/TopicConfigurationRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/TopicConfigurationRequest.java
@@ -24,7 +24,7 @@ public class TopicConfigurationRequest extends AbstractAsyncRequest {
   protected OperationFuture handle(String uuid) {
     OperationFuture future = new OperationFuture("Update Topic Configuration");
     pending(future.operationProgress());
-    _asyncKafkaCruiseControl.sessionExecutor().submit(new UpdateTopicConfigurationRunnable(_asyncKafkaCruiseControl, future, uuid, _parameters));
+    _asyncKafkaCruiseControl.sessionExecutor().execute(new UpdateTopicConfigurationRunnable(_asyncKafkaCruiseControl, future, uuid, _parameters));
     return future;
   }
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorManagerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorManagerTest.java
@@ -106,12 +106,12 @@ public class AnomalyDetectorManagerTest {
     scheduleDetectorAtFixedRate(mockDetectorScheduler, mockTopicAnomalyDetector);
 
     // Starting maintenance event detector.
-    EasyMock.expect(mockDetectorScheduler.submit(mockMaintenanceEventDetector))
-            .andDelegateTo(executorService);
+    mockDetectorScheduler.execute(mockMaintenanceEventDetector);
+    EasyMock.expectLastCall().andDelegateTo(executorService);
 
     // Starting anomaly handler
-    EasyMock.expect(mockDetectorScheduler.submit(EasyMock.isA(AnomalyDetectorManager.AnomalyHandlerTask.class)))
-            .andDelegateTo(executorService);
+    mockDetectorScheduler.execute(EasyMock.isA(AnomalyDetectorManager.AnomalyHandlerTask.class));
+    EasyMock.expectLastCall().andDelegateTo(executorService);
   }
 
   private static void shutdownDetector(ScheduledExecutorService mockDetectorScheduler,


### PR DESCRIPTION
This PR resolves #2052 

- We should use `ExecutorService#execute` to make uncaught exception handler works
  * In most places, we don't need return value of `submit`
