### PR TITLE
Add more logging to help debugging the time spent on goal based operation

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/progress/OperationProgress.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/progress/OperationProgress.java
@@ -101,6 +101,26 @@ public class OperationProgress {
   }
 
   /**
+   * @return the up-to-date total execution time on the progress
+   */
+  public synchronized long getCurrentTotalExecutionTime() {
+    if (_startTimes.isEmpty()) {
+      return 0;
+    } else {
+      long currentTime = System.currentTimeMillis();
+      long startTime = _startTimes.get(0);
+      return currentTime - startTime;
+    }
+  }
+
+  /**
+   * @return the name of the operation
+   */
+  public String getOperation() {
+    return _operation;
+  }
+
+  /**
    * @return The map describing the progress of the operation.
    */
   public Map<String, Object> getJsonStructure() {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/progress/OperationProgress.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/async/progress/OperationProgress.java
@@ -103,7 +103,7 @@ public class OperationProgress {
   /**
    * @return the up-to-date total execution time on the progress
    */
-  public synchronized long getCurrentTotalExecutionTime() {
+  public synchronized long getCurrentTotalExecutionTimeMs() {
     if (_startTimes.isEmpty()) {
       return 0;
     } else {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -832,6 +832,9 @@ public class Executor {
                             isTriggeredByUserRequest, loadMonitor);
       startExecution(loadMonitor, null, removedBrokers, replicationThrottle, isTriggeredByUserRequest);
     } catch (Exception e) {
+      if (e instanceof OngoingExecutionException) {
+        LOG.info("Broker removal operation with uuid {} aborted due to ongoing execution", uuid);
+      }
       processExecuteProposalsFailure();
       throw e;
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/GoalBasedOperationRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/GoalBasedOperationRunnable.java
@@ -213,7 +213,7 @@ public abstract class GoalBasedOperationRunnable extends OperationRunnable {
     if (_operationProgress != null) {
       long totalTimeMs = _operationProgress.getCurrentTotalExecutionTimeMs();
       LOG.info("Operation {} finished with uuid {}; total time: {}ms; steps: {}",
-          _operationProgress.getOperation(), _uuid, totalTime, _operationProgress);
+          _operationProgress.getOperation(), _uuid, totalTimeMs, _operationProgress);
     }
     _operationProgress = null;
     _combinedCompletenessRequirements = null;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/GoalBasedOperationRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/GoalBasedOperationRunnable.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.goalsByPriority;
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.sanityCheckGoals;
@@ -34,6 +36,7 @@ import static com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.Ru
  * An abstract class to extract the common logic of goal based operation runnables.
  */
 public abstract class GoalBasedOperationRunnable extends OperationRunnable {
+  private static final Logger LOG = LoggerFactory.getLogger(GoalBasedOperationRunnable.class);
   protected final List<String> _goals;
   protected final ModelCompletenessRequirements _modelCompletenessRequirements;
   protected final boolean _dryRun;
@@ -207,6 +210,11 @@ public abstract class GoalBasedOperationRunnable extends OperationRunnable {
    * Perform the memory clean up after {@link #computeResult()}.
    */
   protected void finish() {
+    if (_operationProgress != null) {
+      long totalTime = _operationProgress.getCurrentTotalExecutionTime();
+      LOG.info("Operation {} finished with uuid {}; total time: {}ms; steps: {}",
+          _operationProgress.getOperation(), _uuid, totalTime, _operationProgress);
+    }
     _operationProgress = null;
     _combinedCompletenessRequirements = null;
     if (_goalsByPriority != null) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/GoalBasedOperationRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/GoalBasedOperationRunnable.java
@@ -211,7 +211,7 @@ public abstract class GoalBasedOperationRunnable extends OperationRunnable {
    */
   protected void finish() {
     if (_operationProgress != null) {
-      long totalTime = _operationProgress.getCurrentTotalExecutionTime();
+      long totalTimeMs = _operationProgress.getCurrentTotalExecutionTimeMs();
       LOG.info("Operation {} finished with uuid {}; total time: {}ms; steps: {}",
           _operationProgress.getOperation(), _uuid, totalTime, _operationProgress);
     }


### PR DESCRIPTION
## Summary
1. Why: 

Some cruise control operation, like broker removal, has to go through a few steps. It may also be in pending state for some time due to thread pool resource limitations or ongoing operations. We want to have additional observability on the time it takes for each step so that we know where the potential improvement will be.

2. What: 

Additional loggings are added to track the total time and time spent on each step for the goal based operation.

## Categorization
- [ ] documentation
- [ ] bugfix
- [ ] new feature
- [ ] refactor
- [ ] security/CVE
- [x] other
