### PR TITLE
Add documentation category to PR template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -22,10 +22,11 @@
 4. <!-- use <detail> tag for large snippets -->
 
 ## Categorization
+- [ ] documentation
 - [ ] bugfix
 - [ ] new feature
 - [ ] refactor
-- [ ] CVE
+- [ ] security/CVE
 - [ ] other
 
 This PR resolves #<Replace-Me-With-The-Issue-Number-Addressed-By-This-PR> if any.


### PR DESCRIPTION
## Summary
1. Why:  to categorize documentation PRs
2. What: adds "documentation" category to the PR template

## Expected Behavior
- when users make documentation changes
- they should be able to specify documentation as a change category

## Actual Behavior
- no documentation category to specify

## Known Workarounds
n/a

## Additional evidence
n/a

## Categorization
- [ ] documentation
- [ ] bugfix
- [ ] new feature
- [ ] refactor
- [ ] CVE
- [x] other
