### PR TITLE
`main` branch migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Cruise Control for Apache Kafka
     * Adjust replication factor
 
 ### Environment Requirements ###
+* The `migrate_to_kafka_3_5` branch of Cruise Control is compatible with Apache Kafka `3.5` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `3.5.*`)
 * The `migrate_to_kafka_2_5` branch of Cruise Control is compatible with Apache Kafka `2.5` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.*`),
   `2.6` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.11+`), `2.7` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.36+`),
   `2.8` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.66+`), `3.0` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.85+`),

--- a/README.md
+++ b/README.md
@@ -47,15 +47,16 @@ Cruise Control for Apache Kafka
     * Adjust replication factor
 
 ### Environment Requirements ###
-* The `migrate_to_kafka_3_5` branch of Cruise Control is compatible with Apache Kafka `3.5` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `3.5.*`)
-* The `migrate_to_kafka_2_5` branch of Cruise Control is compatible with Apache Kafka `2.5` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.*`),
+* The `migrate_to_kafka_3_5` branch of Cruise Control is compatible with Apache Kafka `3.5+` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `3.5.*`)
+* The `migrate_to_kafka_2_5` branch of Cruise Control is compatible with Apache Kafka `2.5+` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.*`),
   `2.6` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.11+`), `2.7` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.36+`),
   `2.8` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.66+`), `3.0` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.85+`),
   and `3.1` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.85+`).
 * The `migrate_to_kafka_2_4` branch of Cruise Control is compatible with Apache Kafka `2.4` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.4.*`).
 * The `kafka_2_0_to_2_3` branch (deprecated) of Cruise Control is compatible with Apache Kafka `2.0`, `2.1`, `2.2`, and `2.3` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.0.*`).
 * The `kafka_0_11_and_1_0` branch (deprecated) of Cruise Control is compatible with Apache Kafka `0.11.0.0`, `1.0`, and `1.1` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `0.1.*`).
-* The current default branch of Cruise Control is `migrate_to_kafka_2_5`.
+
+* The current default branch of Cruise Control is `migrate_to_kafka_3_5`.
 * `message.format.version` `0.10.0` and above is needed.
 * The `kafka_2_0_to_2_3` and `kafka_0_11_and_1_0` branches compile with `Scala 2.11`.
 * The branch `migrate_to_kafka_2_4` compiles with `Scala 2.12`.

--- a/README.md
+++ b/README.md
@@ -47,16 +47,14 @@ Cruise Control for Apache Kafka
     * Adjust replication factor
 
 ### Environment Requirements ###
-* The `migrate_to_kafka_3_5` branch of Cruise Control is compatible with Apache Kafka `3.5+` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `3.5.*`)
-* The `migrate_to_kafka_2_5` branch of Cruise Control is compatible with Apache Kafka `2.5+` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.*`),
+* The `main` (previously `migrate_to_kafka_2_5`) branch of Cruise Control is compatible with Apache Kafka `2.5+` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.*`),
   `2.6` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.11+`), `2.7` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.36+`),
   `2.8` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.66+`), `3.0` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.85+`),
   and `3.1` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.85+`).
 * The `migrate_to_kafka_2_4` branch of Cruise Control is compatible with Apache Kafka `2.4` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.4.*`).
 * The `kafka_2_0_to_2_3` branch (deprecated) of Cruise Control is compatible with Apache Kafka `2.0`, `2.1`, `2.2`, and `2.3` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.0.*`).
 * The `kafka_0_11_and_1_0` branch (deprecated) of Cruise Control is compatible with Apache Kafka `0.11.0.0`, `1.0`, and `1.1` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `0.1.*`).
-
-* The current default branch of Cruise Control is `migrate_to_kafka_3_5`.
+* The current default branch of Cruise Control is `main`.
 * `message.format.version` `0.10.0` and above is needed.
 * The `kafka_2_0_to_2_3` and `kafka_0_11_and_1_0` branches compile with `Scala 2.11`.
 * The branch `migrate_to_kafka_2_4` compiles with `Scala 2.12`.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Cruise Control for Apache Kafka
 * The `migrate_to_kafka_2_4` branch of Cruise Control is compatible with Apache Kafka `2.4` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.4.*`).
 * The `kafka_2_0_to_2_3` branch (deprecated) of Cruise Control is compatible with Apache Kafka `2.0`, `2.1`, `2.2`, and `2.3` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.0.*`).
 * The `kafka_0_11_and_1_0` branch (deprecated) of Cruise Control is compatible with Apache Kafka `0.11.0.0`, `1.0`, and `1.1` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `0.1.*`).
-* The current default branch of Cruise Control is `main`.
 * `message.format.version` `0.10.0` and above is needed.
 * The `kafka_2_0_to_2_3` and `kafka_0_11_and_1_0` branches compile with `Scala 2.11`.
 * The branch `migrate_to_kafka_2_4` compiles with `Scala 2.12`.


### PR DESCRIPTION
- Kafka 3 is supported since #1788 making `migrate_to_kafka_2_5` default branch misleading
- logs `migrate_to_kafka_2_5` -> `main` branch migration
- update README

This PR resolves [We should update the README for kafka-version support · Issue #2134 · linkedin/cruise-control][1]

[1]:https://github.com/linkedin/cruise-control/issues/2134#event-12188013773

## Instructions
Steps to update your branch to get merged to `main`

```
  git branch -m migrate_to_kafka_2_5 main
  git fetch origin
  git branch -u origin/main main
  git remote set-head origin -a
```