### PR TITLE
Change log level in createKafkaZkClient

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControlUtils.java
@@ -551,7 +551,7 @@ public final class KafkaCruiseControlUtils {
                                                             Integer.MAX_VALUE, new SystemTime(), zkClientName, zkClientConfig, metricGroup,
                                                             metricType, false);
     } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-      LOG.debug("Unable to find apply method in KafkaZkClient for Kafka 3.1+.", e);
+      LOG.error("Unable to find apply method in KafkaZkClient for Kafka 3.1+.", e);
     }
     if (kafkaZkClient == null) {
       try {
@@ -563,7 +563,7 @@ public final class KafkaCruiseControlUtils {
         kafkaZkClient = (KafkaZkClient) kafka31MinusMet.invoke(null, connectString, zkSecurityEnabled, ZK_SESSION_TIMEOUT, ZK_CONNECTION_TIMEOUT,
                                                                Integer.MAX_VALUE, new SystemTime(), metricGroup, metricType, zkClientName, zkConfig);
       } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-        LOG.debug("Unable to find apply method in KafkaZkClient for Kafka 3.1-.", e);
+        LOG.error("Unable to find apply method in KafkaZkClient for Kafka 3.1-.", e);
       }
     }
     if (kafkaZkClient != null) {


### PR DESCRIPTION
## Summary
1. Why
We run kafka 3.0 with the 3.0.0 version and get the following error:
```
java.util.NoSuchElementException: Unable to find viable apply function version for the KafkaZkClient class 
        at com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.createKafkaZkClient(KafkaCruiseControlUtils.java:572) ~[com.linkedin.cruisec
ontrol.cruise-control-3.0.0.jar:?]
        at com.linkedin.kafka.cruisecontrol.detector.ZKBrokerFailureDetector.<init>(ZKBrokerFailureDetector.java:46) ~[com.linkedin.cruisecontro
l.cruise-control-3.0.0.jar:?]
        at com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorManager.<init>(AnomalyDetectorManager.java:116) ~[com.linkedin.cruisecontrol
.cruise-control-3.0.0.jar:?]
        at com.linkedin.kafka.cruisecontrol.KafkaCruiseControl.<init>(KafkaCruiseControl.java:124) ~[com.linkedin.cruisecontrol.cruise-control-3
.0.0.jar:?]
...
```

The current log is not sufficient to help to determine what is the error.

2. What
Changing log level to error when there is an exception to invoke KafkaZkClient.apply().

