### PR TITLE
Replace deprecated methods to support Kafka 4.0.0

### DIFF
--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
@@ -374,6 +374,7 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
     String cruiseControlMetricsTopic = _metricsTopic.name();
 
     try {
+      // For compatibility with Kafka 4.0 and beyond we must use new API methods.
       Method topicDescriptionMethod = topicNameValuesMethod();
 
       DescribeTopicsResult describeTopicsResult = _adminClient.describeTopics(Collections.singletonList(cruiseControlMetricsTopic));
@@ -521,8 +522,8 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
 
   /**
    * Attempts to retrieve the method for mapping topic names to futures from the {@link org.apache.kafka.clients.admin.DescribeTopicsResult} class.
-   * This method first tries to get the {@code topicNameValues()} method, which is available in Kafka 4.0.0 or later.
-   * If the method is not found, it falls back to trying to retrieve the {@code values()} method, which is available in Kafka 3.0.0 or earlier.
+   * This method first tries to get the {@code topicNameValues()} method, which is available in Kafka 3.1.0 and later.
+   * If the method is not found, it falls back to trying to retrieve the {@code values()} method, which is available in Kafka 3.9.0 and earlier.
    *
    * If neither of these methods is found, a {@link RuntimeException} is thrown.
    *
@@ -546,7 +547,7 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
         // Second we try to get the values() method
         topicDescriptionMethod = DescribeTopicsResult.class.getMethod("values");
       } catch (NoSuchMethodException exception) {
-        LOG.info("Failed to get method values() from DescribeTopicsResult class since we are probably on kafka 3.0.0 or older: ", exception);
+        LOG.info("Failed to get method values() from DescribeTopicsResult class: ", exception);
       }
     }
 

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
@@ -378,8 +378,8 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
 
       DescribeTopicsResult describeTopicsResult = _adminClient.describeTopics(Collections.singletonList(cruiseControlMetricsTopic));
 
-      Map<String, KafkaFuture<TopicDescription>> topicDescriptionMap =
-              (Map<String, KafkaFuture<TopicDescription>>) topicDescriptionMethod.invoke(describeTopicsResult);
+      Map<String, KafkaFuture<TopicDescription>> topicDescriptionMap = (Map<String, KafkaFuture<TopicDescription>>) topicDescriptionMethod
+              .invoke(describeTopicsResult);
 
       TopicDescription topicDescription = topicDescriptionMap.get(cruiseControlMetricsTopic).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
 

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
@@ -373,7 +373,7 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
     try {
       // Retrieve topic partition count to check and update.
       TopicDescription topicDescription =
-          _adminClient.describeTopics(Collections.singletonList(cruiseControlMetricsTopic)).values()
+          _adminClient.describeTopics(Collections.singletonList(cruiseControlMetricsTopic)).topicNameValues()
                       .get(cruiseControlMetricsTopic).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
       if (topicDescription.partitions().size() < _metricsTopic.numPartitions()) {
         _adminClient.createPartitions(Collections.singletonMap(cruiseControlMetricsTopic,

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
@@ -384,8 +384,7 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
       TopicDescription topicDescription = topicDescriptionMap.get(cruiseControlMetricsTopic).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
       if (topicDescription.partitions().size() < _metricsTopic.numPartitions()) {
-        _adminClient.createPartitions(Collections.singletonMap(cruiseControlMetricsTopic,
-                NewPartitions.increaseTo(_metricsTopic.numPartitions())));
+        _adminClient.createPartitions(Collections.singletonMap(cruiseControlMetricsTopic, NewPartitions.increaseTo(_metricsTopic.numPartitions())));
       }
 
     } catch (InterruptedException | ExecutionException | TimeoutException | InvocationTargetException | IllegalAccessException e) {
@@ -537,16 +536,16 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
     Method topicDescriptionMethod = null;
     try {
       // First we try to get the topicNameValues() method
-      topicDescriptionMethod = Class.forName("org.apache.kafka.clients.admin.DescribeTopicsResult").getMethod("topicNameValues");
-    } catch (ClassNotFoundException | NoSuchMethodException exception) {
+      topicDescriptionMethod = DescribeTopicsResult.class.getMethod("topicNameValues");
+    } catch (NoSuchMethodException exception) {
       LOG.info("Failed to get method topicNameValues() from DescribeTopicsResult class since we are probably on kafka 3.0.0 or older: ", exception);
     }
 
     if (topicDescriptionMethod == null) {
       try {
         // Second we try to get the values() method
-        topicDescriptionMethod = Class.forName("org.apache.kafka.clients.admin.DescribeTopicsResult").getMethod("values");
-      } catch (ClassNotFoundException | NoSuchMethodException exception) {
+        topicDescriptionMethod = DescribeTopicsResult.class.getMethod("values");
+      } catch (NoSuchMethodException exception) {
         LOG.info("Failed to get method values() from DescribeTopicsResult class since we are probably on kafka 3.0.0 or older: ", exception);
       }
     }

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
@@ -387,7 +387,6 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
       if (topicDescription.partitions().size() < _metricsTopic.numPartitions()) {
         _adminClient.createPartitions(Collections.singletonMap(cruiseControlMetricsTopic, NewPartitions.increaseTo(_metricsTopic.numPartitions())));
       }
-
     } catch (InterruptedException | ExecutionException | TimeoutException | InvocationTargetException | IllegalAccessException e) {
       LOG.warn("Partition count increase to {} for topic {} failed{}.", _metricsTopic.numPartitions(), cruiseControlMetricsTopic,
                (e.getCause() instanceof ReassignmentInProgressException) ? " due to ongoing reassignment" : "", e);

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/exception/KafkaTopicDescriptionException.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/exception/KafkaTopicDescriptionException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.metricsreporter.exception;
+
+/**
+ * If an error occurs while retrieving the topic description,
+ * or if the topic name retrieval method cannot be found or invoked properly. This includes
+ * exceptions related to reflection (e.g., {@link NoSuchMethodException}), invocation issues,
+ * execution exceptions, timeouts, and interruptions.
+ */
+public class KafkaTopicDescriptionException extends Exception {
+
+    public KafkaTopicDescriptionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterAutoCreateTopicTest.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterAutoCreateTopicTest.java
@@ -9,6 +9,7 @@ import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaTestUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -150,16 +151,16 @@ public class CruiseControlMetricsReporterAutoCreateTopicTest extends CCKafkaClie
         Method topicDescriptionMethod = null;
         try {
             // First we try to get the topicNameValues() method
-            topicDescriptionMethod = Class.forName("org.apache.kafka.clients.admin.DescribeTopicsResult").getMethod("topicNameValues");
-        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            topicDescriptionMethod = DescribeTopicsResult.class.getMethod("topicNameValues");
+        } catch (NoSuchMethodException e) {
             LOG.info("Failed to get method topicNameValues() from DescribeTopicsResult class since we are probably on kafka 3.0.0 or older: ", e);
         }
 
         if (topicDescriptionMethod == null) {
             try {
                 // Second we try to get the values() method
-                topicDescriptionMethod = Class.forName("org.apache.kafka.clients.admin.DescribeTopicsResult").getMethod("values");
-            } catch (ClassNotFoundException | NoSuchMethodException e) {
+                topicDescriptionMethod = DescribeTopicsResult.class.getMethod("values");
+            } catch (NoSuchMethodException e) {
                 LOG.info("Failed to get method values() from DescribeTopicsResult class since we are probably on kafka 3.0.0 or older: ", e);
             }
         }

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterAutoCreateTopicTest.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterAutoCreateTopicTest.java
@@ -25,12 +25,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -122,7 +120,9 @@ public class CruiseControlMetricsReporterAutoCreateTopicTest extends CCKafkaClie
         Map<String, KafkaFuture<TopicDescription>> topicDescriptionMap;
 
         try {
-            topicDescriptionMap = (Map<String, KafkaFuture<TopicDescription>>) topicDescriptionMethod.invoke(adminClient.describeTopics(Collections.singleton(TOPIC)));
+            topicDescriptionMap =
+                    (Map<String, KafkaFuture<TopicDescription>>) topicDescriptionMethod
+                            .invoke(adminClient.describeTopics(Collections.singleton(TOPIC)));
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
@@ -151,16 +151,16 @@ public class CruiseControlMetricsReporterAutoCreateTopicTest extends CCKafkaClie
         try {
             // First we try to get the topicNameValues() method
             topicDescriptionMethod = Class.forName("org.apache.kafka.clients.admin.DescribeTopicsResult").getMethod("topicNameValues");
-        } catch (ClassNotFoundException | NoSuchMethodException exception) {
-            LOG.info("Failed to get method topicNameValues() from DescribeTopicsResult class since we are probably on kafka 3.0.0 or older: ", exception);
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            LOG.info("Failed to get method topicNameValues() from DescribeTopicsResult class since we are probably on kafka 3.0.0 or older: ", e);
         }
 
         if (topicDescriptionMethod == null) {
             try {
                 // Second we try to get the values() method
                 topicDescriptionMethod = Class.forName("org.apache.kafka.clients.admin.DescribeTopicsResult").getMethod("values");
-            } catch (ClassNotFoundException | NoSuchMethodException exception) {
-                LOG.info("Failed to get method values() from DescribeTopicsResult class since we are probably on kafka 3.0.0 or older: ", exception);
+            } catch (ClassNotFoundException | NoSuchMethodException e) {
+                LOG.info("Failed to get method values() from DescribeTopicsResult class since we are probably on kafka 3.0.0 or older: ", e);
             }
         }
 

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterAutoCreateTopicTest.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterAutoCreateTopicTest.java
@@ -23,8 +23,6 @@ import org.apache.kafka.server.config.ServerLogConfigs;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -39,7 +37,6 @@ import static org.junit.Assert.assertEquals;
 public class CruiseControlMetricsReporterAutoCreateTopicTest extends CCKafkaClientsIntegrationTestHarness {
     protected static final String TOPIC = "CruiseControlMetricsReporterTest";
     protected static final String TEST_TOPIC = "TestTopic";
-    private static final Logger LOG = LoggerFactory.getLogger(CruiseControlMetricsReporterAutoCreateTopicTest.class);
 
     /**
      * Setup the unit test.

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterAutoCreateTopicTest.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterAutoCreateTopicTest.java
@@ -107,7 +107,7 @@ public class CruiseControlMetricsReporterAutoCreateTopicTest extends CCKafkaClie
         Properties props = new Properties();
         props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
         AdminClient adminClient = AdminClient.create(props);
-        TopicDescription topicDescription = adminClient.describeTopics(Collections.singleton(TOPIC)).values().get(TOPIC).get();
+        TopicDescription topicDescription = adminClient.describeTopics(Collections.singleton(TOPIC)).topicNameValues().get(TOPIC).get();
         // assert that the metrics topic was created with partitions and replicas as configured for the metrics report auto-creation
         assertEquals(1, topicDescription.partitions().size());
         assertEquals(1, topicDescription.partitions().get(0).replicas().size());

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterTest.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterTest.java
@@ -24,7 +24,6 @@ import java.util.regex.Pattern;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaTestUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -50,6 +49,7 @@ import org.slf4j.LoggerFactory;
 
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter.DEFAULT_BOOTSTRAP_SERVERS_HOST;
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter.DEFAULT_BOOTSTRAP_SERVERS_PORT;
+import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter.topicNameValuesMethod;
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_CONFIG;
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS_CONFIG;
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_REPLICATION_FACTOR_CONFIG;
@@ -198,6 +198,7 @@ public class CruiseControlMetricsReporterTest extends CCKafkaClientsIntegrationT
     props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
     AdminClient adminClient = AdminClient.create(props);
 
+    // For compatibility with Kafka 4.0 and beyond we must use new API methods.
     Method topicDescriptionMethod = topicNameValuesMethod();
 
     Map<String, KafkaFuture<TopicDescription>> topicDescriptionMap;
@@ -270,43 +271,5 @@ public class CruiseControlMetricsReporterTest extends CCKafkaClientsIntegrationT
     assertTrue(urlParsePattern.matcher(bootstrapServers).matches());
     assertEquals(DEFAULT_BOOTSTRAP_SERVERS_HOST, bootstrapServers.split(":")[0]);
     assertEquals(DEFAULT_BOOTSTRAP_SERVERS_PORT, bootstrapServers.split(":")[1]);
-  }
-
-  /**
-   * Attempts to retrieve the method for mapping topic names to futures from the {@link org.apache.kafka.clients.admin.DescribeTopicsResult} class.
-   * This method first tries to get the {@code topicNameValues()} method, which is available in Kafka 4.0.0 or later.
-   * If the method is not found, it falls back to trying to retrieve the {@code values()} method, which is available in Kafka 3.0.0 or earlier.
-   *
-   * If neither of these methods is found, a {@link RuntimeException} is thrown.
-   *
-   * <p>This method is useful for ensuring compatibility with both older and newer versions of Kafka clients.</p>
-   *
-   * @return the {@link Method} object representing the {@code topicNameValues()} or {@code values()} method.
-   * @throws RuntimeException if neither the {@code values()} nor {@code topicNameValues()} methods are found.
-   */
-  /* test */ static Method topicNameValuesMethod() {
-    //
-    Method topicDescriptionMethod = null;
-    try {
-      // First we try to get the topicNameValues() method
-      topicDescriptionMethod = DescribeTopicsResult.class.getMethod("topicNameValues");
-    } catch (NoSuchMethodException exception) {
-      LOG.info("Failed to get method topicNameValues() from DescribeTopicsResult class since we are probably on kafka 3.0.0 or older: ", exception);
-    }
-
-    if (topicDescriptionMethod == null) {
-      try {
-        // Second we try to get the values() method
-        topicDescriptionMethod = DescribeTopicsResult.class.getMethod("values");
-      } catch (NoSuchMethodException exception) {
-        LOG.info("Failed to get method values() from DescribeTopicsResult class since we are probably on kafka 3.0.0 or older: ", exception);
-      }
-    }
-
-    if (topicDescriptionMethod != null) {
-      return topicDescriptionMethod;
-    } else {
-      throw new RuntimeException("Unable to find both values() and topicNameValues() method in the DescribeTopicsResult class ");
-    }
   }
 }

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterTest.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterTest.java
@@ -44,8 +44,6 @@ import org.apache.kafka.server.config.ServerLogConfigs;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter.DEFAULT_BOOTSTRAP_SERVERS_HOST;
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter.DEFAULT_BOOTSTRAP_SERVERS_PORT;
@@ -60,7 +58,6 @@ import static org.junit.Assert.assertTrue;
 public class CruiseControlMetricsReporterTest extends CCKafkaClientsIntegrationTestHarness {
   protected static final String TOPIC = "CruiseControlMetricsReporterTest";
   private static final String HOST = "127.0.0.1";
-  private static final Logger LOG = LoggerFactory.getLogger(CruiseControlMetricsReporterAutoCreateTopicTest.class);
 
   /**
    * Setup the unit test.

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterTest.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterTest.java
@@ -4,12 +4,11 @@
 
 package com.linkedin.kafka.cruisecontrol.metricsreporter;
 
+import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.KafkaTopicDescriptionException;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.CruiseControlMetric;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.MetricSerde;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCEmbeddedBroker;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaClientsIntegrationTestHarness;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -18,7 +17,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaTestUtils;
@@ -35,7 +33,6 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
 import org.apache.kafka.network.SocketServerConfigs;
@@ -47,7 +44,7 @@ import org.junit.Test;
 
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter.DEFAULT_BOOTSTRAP_SERVERS_HOST;
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter.DEFAULT_BOOTSTRAP_SERVERS_PORT;
-import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter.topicNameValuesMethod;
+import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter.getTopicDescription;
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_CONFIG;
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS_CONFIG;
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_REPLICATION_FACTOR_CONFIG;
@@ -189,25 +186,19 @@ public class CruiseControlMetricsReporterTest extends CCKafkaClientsIntegrationT
   }
 
   @Test
-  public void testUpdatingMetricsTopicConfig() throws ExecutionException, InterruptedException {
+  public void testUpdatingMetricsTopicConfig() throws InterruptedException {
     Properties props = new Properties();
     setSecurityConfigs(props, "admin");
     props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
     AdminClient adminClient = AdminClient.create(props);
 
     // For compatibility with Kafka 4.0 and beyond we must use new API methods.
-    Method topicDescriptionMethod = topicNameValuesMethod();
-
-    Map<String, KafkaFuture<TopicDescription>> topicDescriptionMap;
-
+    TopicDescription topicDescription;
     try {
-      topicDescriptionMap = (Map<String, KafkaFuture<TopicDescription>>) topicDescriptionMethod
-              .invoke(adminClient.describeTopics(Collections.singleton(TOPIC)));
-    } catch (IllegalAccessException | InvocationTargetException e) {
+      topicDescription = getTopicDescription(adminClient, TOPIC);
+    } catch (KafkaTopicDescriptionException e) {
       throw new RuntimeException(e);
     }
-
-    TopicDescription topicDescription = topicDescriptionMap.get(TOPIC).get();
     assertEquals(1, topicDescription.partitions().size());
     // Shutdown broker
     _brokers.get(0).shutdown();
@@ -222,15 +213,12 @@ public class CruiseControlMetricsReporterTest extends CCKafkaClientsIntegrationT
     // Wait for broker to boot up
     Thread.sleep(5000);
 
+    // Check whether the topic config is updated
     try {
-      topicDescriptionMap = (Map<String, KafkaFuture<TopicDescription>>) topicDescriptionMethod
-              .invoke(adminClient.describeTopics(Collections.singleton(TOPIC)));
-    } catch (IllegalAccessException | InvocationTargetException e) {
+      topicDescription = getTopicDescription(adminClient, TOPIC);
+    } catch (KafkaTopicDescriptionException e) {
       throw new RuntimeException(e);
     }
-
-    // Check whether the topic config is updated
-    topicDescription = topicDescriptionMap.get(TOPIC).get();
     assertEquals(2, topicDescription.partitions().size());
   }
 

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterTest.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterTest.java
@@ -190,7 +190,7 @@ public class CruiseControlMetricsReporterTest extends CCKafkaClientsIntegrationT
     setSecurityConfigs(props, "admin");
     props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
     AdminClient adminClient = AdminClient.create(props);
-    TopicDescription topicDescription = adminClient.describeTopics(Collections.singleton(TOPIC)).values().get(TOPIC).get();
+    TopicDescription topicDescription = adminClient.describeTopics(Collections.singleton(TOPIC)).topicNameValues().get(TOPIC).get();
     assertEquals(1, topicDescription.partitions().size());
     // Shutdown broker
     _brokers.get(0).shutdown();
@@ -205,7 +205,7 @@ public class CruiseControlMetricsReporterTest extends CCKafkaClientsIntegrationT
     // Wait for broker to boot up
     Thread.sleep(5000);
     // Check whether the topic config is updated
-    topicDescription = adminClient.describeTopics(Collections.singleton(TOPIC)).values().get(TOPIC).get();
+    topicDescription = adminClient.describeTopics(Collections.singleton(TOPIC)).topicNameValues().get(TOPIC).get();
     assertEquals(2, topicDescription.partitions().size());
   }
 

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterTest.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterTest.java
@@ -8,7 +8,6 @@ import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.CruiseControlMetr
 import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.MetricSerde;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCEmbeddedBroker;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaClientsIntegrationTestHarness;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
@@ -17,17 +16,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaTestUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -56,7 +52,6 @@ import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetr
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_AUTO_CREATE_CONFIG;
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS_CONFIG;
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_REPLICATION_FACTOR_CONFIG;
-import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsUtils.CLIENT_REQUEST_TIMEOUT_MS;
 import static com.linkedin.kafka.cruisecontrol.metricsreporter.metric.RawMetricType.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -65,7 +60,6 @@ public class CruiseControlMetricsReporterTest extends CCKafkaClientsIntegrationT
   protected static final String TOPIC = "CruiseControlMetricsReporterTest";
   private static final String HOST = "127.0.0.1";
   private static final Logger LOG = LoggerFactory.getLogger(CruiseControlMetricsReporterAutoCreateTopicTest.class);
-
 
   /**
    * Setup the unit test.
@@ -208,7 +202,8 @@ public class CruiseControlMetricsReporterTest extends CCKafkaClientsIntegrationT
     Map<String, KafkaFuture<TopicDescription>> topicDescriptionMap;
 
     try {
-      topicDescriptionMap = (Map<String, KafkaFuture<TopicDescription>>) topicDescriptionMethod.invoke(adminClient.describeTopics(Collections.singleton(TOPIC)));
+      topicDescriptionMap = (Map<String, KafkaFuture<TopicDescription>>) topicDescriptionMethod
+              .invoke(adminClient.describeTopics(Collections.singleton(TOPIC)));
     } catch (IllegalAccessException | InvocationTargetException e) {
       throw new RuntimeException(e);
     }

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterTest.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterTest.java
@@ -203,38 +203,14 @@ public class CruiseControlMetricsReporterTest extends CCKafkaClientsIntegrationT
     props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
     AdminClient adminClient = AdminClient.create(props);
 
-    // Starting with Kafka 4.0.0, the deprecated method "values()" class is completely removed from "org.apache.kafka.clients.admin.DescribeTopicsResult"
-    // so we have to use the new method "topicNameValues".
-    // To make sure that the internal build pass, this logic is introduced to choose the API based on the Kafka version
-    Method topicDescriptionMethod = null;
-
-    try {
-      // First we try to get the topicNameValues() method
-      topicDescriptionMethod = Class.forName("org.apache.kafka.clients.admin.DescribeTopicsResult").getMethod("topicNameValues");
-    } catch (ClassNotFoundException | NoSuchMethodException exception) {
-      LOG.info("Failed to get method topicNameValues() from DescribeTopicsResult class since we are probably on kafka 3.0.0 or older: ", exception);
-    }
-
-    if (topicDescriptionMethod == null) {
-      try {
-        // Second we try to get the values() method
-        topicDescriptionMethod = Class.forName("org.apache.kafka.clients.admin.DescribeTopicsResult").getMethod("values");
-      } catch (ClassNotFoundException | NoSuchMethodException exception) {
-        LOG.info("Failed to get method values() from DescribeTopicsResult class since we are probably on kafka 3.0.0 or older: ", exception);
-      }
-    }
+    Method topicDescriptionMethod = topicNameValuesMethod();
 
     Map<String, KafkaFuture<TopicDescription>> topicDescriptionMap;
 
-    if (topicDescriptionMethod != null) {
-      try {
-        topicDescriptionMap = (Map<String, KafkaFuture<TopicDescription>>) topicDescriptionMethod.invoke(adminClient.describeTopics(Collections.singleton(TOPIC)));
-
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        throw new RuntimeException(e);
-      }
-    } else {
-      throw new NoSuchElementException("Unable to find both values() and topicNameValues() method in the DescribeTopicsResult class");
+    try {
+      topicDescriptionMap = (Map<String, KafkaFuture<TopicDescription>>) topicDescriptionMethod.invoke(adminClient.describeTopics(Collections.singleton(TOPIC)));
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      throw new RuntimeException(e);
     }
 
     TopicDescription topicDescription = topicDescriptionMap.get(TOPIC).get();
@@ -290,5 +266,43 @@ public class CruiseControlMetricsReporterTest extends CCKafkaClientsIntegrationT
     assertTrue(urlParsePattern.matcher(bootstrapServers).matches());
     assertEquals(DEFAULT_BOOTSTRAP_SERVERS_HOST, bootstrapServers.split(":")[0]);
     assertEquals(DEFAULT_BOOTSTRAP_SERVERS_PORT, bootstrapServers.split(":")[1]);
+  }
+
+  /**
+   * Attempts to retrieve the method for mapping topic names to futures from the {@link org.apache.kafka.clients.admin.DescribeTopicsResult} class.
+   * This method first tries to get the {@code topicNameValues()} method, which is available in Kafka 4.0.0 or later.
+   * If the method is not found, it falls back to trying to retrieve the {@code values()} method, which is available in Kafka 3.0.0 or earlier.
+   *
+   * If neither of these methods is found, a {@link RuntimeException} is thrown.
+   *
+   * <p>This method is useful for ensuring compatibility with both older and newer versions of Kafka clients.</p>
+   *
+   * @return the {@link Method} object representing the {@code topicNameValues()} or {@code values()} method.
+   * @throws RuntimeException if neither the {@code values()} nor {@code topicNameValues()} methods are found.
+   */
+  /* test */ static Method topicNameValuesMethod() {
+    //
+    Method topicDescriptionMethod = null;
+    try {
+      // First we try to get the topicNameValues() method
+      topicDescriptionMethod = Class.forName("org.apache.kafka.clients.admin.DescribeTopicsResult").getMethod("topicNameValues");
+    } catch (ClassNotFoundException | NoSuchMethodException exception) {
+      LOG.info("Failed to get method topicNameValues() from DescribeTopicsResult class since we are probably on kafka 3.0.0 or older: ", exception);
+    }
+
+    if (topicDescriptionMethod == null) {
+      try {
+        // Second we try to get the values() method
+        topicDescriptionMethod = Class.forName("org.apache.kafka.clients.admin.DescribeTopicsResult").getMethod("values");
+      } catch (ClassNotFoundException | NoSuchMethodException exception) {
+        LOG.info("Failed to get method values() from DescribeTopicsResult class since we are probably on kafka 3.0.0 or older: ", exception);
+      }
+    }
+
+    if (topicDescriptionMethod != null) {
+      return topicDescriptionMethod;
+    } else {
+      throw new RuntimeException("Unable to find both values() and topicNameValues() method in the DescribeTopicsResult class ");
+    }
   }
 }


### PR DESCRIPTION
## Summary
1. Why: Cruise Control metrics reporter package seems to be using some deprecated method for some time now which are completely removed in Kafka 4.0.0. These deprecated method makes CC incompatible with Kafka 4.0 and beyond.
```
2025-02-22T22:27:38,802 ERROR Uncaught exception in thread 'CruiseControlMetricsReporterRunner': (org.apache.kafka.common.utils.KafkaThread) [CruiseControlMetricsReporterRunner]
java.lang.NoSuchMethodError: 'java.util.Map org.apache.kafka.clients.admin.DescribeTopicsResult.values()'
        at com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter.maybeIncreaseTopicPartitionCount(CruiseControlMetricsReporter.java:376) ~[cruise-control-metrics-reporter-2.5.141.jar:?]
        at com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter.maybeUpdateCruiseControlMetricsTopic(CruiseControlMetricsReporter.java:348) ~[cruise-control-metrics-reporter-2.5.141.jar:?]
        at com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter.run(CruiseControlMetricsReporter.java:395) ~[cruise-control-metrics-reporter-2.5.141.jar:?]
        at java.base/java.lang.Thread.run(Thread.java:840) [?:?] 
```        

2. What: This PR replaces the deprecated method with the ones that should be used in place of them .


## Categorization
- [ ] documentation
- [ ] bugfix
- [ ] new feature
- [ ] refactor
- [ ] security/CVE
- [ ] other

This PR resolves #<Replace-Me-With-The-Issue-Number-Addressed-By-This-PR> if any.
