### PR TITLE
fix: updated jetty version to 9.4.57.v20241219 to address CVE-2024-13009

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,5 @@ scalaVersion=2.13.13
 kafkaVersion=3.8.0
 zookeeperVersion=3.9.3
 nettyVersion=4.1.114.Final
-jettyVersion=9.4.56.v20240826
+jettyVersion=9.4.57.v20241219
 vertxVersion=4.5.8


### PR DESCRIPTION

## Summary

updated jetty version to `9.4.57.v20241219` to address `CVE-2024-13009`


## Categorization
- [x] security/CVE


This PR resolves #2277
