### PR TITLE
Upgrade simplekdc to 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -315,7 +315,7 @@ project(':cruise-control') {
     testImplementation 'commons-io:commons-io:2.11.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13:tests'
     testImplementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
-    testImplementation 'org.apache.kerby:kerb-simplekdc:2.0.1'
+    testImplementation 'org.apache.kerby:kerb-simplekdc:2.1.0'
     testImplementation 'com.jayway.jsonpath:json-path:2.7.0'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.9'
     testImplementation 'org.powermock:powermock-api-easymock:2.0.9'


### PR DESCRIPTION
Upgrading simplekdc version to "2.1.0" which supports a change that can correctly use security classes based on what version of IBM Semeru JDK(if applicable) is being used.

There is no regression observed using Semeru, OpenJDK and Temurin JDKs.

This newer version(released on 14 August 2024) also caters vulnerability in deps mentioned  [here](https://github.com/linkedin/cruise-control/pull/2179#issuecomment-2297676772) as **org.jboss.xnio:xnio-api** is updated to [**3.8.16**](https://github.com/apache/directory-kerby/releases/tag/kerby-all-2.1.0#:~:text=Bump%20org.jboss.xnio%3Axnio%2Dapi%20from%203.8.15.Final%20to%203.8.16.Final).
cc @mhratson 

This PR resolves #2178
