### PR TITLE
Add JMX Prometheus exporter agent

### DIFF
--- a/kafka-cruise-control-start.sh
+++ b/kafka-cruise-control-start.sh
@@ -184,6 +184,9 @@ fi
 # If Cygwin is detected, classpath is converted to Windows format.
 (( CYGWIN )) && CLASSPATH=$(cygpath --path --mixed "${CLASSPATH}")
 
+# Configure the JMX exporter agent.
+JVM_OPTS="$JVM_OPTS -javaagent:observability/jmx_prometheus_javaagent-1.2.0.jar=7071:observability/jmx_exporter_config.yaml"
+
 # Launch mode
 if [ "x$DAEMON_MODE" = "xtrue" ]; then
   nohup $JAVA $KAFKA_HEAP_OPTS $KAFKA_JVM_PERFORMANCE_OPTS $KAFKA_GC_LOG_OPTS $KAFKA_JMX_OPTS $KAFKA_LOG4J_OPTS -cp $CLASSPATH $KAFKA_OPTS com.linkedin.kafka.cruisecontrol.KafkaCruiseControlMain "$@" > "$CONSOLE_OUTPUT_FILE" 2>&1 < /dev/null &

--- a/kafka-cruise-control-start.sh
+++ b/kafka-cruise-control-start.sh
@@ -185,7 +185,7 @@ fi
 (( CYGWIN )) && CLASSPATH=$(cygpath --path --mixed "${CLASSPATH}")
 
 # Configure the JMX exporter agent.
-JVM_OPTS="$JVM_OPTS -javaagent:observability/jmx_prometheus_javaagent-1.2.0.jar=7071:observability/jmx_exporter_config.yaml"
+KAFKA_OPTS="$KAFKA_OPTS -javaagent:observability/jmx_prometheus_javaagent-1.2.0.jar=7071:observability/jmx_exporter_config.yaml"
 
 # Launch mode
 if [ "x$DAEMON_MODE" = "xtrue" ]; then

--- a/kafka-cruise-control-start.sh
+++ b/kafka-cruise-control-start.sh
@@ -185,7 +185,7 @@ fi
 (( CYGWIN )) && CLASSPATH=$(cygpath --path --mixed "${CLASSPATH}")
 
 # Configure the JMX exporter agent.
-KAFKA_OPTS="$KAFKA_OPTS -javaagent:observability/jmx_prometheus_javaagent-1.2.0.jar=7071:observability/jmx_exporter_config.yaml"
+KAFKA_OPTS="$KAFKA_OPTS -javaagent:observability/jmx_prometheus_javaagent-1.5.0.jar=7071:observability/jmx_exporter_config.yaml"
 
 # Launch mode
 if [ "x$DAEMON_MODE" = "xtrue" ]; then

--- a/observability/jmx_exporter_config.yaml
+++ b/observability/jmx_exporter_config.yaml
@@ -1,0 +1,4 @@
+lowercaseOutputName: false
+lowercaseOutputLabelNames: false
+rules:
+  - pattern: ""


### PR DESCRIPTION
## What

Provides a [JMX exporter](https://github.com/prometheus/jmx_exporter) agent (version [1.5.0](https://github.com/prometheus/jmx_exporter/releases/tag/1.5.0)) to CC. 

This allows CC to expose its JMX metrics in a Prometheus format via a `/metrics` endpoint on the `7071` port (hardcoded but can be made configurable if people think that'd be useful).

Resolves #2350.

## Why

Enables CC to be observed from a Prometheus/Grafana observability setup, which in turn enables creating dashboards for CC's health and performance, alerts for degradations, and so on.

## Categorization
- [ ] documentation
- [ ] bugfix
- [x] new feature
- [ ] refactor
- [ ] security/CVE
- [ ] other
