### PR TITLE
fix: throttle cleanup hang when broker uses default throttle configs

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
@@ -381,7 +381,9 @@ class ReplicationThrottleHelper {
         if (entry.getValue() != null) {
           return false;
         }
-      } else if (configEntry.source().equals(ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG) && entry.getValue() == null) {
+      } else if ((configEntry.source().equals(ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG)
+                  || configEntry.source().equals(ConfigEntry.ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG))
+                 && entry.getValue() == null) {
         LOG.debug("Found static broker config: {}, skipping comparison", configEntry);
       } else if (!Objects.equals(entry.getValue(), configEntry.value())) {
         return false;


### PR DESCRIPTION
Prevent throttle cleanup from hanging on brokers with dynamic default replication
throttle values by treating default/static values as cleared when expecting null,
allowing execution to advance.

## Summary

1. Why: if cluster has DYNAMIC_DEFAULT_BROKER_CONFIG for `replication.throttled` settings cc fails to clear its own replication throttle. 


## Expected Behavior

1. Rebalancing works

## Actual Behavior

1. ReplicationThrottleHelper.waitForConfigs gets stuck

## Steps to Reproduce

1. set DYNAMIC_DEFAULT_BROKER_CONFIG `leader.replication.throttled.rate` cluster-wide
2. run rebalance
3. it'll get get stuck after a first batch of movements

## Categorization
- [ ] documentation
- [x] bugfix
- [ ] new feature
- [ ] refactor
- [ ] security/CVE
- [ ] other


