### PR TITLE
Update jettyVersion to 9.4.58.v20250814

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ org.gradle.jvmargs=-Xms512m -Xmx512m
 scalaVersion=2.13.13
 kafkaVersion=4.0.0
 nettyVersion=4.1.118.Final
-jettyVersion=9.4.56.v20240826
+jettyVersion=9.4.58.v20250814
 vertxVersion=4.5.8


### PR DESCRIPTION
Update jettyVersion to 9.4.58.v20250814 to fix CVEs

## Summary
1. Why: Update jettyVersion to 9.4.58.v20250814 to fix CVEs
2. What:  Update jettyVersion to 9.4.58.v20250814


This PR resolves #2314  if any.
