### PR TITLE
updating nimbus-jose-jwt to 10.0.2 to address CVE-2025-53864

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -291,7 +291,7 @@ project(':cruise-control') {
     implementation 'com.google.code.gson:gson:2.9.0'
     implementation "org.eclipse.jetty:jetty-server:${jettyVersion}"
     implementation 'io.dropwizard.metrics:metrics-jmx:4.2.9'
-    implementation 'com.nimbusds:nimbus-jose-jwt:9.45'
+    implementation 'com.nimbusds:nimbus-jose-jwt:10.0.2'
     implementation 'io.swagger.parser.v3:swagger-parser-v3:2.1.16'
     implementation 'io.github.classgraph:classgraph:4.8.141'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'


### PR DESCRIPTION
Why:
Address CVE-2025-53864, a vulnerability affecting com.nimbusds:nimbus-jose-jwt.

What:
Updated dependency configuration in Gradle build to use nimbus-jose-jwt version 10.0.2, which resolves the identified vulnerability.
Replaces the previously used 9.45, which is affected by the CVE.
This is a major version update but there is nothing in the release notes which would indicate that there will be an issue with this change (https://bitbucket.org/connect2id/nimbus-jose-jwt/src/master/CHANGELOG.txt). All tests / build for cruise-control ran successfully after changes.

Expected Behavior:
Vulnerability scans should no longer report the affected version of nimbus-jose-jwt.
cruise-control should continue to build and function correctly with the updated dependency.

Actual Behavior:
Vulnerability scanning no longer reports the CVE.
cruise-control build and functionality remain unaffected after the update.

Categorization:
security/CVE