### PR TITLE
Add bulk replication throttle mode (set throttle once inter-broker)

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
@@ -610,6 +610,15 @@ public final class ExecutorConfig {
   public static final String AUTO_STOP_EXTERNAL_AGENT_DOC = "When starting a new proposal execution while external agent is reassigning partitions,"
       + " automatically stop the external agent and start the execution."
       + " Set to false to keep the external agent reassignment and skip starting the execution.";
+
+  /**
+   * <code>bulk.replication.throttle.enabled</code>
+   */
+  public static final String BULK_REPLICATION_THROTTLE_ENABLED_CONFIG = "bulk.replication.throttle.enabled";
+  public static final boolean DEFAULT_BULK_REPLICATION_THROTTLE_ENABLED = false;
+  public static final String BULK_REPLICATION_THROTTLE_ENABLED_DOC = "If true, Cruise Control sets replication throttles once "
+      + "before starting inter-broker replica movements and clears them once after inter-broker replica movements end. "
+      + "If false, throttles are set/cleared per batch.";
   private ExecutorConfig() {
   }
 
@@ -990,6 +999,11 @@ public final class ExecutorConfig {
                             ConfigDef.Type.BOOLEAN,
                             DEFAULT_AUTO_STOP_EXTERNAL_AGENT,
                             ConfigDef.Importance.MEDIUM,
-                            AUTO_STOP_EXTERNAL_AGENT_DOC);
+                            AUTO_STOP_EXTERNAL_AGENT_DOC)
+                    .define(BULK_REPLICATION_THROTTLE_ENABLED_CONFIG,
+                            ConfigDef.Type.BOOLEAN,
+                            DEFAULT_BULK_REPLICATION_THROTTLE_ENABLED,
+                            ConfigDef.Importance.MEDIUM,
+                            BULK_REPLICATION_THROTTLE_ENABLED_DOC);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -1606,13 +1606,33 @@ public class Executor {
 
     private void interBrokerMoveReplicas() throws InterruptedException, ExecutionException, TimeoutException {
       Set<Integer> currentDeadBrokersWithReplicas = _loadMonitor.deadBrokersWithReplicas(MAX_METADATA_WAIT_MS);
-      ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(_adminClient, _replicationThrottle,
-          currentDeadBrokersWithReplicas);
+      ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(_adminClient, _replicationThrottle, currentDeadBrokersWithReplicas);
+      final boolean bulkThrottleEnabled = _config.getBoolean(ExecutorConfig.BULK_REPLICATION_THROTTLE_ENABLED_CONFIG);
       int numTotalPartitionMovements = _executionTaskManager.numRemainingInterBrokerPartitionMovements();
       long totalDataToMoveInMB = _executionTaskManager.remainingInterBrokerDataToMoveInMB();
       long startTime = System.currentTimeMillis();
       LOG.info("User task {}: Starting {} inter-broker partition movements.", _uuid, numTotalPartitionMovements);
 
+      // If bulk throttle is enabled, set throttles once for all pending inter-broker tasks before entering the loop.
+      if (bulkThrottleEnabled && _replicationThrottle != null && numTotalPartitionMovements > 0) {
+        ExecutionTasksSummary summaryAtStart = _executionTaskManager.getExecutionTasksSummary(
+            Collections.singleton(INTER_BROKER_REPLICA_ACTION));
+        Map<ExecutionTaskState, Set<ExecutionTask>> interBrokerTasksByState = summaryAtStart.filteredTasksByState()
+            .get(INTER_BROKER_REPLICA_ACTION);
+        Set<ExecutionTask> pendingAtStart = interBrokerTasksByState.getOrDefault(ExecutionTaskState.PENDING,
+            Collections.emptySet());
+        // Filter out proposals for non-existent topics to avoid admin timeouts on config changes for non-existent topics.
+        Set<String> existingTopics = _metadataClient.refreshMetadata().cluster().topics();
+        List<ExecutionProposal> proposalsForExistingTopics = pendingAtStart.stream()
+            .map(ExecutionTask::proposal)
+            .filter(p -> existingTopics.contains(p.topic()))
+            .collect(Collectors.toList());
+        long numExistingTopicsToThrottle = proposalsForExistingTopics.stream().map(ExecutionProposal::topic).distinct().count();
+        LOG.info("User task {}: Applying bulk replication throttle of {} B/s to {} inter-broker movements "
+                + "({} pending before filtering) across {} topics.",
+          _uuid, _replicationThrottle, proposalsForExistingTopics.size(), pendingAtStart.size(), numExistingTopicsToThrottle);
+        throttleHelper.setThrottles(proposalsForExistingTopics);
+      }
       int partitionsToMove = numTotalPartitionMovements;
       // Exhaust all the pending partition movements.
       while ((partitionsToMove > 0 || !inExecutionTasks().isEmpty()) && _stopSignal.get() == NO_STOP_EXECUTION) {
@@ -1622,7 +1642,9 @@ public class Executor {
 
         AlterPartitionReassignmentsResult result = null;
         if (!tasksToExecute.isEmpty()) {
-          throttleHelper.setThrottles(tasksToExecute.stream().map(ExecutionTask::proposal).collect(Collectors.toList()));
+          if (!bulkThrottleEnabled) {
+            throttleHelper.setThrottles(tasksToExecute.stream().map(ExecutionTask::proposal).collect(Collectors.toList()));
+          }
           // Execute the tasks.
           _executionTaskManager.markTasksInProgress(tasksToExecute);
           result = ExecutionUtils.submitReplicaReassignmentTasks(_adminClient, tasksToExecute);
@@ -1644,7 +1666,44 @@ public class Executor {
             .filter(t -> t.state() == ExecutionTaskState.IN_PROGRESS)
             .collect(Collectors.toList());
         inProgressTasks.addAll(inExecutionTasks());
-
+        if (!bulkThrottleEnabled) {
+          throttleHelper.clearThrottles(completedTasks, inProgressTasks);
+        }
+      }
+      if (bulkThrottleEnabled && _replicationThrottle != null) {
+        ExecutionTasksSummary summaryAtEnd = _executionTaskManager.getExecutionTasksSummary(
+            Collections.singleton(INTER_BROKER_REPLICA_ACTION));
+        Map<ExecutionTaskState, Set<ExecutionTask>> interBrokerTasksByState = summaryAtEnd.filteredTasksByState()
+            .get(INTER_BROKER_REPLICA_ACTION);
+        List<ExecutionTask> completedTasks = new ArrayList<>();
+        if (interBrokerTasksByState != null) {
+          completedTasks.addAll(
+              interBrokerTasksByState.getOrDefault(ExecutionTaskState.COMPLETED, Collections.emptySet()));
+          completedTasks.addAll(
+              interBrokerTasksByState.getOrDefault(ExecutionTaskState.ABORTED, Collections.emptySet()));
+          completedTasks.addAll(
+              interBrokerTasksByState.getOrDefault(ExecutionTaskState.DEAD, Collections.emptySet()));
+        }
+        List<ExecutionTask> inProgressTasks = new ArrayList<>();
+        if (interBrokerTasksByState != null) {
+          inProgressTasks.addAll(
+              interBrokerTasksByState.getOrDefault(ExecutionTaskState.IN_PROGRESS, Collections.emptySet()));
+          inProgressTasks.addAll(
+              interBrokerTasksByState.getOrDefault(ExecutionTaskState.ABORTING, Collections.emptySet()));
+        }
+        int completedCount = interBrokerTasksByState == null ? 0
+            : interBrokerTasksByState.getOrDefault(ExecutionTaskState.COMPLETED, Collections.emptySet()).size();
+        int abortedCount = interBrokerTasksByState == null ? 0
+            : interBrokerTasksByState.getOrDefault(ExecutionTaskState.ABORTED, Collections.emptySet()).size();
+        int deadCount = interBrokerTasksByState == null ? 0
+            : interBrokerTasksByState.getOrDefault(ExecutionTaskState.DEAD, Collections.emptySet()).size();
+        int inProgressCount = interBrokerTasksByState == null ? 0
+            : interBrokerTasksByState.getOrDefault(ExecutionTaskState.IN_PROGRESS, Collections.emptySet()).size();
+        int abortingCount = interBrokerTasksByState == null ? 0
+            : interBrokerTasksByState.getOrDefault(ExecutionTaskState.ABORTING, Collections.emptySet()).size();
+        LOG.info("User task {}: Clearing bulk replication throttles (configured rate: {} B/s). "
+                + "Completed: {}, Aborted: {}, Dead: {}, InProgress: {}, Aborting: {}.",
+            _uuid, _replicationThrottle, completedCount, abortedCount, deadCount, inProgressCount, abortingCount);
         throttleHelper.clearThrottles(completedTasks, inProgressTasks);
       }
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -35,6 +35,7 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import java.util.HashSet;
+import java.util.stream.Collectors;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
@@ -42,6 +43,8 @@ import kafka.zk.KafkaZkClient;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.AlterPartitionReassignmentsResult;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.ElectLeadersResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
@@ -52,6 +55,7 @@ import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
@@ -420,6 +424,205 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
     long validValue = minExecutionProgressCheckIntervalMs + (defaultExecutionProgressCheckIntervalMs - minExecutionProgressCheckIntervalMs) / 2;
     executor.setExecutionProgressCheckIntervalMs(validValue);
     assertEquals(validValue, executor.executionProgressCheckIntervalMs());
+  }
+
+  @Test
+  public void testInterBrokerMoveReplicasWhenBulkThrottleEnabledThenThrottleApplied()
+      throws InterruptedException, OngoingExecutionException {
+      // Prepare topics and proposals
+      Map<String, TopicDescription> topicDescriptions = createTopics((int) PRODUCE_SIZE_IN_BYTES);
+      int initialLeader0 = topicDescriptions.get(TOPIC0).partitions().get(0).leader().id();
+      int initialLeader1 = topicDescriptions.get(TOPIC1).partitions().get(0).leader().id();
+
+      ExecutionProposal proposal0 =
+          new ExecutionProposal(TP0, PRODUCE_SIZE_IN_BYTES, new ReplicaPlacementInfo(initialLeader0),
+              Collections.singletonList(new ReplicaPlacementInfo(initialLeader0)),
+              Collections.singletonList(new ReplicaPlacementInfo(initialLeader0 == 0 ? 1 : 0)));
+      ExecutionProposal proposal1 =
+          new ExecutionProposal(TP1, 0, new ReplicaPlacementInfo(initialLeader1),
+              Arrays.asList(new ReplicaPlacementInfo(initialLeader1), new ReplicaPlacementInfo(initialLeader1 == 0 ? 1 : 0)),
+              Arrays.asList(new ReplicaPlacementInfo(initialLeader1 == 0 ? 1 : 0), new ReplicaPlacementInfo(initialLeader1)));
+
+      Collection<ExecutionProposal> proposalsToExecute = Arrays.asList(proposal0, proposal1);
+
+      // Enable bulk throttle in config
+      Properties props = getExecutorProperties();
+      props.setProperty(ExecutorConfig.BULK_REPLICATION_THROTTLE_ENABLED_CONFIG, "true");
+      KafkaCruiseControlConfig configs = new KafkaCruiseControlConfig(props);
+
+      UserTaskManager.UserTaskInfo mockUserTaskInfo = getMockUserTaskInfo();
+      UserTaskManager mockUserTaskManager = getMockUserTaskManager(RANDOM_UUID, mockUserTaskInfo, Collections.singletonList(true));
+      LoadMonitor mockLoadMonitor = getMockLoadMonitor();
+      AnomalyDetectorManager mockAnomalyDetectorManager = getMockAnomalyDetector(RANDOM_UUID, false);
+      EasyMock.replay(mockUserTaskInfo, mockUserTaskManager, mockLoadMonitor, mockAnomalyDetectorManager);
+
+      MetricRegistry metricRegistry = new MetricRegistry();
+      Executor executor = new Executor(configs, Time.SYSTEM, metricRegistry, mockAnomalyDetectorManager);
+      executor.setUserTaskManager(mockUserTaskManager);
+
+      // Start execution with replication throttle
+      final long replicationThrottle = PRODUCE_SIZE_IN_BYTES;
+      executor.setGeneratingProposalsForExecution(RANDOM_UUID, ExecutorTest.class::getSimpleName, true);
+      executor.executeProposals(proposalsToExecute, Collections.emptySet(), null, mockLoadMonitor, null, null, null, null, null,
+          null, null, replicationThrottle, true, RANDOM_UUID, false, false);
+
+      // Wait for inter-broker movement to start
+      waitUntilTrue(() -> (executor.state().state() == ExecutorState.State.INTER_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS),
+          "Inter-broker replica movement task did not start within the time limit", EXECUTION_DEADLINE_MS, EXECUTION_SHORT_CHECK_MS);
+
+      try (AdminClient adminClient = KafkaCruiseControlUtils.createAdminClient(
+          Collections.singletonMap(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()))) {
+
+          waitUntilTrue(() -> {
+                  try {
+                      for (int brokerId : List.of(0, 1)) {
+                          ConfigResource cf = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(brokerId));
+                          Map<ConfigResource, Config> cfg = adminClient.describeConfigs(Collections.singletonList(cf)).all().get();
+                          Config brokerCfg = cfg.get(cf);
+                          String leaderActual = brokerCfg.get(ReplicationThrottleHelper.LEADER_THROTTLED_RATE) == null
+                              ? null : brokerCfg.get(ReplicationThrottleHelper.LEADER_THROTTLED_RATE).value();
+                          String followerActual = brokerCfg.get(ReplicationThrottleHelper.FOLLOWER_THROTTLED_RATE) == null
+                              ? null : brokerCfg.get(ReplicationThrottleHelper.FOLLOWER_THROTTLED_RATE).value();
+                          if (!String.valueOf(replicationThrottle).equals(leaderActual)
+                              || !String.valueOf(replicationThrottle).equals(followerActual)) {
+                              return false;
+                          }
+                      }
+                      return true;
+                  } catch (Exception e) {
+                      return false;
+                  }
+              },
+              "Throttle rate not applied to brokers in time",
+              EXECUTION_DEADLINE_MS,
+              EXECUTION_SHORT_CHECK_MS);
+
+          Set<String> topicsSnapshot = proposalsToExecute.stream().map(ExecutionProposal::topic).collect(Collectors.toSet());
+          for (String topic : topicsSnapshot) {
+              waitUntilTrue(() -> {
+                      try {
+                          ConfigResource cf = new ConfigResource(ConfigResource.Type.TOPIC, topic);
+                          Map<ConfigResource, Config> cfg = adminClient.describeConfigs(Collections.singletonList(cf)).all().get();
+                          Config topicCfg = cfg.get(cf);
+                          String leaderReplicas = topicCfg.get(ReplicationThrottleHelper.LEADER_THROTTLED_REPLICAS) == null
+                              ? null : topicCfg.get(ReplicationThrottleHelper.LEADER_THROTTLED_REPLICAS).value();
+                          String followerReplicas = topicCfg.get(ReplicationThrottleHelper.FOLLOWER_THROTTLED_REPLICAS) == null
+                              ? null : topicCfg.get(ReplicationThrottleHelper.FOLLOWER_THROTTLED_REPLICAS).value();
+                          return leaderReplicas != null && !leaderReplicas.isEmpty() && leaderReplicas.contains("0:")
+                              && followerReplicas != null && !followerReplicas.isEmpty() && followerReplicas.contains("0:");
+                      } catch (Exception e) {
+                          return false;
+                      }
+                  },
+                  "Topic throttled replicas not applied for topic " + topic,
+                  EXECUTION_DEADLINE_MS,
+                  EXECUTION_SHORT_CHECK_MS);
+          }
+
+          // Explicitly stop to avoid long wait, then ensure background execution is drained
+          executor.userTriggeredStopExecution(false);
+          waitUntilTrue(() -> (!executor.hasOngoingExecution() && executor.state().state() == ExecutorState.State.NO_TASK_IN_PROGRESS),
+              "Stopped proposal execution did not finish within the time limit", EXECUTION_DEADLINE_MS, EXECUTION_REGULAR_CHECK_MS);
+      }
+  }
+
+  @Test
+  public void testInterBrokerMoveReplicasWhenBulkThrottleEnabledThenThrottleClearedAtEnd()
+      throws InterruptedException, OngoingExecutionException {
+      // Prepare topics and proposals
+      Map<String, TopicDescription> topicDescriptions = createTopics((int) PRODUCE_SIZE_IN_BYTES);
+      int initialLeader0 = topicDescriptions.get(TOPIC0).partitions().get(0).leader().id();
+      int initialLeader1 = topicDescriptions.get(TOPIC1).partitions().get(0).leader().id();
+
+      ExecutionProposal proposal0 =
+          new ExecutionProposal(TP0, PRODUCE_SIZE_IN_BYTES, new ReplicaPlacementInfo(initialLeader0),
+              Collections.singletonList(new ReplicaPlacementInfo(initialLeader0)),
+              Collections.singletonList(new ReplicaPlacementInfo(initialLeader0 == 0 ? 1 : 0)));
+      ExecutionProposal proposal1 =
+          new ExecutionProposal(TP1, 0, new ReplicaPlacementInfo(initialLeader1),
+              Arrays.asList(new ReplicaPlacementInfo(initialLeader1), new ReplicaPlacementInfo(initialLeader1 == 0 ? 1 : 0)),
+              Arrays.asList(new ReplicaPlacementInfo(initialLeader1 == 0 ? 1 : 0), new ReplicaPlacementInfo(initialLeader1)));
+
+      Collection<ExecutionProposal> proposalsToExecute = Arrays.asList(proposal0, proposal1);
+
+      // Enable bulk throttle in config
+      Properties props = getExecutorProperties();
+      props.setProperty(ExecutorConfig.BULK_REPLICATION_THROTTLE_ENABLED_CONFIG, "true");
+      KafkaCruiseControlConfig configs = new KafkaCruiseControlConfig(props);
+
+      UserTaskManager.UserTaskInfo mockUserTaskInfo = getMockUserTaskInfo();
+      UserTaskManager mockUserTaskManager = getMockUserTaskManager(RANDOM_UUID, mockUserTaskInfo, Collections.singletonList(true));
+      LoadMonitor mockLoadMonitor = getMockLoadMonitor();
+      AnomalyDetectorManager mockAnomalyDetectorManager = getMockAnomalyDetector(RANDOM_UUID, false);
+      EasyMock.replay(mockUserTaskInfo, mockUserTaskManager, mockLoadMonitor, mockAnomalyDetectorManager);
+
+      MetricRegistry metricRegistry = new MetricRegistry();
+      Executor executor = new Executor(configs, Time.SYSTEM, metricRegistry, mockAnomalyDetectorManager);
+      executor.setUserTaskManager(mockUserTaskManager);
+
+      // Start execution with replication throttle
+      final long replicationThrottle = PRODUCE_SIZE_IN_BYTES;
+      executor.setGeneratingProposalsForExecution(RANDOM_UUID, ExecutorTest.class::getSimpleName, true);
+      executor.executeProposals(proposalsToExecute, Collections.emptySet(), null, mockLoadMonitor, null, null, null, null, null,
+          null, null, replicationThrottle, true, RANDOM_UUID, false, false);
+
+      // Ensure execution started, confirm reassignments began, then stop to expedite teardown and wait for completion
+      waitUntilTrue(() -> (executor.state().state() == ExecutorState.State.INTER_BROKER_REPLICA_MOVEMENT_TASK_IN_PROGRESS),
+          "Inter-broker replica movement task did not start within the time limit", EXECUTION_DEADLINE_MS, EXECUTION_SHORT_CHECK_MS);
+      verifyOngoingPartitionReassignments(Collections.singleton(TP0));
+      executor.userTriggeredStopExecution(false);
+      waitUntilTrue(() -> (!executor.hasOngoingExecution() && executor.state().state() == ExecutorState.State.NO_TASK_IN_PROGRESS),
+          "Stopped proposal execution did not finish within the time limit", EXECUTION_DEADLINE_MS * 3, EXECUTION_REGULAR_CHECK_MS);
+
+      // Verify throttles are cleared at the end
+      try (AdminClient adminClient = KafkaCruiseControlUtils.createAdminClient(
+          Collections.singletonMap(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker(0).plaintextAddr()))) {
+
+          waitUntilTrue(() -> {
+                  try {
+                      for (int brokerId : List.of(0, 1)) {
+                          ConfigResource cf = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(brokerId));
+                          Map<ConfigResource, Config> cfg = adminClient.describeConfigs(Collections.singletonList(cf)).all().get();
+                          Config brokerCfg = cfg.get(cf);
+                          String leaderActual = brokerCfg.get(ReplicationThrottleHelper.LEADER_THROTTLED_RATE) == null
+                              ? null : brokerCfg.get(ReplicationThrottleHelper.LEADER_THROTTLED_RATE).value();
+                          String followerActual = brokerCfg.get(ReplicationThrottleHelper.FOLLOWER_THROTTLED_RATE) == null
+                              ? null : brokerCfg.get(ReplicationThrottleHelper.FOLLOWER_THROTTLED_RATE).value();
+                          if (leaderActual != null || followerActual != null) {
+                              return false;
+                          }
+                      }
+                      return true;
+                  } catch (Exception e) {
+                      return false;
+                  }
+              },
+              "Throttle not cleared from brokers in time",
+              EXECUTION_DEADLINE_MS,
+              EXECUTION_SHORT_CHECK_MS);
+
+          // Topic replicas cleared
+          Set<String> topicsSnapshot = proposalsToExecute.stream().map(ExecutionProposal::topic).collect(Collectors.toSet());
+          for (String topic : topicsSnapshot) {
+              waitUntilTrue(() -> {
+                      try {
+                          ConfigResource cf = new ConfigResource(ConfigResource.Type.TOPIC, topic);
+                          Map<ConfigResource, Config> cfg = adminClient.describeConfigs(Collections.singletonList(cf)).all().get();
+                          Config topicCfg = cfg.get(cf);
+                          ConfigEntry leaderEntry = topicCfg.get(ReplicationThrottleHelper.LEADER_THROTTLED_REPLICAS);
+                          ConfigEntry followerEntry = topicCfg.get(ReplicationThrottleHelper.FOLLOWER_THROTTLED_REPLICAS);
+                          boolean leaderCleared = leaderEntry == null || leaderEntry.value() == null || leaderEntry.value().isEmpty();
+                          boolean followerCleared = followerEntry == null || followerEntry.value() == null || followerEntry.value().isEmpty();
+                          return leaderCleared && followerCleared;
+                      } catch (Exception e) {
+                          return false;
+                      }
+                  },
+                  "Topic throttled replicas not cleared for topic " + topic,
+                  EXECUTION_DEADLINE_MS,
+                  EXECUTION_SHORT_CHECK_MS);
+          }
+      }
   }
 
   @Test


### PR DESCRIPTION
## Summary
1. Why: Per-batch replication throttle set/clear causes excessive AdminClient calls when many batches involve the same brokers, significantly slowing rebalances. This PR proposes a bulk mode that sets the replication bytes throttle once before inter-broker movements and clears it once after, reducing Admin overhead and improving execution time. 
2. What:
   - Add `bulk.replication.throttle.enabled` (default: `false`) to `ExecutorConfig`.
   - In `Executor`, when enabled:
     - Set throttles once before inter-broker partition movements begin (filtering to existing topics).
     - Clear throttles once after all inter-broker partition movements complete, with summary logging (completed/aborted/dead/in-progress/aborting).
   - Keep existing per-batch behavior when disabled.
   - Update tests to cover both bulk and non-bulk paths.
   - Follow-ups: Improvements to the Kafka calls inside ReplicationThrottleHelper are being addressed in a separate PR; this PR focuses solely on bulk set/clear semantics.

## Expected Behavior
- With `bulk.replication.throttle.enabled=true`:
  - Throttles are applied once at the start of inter-broker moves and cleared once at the end.
  - Fewer AdminClient set/clear calls → faster rebalances.
  - No functional change to movement semantics; only fewer config mutations.
- With `bulk.replication.throttle.enabled=false`:
  - Current per-batch set/clear behavior remains unchanged.

## Actual Behavior
- Throttles are currently set before each batch and cleared after each batch if no other tasks are active on the same broker.
- When many batches affect the same brokers, the same throttle is repeatedly set/cleared.
- Each Admin request can take seconds (~20s observed locally), causing noticeable slowdowns.

## Steps to Reproduce
1. Prepare a rebalance plan with many inter-broker replica movements that repeatedly involve the same brokers.
2. Run the rebalance with current behavior (bulk disabled) and observe repeated set/clear throttle Admin calls per batch.
3. Measure end-to-end inter-broker phase duration.
4. Enable `bulk.replication.throttle.enabled=true` and re-run to observe reduced Admin calls and improved completion time.

## Additional evidence
1. Environment (test settings):
   - `concurrency.adjuster.max.partition.movements.per.broker=12`
   - `default.replica.movement.strategies=com.linkedin.kafka.cruisecontrol.executor.strategy.PrioritizeMinIsrWithOfflineReplicasStrategy,com.linkedin.kafka.cruisecontrol.executor.strategy.PrioritizeOneAboveMinIsrWithOfflineReplicasStrategy,com.linkedin.kafka.cruisecontrol.executor.strategy.PrioritizeSmallReplicaMovementStrategy,com.linkedin.kafka.cruisecontrol.executor.strategy.BaseReplicaMovementStrategy`
2. Scenario and results:
   - 900 partitions to rebalance (800 small, 100 large).
   - Before (bulk disabled): moving the 800 small partitions took over 1 hour 30 minutes.
   - After enabling `bulk.replication.throttle.enabled`: the 800 small partitions completed within a few minutes.
3. Logs: added summary logs when clearing bulk throttles (Completed/Aborted/Dead/InProgress/Aborting counts).
4. Follow-ups:
   - We are improving the Kafka call patterns inside `ReplicationThrottleHelper` in a separate PR; this PR intentionally limits scope to the bulk set/clear behavior.

## Categorization
- [ ] documentation
- [ ] bugfix
- [x] new feature
- [ ] refactor
- [ ] security/CVE
- [ ] other

This PR resolves #1972 