### PR TITLE
Addition of metrics to track when self-healing started/ended

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/AnomalyDetectorManager.java
@@ -559,18 +559,18 @@ public class AnomalyDetectorManager {
             skipReportingIfNotUpdated = anomalyType == KafkaAnomalyType.BROKER_FAILURE;
             throw ofe;
           } finally {
-            handlePostFixAnomaly(isReadyToFix, fixStarted, anomalyId, skipReportingIfNotUpdated);
+            handlePostFixAnomaly(isReadyToFix, fixStarted, anomalyId, skipReportingIfNotUpdated, anomalyType);
           }
         }
       }
     }
 
-    private void handlePostFixAnomaly(boolean isReadyToFix, boolean fixStarted, String anomalyId, boolean skipReportingIfNotUpdated) {
+    private void handlePostFixAnomaly(boolean isReadyToFix, boolean fixStarted, String anomalyId, boolean skipReportingIfNotUpdated, AnomalyType anomalyType) {
       if (isReadyToFix) {
         _anomalyDetectorState.onAnomalyHandle(_anomalyInProgress, fixStarted ? AnomalyState.Status.FIX_STARTED
                                                                              : AnomalyState.Status.FIX_FAILED_TO_START);
         if (fixStarted) {
-          _anomalyDetectorState.incrementNumSelfHealingStarted();
+          _anomalyDetectorState.incrementNumSelfHealingStarted(anomalyType);
           LOG.info("[{}] Self-healing started successfully.", anomalyId);
         } else {
           _anomalyDetectorState.incrementNumSelfHealingFailedToStart();


### PR DESCRIPTION
## Summary
1. Why: We earlier had the metrics in self healing fro knowing the timestamp at which the self-healing started bu it was not classified based on the anomalies. We also didn't had any metrics that can tell us when self healing was ended
2. What: This PR adds new metrics regarding self-healing which can show the no. of self healing started per anomaly as well as the timestamp when healing started and also we have metrics which can now tell us the self haling ended timestamp per anomaly

## Categorization
- [ ] new feature

This PR resolves #2266.
