### PR TITLE
[ISSUE 2118] Duplicate logs observer in cruise control

### DIFF
--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -47,10 +47,6 @@ logger.cruisecontrol.name=com.linkedin.kafka.cruisecontrol
 logger.cruisecontrol.level=info
 logger.cruisecontrol.appenderRef.kafkaCruiseControlAppender.ref=kafkaCruiseControlFile
 
-logger.detector.name=com.linkedin.kafka.cruisecontrol.detector
-logger.detector.level=info
-logger.detector.appenderRef.kafkaCruiseControlAppender.ref=kafkaCruiseControlFile
-
 logger.operationLogger.name=operationLogger
 logger.operationLogger.level=info
 logger.operationLogger.appenderRef.operationAppender.ref=operationFile
@@ -59,6 +55,5 @@ logger.CruiseControlPublicAccessLogger.name=CruiseControlPublicAccessLogger
 logger.CruiseControlPublicAccessLogger.level=info
 logger.CruiseControlPublicAccessLogger.appenderRef.requestAppender.ref=requestFile
 
-rootLogger.appenderRefs=console, kafkaCruiseControlAppender
+rootLogger.appenderRefs=console
 rootLogger.appenderRef.console.ref=STDOUT
-rootLogger.appenderRef.kafkaCruiseControlAppender.ref=kafkaCruiseControlFile


### PR DESCRIPTION
- Removed kafkaCruiseControlFile appender from root and from com.linkedin.kafka.cruisecontrol.detector loggers to prevent duplicated log messages

This PR resolves #2118 
