### PR TITLE
updating netty to v. 4.1.118.Final

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,6 @@ org.gradle.jvmargs=-Xms512m -Xmx512m
 scalaVersion=2.13.13
 kafkaVersion=3.8.0
 zookeeperVersion=3.9.3
-nettyVersion=4.1.114.Final
+nettyVersion=4.1.118.Final
 jettyVersion=9.4.56.v20240826
 vertxVersion=4.5.8


### PR DESCRIPTION
**Why:**
Update to address CVE-2025-25193 and CVE-2025-24970
https://nvd.nist.gov/vuln/detail/CVE-2025-25193
https://nvd.nist.gov/vuln/detail/CVE-2025-24970

**What:**
Netty version 4.1.114.Final to 4.1.118.Final
Affecting io.netty:netty-handler and io.netty:netty-transport-native-epoll

**Expected Behavior:**
Vulnerability scanning should not output evidence of impacted netty version after update
cruise-control should build successfully after update.

**Actual Behavior:**
Vulnerability scanning did not output evidence of impacted netty version after update
cruise-control build was successful after update.

**Categorization:** 
security/CVE