### PR TITLE
Fixing Unexpected method calls: HttpSession.invalidate

### DIFF
--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManagerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManagerTest.java
@@ -25,6 +25,14 @@ import static com.linkedin.kafka.cruisecontrol.servlet.KafkaCruiseControlServlet
 
 public class UserTaskManagerTest {
 
+  private static HttpSession getMockHttpSession(long lastAccessedTimeReturn) {
+    HttpSession mockHttpSession = EasyMock.mock(HttpSession.class);
+    EasyMock.expect(mockHttpSession.getLastAccessedTime()).andReturn(lastAccessedTimeReturn).anyTimes();
+    mockHttpSession.invalidate();
+    EasyMock.expectLastCall().andVoid().anyTimes();
+    return mockHttpSession;
+  }
+
   @Test
   public void testCreateUserTask() throws Exception {
     UUID testUserTaskId = UUID.randomUUID();
@@ -32,8 +40,7 @@ public class UserTaskManagerTest {
     UserTaskManager.UuidGenerator mockUuidGenerator = EasyMock.mock(UserTaskManager.UuidGenerator.class);
     EasyMock.expect(mockUuidGenerator.randomUUID()).andReturn(testUserTaskId).anyTimes();
 
-    HttpSession mockHttpSession = EasyMock.mock(HttpSession.class);
-    EasyMock.expect(mockHttpSession.getLastAccessedTime()).andReturn(100L).anyTimes();
+    HttpSession mockHttpSession = getMockHttpSession(100L);
 
     HttpServletRequest mockHttpServletRequest1 = prepareServletRequest(mockHttpSession, null);
 
@@ -109,8 +116,7 @@ public class UserTaskManagerTest {
     UserTaskManager.UuidGenerator mockUuidGenerator = EasyMock.mock(UserTaskManager.UuidGenerator.class);
     EasyMock.expect(mockUuidGenerator.randomUUID()).andReturn(testUserTaskId).anyTimes();
 
-    HttpSession mockHttpSession = EasyMock.mock(HttpSession.class);
-    EasyMock.expect(mockHttpSession.getLastAccessedTime()).andReturn(100L).anyTimes();
+    HttpSession mockHttpSession = getMockHttpSession(System.currentTimeMillis());
 
     Map<String, String []> requestParams1 = new HashMap<>();
     requestParams1.put("param", new String[]{"true"});
@@ -157,9 +163,7 @@ public class UserTaskManagerTest {
     UserTaskManager.UuidGenerator mockUuidGenerator = EasyMock.mock(UserTaskManager.UuidGenerator.class);
     EasyMock.expect(mockUuidGenerator.randomUUID()).andReturn(testUserTaskId).anyTimes();
 
-    HttpSession mockHttpSession = EasyMock.mock(HttpSession.class);
-    // Change mock session's last access time to always return current time to avoid unintended recycling of session.
-    EasyMock.expect(mockHttpSession.getLastAccessedTime()).andReturn(System.currentTimeMillis()).anyTimes();
+    HttpSession mockHttpSession = getMockHttpSession(System.currentTimeMillis());
 
     HttpServletRequest mockHttpServletRequest = prepareServletRequest(mockHttpSession, null);
 
@@ -192,9 +196,7 @@ public class UserTaskManagerTest {
 
   @Test
   public void testCompletedTasks() throws Exception {
-    HttpSession mockHttpSession = EasyMock.mock(HttpSession.class);
-    EasyMock.expect(mockHttpSession.getLastAccessedTime()).andReturn(100L).anyTimes();
-    mockHttpSession.invalidate();
+    HttpSession mockHttpSession = getMockHttpSession(100L);
 
     HttpServletRequest mockHttpServletRequest = prepareServletRequest(mockHttpSession, null);
     UserTaskManager.UuidGenerator mockUuidGenerator = EasyMock.mock(UserTaskManager.UuidGenerator.class);
@@ -234,9 +236,7 @@ public class UserTaskManagerTest {
     EasyMock.expect(mockUuidGenerator.randomUUID()).andReturn(testUserTaskId).anyTimes();
 
     Time mockTime = new MockTime();
-    HttpSession mockHttpSession = EasyMock.mock(HttpSession.class);
-    EasyMock.expect(mockHttpSession.getLastAccessedTime()).andReturn(mockTime.milliseconds()).anyTimes();
-    mockHttpSession.invalidate();
+    HttpSession mockHttpSession = getMockHttpSession(100L);
     HttpServletRequest mockHttpServletRequest = prepareServletRequest(mockHttpSession, null);
 
     OperationFuture future = new OperationFuture("future");
@@ -265,8 +265,7 @@ public class UserTaskManagerTest {
 
   @Test
   public void testMaximumActiveTasks() throws Exception {
-    HttpSession mockHttpSession1 = EasyMock.mock(HttpSession.class);
-    EasyMock.expect(mockHttpSession1.getLastAccessedTime()).andReturn(100L).anyTimes();
+    HttpSession mockHttpSession1 = getMockHttpSession(100L);
 
     HttpServletRequest mockHttpServletRequest1 = prepareServletRequest(mockHttpSession1, null);
 
@@ -285,9 +284,7 @@ public class UserTaskManagerTest {
             userTaskManager.getOrCreateUserTask(requestContext, uuid -> future, 0, true, null).get(0);
     Assert.assertEquals(future, future1);
     EasyMock.verify(mockHttpSession1, mockHttpServletRequest1, mockHttpServletResponse);
-    HttpSession mockHttpSession2 = EasyMock.mock(HttpSession.class);
-    EasyMock.expect(mockHttpSession2.getLastAccessedTime()).andReturn(100L).anyTimes();
-    EasyMock.replay(mockHttpSession2);
+    HttpSession mockHttpSession2 = getMockHttpSession(100L);
     EasyMock.reset(mockHttpServletResponse);
 
     HttpServletRequest mockHttpServletRequest2 = prepareServletRequest(mockHttpSession2, null, "/test2", Collections.emptyMap());


### PR DESCRIPTION
## Summary
1. Why: The test failed sometimes with unexpected method calls.
2. What: The fix is preparing the test to accept invalidate method call too

## Expected Behavior
Tests are running without failure

## Actual Behavior
Tests are failing sometimes with unexpected method call.

## Steps to Reproduce
1. setup repeated run on e.g. `testCreateUserTask` in IDE
2. observe failure after multiple successful runs (for me it was failing after around 250 successful runs)


## Additional evidence
```
java.lang.AssertionError: On mock #2 (zero indexed): 
  Unexpected method calls:
    HttpSession.invalidate()
	at org.easymock.EasyMock.getAssertionError(EasyMock.java:2230)
	at org.easymock.EasyMock.verify(EasyMock.java:2058)
	at com.linkedin.kafka.cruisecontrol.servlet.UserTaskManagerTest.testCreateUserTask(UserTaskManagerTest.java:59)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:112)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:40)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:60)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:52)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy5.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$2.run(TestWorker.java:176)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
```

## Categorization
- [x] bugfix
- [ ] new feature
- [ ] refactor
- [ ] CVE
- [ ] other

