### PR TITLE
ReplicationThrottleHelper: Add support for AdminClient bulk operations

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
@@ -434,22 +434,6 @@ class ReplicationThrottleHelper {
   }
 
   // Retries until we can read the configs changes we just wrote
-  void waitForConfigs(ConfigResource cf, Collection<AlterConfigOp> ops) {
-    // Use HashMap::new instead of Collectors.toMap to allow inserting null values
-    Map<String, String> expectedConfigs = ops.stream()
-            .collect(HashMap::new, (m, o) -> m.put(o.configEntry().name(), o.configEntry().value()), HashMap::putAll);
-    boolean retryResponse = CruiseControlMetricsUtils.retry(() -> {
-      try {
-        return !configsEqual(getEntityConfigs(cf), expectedConfigs);
-      } catch (ExecutionException | InterruptedException | TimeoutException e) {
-        return false;
-      }
-    }, _retries);
-    if (!retryResponse) {
-      throw new IllegalStateException("The following configs " + ops + " were not applied to " + cf + " within the time limit");
-    }
-  }
-
   void waitForConfigs(Map<ConfigResource, Collection<AlterConfigOp>> opsByResource) {
     Map<ConfigResource, Map<String, String>> expectedByResource = new HashMap<>();
     for (Map.Entry<ConfigResource, Collection<AlterConfigOp>> entry : opsByResource.entrySet()) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
@@ -521,15 +521,15 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     EasyMock.replay(mockAdminClient);
     ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, 100L, retries);
     ConfigResource cf = new ConfigResource(ConfigResource.Type.TOPIC, TOPIC0);
-    assertThrows(IllegalStateException.class, () -> throttleHelper.waitForConfigs(cf, Collections.singletonList(
-            new AlterConfigOp(new ConfigEntry("k", "v"), AlterConfigOp.OpType.SET)
-    )));
+    Map<ConfigResource, Collection<AlterConfigOp>> opsByResource = Collections.singletonMap(cf,
+            Collections.singletonList(new AlterConfigOp(new ConfigEntry("k", "v"), AlterConfigOp.OpType.SET)));
+    assertThrows(IllegalStateException.class, () -> throttleHelper.waitForConfigs(opsByResource));
 
     // Case 2: queue a single result and call checkConfigs with matching configs, so it succeeds
     EasyMock.reset(mockAdminClient);
     expectDescribeTopicConfigs(mockAdminClient, TOPIC0, EMPTY_CONFIG, true);
     EasyMock.replay(mockAdminClient);
-    throttleHelper.waitForConfigs(cf, Collections.emptyList());
+    throttleHelper.waitForConfigs(Collections.singletonMap(cf, Collections.emptyList()));
   }
 
   @Test


### PR DESCRIPTION
### Summary
1. Why: Per-entity AdminClient calls (`incrementalAlterConfigs`/`describeConfigs`) scale poorly on large clusters and are fragile when topics are deleted mid-run.
2. What: Replaced the legacy per-entity configuration path with a new bulk-based implementation as the default behavior.
The new design applies and verifies broker and topic throttles in batches by default

### Expected Behavior
- Same throttling semantics as before with significantly fewer AdminClient round-trips and lower latency on large operations.
- Bulk verification reduces describe calls by grouping resources.
- Non-existent topics detected and skipped without failing the whole operation.
- Safe no-op on empty inputs.
- Continues to respect wildcard `*` and static broker configs (skips removal of static values).

### Actual Behavior (Before Change)
- Previous per-entity path triggers many calls per broker/topic, causing slowdowns and timeouts in large clusters.
- Config verification performed per resource, increasing cost.

### Steps to Reproduce
1. In a cluster with 100+ brokers and many topics/partitions, generate large inter-broker replica movements.
2. Compare old per-entity implementation (pre-change) vs. new default bulk implementation.
3. Record total execution time, AdminClient call counts, and any timeouts/failures.

### Additional evidence
1. Environment: Kafka version, cluster size (brokers/topics/partitions), Cruise Control version.
2. Logs: Presence of “Removing leader/follower throttle rate …”, and bulk verification messages.
3. Metrics: Before/after comparisons of call counts, execution time.

### Categorization
- [ ] documentation
- [ ] bugfix
- [ ] new feature
- [x] refactor
- [ ] security/CVE
- [ ] other

This PR resolves #1972 