### PR TITLE
Set Embedded Zookeeper listen on 127.0.0.1

### DIFF
--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/utils/CCEmbeddedZookeeper.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/utils/CCEmbeddedZookeeper.java
@@ -5,7 +5,6 @@
 package com.linkedin.kafka.cruisecontrol.metricsreporter.utils;
 
 import java.io.File;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.concurrent.CountDownLatch;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
@@ -14,7 +13,7 @@ import org.apache.zookeeper.server.ZooKeeperServer;
 
 
 public class CCEmbeddedZookeeper implements AutoCloseable {
-  private final String _hostAddress;
+  private final String _hostAddress = "127.0.0.1";
   private final int _port;
   private final ZooKeeperServer _zk;
   private final ServerCnxnFactory _cnxnFactory;
@@ -27,9 +26,7 @@ public class CCEmbeddedZookeeper implements AutoCloseable {
       File logDir = CCKafkaTestUtils.newTempDir();
       _zk = new ZooKeeperServer(snapshotDir, logDir, tickTime);
       _cnxnFactory = new NIOServerCnxnFactory();
-      InetAddress localHost = InetAddress.getLocalHost();
-      _hostAddress = localHost.getHostAddress();
-      InetSocketAddress bindAddress = new InetSocketAddress(localHost, 0);
+      InetSocketAddress bindAddress = new InetSocketAddress(_hostAddress, 0);
       _cnxnFactory.configure(bindAddress, 0);
       _cnxnFactory.startup(_zk);
       _port = _zk.getClientPort();


### PR DESCRIPTION
## Summary
1. Why: when on VPN, I can't run Cruise Control tests as ZK is binding to local real ip address and local network is restricted.
2. What: changing to bind to 127.0.0.1 fixes it (got the idea from Kafka embedded ZK setup. I think it won't make any difference how automation or human would run the tests, pls correct me if I'm wrong.

## Categorization
- [ ] bugfix
- [ ] new feature
- [ ] refactor
- [ ] CVE
- [x] other

