### PR TITLE
Removing unnecessary runtime dependency of core: spotbugs-annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,7 +189,6 @@ project(':cruise-control-core') {
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.17.2"
     implementation 'org.apache.commons:commons-math3:3.6.1'
     api "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
-    implementation 'com.github.spotbugs:spotbugs-annotations:4.8.6'
 
     api "io.vertx:vertx-core:${vertxVersion}"
     api "io.vertx:vertx-web:${vertxVersion}"


### PR DESCRIPTION
## Summary
1. Why: spotbugs-annotation is not used, originally was added as findbugs but at wrong scope I believe, but now it's not used at all
2. What: removing the unused dependency, cleaner dependency tree and not leaking as transitive at other projects (at Strimzi for example)

## Expected Behavior
spotbugs-annotation not appearing in the runtime dependencies any more

## Actual Behavior
spotbugs-annotation is in the runtime dependencies of cruise control

## Steps to Reproduce
1. run `./gradlew :cruise-control:dependencies`
2. check the output

## Known Workarounds
Explicit exclusion is required in projects using the Cruise Control dependency.

## Categorization
- [ ] documentation
- [ ] bugfix
- [ ] new feature
- [ ] refactor
- [ ] security/CVE
- [x] other
