### PR TITLE
Fix: intra.broker.goals cannot be configured as default.goals

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -197,8 +197,8 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
       throw new ConfigException("Attempt to configure default goals configuration with an empty list of goals.");
     }
 
-    // Ensure that default goals are supported inter-broker goals.
-    if (defaultGoalNames.stream().anyMatch(g -> !interBrokerGoalNames.contains(g))) {
+    // Ensure that default goals are supported inter-broker or intra-broker goals.
+    if (defaultGoalNames.stream().anyMatch(g -> !interBrokerGoalNames.contains(g) && !intraBrokerGoalNames.contains(g))) {
       throw new ConfigException(String.format("Attempt to configure default goals with unsupported goals (%s:%s and %s:%s).",
                                               AnalyzerConfig.DEFAULT_GOALS_CONFIG, defaultGoalNames,
                                               AnalyzerConfig.GOALS_CONFIG, interBrokerGoalNames));

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -199,9 +199,10 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
 
     // Ensure that default goals are supported inter-broker or intra-broker goals.
     if (defaultGoalNames.stream().anyMatch(g -> !interBrokerGoalNames.contains(g) && !intraBrokerGoalNames.contains(g))) {
-      throw new ConfigException(String.format("Attempt to configure default goals with unsupported goals (%s:%s and %s:%s).",
+      throw new ConfigException(String.format("Attempt to configure default goals with unsupported goals (%s:%s and %s:%s and %s:%s).",
                                               AnalyzerConfig.DEFAULT_GOALS_CONFIG, defaultGoalNames,
-                                              AnalyzerConfig.GOALS_CONFIG, interBrokerGoalNames));
+                                              AnalyzerConfig.GOALS_CONFIG, interBrokerGoalNames,
+                                              AnalyzerConfig.INTRA_BROKER_GOALS_CONFIG, intraBrokerGoalNames));
     }
 
     // Ensure that hard goals are contained in default goals.


### PR DESCRIPTION
## Summary
1. Why: KafkaCruiseControlConfig sanity checks prevent to configure inter broker goals as default goals.
2. What: Modify the sanity check to allow adding intra broker goals to the `default.goals`

## Expected Behavior
I can add (enable) goals to the `default.goals` list from both the intra and inter broker goals
![image](https://github.com/user-attachments/assets/193cbaa3-c3e7-4b48-bb66-d5959bd6bec4)


## Actual Behavior
Sanity checks ensure the following rules:
- **goals and intra broker goals should be disjoint** (an intra broker goal cant be in the `goals` and the `intra.broker.goals` at the same time)
- **`default.goals` should be a subset of `goals`** (As a result of this, we could not add intra broker goal to the `default.goals`)
- **`intra.broker.goals` cant be empty** (you could not move all the intra broker roles to the goals)
![image](https://github.com/user-attachments/assets/902e1309-a92a-495d-a790-16e63fa94bca)


We could not add intra goal to the `default.goals` without a trick (see in the workaround section) 

## Steps to Reproduce
Try to enable an intra broker goal by adding it to the `default. goals`

## Known Workarounds
You can remove 1 intra broker goal from the `intra.broker.goals` config and add that to the `goals` (keep in mind that the other one should be in the `intra.broker.goals` as the list cant be empty) this way you can add that 1 goal to the `default.goals` and enable it

Note that this way we still cant enable both of the currently available intra broker goals as 1 have to be in the intra.broker.goals list to avoid hitting the mentioned sanity check. So only 1 intra goal at a time.

## Categorization
- [ ] documentation
- [x] bugfix
- [ ] new feature
- [ ] refactor
- [ ] security/CVE
- [ ] other

