### PR TITLE
Enable info level log after each goal optimization

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/GoalOptimizer.java
@@ -481,13 +481,19 @@ public class GoalOptimizer implements Runnable {
         violatedGoalNamesAfterOptimization.add(goal.name());
       }
 
-      LOG.debug("[{}/{}] Generated {} proposals for {}{}.", optimizedGoals.size(), _goalsByPriority.size(), hasDiff ? "some" : "no",
-                isSelfHealing ? "self-healing " : "", goal.name());
       step.done();
       if (LOG.isDebugEnabled()) {
         LOG.debug("Broker level stats after optimization: {}", clusterModel.brokerStats(null));
       }
       provisionResponse.aggregate(goal.provisionResponse());
+      LOG.info("[{}/{}] Generated {} proposals for {}{}. Provision status: {}; aggregated provision status: {}",
+               optimizedGoals.size(),
+               _goalsByPriority.size(),
+               hasDiff ? "some" : "no",
+               isSelfHealing ? "self-healing " : "",
+               goal.name(),
+               goal.provisionResponse().status(),
+               provisionResponse.status());
     }
 
     setHasUnfixableProposalOptimization(false, goalsByPriority);


### PR DESCRIPTION
This PR is to enable info level log after each goal optimization.

Previously the log is a debug level log. Since we believe this log expose critical information of Cruise Control at runtime, we enabled the log in this PR. In addition, we add provision status to the log to show what of the provision status of each goal.