### PR TITLE
Fix the Circle CI error by removing the test-multi-arch job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,13 +75,6 @@ workflows:
   version: 2.1
   build-and-publish:
     jobs:
-      - test-multi-arch:
-          matrix:
-            parameters:
-              platform: ["s390x"]
-          filters:
-            tags:
-              only: /.*/
       - build:
           filters:
             tags:
@@ -89,7 +82,6 @@ workflows:
       - integration-test:
           requires:
             - build
-            - test-multi-arch
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,37 +2,6 @@ version: 2.1
 
 jobs:
 
-  test-multi-arch:
-    parameters:
-      platform:
-        type: string
-    environment:
-      _JAVA_OPTIONS: "-Xms512m -Xmx1g"
-      DOCKER_CLI_EXPERIMENTAL: "enabled"
-    working_directory: ~/workspace
-    machine:
-      image: ubuntu-2004:202107-02
-    steps:
-      - checkout
-      - run: |
-         # install required qemu libraries
-         docker run --rm --privileged tonistiigi/binfmt:latest --install all
-         # run docker container with qemu emulation
-         docker run --rm \
-           --platform << parameters.platform >> \
-           --name qemu-cross-<< parameters.platform >> \
-           --mount type=bind,source=${PWD},target=/github_workspace \
-           --workdir /github_workspace \
-           << parameters.platform >>/eclipse-temurin:11-jdk-focal uname -a; ./gradlew --no-daemon -PmaxParallelForks=1 build
-      - run:
-          command: mkdir ~/test-results
-      - run:
-          command: find ~/workspace -type f -regex ".*/test-results/.*xml" -exec ln {} ~/test-results/ \;
-      - store_test_results:
-          path: ~/test-results
-      - store_artifacts:
-          path: ~/test-results
-
   build:
     environment:
       _JAVA_OPTIONS: "-Xms512m -Xmx1g"


### PR DESCRIPTION
## Summary
1. Why: 

`test-multi-arch` job fails due to image ubuntu-2004:202107-02 is unavailable. See https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/.

On the other hand, builds and integration tests on other platforms pass.

2. What: 

Removed the job `test-multi-arch` to unblock the PR workflow.

I also tried to fix this by using the `default` machine image as suggested in the above link but it [failed](https://app.circleci.com/pipelines/github/linkedin/cruise-control/2467/workflows/42acc46b-01da-44cc-8fff-d06800a6f1d7/jobs/6740) in findbugs due to class file version issue. 


## Categorization
- [ ] documentation
- [ ] bugfix
- [ ] new feature
- [ ] refactor
- [ ] security/CVE
- [x ] other

