### PR TITLE
Fix endpoint metrics involving task execution

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -1295,6 +1295,7 @@ public class Executor {
     private long _lastSlowTaskReportingTimeMs;
     private static final boolean FORCE_PAUSE_SAMPLING = true;
     private final Timer _executionTimerInvolveBrokerRemovalOrDemotion;
+    private final UserTaskManager.UserTaskInfo _userTaskInfo;
 
     ProposalExecutionRunnable(LoadMonitor loadMonitor,
                               Collection<Integer> demotedBrokers,
@@ -1342,14 +1343,28 @@ public class Executor {
       } else {
         _executionTimerInvolveBrokerRemovalOrDemotion = null;
       }
+
+      // If the task is triggered from a user request, mark the task to be in-execution state in user task manager and
+      // retrieve the associated user task information.
+      if (_isTriggeredByUserRequest) {
+        // For userTaskInfo that involves proposal execution, we would like its successfulRequestExecutionTimer be updated
+        // after the proposal execution being completed and be updated in markTaskExecutionFinished instead of in
+        // checkActiveUserTasks. checkActiveUserTasks would update the timer if _userTaskInfo.isUserTaskDone() is true.
+        // _userTaskInfo.isUserTaskDone() is associated whether the OptimizationResult is computed, and is not associated
+        // whether the proposal execution is completed or not. Thus, call markTaskExecutionBegan in the constructor to
+        // remove _userTaskInfo from _uuidToActiveUserTaskInfoMap before _userTaskInfo.isUserTaskDone() being true.
+        _userTaskInfo = _userTaskManager.markTaskExecutionBegan(_uuid);
+      } else {
+        _userTaskInfo = null;
+      }
     }
 
     public void run() {
       LOG.info("Starting executing balancing proposals.");
       final long start = System.currentTimeMillis();
       try {
-        UserTaskManager.UserTaskInfo userTaskInfo = initExecution();
-        execute(userTaskInfo);
+        initExecution();
+        execute(_userTaskInfo);
       } catch (Exception e) {
         LOG.error("ProposalExecutionRunnable got exception during run", e);
       } finally {
@@ -1362,19 +1377,11 @@ public class Executor {
       LOG.info("Execution finished.");
     }
 
-    private UserTaskManager.UserTaskInfo initExecution() {
-      UserTaskManager.UserTaskInfo userTaskInfo = null;
-      // If the task is triggered from a user request, mark the task to be in-execution state in user task manager and
-      // retrieve the associated user task information.
-      if (_isTriggeredByUserRequest) {
-        userTaskInfo = _userTaskManager.markTaskExecutionBegan(_uuid);
-      }
+    private void initExecution() {
       String reason = _reasonSupplier.get();
       _executorState = ExecutorState.executionStarting(_uuid, reason, _recentlyDemotedBrokers, _recentlyRemovedBrokers, _isTriggeredByUserRequest);
       OPERATION_LOG.info("Task [{}] execution starts. The reason of execution is {}.", _uuid, reason);
       _ongoingExecutionIsBeingModified.set(false);
-
-      return userTaskInfo;
     }
 
     /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -1347,8 +1347,6 @@ public class Executor {
 
       // If the task is triggered from a user request, mark the task to be in-execution state in user task manager and
       // retrieve the associated user task information.
-      //If the task is triggered from a user request, mark the task to be in-execution state in user task manager and
-      //retrieve the associated user task information.
       if (_isTriggeredByUserRequest) {
         // For userTaskInfo that involves proposal execution, we would like its successfulRequestExecutionTimer be updated
         // after the proposal execution being completed and be updated in markTaskExecutionFinished instead of in
@@ -1382,7 +1380,7 @@ public class Executor {
 
     private void initExecution() {
       if (_isTriggeredByUserRequest) {
-        _userTaskManager.logInExecutionTask();
+        _userTaskManager.logInExecutionTaskOperation();
       }
       String reason = _reasonSupplier.get();
       _executorState = ExecutorState.executionStarting(_uuid, reason, _recentlyDemotedBrokers, _recentlyRemovedBrokers, _isTriggeredByUserRequest);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -1346,12 +1346,14 @@ public class Executor {
 
       // If the task is triggered from a user request, mark the task to be in-execution state in user task manager and
       // retrieve the associated user task information.
+      //If the task is triggered from a user request, mark the task to be in-execution state in user task manager and
+      //retrieve the associated user task information.
       if (_isTriggeredByUserRequest) {
         // For userTaskInfo that involves proposal execution, we would like its successfulRequestExecutionTimer be updated
         // after the proposal execution being completed and be updated in markTaskExecutionFinished instead of in
         // checkActiveUserTasks. checkActiveUserTasks would update the timer if _userTaskInfo.isUserTaskDone() is true.
-        // _userTaskInfo.isUserTaskDone() is associated whether the OptimizationResult is computed, and is not associated
-        // whether the proposal execution is completed or not. Thus, call markTaskExecutionBegan in the constructor to
+        // _userTaskInfo.isUserTaskDone() is associated with whether the OptimizationResult is computed, and is not associated
+        // with whether the proposal execution is completed or not. Thus, call markTaskExecutionBegan in the constructor to
         // remove _userTaskInfo from _uuidToActiveUserTaskInfoMap before _userTaskInfo.isUserTaskDone() being true.
         _userTaskInfo = _userTaskManager.markTaskExecutionBegan(_uuid);
       } else {
@@ -1378,6 +1380,7 @@ public class Executor {
     }
 
     private void initExecution() {
+      _userTaskManager.logInExecutionTask();
       String reason = _reasonSupplier.get();
       _executorState = ExecutorState.executionStarting(_uuid, reason, _recentlyDemotedBrokers, _recentlyRemovedBrokers, _isTriggeredByUserRequest);
       OPERATION_LOG.info("Task [{}] execution starts. The reason of execution is {}.", _uuid, reason);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -1310,6 +1310,7 @@ public class Executor {
         _noOngoingExecutionSemaphore.release();
         _stopSignal.set(NO_STOP_EXECUTION);
         _executionStoppedByUser.set(false);
+        _userTaskInfo = null;
         LOG.error("Failed to initialize proposal execution.");
         throw new IllegalStateException("User task manager cannot be null.");
       }
@@ -1380,7 +1381,9 @@ public class Executor {
     }
 
     private void initExecution() {
-      _userTaskManager.logInExecutionTask();
+      if (_isTriggeredByUserRequest) {
+        _userTaskManager.logInExecutionTask();
+      }
       String reason = _reasonSupplier.get();
       _executorState = ExecutorState.executionStarting(_uuid, reason, _recentlyDemotedBrokers, _recentlyRemovedBrokers, _isTriggeredByUserRequest);
       OPERATION_LOG.info("Task [{}] execution starts. The reason of execution is {}.", _uuid, reason);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
@@ -405,12 +405,19 @@ public class UserTaskManager implements Closeable {
 
     if (_uuidToActiveUserTaskInfoMap.containsKey(userTaskId)) {
       _inExecutionUserTaskInfo = _uuidToActiveUserTaskInfoMap.remove(userTaskId).setState(TaskState.IN_EXECUTION);
-      // Normally a user task's operation result is logged when the task's state is transferred from ACTIVE to COMPLETED_WITH_ERROR.
-      // If the user task's state is transferred from ACTIVE directly to IN_EXECUTION, need to log the task's operation result here.
-      _inExecutionUserTaskInfo.logOperation();
     }
 
     return _inExecutionUserTaskInfo;
+  }
+
+  /** Normally a user task's operation result is logged when the task's state is transferred from ACTIVE to COMPLETED or
+   * COMPLETED_WITH_ERROR. If the user task's state is transferred from ACTIVE directly to IN_EXECUTION,
+   * need to log the task's operation result.
+   */
+  public synchronized void logInExecutionTask() {
+    if (_inExecutionUserTaskInfo != null) {
+      _inExecutionUserTaskInfo.logOperation();
+    }
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
@@ -410,11 +410,12 @@ public class UserTaskManager implements Closeable {
     return _inExecutionUserTaskInfo;
   }
 
-  /** Normally a user task's operation result is logged when the task's state is transferred from ACTIVE to COMPLETED or
+  /**
+   * Normally a user task's operation result is logged when the task's state is transferred from ACTIVE to COMPLETED or
    * COMPLETED_WITH_ERROR. If the user task's state is transferred from ACTIVE directly to IN_EXECUTION,
    * need to log the task's operation result.
    */
-  public synchronized void logInExecutionTask() {
+  public synchronized void logInExecutionTaskOperation() {
     if (_inExecutionUserTaskInfo != null) {
       _inExecutionUserTaskInfo.logOperation();
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
@@ -441,7 +441,6 @@ public class UserTaskManager implements Closeable {
     _uuidToCompletedUserTaskInfoMap.get(_inExecutionUserTaskInfo.endPoint().endpointType())
                                    .put(_inExecutionUserTaskInfo.userTaskId(), _inExecutionUserTaskInfo);
     _inExecutionUserTaskInfo = null;
-
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
@@ -420,7 +420,9 @@ public class UserTaskManager implements Closeable {
    * @param completeWithError Whether the task execution finished with error or not.
    */
   public synchronized void markTaskExecutionFinished(String uuid, boolean completeWithError) {
-    LOG.debug("Task execution with uuid {} completed{}.", uuid, completeWithError ? " with error" : "");
+    final long requestCompleteTime = _time.milliseconds() - _inExecutionUserTaskInfo._startMs;
+    _successfulRequestExecutionTimer.get(_inExecutionUserTaskInfo.endPoint()).update(requestCompleteTime, TimeUnit.MILLISECONDS);
+    LOG.info("Task execution with uuid {} completed{}. Total time: {} ms", uuid, completeWithError ? " with error" : "", requestCompleteTime);
     if (!_inExecutionUserTaskInfo.userTaskId().equals(UUID.fromString(uuid))) {
       throw new IllegalStateException(String.format("Task %s is not found in UserTaskManager.", uuid));
     }
@@ -432,6 +434,7 @@ public class UserTaskManager implements Closeable {
     _uuidToCompletedUserTaskInfoMap.get(_inExecutionUserTaskInfo.endPoint().endpointType())
                                    .put(_inExecutionUserTaskInfo.userTaskId(), _inExecutionUserTaskInfo);
     _inExecutionUserTaskInfo = null;
+
   }
 
   /**

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -699,6 +699,7 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
                                                         UserTaskManager.UserTaskInfo userTaskInfo,
                                                         List<Boolean> completeWithError) {
     UserTaskManager mockUserTaskManager = EasyMock.mock(UserTaskManager.class);
+    mockUserTaskManager.logInExecutionTask();
     // Handle the case that the execution started, but did not finish.
     if (completeWithError.isEmpty()) {
       EasyMock.expect(mockUserTaskManager.markTaskExecutionBegan(uuid)).andReturn(userTaskInfo).once();

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -485,7 +485,7 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
     UserTaskManager.UserTaskInfo mockUserTaskInfo = getMockUserTaskInfo();
     // This tests runs two consecutive executions. First one completes w/o error, but the second one with error.
     UserTaskManager mockUserTaskManager = getMockUserTaskManager(RANDOM_UUID, mockUserTaskInfo, Arrays.asList(false, true));
-    mockUserTaskManager.logInExecutionTask();
+    mockUserTaskManager.logInExecutionTaskOperation();
     EasyMock.replay(mockMetadataClient, mockLoadMonitor, mockAnomalyDetectorManager, mockUserTaskInfo, mockUserTaskManager);
 
     Collection<ExecutionProposal> proposalsToExecute = Collections.singletonList(proposal);
@@ -700,7 +700,7 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
                                                         UserTaskManager.UserTaskInfo userTaskInfo,
                                                         List<Boolean> completeWithError) {
     UserTaskManager mockUserTaskManager = EasyMock.mock(UserTaskManager.class);
-    mockUserTaskManager.logInExecutionTask();
+    mockUserTaskManager.logInExecutionTaskOperation();
     // Handle the case that the execution started, but did not finish.
     if (completeWithError.isEmpty()) {
       EasyMock.expect(mockUserTaskManager.markTaskExecutionBegan(uuid)).andReturn(userTaskInfo).once();

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -485,6 +485,7 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
     UserTaskManager.UserTaskInfo mockUserTaskInfo = getMockUserTaskInfo();
     // This tests runs two consecutive executions. First one completes w/o error, but the second one with error.
     UserTaskManager mockUserTaskManager = getMockUserTaskManager(RANDOM_UUID, mockUserTaskInfo, Arrays.asList(false, true));
+    mockUserTaskManager.logInExecutionTask();
     EasyMock.replay(mockMetadataClient, mockLoadMonitor, mockAnomalyDetectorManager, mockUserTaskInfo, mockUserTaskManager);
 
     Collection<ExecutionProposal> proposalsToExecute = Collections.singletonList(proposal);


### PR DESCRIPTION
This PR resolves #2068.
This fix has markTaskExecutionFinished to update the endpoint timer metrics when the execution is done and also eliminates the race condition between checkActiveUserTasks and startExecution on updating the metrics.