### PR TITLE
Log partition movements before throwing exception

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -47,6 +47,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterPartitionReassignmentsResult;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.admin.ElectLeadersResult;
+import org.apache.kafka.clients.admin.PartitionReassignment;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
@@ -1048,15 +1049,19 @@ public class Executor {
    */
   private void sanityCheckOngoingMovement() throws OngoingExecutionException {
     boolean hasOngoingPartitionReassignments;
+    Map<TopicPartition, PartitionReassignment> ongoingPartitionReassignments;
     try {
-      hasOngoingPartitionReassignments = hasOngoingPartitionReassignments();
+       ongoingPartitionReassignments = ExecutionUtils.ongoingPartitionReassignments(_adminClient);
+      // avoid calling hasOngoingPartitionReassignments() to save 1 request.
+      hasOngoingPartitionReassignments = !ongoingPartitionReassignments.keySet().isEmpty();
     } catch (TimeoutException | InterruptedException | ExecutionException e) {
       // This may indicate transient (e.g. network) issues.
       throw new IllegalStateException("Failed to retrieve if there are already ongoing partition reassignments.", e);
     }
     // Note that in case there is an ongoing partition reassignment, we do not unpause metric sampling.
     if (hasOngoingPartitionReassignments) {
-      throw new OngoingExecutionException("There are ongoing inter-broker partition movements.");
+      LOG.error("Ongoing inter-broker partition movements: {}", ongoingPartitionReassignments);
+      throw new OngoingExecutionException("There are ongoing inter-broker partition movements");
     } else {
       boolean hasOngoingIntraBrokerReplicaMovement;
       try {


### PR DESCRIPTION
## Details
`OngoingExecutionException` exception message could be more informative, but due to potentially having multiple partition movements at the same time logging partition movement details is a cleaner approach rather than adding the details into the exception message.

Having partition movement details is useful for troubleshooting in cases when partition movements are ongoing for a long time.