### PR TITLE
bugfix: exclude transitive logback dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,6 +169,7 @@ project(':cruise-control-core') {
     configurations.all {
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       exclude group: 'log4j', module: 'log4j'
+      exclude group: 'ch.qos.logback'
     }
     implementation "org.slf4j:slf4j-api:1.7.36"
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.17.2"
@@ -267,6 +268,7 @@ project(':cruise-control') {
     configurations.all {
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       exclude group: 'log4j', module: 'log4j'
+      exclude group: 'ch.qos.logback'
     }
 
     api project(':cruise-control-metrics-reporter')
@@ -437,6 +439,7 @@ project(':cruise-control-metrics-reporter') {
     configurations.all {
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       exclude group: 'log4j', module: 'log4j'
+      exclude group: 'ch.qos.logback'
     }
 
     implementation "org.slf4j:slf4j-api:1.7.36"


### PR DESCRIPTION
Exclude logback from being depended on transitively (following established pattern for excluding log4j:log4j)

Why:
A logback slf4j binding is being pulled in via zookeeper causing issues at runtime because we have two slf4j bindings available. Slf4j chooses one implementation and it can pick logback, which is unexpected.

To reproduce on `main`:

```
gradle clean build -q -x test && ./kafka-cruise-control-start.sh config/cruisecontrol.properties 2>&1 | grep SLF4J
... gradle noises ...
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/robeyoun/development/upstream/cruise-control/cruise-control/build/dependant-libs/log4j-slf4j-impl-2.17.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/robeyoun/development/upstream/cruise-control/cruise-control/build/dependant-libs/logback-classic-1.2.10.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
```

This PR resolves #2174