### PR TITLE
Fix PartitionSizeAnomalyFinder, to be able to handle custom SELF_HEALING_PARTITION_SIZE_THRESHOLD_MB value

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/PartitionSizeAnomalyFinder.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/PartitionSizeAnomalyFinder.java
@@ -108,9 +108,9 @@ public class PartitionSizeAnomalyFinder implements TopicAnomalyFinder {
     String topicExcludedFromCheck = (String) configs.get(TOPIC_EXCLUDED_FROM_PARTITION_SIZE_CHECK);
     _topicExcludedFromCheck = Pattern.compile(topicExcludedFromCheck == null ? DEFAULT_TOPIC_EXCLUDED_FROM_PARTITION_SIZE_CHECK
                                                                              : topicExcludedFromCheck);
-    Integer partitionSizeThreshold = (Integer) configs.get(SELF_HEALING_PARTITION_SIZE_THRESHOLD_MB_CONFIG);
+    String partitionSizeThreshold = (String) configs.get(SELF_HEALING_PARTITION_SIZE_THRESHOLD_MB_CONFIG);
     _partitionSizeThresholdInMb = partitionSizeThreshold == null ? DEFAULT_SELF_HEALING_PARTITION_SIZE_THRESHOLD_MB
-                                                                 : partitionSizeThreshold;
+                                                                 : Integer.parseInt(partitionSizeThreshold);
     String topicPartitionSizeAnomalyClass = (String) configs.get(TOPIC_PARTITION_SIZE_ANOMALY_CLASS_CONFIG);
     if (topicPartitionSizeAnomalyClass == null) {
       _topicPartitionSizeAnomalyClass = DEFAULT_TOPIC_PARTITION_SIZE_ANOMALY_CLASS;


### PR DESCRIPTION

## Summary
1. Why: I ran into the following exception when I tried to customize the SELF_HEALING_PARTITION_SIZE_THRESHOLD_MB in PartitionSizeAnomalyFinder
```
java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Integer (java.lang.String and java.lang.Integer are in module java.base of loader 'bootstrap')
	at com.linkedin.kafka.cruisecontrol.detector.PartitionSizeAnomalyFinder.configure(PartitionSizeAnomalyFinder.java:111) ~[classes/:?]
	at com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig.getConfiguredInstances(KafkaCruiseControlConfig.java:119) ~[classes/:?]
	at com.linkedin.kafka.cruisecontrol.detector.TopicAnomalyDetector.<init>(TopicAnomalyDetector.java:32) ~[classes/:?]
	at com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorManager.<init>(AnomalyDetectorManager.java:120) ~[classes/:?]

```
3. What: 
I have fixed the config reader code to parse the integer value

## Expected Behavior
Be able to reconfigure the SELF_HEALING_PARTITION_SIZE_THRESHOLD_MB

## Actual Behavior
I cant reconfigure the SELF_HEALING_PARTITION_SIZE_THRESHOLD_MB

## Steps to Reproduce
1. Enable the PartitionSizeAnomaly finder `topic.anomaly.finder.class=com.linkedin.kafka.cruisecontrol.detector.PartitionSizeAnomalyFinder`
2. Provide a custom value for `self.healing.partition.size.threshold.mb=1024`
3. Start CC

## Known Workarounds
NO


## Categorization
- [ ] documentation
- [x] bugfix
- [ ] new feature
- [ ] refactor
- [ ] security/CVE
- [ ] other

