### PR TITLE
update scala to support java 21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 org.gradle.parallel=false
 org.gradle.jvmargs=-Xms512m -Xmx512m
-scalaVersion=2.13.10
+scalaVersion=2.13.13
 kafkaVersion=3.5.1
 zookeeperVersion=3.8.3
 nettyVersion=4.1.100.Final


### PR DESCRIPTION
A number of java interop issues have been resolved in scala:

https://github.com/scala/scala/pulls?q=label%3A%22java+interop%22+is%3Aclosed

As it stands compiling using jdk 21 fails with:

```
116.0 > Task :cruise-control:compileScala
116.0 error:
116.0   bad constant pool index: 0 at pos: 48461
116.0      while compiling: <no file>
116.0         during phase: globalPhase=<no phase>, enteringPhase=<some phase>
116.0      library version: version 2.13.10
116.0     compiler version: version 2.13.10
```

Its not clear which of the versions between .10 and .13 resolves it but I think its safe to move to [.13](https://github.com/scala/scala/releases) which also happens to resolve the compile issue.

This PR resolves #2138.
