### PR TITLE
Catch NoSuchFileException on load failed brokers list

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AbstractBrokerFailureDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AbstractBrokerFailureDetector.java
@@ -15,6 +15,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -118,7 +119,7 @@ public abstract class AbstractBrokerFailureDetector extends AbstractAnomalyDetec
     String failedBrokerListString = null;
     try {
       failedBrokerListString = readFileToString(_failedBrokersFile, StandardCharsets.UTF_8);
-    } catch (FileNotFoundException fnfe) {
+    } catch (FileNotFoundException | NoSuchFileException fnfe) {
       // This means no previous failures have ever been persisted in the file.
       failedBrokerListString = "";
     } catch (IOException ioe) {


### PR DESCRIPTION
By enabling broker failure detection with `kafka.broker.failure.detection.enable=true` we have got a CC log (on the first startup without any brokers' failures) which print an error like this:

```shell
2025-03-03 11:53:29 ERROR AbstractBrokerFailureDetector:126 - Failed to load the failed broker list.
java.nio.file.NoSuchFileException: fileStore/failedBrokers.txt
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:92) ~[?:?]
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106) ~[?:?]
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111) ~[?:?]
	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:218) ~[?:?]
	at java.nio.file.Files.newByteChannel(Files.java:380) ~[?:?]
	at java.nio.file.Files.newByteChannel(Files.java:432) ~[?:?]
	at java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:422) ~[?:?]
	at java.nio.file.Files.newInputStream(Files.java:160) ~[?:?]
	at org.apache.commons.io.FileUtils.lambda$readFileToString$12(FileUtils.java:2615) ~[commons-io-2.15.1.redhat-00001.jar:2.15.1.redhat-00001]
	at org.apache.commons.io.IOUtils.toString(IOUtils.java:3239) ~[commons-io-2.15.1.redhat-00001.jar:2.15.1.redhat-00001]
	at org.apache.commons.io.IOUtils.toString(IOUtils.java:3214) ~[commons-io-2.15.1.redhat-00001.jar:2.15.1.redhat-00001]
	at org.apache.commons.io.FileUtils.readFileToString(FileUtils.java:2615) ~[commons-io-2.15.1.redhat-00001.jar:2.15.1.redhat-00001]
	at com.linkedin.kafka.cruisecontrol.detector.AbstractBrokerFailureDetector.loadPersistedFailedBrokerList(AbstractBrokerFailureDetector.java:120) ~[cruise-control-2.5.141.redhat-00002.jar:2.5.141.redhat-00002]
	at com.linkedin.kafka.cruisecontrol.detector.KafkaBrokerFailureDetector.<init>(KafkaBrokerFailureDetector.java:32) ~[cruise-control-2.5.141.redhat-00002.jar:2.5.141.redhat-00002]
	at com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorManager.<init>(AnomalyDetectorManager.java:114) ~[cruise-control-2.5.141.redhat-00002.jar:2.5.141.redhat-00002]
	at com.linkedin.kafka.cruisecontrol.KafkaCruiseControl.<init>(KafkaCruiseControl.java:124) ~[cruise-control-2.5.141.redhat-00002.jar:2.5.141.redhat-00002]
	at com.linkedin.kafka.cruisecontrol.async.AsyncKafkaCruiseControl.<init>(AsyncKafkaCruiseControl.java:34) ~[cruise-control-2.5.141.redhat-00002.jar:2.5.141.redhat-00002]
	at com.linkedin.kafka.cruisecontrol.KafkaCruiseControlApp.<init>(KafkaCruiseControlApp.java:36) ~[cruise-control-2.5.141.redhat-00002.jar:2.5.141.redhat-00002]
	at com.linkedin.kafka.cruisecontrol.KafkaCruiseControlServletApp.<init>(KafkaCruiseControlServletApp.java:32) ~[cruise-control-2.5.141.redhat-00002.jar:2.5.141.redhat-00002]
	at com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.getCruiseControlApp(KafkaCruiseControlUtils.java:926) ~[cruise-control-2.5.141.redhat-00002.jar:2.5.141.redhat-00002]
	at com.linkedin.kafka.cruisecontrol.KafkaCruiseControlMain.main(KafkaCruiseControlMain.java:37) ~[cruise-control-2.5.141.redhat-00002.jar:2.5.141.redhat-00002]
```

Of course it's not an error per se because the list is obviously empty due to the fact the file doesn't exist.
The reason is that the current code is trying to catch a `FileNotFoundException` while it's raised a `NoSuchFileException` instead.
This PR adds the catching of both.