### PR TITLE
Replace DescribeLogDirsResult.values method with descriptions method

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DiskFailureDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DiskFailureDetector.java
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.common.Node;
-import org.apache.kafka.common.protocol.Errors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,10 +88,10 @@ public class DiskFailureDetector extends AbstractAnomalyDetector implements Runn
       }
       Map<Integer, Map<String, Long>> failedDisksByBroker = new HashMap<>();
       Set<Integer> aliveBrokers = _kafkaCruiseControl.kafkaCluster().nodes().stream().mapToInt(Node::id).boxed().collect(Collectors.toSet());
-      _adminClient.describeLogDirs(aliveBrokers).values().forEach((broker, future) -> {
+      _adminClient.describeLogDirs(aliveBrokers).descriptions().forEach((broker, future) -> {
         try {
           future.get(_config.getLong(LOGDIR_RESPONSE_TIMEOUT_MS_CONFIG), TimeUnit.MILLISECONDS).forEach((logdir, info) -> {
-            if (info.error != Errors.NONE) {
+            if (info.error() != null) {
               failedDisksByBroker.putIfAbsent(broker, new HashMap<>());
               failedDisksByBroker.get(broker).put(logdir, _kafkaCruiseControl.timeMs());
             }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorAdminUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorAdminUtils.java
@@ -15,18 +15,18 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.LogDirDescription;
+import org.apache.kafka.clients.admin.ReplicaInfo;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartitionReplica;
 import org.apache.kafka.common.errors.KafkaStorageException;
 import org.apache.kafka.common.errors.LogDirNotFoundException;
 import org.apache.kafka.common.errors.ReplicaNotAvailableException;
-import org.apache.kafka.common.protocol.Errors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.linkedin.kafka.cruisecontrol.config.constants.ExecutorConfig.LOGDIR_RESPONSE_TIMEOUT_MS_CONFIG;
 import static org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult.ReplicaLogDirInfo;
-import static org.apache.kafka.common.requests.DescribeLogDirsResponse.LogDirInfo;
 
 public final class ExecutorAdminUtils {
   private static final Logger LOG = LoggerFactory.getLogger(ExecutorAdminUtils.class);
@@ -104,15 +104,16 @@ public final class ExecutorAdminUtils {
    * @param config The config object that holds all the Cruise Control related configs
    * @return {@code true} if there is ongoing intra-broker replica movement.
    */
-  static boolean hasOngoingIntraBrokerReplicaMovement(Collection<Integer> brokersToCheck, AdminClient adminClient,
+  static boolean hasOngoingIntraBrokerReplicaMovement(Collection<Integer> brokersToCheck,
+                                                      AdminClient adminClient,
                                                       KafkaCruiseControlConfig config)
       throws InterruptedException, ExecutionException, TimeoutException {
-    Map<Integer, KafkaFuture<Map<String, LogDirInfo>>> logDirsByBrokerId = adminClient.describeLogDirs(brokersToCheck).values();
-    for (Map.Entry<Integer, KafkaFuture<Map<String, LogDirInfo>>> entry : logDirsByBrokerId.entrySet()) {
-      Map<String, LogDirInfo> logInfos = entry.getValue().get(config.getLong(LOGDIR_RESPONSE_TIMEOUT_MS_CONFIG), TimeUnit.MILLISECONDS);
-      for (LogDirInfo info : logInfos.values()) {
-        if (info.error == Errors.NONE) {
-          if (info.replicaInfos.values().stream().anyMatch(i -> i.isFuture)) {
+    Map<Integer, KafkaFuture<Map<String, LogDirDescription>>> logDirsByBrokerId = adminClient.describeLogDirs(brokersToCheck).descriptions();
+    for (Map.Entry<Integer, KafkaFuture<Map<String, LogDirDescription>>> entry : logDirsByBrokerId.entrySet()) {
+      Map<String, LogDirDescription> logInfos = entry.getValue().get(config.getLong(LOGDIR_RESPONSE_TIMEOUT_MS_CONFIG), TimeUnit.MILLISECONDS);
+      for (LogDirDescription info : logInfos.values()) {
+        if (info.error() == null) {
+          if (info.replicaInfos().values().stream().anyMatch(ReplicaInfo::isFuture)) {
             return true;
           }
         }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
@@ -38,11 +38,11 @@ import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.admin.DescribeLogDirsResult;
+import org.apache.kafka.clients.admin.LogDirDescription;
+import org.apache.kafka.clients.admin.ReplicaInfo;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
-import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.requests.DescribeLogDirsResponse;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.config.TopicConfig;
@@ -533,8 +533,8 @@ public class LoadMonitorTest {
 
     // Create mock DescribeLogDirsResult
     DescribeLogDirsResult mockDescribeLogDirsResult = EasyMock.mock(DescribeLogDirsResult.class);
-    EasyMock.expect(mockDescribeLogDirsResult.values())
-            .andReturn(getDescribeLogDirsResultValues())
+    EasyMock.expect(mockDescribeLogDirsResult.descriptions())
+        .andReturn(getDescribeLogDirsResultDescriptions())
             .anyTimes();
     EasyMock.replay(mockDescribeLogDirsResult);
 
@@ -607,28 +607,26 @@ public class LoadMonitorTest {
     return Collections.singletonMap(CLUSTER_CONFIG, clusterConfigFuture);
   }
 
-  private Map<Integer, KafkaFuture<Map<String, DescribeLogDirsResponse.LogDirInfo>>> getDescribeLogDirsResultValues() {
+  private Map<Integer, KafkaFuture<Map<String, LogDirDescription>>> getDescribeLogDirsResultDescriptions() {
 
-    Map<Integer, KafkaFuture<Map<String, DescribeLogDirsResponse.LogDirInfo>>> futureByBroker = new HashMap<>();
-    Map<String, DescribeLogDirsResponse.LogDirInfo> logdirInfoBylogdir = new HashMap<>();
-    Map<TopicPartition, DescribeLogDirsResponse.ReplicaInfo> replicaInfoByPartition = new HashMap<>();
-    replicaInfoByPartition.put(T0P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-    replicaInfoByPartition.put(T0P1, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-    replicaInfoByPartition.put(T1P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-    replicaInfoByPartition.put(T1P1, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-    logdirInfoBylogdir.put("/tmp/kafka-logs", new DescribeLogDirsResponse.LogDirInfo(Errors.NONE, replicaInfoByPartition));
+    Map<Integer, KafkaFuture<Map<String, LogDirDescription>>> futureByBroker = new HashMap<>();
+    Map<String, LogDirDescription> logdirInfoBylogdir = new HashMap<>();
+    Map<TopicPartition, ReplicaInfo> replicaInfoByPartition = new HashMap<>();
+    replicaInfoByPartition.put(T0P0, new ReplicaInfo(0, 0, false));
+    replicaInfoByPartition.put(T0P1, new ReplicaInfo(0, 0, false));
+    replicaInfoByPartition.put(T1P0, new ReplicaInfo(0, 0, false));
+    replicaInfoByPartition.put(T1P1, new ReplicaInfo(0, 0, false));
+    logdirInfoBylogdir.put("/tmp/kafka-logs", new LogDirDescription(null, replicaInfoByPartition));
     futureByBroker.put(0, completedFuture(logdirInfoBylogdir));
 
     logdirInfoBylogdir = new HashMap<>();
     replicaInfoByPartition = new HashMap<>();
-    replicaInfoByPartition.put(T0P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-    replicaInfoByPartition.put(T0P1, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-    replicaInfoByPartition.put(T1P0, new DescribeLogDirsResponse.ReplicaInfo(0, 0, false));
-    logdirInfoBylogdir.put("/tmp/kafka-logs-1", new DescribeLogDirsResponse.LogDirInfo(Errors.NONE, replicaInfoByPartition));
+    replicaInfoByPartition.put(T0P0, new ReplicaInfo(0, 0, false));
+    replicaInfoByPartition.put(T0P1, new ReplicaInfo(0, 0, false));
+    replicaInfoByPartition.put(T1P0, new ReplicaInfo(0, 0, false));
+    logdirInfoBylogdir.put("/tmp/kafka-logs-1", new LogDirDescription(null, replicaInfoByPartition));
     logdirInfoBylogdir.put("/tmp/kafka-logs-2",
-                           new DescribeLogDirsResponse.LogDirInfo(Errors.NONE,
-                                                                  Collections.singletonMap(T1P1,
-                                                                                           new DescribeLogDirsResponse.ReplicaInfo(0, 0, false))));
+        new LogDirDescription(null, Collections.singletonMap(T1P1, new ReplicaInfo(0, 0, false))));
     futureByBroker.put(1, completedFuture(logdirInfoBylogdir));
     return futureByBroker;
   }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitorTest.java
@@ -534,7 +534,7 @@ public class LoadMonitorTest {
     // Create mock DescribeLogDirsResult
     DescribeLogDirsResult mockDescribeLogDirsResult = EasyMock.mock(DescribeLogDirsResult.class);
     EasyMock.expect(mockDescribeLogDirsResult.descriptions())
-        .andReturn(getDescribeLogDirsResultDescriptions())
+            .andReturn(getDescribeLogDirsResultDescriptions())
             .anyTimes();
     EasyMock.replay(mockDescribeLogDirsResult);
 


### PR DESCRIPTION
### Issue
The values method of the DescribeLogDirsResult class is deprecated since Kafka 2.7.

### Changes
The deprecated values method has been removed and replaced with the descriptions method.

