### PR TITLE
feat(ci): Enable cruise-control on ppc64le arch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
       matrix:
         java-ver: [17]
         java-dist: ['temurin']
-        hw_platform: ['s390x']
+        hw_platform: ['s390x', 'ppc64le']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
1. Why: To enable CI/CD builds for the `ppc64le` architecture, as requested in issue #1486.
2. What: This PR adds `'ppc64le'` to the `hw_platform` matrix within the `build-platform` job in the `.github/workflows/ci.yaml` file.

## Actual Behavior
The CI pipeline does not currently run builds or tests on the `ppc64le` architecture.

## Steps to Reproduce
N/A

## Known Workarounds
N/A

## Additional evidence
N/A

## Categorization
- [ ] documentation
- [ ] bugfix
- [ ] new feature
- [ ] refactor
- [ ] security/CVE
- [x] other (CI/CD change)

This PR resolves #1486.
