### PR TITLE
Expose AdminClient exception when failing to describe the cluster

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaAdminTopicConfigProvider.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaAdminTopicConfigProvider.java
@@ -171,7 +171,7 @@ public class KafkaAdminTopicConfigProvider implements TopicConfigProvider {
     try {
       clusterConfigs = describeClusterConfigs(_adminClient, DESCRIBE_CLUSTER_CONFIGS_TIMEOUT);
     } catch (InterruptedException | ExecutionException e) {
-      throw new RuntimeException("Failed to describe Kafka cluster configs.");
+      throw new RuntimeException("Failed to describe Kafka cluster configs.", e);
     }
 
     if (clusterConfigs != null) {


### PR DESCRIPTION
If the `AdminClient` fails to describe the cluster, the exception is not exposed.

```
 2024-09-23 20:03:28,871 ERROR com.linkedin.kafka.cruisecontrol.KafkaCruiseControlMain: [main]: Uncaught exception on thread Thread[main,5,main]
java.lang.RuntimeException: Failed to describe Kafka cluster configs.
        at com.linkedin.kafka.cruisecontrol.config.KafkaAdminTopicConfigProvider.configure(KafkaAdminTopicConfigProvider.java:174) ~[cruise-control-2.5.116.jar:?]
        at com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfigUtils.getConfiguredInstance(KafkaCruiseControlConfigUtils.java:49) ~[cruise-control-2.5.116.jar:?]
        at com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig.getConfiguredInstance(KafkaCruiseControlConfig.java:98) ~[cruise-control-2.5.116.jar:?]
        at com.linkedin.kafka.cruisecontrol.monitor.LoadMonitor.<init>(LoadMonitor.java:155) ~[cruise-control-2.5.116.jar:?]
        at com.linkedin.kafka.cruisecontrol.monitor.LoadMonitor.<init>(LoadMonitor.java:124) ~[cruise-control-2.5.116.jar:?]
        at com.linkedin.kafka.cruisecontrol.KafkaCruiseControl.<init>(KafkaCruiseControl.java:126) ~[cruise-control-2.5.116.jar:?]
        at com.linkedin.kafka.cruisecontrol.async.AsyncKafkaCruiseControl.<init>(AsyncKafkaCruiseControl.java:34) ~[cruise-control-2.5.116.jar:?]
        at com.linkedin.kafka.cruisecontrol.KafkaCruiseControlApp.<init>(KafkaCruiseControlApp.java:36) ~[cruise-control-2.5.116.jar:?]
        at com.linkedin.kafka.cruisecontrol.KafkaCruiseControlServletApp.<init>(KafkaCruiseControlServletApp.java:32) ~[cruise-control-2.5.116.jar:?]
        at com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.getCruiseControlApp(KafkaCruiseControlUtils.java:923) ~[cruise-control-2.5.116.jar:?]
        at com.linkedin.kafka.cruisecontrol.KafkaCruiseControlMain.main(KafkaCruiseControlMain.java:37) ~[cruise-control-2.5.116.jar:?]
```

The reason is that the exception generated by AdminClient is caught and a generic RuntimeException is thrown in `KafkaAdminTopicConfigProvider` but the original error trace is lost. This PR adds the original exception as the **cause** of the newly thrown RuntimeException. This change can  improve troubleshooting and makes it much easier to figure out what went wrong with the `DESCRIBE_CLUSTER` API call.