### PR TITLE
Migrate AutoCreateTopicTest to TestContainers

### DIFF
--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterAutoCreateTopicTest.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporterAutoCreateTopicTest.java
@@ -7,6 +7,7 @@ package com.linkedin.kafka.cruisecontrol.metricsreporter;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.exception.KafkaTopicDescriptionException;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCContainerizedKraftCluster;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.CCKafkaClientsIntegrationTestHarness;
+import com.linkedin.kafka.cruisecontrol.metricsreporter.utils.KafkaServerConfigs;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
@@ -27,8 +28,6 @@ import static com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetr
 import static org.junit.Assert.assertEquals;
 
 public class CruiseControlMetricsReporterAutoCreateTopicTest extends CCKafkaClientsIntegrationTestHarness {
-    private static final int NUM_OF_BROKERS = 2;
-    private static final String HOST = "127.0.0.1";
     protected static final String TOPIC = "CruiseControlMetricsReporterTest";
     protected static final String TEST_TOPIC = "TestTopic";
     private CCContainerizedKraftCluster _cluster;
@@ -41,7 +40,7 @@ public class CruiseControlMetricsReporterAutoCreateTopicTest extends CCKafkaClie
         Properties adminClientProps = new Properties();
         setSecurityConfigs(adminClientProps, "admin");
 
-        _cluster = new CCContainerizedKraftCluster(NUM_OF_BROKERS, buildBrokerConfigs(), adminClientProps);
+        _cluster = new CCContainerizedKraftCluster(2, buildBrokerConfigs(), adminClientProps);
         _cluster.start();
         _bootstrapUrl = _cluster.getExternalBootstrapAddress();
 
@@ -92,7 +91,7 @@ public class CruiseControlMetricsReporterAutoCreateTopicTest extends CCKafkaClie
         Properties props = new Properties();
         props.setProperty(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG, CruiseControlMetricsReporter.class.getName());
         props.setProperty(CruiseControlMetricsReporterConfig.config(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG),
-          HOST + ":" + CCContainerizedKraftCluster.CONTAINER_INTERNAL_LISTENER_PORT);
+          "127.0.0.1:" + CCContainerizedKraftCluster.CONTAINER_INTERNAL_LISTENER_PORT);
         props.put("listener.security.protocol.map", String.join(",",
           CCContainerizedKraftCluster.CONTROLLER_LISTENER_NAME + ":PLAINTEXT",
           CCContainerizedKraftCluster.INTERNAL_LISTENER_NAME + ":PLAINTEXT",
@@ -106,10 +105,10 @@ public class CruiseControlMetricsReporterAutoCreateTopicTest extends CCKafkaClie
         props.setProperty(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_NUM_PARTITIONS_CONFIG, "1");
         props.setProperty(CruiseControlMetricsReporterConfig.CRUISE_CONTROL_METRICS_TOPIC_REPLICATION_FACTOR_CONFIG, "1");
         // disable topic auto-creation to leave the metrics reporter to create the metrics topic
-        props.setProperty("auto.create.topics.enable", "false");
-        props.setProperty("offsets.topic.replication.factor", "1");
-        props.setProperty("default.replication.factor", "2");
-        props.setProperty("num.partitions", "2");
+        props.setProperty(KafkaServerConfigs.AUTO_CREATE_TOPICS_ENABLE_CONFIG, "false");
+        props.setProperty(KafkaServerConfigs.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, "1");
+        props.setProperty(KafkaServerConfigs.DEFAULT_REPLICATION_FACTOR_CONFIG, "2");
+        props.setProperty(KafkaServerConfigs.NUM_PARTITIONS_CONFIG, "2");
         return props;
     }
 

--- a/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/utils/KafkaServerConfigs.java
+++ b/cruise-control-metrics-reporter/src/test/java/com/linkedin/kafka/cruisecontrol/metricsreporter/utils/KafkaServerConfigs.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+package com.linkedin.kafka.cruisecontrol.metricsreporter.utils;
+
+/**
+ * Defines Kafka broker configuration keys to avoid relying on internal Kafka classes.
+ * This reduces coupling to Kafka's internal APIs and improves long-term maintainability.
+ */
+public final class KafkaServerConfigs {
+    public static final String AUTO_CREATE_TOPICS_ENABLE_CONFIG = "auto.create.topics.enable";
+    public static final String OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG = "offsets.topic.replication.factor";
+    public static final String DEFAULT_REPLICATION_FACTOR_CONFIG = "default.replication.factor";
+    public static final String NUM_PARTITIONS_CONFIG = "num.partitions";
+
+    private KafkaServerConfigs() { }
+}
+


### PR DESCRIPTION
## Summary
1. Why: This PR is the next iteration of the TestContainers migration following the initial migration [PR](https://github.com/linkedin/cruise-control/pull/2303) in effort to remove the Cruise Control tests dependence on internal Kafka APIs. As detailed in issue Migrate off internal Kafka APIs to Improve Compatibility and Maintainability #2282, the existing Cruise Control tests rely on the Kafka server wrapper class, `CCEmbeddedBroker`, which uses several non-public Kafka APIs. These internal APIs lack stability and compatibility guarantees, making it increasingly difficult to upgrade Kafka versions. As Kafka evolves, this reliance introduces upgrade friction, version lock-in, and a growing maintenance burden.

2. What: This PR is the next step of the TestContainers migration following this [PR](https://github.com/linkedin/cruise-control/pull/2303). It refactors the `CruiseControlMetricsReporterAutoCreateTopicTest` to replace its dependency on the `CCEmbeddedBroker` class with the [TestContainers](https://java.testcontainers.org/modules/kafka/) Kafka module instead. This helps future-proof Cruise Control by easing upgrades to newer Kafka versions, expanding Kafka versions compatibility, and reducing the ongoing maintenance overhead.

## Categorization
- [ ] documentation
- [ ] bugfix
- [ ] new feature
- [x] refactor
- [ ] security/CVE
- [ ] other

This PR partially resolves [#2282](https://github.com/linkedin/cruise-control/issues/2282).
