### PR TITLE
Update README.md to say what versions support Kafka 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Cruise Control for Apache Kafka
 * The `main` (previously `migrate_to_kafka_2_5`) branch of Cruise Control is compatible with Apache Kafka `2.5+` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.*`),
   `2.6` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.11+`), `2.7` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.36+`),
   `2.8` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.66+`), `3.0` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.85+`),
-  and `3.1` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.85+`).
+  `3.1` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.85+`), and `3.8` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.5.142+`)
 * The `migrate_to_kafka_2_4` branch of Cruise Control is compatible with Apache Kafka `2.4` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.4.*`).
 * The `kafka_2_0_to_2_3` branch (deprecated) of Cruise Control is compatible with Apache Kafka `2.0`, `2.1`, `2.2`, and `2.3` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `2.0.*`).
 * The `kafka_0_11_and_1_0` branch (deprecated) of Cruise Control is compatible with Apache Kafka `0.11.0.0`, `1.0`, and `1.1` (i.e. [Releases](https://github.com/linkedin/cruise-control/releases) with `0.1.*`).


### PR DESCRIPTION
Update README.md to say what versions support Kafka 3.8

Is this version number correct? That's what the changelog says. https://github.com/linkedin/cruise-control/releases/tag/2.5.142

## Summary
1. Why: Improve documentation, so users know what version to use
2. What: Update README.md to say what versions support Kafka 3.8

## Expected Behavior
I would know what branch to use.

## Actual Behavior
I wasn't sure if I should use the main branch or not.

## Steps to Reproduce
Not applicable

## Known Workarounds
Read all the changelogs for all the releases

## Additional evidence
Not applicable

## Categorization
- [X] documentation
- [ ] bugfix
- [ ] new feature
- [ ] refactor
- [ ] security/CVE
- [ ] other

This PR resolves #<Replace-Me-With-The-Issue-Number-Addressed-By-This-PR> if any.
