### PR TITLE
Adjust log4j configuration to use `SizeBasedTriggeringPolicy` and include RollverStrategy

### DIFF
--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -2,11 +2,20 @@
 # Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
 #
 
+# ===============
+# Properties
+# ===============
+property.logDirectoryPath=${env:CRUISE_CONTROL_LOG_DIR_PATH:-.}/logs
+
+# ===============
+# General configs
+# ===============
 rootLogger.level=INFO
 appenders=console, kafkaCruiseControlAppender, operationAppender, requestAppender
 
-property.filename=./logs
-
+# ===============
+# Appender config
+# ===============
 appender.console.type=Console
 appender.console.name=STDOUT
 appender.console.layout.type=PatternLayout
@@ -14,35 +23,45 @@ appender.console.layout.pattern=[%d] %p %m (%c)%n
 
 appender.kafkaCruiseControlAppender.type=RollingFile
 appender.kafkaCruiseControlAppender.name=kafkaCruiseControlFile
-appender.kafkaCruiseControlAppender.fileName=${filename}/kafkacruisecontrol.log
-appender.kafkaCruiseControlAppender.filePattern=${filename}/kafkacruisecontrol.log.%d{yyyy-MM-dd-HH}
+appender.kafkaCruiseControlAppender.fileName=${logDirectoryPath}/kafkacruisecontrol.log
+appender.kafkaCruiseControlAppender.filePattern=${logDirectoryPath}/kafkacruisecontrol.log-%i.gz
 appender.kafkaCruiseControlAppender.layout.type=PatternLayout
 appender.kafkaCruiseControlAppender.layout.pattern=[%d] %p %m (%c)%n
 appender.kafkaCruiseControlAppender.policies.type=Policies
-appender.kafkaCruiseControlAppender.policies.time.type=TimeBasedTriggeringPolicy
-appender.kafkaCruiseControlAppender.policies.time.interval=1
+appender.kafkaCruiseControlAppender.policies.size.type=SizeBasedTriggeringPolicy
+appender.kafkaCruiseControlAppender.policies.size.size=${env:KAFKACRUISECONTROL_APPENDER_LOGFILE_ROTATION_FILESIZE:-10MB}
+appender.kafkaCruiseControlAppender.strategy.type=DefaultRolloverStrategy
+appender.kafkaCruiseControlAppender.strategy.max=5
 
 appender.operationAppender.type=RollingFile
 appender.operationAppender.name=operationFile
-appender.operationAppender.fileName=${filename}/kafkacruisecontrol-operation.log
-appender.operationAppender.filePattern=${filename}/kafkacruisecontrol-operation.log.%d{yyyy-MM-dd}
+appender.operationAppender.fileName=${logDirectoryPath}/kafkacruisecontrol-operation.log
+appender.operationAppender.filePattern=${logDirectoryPath}/kafkacruisecontrol-operation.log-%i.gz
 appender.operationAppender.layout.type=PatternLayout
 appender.operationAppender.layout.pattern=[%d] %p [%c] %m %n
 appender.operationAppender.policies.type=Policies
 appender.operationAppender.policies.time.type=TimeBasedTriggeringPolicy
 appender.operationAppender.policies.time.interval=1
+appender.operationAppender.policies.size.type=SizeBasedTriggeringPolicy
+appender.operationAppender.policies.size.size=${env:OPERATION_APPENDER_LOGFILE_ROTATION_FILESIZE:-10MB}
+appender.operationAppender.strategy.type=DefaultRolloverStrategy
+appender.operationAppender.strategy.max=5
 
 appender.requestAppender.type=RollingFile
 appender.requestAppender.name=requestFile
-appender.requestAppender.fileName=${filename}/kafkacruisecontrol-request.log
-appender.requestAppender.filePattern=${filename}/kafkacruisecontrol-request.log.%d{yyyy-MM-dd-HH}
+appender.requestAppender.fileName=${logDirectoryPath}/kafkacruisecontrol-request.log
+appender.requestAppender.filePattern=${logDirectoryPath}/kafkacruisecontrol-request.log-%i.gz
 appender.requestAppender.layout.type=PatternLayout
 appender.requestAppender.layout.pattern=[%d] %p %m (%c)%n
 appender.requestAppender.policies.type=Policies
-appender.requestAppender.policies.time.type=TimeBasedTriggeringPolicy
-appender.requestAppender.policies.time.interval=1
+appender.requestAppender.policies.size.type=SizeBasedTriggeringPolicy
+appender.requestAppender.policies.size.size=${env:REQUEST_APPENDER_LOGFILE_ROTATION_FILESIZE:-10MB}
+appender.requestAppender.strategy.type=DefaultRolloverStrategy
+appender.requestAppender.strategy.max=5
 
-# Loggers
+# ===============
+# Logger
+# ===============
 logger.cruisecontrol.name=com.linkedin.kafka.cruisecontrol
 logger.cruisecontrol.level=info
 logger.cruisecontrol.appenderRef.kafkaCruiseControlAppender.ref=kafkaCruiseControlFile
@@ -59,6 +78,9 @@ logger.CruiseControlPublicAccessLogger.name=CruiseControlPublicAccessLogger
 logger.CruiseControlPublicAccessLogger.level=info
 logger.CruiseControlPublicAccessLogger.appenderRef.requestAppender.ref=requestFile
 
+# ===============
+# Root logger
+# ===============
 rootLogger.appenderRefs=console, kafkaCruiseControlAppender
 rootLogger.appenderRef.console.ref=STDOUT
 rootLogger.appenderRef.kafkaCruiseControlAppender.ref=kafkaCruiseControlFile


### PR DESCRIPTION
This PR resolves #2163.

With the following settings `logs` directory content look is: 
<img width="732" alt="image" src="https://github.com/linkedin/cruise-control/assets/48213847/bb1cad32-75f9-4700-818d-a5dac3e729a1">

