### PR TITLE
Update jetty Version to 12.1.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ org.gradle.jvmargs=-Xms512m -Xmx512m
 scalaVersion=2.13.13
 kafkaVersion=4.0.0
 nettyVersion=4.1.118.Final
-jettyVersion=9.4.56.v20240826
+jettyVersion=12.1.3
 vertxVersion=4.5.8


### PR DESCRIPTION
Update jetty to 12.1.3 to fix  CVE-2024-13009. Versions prior to 12.x of jetty have reached EOL

## Summary
1. Why: Update jetty to 12.1.3 to fix  CVE-2024-13009. Versions prior to 12.x of jetty have reached EOL
2. What: upgrade jetty to  12.1.3 

This PR resolves #2314  if any.
_