### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ COPY --from=build /workspace/config/ /cc/config/
 COPY --from=build /workspace/observability/ /cc/observability/
 COPY --from=build /workspace/kafka-cruise-control-start.sh /cc/
 RUN chmod +x kafka-cruise-control-start.sh
-EXPOSE 5600
-CMD ["./kafka-cruise-control-start.sh", "config/cruisecontrol.properties", "5600"]
+EXPOSE 9090
+CMD ["./kafka-cruise-control-start.sh", "config/cruisecontrol.properties", "9090"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apk add --no-cache bash
 WORKDIR /cc
 COPY --from=build /workspace/cruise-control/build/ /cc/cruise-control/build/
 COPY --from=build /workspace/config/ /cc/config/
-COPY --from=build /workspace/observability/ /cc/observability/
 COPY --from=build /workspace/kafka-cruise-control-start.sh /cc/
 RUN chmod +x kafka-cruise-control-start.sh
 EXPOSE 9090

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Build Cruise Control in its own stage
+FROM amazoncorretto:21-alpine-jdk AS build
+WORKDIR /workspace
+COPY . .
+RUN ./gradlew clean jar copyDependantLibs --warning-mode all
+
+# Fetch the jars, configs, and the startup script and run Cruise Control
+FROM amazoncorretto:21-alpine AS runtime
+RUN apk add --no-cache bash
+WORKDIR /cc
+COPY --from=build /workspace/cruise-control/build/ /cc/cruise-control/build/
+COPY --from=build /workspace/config/ /cc/config/
+COPY --from=build /workspace/observability/ /cc/observability/
+COPY --from=build /workspace/kafka-cruise-control-start.sh /cc/
+RUN chmod +x kafka-cruise-control-start.sh
+EXPOSE 5600
+CMD ["./kafka-cruise-control-start.sh", "config/cruisecontrol.properties", "5600"]


### PR DESCRIPTION
## What

A simple two-staged Dockerfile that would provide a starting point for creating CC containers.

Resolves #2263. 

## Why

It eases experimentation and deployment, i.e. overall development, of CC.

## Suggestions

- We can perhaps follow up with creating a Helm chart to further ease CC's deployment on k8s. But I'm not sure how much the community wants this.
- We can also think about creating a CI job that builds CC Docker images and stores them in GitHub's registry for this repository.

I might open issues for both so that we can keep track of them and discuss them.

## Categorization
- [ ] documentation
- [ ] bugfix
- [x] new feature
- [ ] refactor
- [ ] security/CVE
- [ ] other

