### PR TITLE
Create dependency-submission.yml

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        # enable full git history for gradle
+        fetch-depth: 0
     - uses: actions/setup-java@v4
       with:
         distribution: temurin

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,23 @@
+name: CI build
+on:
+  push:
+  
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 11
+
+    - name: Setup Gradle to generate and submit dependency graphs
+      uses: gradle/actions/setup-gradle@v3
+      with:
+        dependency-graph: generate-and-submit
+    - name: Run the usual CI build (dependency-graph will be generated and submitted post-job)
+      run: ./gradlew build


### PR DESCRIPTION
Currently seeing a lot of dependency vulnerabilities being triggered by `cruise-control`, wondering if changes could be made to gradle to address these issues

I've made this PR (to enable dependabot) so that there can be some visibility into the dependencies that are currently being marked as vulnerable

Can share access to the dependency vulnerabilties in https://github.com/stephengroat/cruise-control/security/dependabot if anyone is interested

<img width="1245" alt="Screenshot 2024-04-11 at 08 58 48" src="https://github.com/linkedin/cruise-control/assets/1159138/ea17204d-ae90-4f50-898c-5fcbc68014a4">