### PR TITLE
Prometheus sampler to use process CPU metric

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/DefaultPrometheusQuerySupplier.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/DefaultPrometheusQuerySupplier.java
@@ -62,7 +62,7 @@ public class DefaultPrometheusQuerySupplier implements CruiseControlConfigurable
     private void buildTypeToQueryMap() {
         // broker metrics
         _typeToQuery.put(BROKER_CPU_UTIL,
-            String.format("1 - avg by (instance) (irate(node_cpu_seconds_total{mode=\"idle\"}[%dm]))",
+            String.format("avg by (instance) (rate(process_cpu_seconds_total[%dm]))",
                                                         _brokerCpuUtilQueryMinutes));
         _typeToQuery.put(ALL_TOPIC_BYTES_IN,
             "kafka_server_BrokerTopicMetrics_OneMinuteRate{name=\"BytesInPerSec\",topic=\"\"}");

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusMetricSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusMetricSampler.java
@@ -197,7 +197,7 @@ public class PrometheusMetricSampler extends AbstractMetricSampler {
 
                     This can be really frequent, and hence, we are only going to log them at trace level.
                      */
-                    LOG.trace("Invalid query result received from Prometheus for query {}", prometheusQuery, e);
+                    LOG.trace("Invalid query result received from Prometheus for query {} with result {}", prometheusQuery, result, e);
                     resultsSkipped++;
                 }
             }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusMetricSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusMetricSampler.java
@@ -197,7 +197,7 @@ public class PrometheusMetricSampler extends AbstractMetricSampler {
 
                     This can be really frequent, and hence, we are only going to log them at trace level.
                      */
-                    LOG.trace("Invalid query result received from Prometheus for query {} with result {}", prometheusQuery, result, e);
+                    LOG.trace("Invalid query result {} received from Prometheus for query {}", result, prometheusQuery, e);
                     resultsSkipped++;
                 }
             }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusMetricSamplerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusMetricSamplerTest.java
@@ -271,7 +271,7 @@ public class PrometheusMetricSamplerTest {
         config.put(PROMETHEUS_SERVER_ENDPOINT_CONFIG, "kafka-cluster-1.org:9090");
         addCapacityConfig(config);
         _prometheusMetricSampler.configure(config);
-        String expectedQuery = "1 - avg by (instance) (irate(node_cpu_seconds_total{mode=\"idle\"}[2m]))";
+        String expectedQuery = "avg by (instance) (rate(process_cpu_seconds_total[2m]))";
         assertEquals(expectedQuery, _prometheusMetricSampler._metricToPrometheusQueryMap.get(RawMetricType.BROKER_CPU_UTIL));
     }
 
@@ -282,7 +282,7 @@ public class PrometheusMetricSamplerTest {
         config.put(DefaultPrometheusQuerySupplier.PROMETHEUS_BROKER_METRICS_SCRAPING_INTERVAL_SECONDS, "45");
         addCapacityConfig(config);
         _prometheusMetricSampler.configure(config);
-        String expectedQuery = "1 - avg by (instance) (irate(node_cpu_seconds_total{mode=\"idle\"}[2m]))";
+        String expectedQuery = "avg by (instance) (rate(process_cpu_seconds_total[2m]))";
         assertEquals(expectedQuery, _prometheusMetricSampler._metricToPrometheusQueryMap.get(RawMetricType.BROKER_CPU_UTIL));
     }
 
@@ -293,7 +293,7 @@ public class PrometheusMetricSamplerTest {
         config.put(DefaultPrometheusQuerySupplier.PROMETHEUS_BROKER_METRICS_SCRAPING_INTERVAL_SECONDS, "90");
         addCapacityConfig(config);
         _prometheusMetricSampler.configure(config);
-        String expectedQuery = "1 - avg by (instance) (irate(node_cpu_seconds_total{mode=\"idle\"}[3m]))";
+        String expectedQuery = "avg by (instance) (rate(process_cpu_seconds_total[3m]))";
         assertEquals(expectedQuery, _prometheusMetricSampler._metricToPrometheusQueryMap.get(RawMetricType.BROKER_CPU_UTIL));
     }
 
@@ -304,7 +304,7 @@ public class PrometheusMetricSamplerTest {
         config.put(DefaultPrometheusQuerySupplier.PROMETHEUS_BROKER_METRICS_SCRAPING_INTERVAL_SECONDS, "91");
         addCapacityConfig(config);
         _prometheusMetricSampler.configure(config);
-        String expectedQuery = "1 - avg by (instance) (irate(node_cpu_seconds_total{mode=\"idle\"}[4m]))";
+        String expectedQuery = "avg by (instance) (rate(process_cpu_seconds_total[4m]))";
         assertEquals(expectedQuery, _prometheusMetricSampler._metricToPrometheusQueryMap.get(RawMetricType.BROKER_CPU_UTIL));
     }
 


### PR DESCRIPTION
## What

Correct the Prometheus sampler to scrape **Kafka process** CPU usage, not **broker node** CPU usage, by replacing `node_cpu_seconds_total` with `process_cpu_seconds_total`.

This PR resolves #2345. 

As a note, this metric `process_cpu_seconds_total` can pick up other processes (not only Kafka brokers, e.g. Prometheus itself, CC, etc) but that's fine because those entries will just be safely ignored (ref: [here](https://github.com/qbaware/cruise-control/blob/f83b2790e97397b32d53418e6aa2962205563b5b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusMetricSampler.java#L200)). 

```text
[2025-12-17 06:47:05,869[] TRACE Invalid query result received from Prometheus for query avg by (instance) (rate(process_cpu_seconds_total[2m])) with result PrometheusQueryResult{_metric=PrometheusMetric{_instance='cruise-control.local-test-kafka.svc.cluster.local:7071', _topic='null', _partition='null'}, _values=[PrometheusValue{_epochSeconds=1765953965, _value=0.011843652089860672}, PrometheusValue{_epochSeconds=1765954025, _value=0.014332855571480953}]} (com.linkedin.kafka.cruisecontrol.monitor.sampling.prometheus.PrometheusMetricSampler)

com.linkedin.kafka.cruisecontrol.monitor.sampling.prometheus.InvalidPrometheusResultException: Unexpected host cruise-control.local-test-kafka.svc.cluster.local, does not map to any of broker found from Kafka cluster metadata. Brokers found in Kafka cluster metadata = [broker1.kafka.svc.cluster.local, broker0.kafka.svc.cluster.local, broker2.kafka.svc.cluster.local]
    at com.linkedin.kafka.cruisecontrol.monitor.sampling.prometheus.PrometheusMetricSampler.getBrokerId(PrometheusMetricSampler.java:262) ~[cruise-control-0.1.0-SNAPSHOT.jar:?]
    at com.linkedin.kafka.cruisecontrol.monitor.sampling.prometheus.PrometheusMetricSampler.addBrokerMetrics(PrometheusMetricSampler.java:211) ~[cruise-control-0.1.0-SNAPSHOT.jar:?]
    at com.linkedin.kafka.cruisecontrol.monitor.sampling.prometheus.PrometheusMetricSampler.retrieveMetricsForProcessing(PrometheusMetricSampler.java:179) ~[cruise-control-0.1.0-SNAPSHOT.jar:?]
    at com.linkedin.kafka.cruisecontrol.monitor.sampling.AbstractMetricSampler.getSamples(AbstractMetricSampler.java:49) ~[cruise-control-0.1.0-SNAPSHOT.jar:?]
    at com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricFetcher.fetchSamples(MetricFetcher.java:160) ~[cruise-control-0.1.0-SNAPSHOT.jar:?]
    at com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricFetcher.fetchMetricsForAssignedPartitions(MetricFetcher.java:129) ~[cruise-control-0.1.0-SNAPSHOT.jar:?]
    at com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricFetcher.call(MetricFetcher.java:110) ~[cruise-control-0.1.0-SNAPSHOT.jar:?]
    at com.linkedin.kafka.cruisecontrol.monitor.sampling.MetricFetcher.call(MetricFetcher.java:25) ~[cruise-control-0.1.0-SNAPSHOT.jar:?]
    at java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
    at java.lang.Thread.run(Thread.java:1583) ~[?:?]
```

## Why

This is a bug that might produce inconsistent CC behavior between different samplers due to them observing different CPUs.

## Testing

I've manually tested the correctness of the change both locally (local Kafka, JMX exporter, Prometheus) and in the cloud (AWS MSK and Open Monitoring Prometheus).

## Categorization
- [ ] documentation
- [x] bugfix
- [ ] new feature
- [ ] refactor
- [ ] security/CVE
- [ ] other
