### PR TITLE
CI workflow with Github Actions

### DIFF
--- a/.github/workflows/artifactory.yaml
+++ b/.github/workflows/artifactory.yaml
@@ -16,8 +16,8 @@ jobs:
           fetch-depth: 0 # so gradle doesn't fail traversing the history
       - uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java-ver }}
-          distribution: ${{ matrix.java-dist }}
+          java-version: 11
+          distribution: microsoft
           cache: gradle
       - uses: gradle/actions/setup-gradle@v4 # v4.0.0
       - name: publish

--- a/.github/workflows/artifactory.yaml
+++ b/.github/workflows/artifactory.yaml
@@ -1,0 +1,25 @@
+name: Artifactory
+
+on:
+  workflow_dispatch: # manual trigger
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    # if: startsWith(github.event.ref, 'release/')
+    name: publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # so gradle doesn't fail traversing the history
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java-ver }}
+          distribution: ${{ matrix.java-dist }}
+          cache: gradle
+      - uses: gradle/actions/setup-gradle@v4 # v4.0.0
+      - name: publish
+        run: |
+          ./gradlew :artifactoryPublish :cruise-control:artifactoryPublish :cruise-control-core:artifactoryPublish :cruise-control-metrics-reporter:artifactoryPublish

--- a/.github/workflows/artifactory.yaml
+++ b/.github/workflows/artifactory.yaml
@@ -2,8 +2,8 @@ name: Artifactory
 
 on:
   workflow_dispatch: # manual trigger
-  release:
-    types: [published]
+  #release:
+  #  types: [published]
 
 jobs:
   publish:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ jobs:
         with:
           java-version: ${{ matrix.java-ver }}
           distribution: ${{ matrix.java-dist }}
+          cache: gradle
       # see: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
       - uses: gradle/actions/setup-gradle@v4 # v4.0.0
       - name: gradle build
@@ -48,6 +49,7 @@ jobs:
         with:
           java-version: ${{ matrix.java-ver }}
           distribution: ${{ matrix.java-dist }}
+          cache: gradle
       # see: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
       - uses: gradle/actions/setup-gradle@v4 # v4.0.0
       - name: gradle integration test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  test:
+    name: "test with JDK=${{matrix.java-dist}}:${{matrix.java-ver}}"
+    runs-on: [ubuntu-latest]
+    strategy:
+      fail-fast: false
+      matrix:
+        java-ver: [11]
+        java-dist: ['microsoft', 'temurin']
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # so gradle doesn't fail traversing the history
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java-ver }}
+          distribution: ${{ matrix.java-dist }}
+      # see: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+      - uses: gradle/actions/setup-gradle@v4 # v4.0.0
+      - name: gradle build
+        run: ./gradlew --no-daemon -PmaxParallelForks=1 build
+
+  integration-test:
+    name: "integration-test with JDK=${{matrix.java-dist}}:${{matrix.java-ver}}"
+    runs-on: [ubuntu-latest]
+    strategy:
+      fail-fast: false
+      matrix:
+        java-ver: [11]
+        java-dist: ['microsoft', 'temurin']
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # so gradle doesn't fail traversing the history
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java-ver }}
+          distribution: ${{ matrix.java-dist }}
+      # see: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+      - uses: gradle/actions/setup-gradle@v4 # v4.0.0
+      - name: gradle integration test
+        run: ./gradlew --no-daemon -PmaxParallelForks=1 clean integrationTest
+
+  build-platform:
+    name: platform build with JDK=${{matrix.java-dist}}:${{matrix.java-ver}} on ${{matrix.hw_platform}}
+    strategy:
+      fail-fast: false
+      matrix:
+        java-ver: [11]
+        java-dist: ['temurin']
+        hw_platform: ['s390x']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # so gradle doesn't fail traversing the history
+      - run: |
+          # install required qemu libraries
+          docker run --rm --privileged tonistiigi/binfmt:latest --install all
+          # run docker container with qemu emulation
+          docker run --rm \
+            --platform ${{ matrix.hw_platform }} \
+            --name qemu-cross-${{ matrix.hw_platform }} \
+            --mount type=bind,source=${PWD},target=/workspace \
+            --workdir /workspace \
+            ${{matrix.hw_platform}}/eclipse-temurin:11-jdk-focal uname -a; ./gradlew --no-daemon -PmaxParallelForks=1 build


### PR DESCRIPTION
## Summary
### Why
1. GIthub Actions workflow are native GH workflows 
2. Github Actions do not require additional non-github accounts unlike CircleCI
3. plenty of compute resources[^0] available for OSS projects
4. unlike CircleCI resource limits (don't have details)

[^0]:https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration#availability

### What
1. creates CI workflow `ci.yaml`
2. creates Artifactory workflow: `artifactory.yaml`

Workflow structure is documented in the spec[^1]

[^1]:https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions

## Expected Behavior
CI is expected to 
1. execute unit tests
1. execute integration tests
1. execute hw platform unit tests 
1. publish artifacts to the artifactory when a tag is published
1. provide ability to re-run tests on failures
1. report results to corresponding PR/branch 

which is to be used as quality gates for PR merging.

## Actual Behavior
1. current Circle CI integration provides [1] [2] [3] [4] from the expected behavior
4. but re-run-ing checks requires additional efforts like logging in into the Circle CI 
5. which slows PR feedback loop as users may not have CircleCI credentials and knowledge of the system

[1]:https://github.com/linkedin/cruise-control/blob/a298df86095532264f13ca7490cfabb8ff68839f/.circleci/config.yml#L51-L53
[2]:https://github.com/linkedin/cruise-control/blob/a298df86095532264f13ca7490cfabb8ff68839f/.circleci/config.yml#L51-L53
[3]:https://github.com/linkedin/cruise-control/blob/a298df86095532264f13ca7490cfabb8ff68839f/.circleci/config.yml#L5-L34
[4]:https://github.com/linkedin/cruise-control/blob/a298df86095532264f13ca7490cfabb8ff68839f/.circleci/config.yml#L94-L103

## Steps to reproduce
1. see failed PR checks, ie https://github.com/linkedin/cruise-control/pull/2133

## Known Workarounds
1. asking PR authors to trigger build

## Migration Plan
1. add GH Actions integration along with CircleCI
2. confirm GH Actions provide equivalent or better functionality 
3. remove CircleCI integration
4. ensure publishing via GH actions works

## Categorization
- [x] refactor

## Example
This PR has both GH Action and CircleCI checks running:

<img width="975" alt="image" src="https://github.com/user-attachments/assets/a8863368-5412-4bc4-ac05-99f854fbd9df">

Note how CircleCI doesn't report timing, and is actually [slower](https://app.circleci.com/pipelines/github/linkedin/cruise-control/2440/workflows/38492063-0242-4b9b-b8fa-5e0c96313f8e/jobs/6687) in current configuration, making GH action complete workflows in 32m vs [40m](https://app.circleci.com/pipelines/github/linkedin/cruise-control/2440/workflows/38492063-0242-4b9b-b8fa-5e0c96313f8e/jobs/6687) 
<img width="327" alt="image" src="https://github.com/user-attachments/assets/9b2c1669-9acf-421d-b82c-fe84920cc053">