### PR TITLE
Fix deadlock between Executor and UserTaskManager

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
@@ -406,19 +406,11 @@ public class UserTaskManager implements Closeable {
     if (_uuidToActiveUserTaskInfoMap.containsKey(userTaskId)) {
       _inExecutionUserTaskInfo = _uuidToActiveUserTaskInfoMap.remove(userTaskId).setState(TaskState.IN_EXECUTION);
     }
+    // Normally a user task's operation result is logged when the task's state is transferred from ACTIVE to COMPLETED_WITH_ERROR.
+    // If the user task's state is transferred from ACTIVE directly to IN_EXECUTION, need to log the task's operation result here.
+    _inExecutionUserTaskInfo.logOperation();
 
     return _inExecutionUserTaskInfo;
-  }
-
-  /**
-   * Normally a user task's operation result is logged when the task's state is transferred from ACTIVE to COMPLETED or
-   * COMPLETED_WITH_ERROR. If the user task's state is transferred from ACTIVE directly to IN_EXECUTION,
-   * need to log the task's operation result.
-   */
-  public synchronized void logInExecutionTaskOperation() {
-    if (_inExecutionUserTaskInfo != null) {
-      _inExecutionUserTaskInfo.logOperation();
-    }
   }
 
   /**

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -485,7 +485,6 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
     UserTaskManager.UserTaskInfo mockUserTaskInfo = getMockUserTaskInfo();
     // This tests runs two consecutive executions. First one completes w/o error, but the second one with error.
     UserTaskManager mockUserTaskManager = getMockUserTaskManager(RANDOM_UUID, mockUserTaskInfo, Arrays.asList(false, true));
-    mockUserTaskManager.logInExecutionTaskOperation();
     EasyMock.replay(mockMetadataClient, mockLoadMonitor, mockAnomalyDetectorManager, mockUserTaskInfo, mockUserTaskManager);
 
     Collection<ExecutionProposal> proposalsToExecute = Collections.singletonList(proposal);
@@ -700,7 +699,6 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
                                                         UserTaskManager.UserTaskInfo userTaskInfo,
                                                         List<Boolean> completeWithError) {
     UserTaskManager mockUserTaskManager = EasyMock.mock(UserTaskManager.class);
-    mockUserTaskManager.logInExecutionTaskOperation();
     // Handle the case that the execution started, but did not finish.
     if (completeWithError.isEmpty()) {
       EasyMock.expect(mockUserTaskManager.markTaskExecutionBegan(uuid)).andReturn(userTaskInfo).once();


### PR DESCRIPTION
This PR fixes the deadlock introduced by PR #2069 by partially reverting changes in that PR by moving _userTaskManager.markTaskExecutionBegan(_uuid) from the constructor of ProposalExecutionRunnable back to its run() thread. This avoids the deadlock formed between Executor and UserTaskManager. The initialization of ProposalExecutionRunnable is under Executor's monitor lock and _userTaskManager.markTaskExecutionBegan aquires UserTaskManager's monitor lock. On the other hand, the process of StopProposalRequest enters UserTaskManager's monitor lock first, and then acquires Executor's monitor lock. 

With this change, we would have the issue back that [request]-successful-request-execution-timer may or may not record the proposal computing time for request that requires proposal execution depending on the race condition between the task is removed from _uuidToActiveUserTaskInfoMap and checkActiveUserTasks is called. This issue will be addressed in a separate PR. 