### PR TITLE
Update build.gradle, build-info-extractor-gradle:4.24.14 -> 5.2.4

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
   implementation 'org.ajoberstar:grgit:1.7.2'
   implementation 'org.apache.httpcomponents:fluent-hc:4.5.13'
-  implementation('org.jfrog.buildinfo:build-info-extractor-gradle:4.24.14') {
+  implementation('org.jfrog.buildinfo:build-info-extractor-gradle:5.2.4') {
     exclude module: 'groovy-all'
   }
 }


### PR DESCRIPTION
bump build-info-extractor to 5.2.4

## Summary
1. Why: current version have multiple vulnerabilitis
org.jfrog.buildinfo:build-info-extractor-gradle@4.24.14 → org.jfrog.buildinfo:build-info-api@2.28.8 → com.thoughtworks.xstream:xstream@1.4.17

one of them have xstream with remove code execution
https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569183
weneed to update gradle, which will update dependecy on build-info-api which is not using xstream at all

2. What: bupm versoin

## Expected Behavior
no changes

## Actual Behavior
no changes

## Categorization
- [ ] documentation
- [ ] bugfix
- [ ] new feature
- [ ] refactor
- [x] security/CVE
- [ ] other
