### PR TITLE
Upgrade lz4-java to 1.8.1 to fix CVE-2025-12183

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -334,6 +334,9 @@ project(':cruise-control') {
       implementation("commons-beanutils:commons-beanutils:1.11.0") {
         because("version 1.9.4 pulled from kafa 3.9.1 has CVE-2025-48734 in it, which is fixed in 1.11.0")
       }
+      implementation("org.lz4:lz4-java:${lz4JavaVersion}") {
+        because("CVE-2025-12183: Security vulnerability in 1.8.0")
+      }
     }
 
     testImplementation project(path: ':cruise-control-metrics-reporter', configuration: 'testOutput')

--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,17 @@ subprojects {
   apply plugin: "com.github.spotbugs"
   apply plugin: 'jacoco'
 
+  configurations.all {
+    resolutionStrategy {
+      capabilitiesResolution {
+        withCapability('org.lz4:lz4-java') {
+          select('org.lz4:lz4-java:0')
+          because 'CVE-2025-12183: Prefer org.lz4 over at.yawk.lz4'
+        }
+      }
+    }
+  }
+
   // This project requires Java 17
   sourceCompatibility = JavaVersion.VERSION_17
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,4 @@ nettyVersion=4.1.118.Final
 jettyVersion=9.4.56.v20240826
 vertxVersion=4.5.8
 testcontainersVersion=1.21.3
+lz4JavaVersion=1.8.1


### PR DESCRIPTION
## Summary
1. Why: Upgrade lz4-java to address CVE-2025-12183 security vulnerability.
2. What: Upgraded lz4-java from 1.8.0 to 1.8.1 using dependency constraints and capability resolution.

## Expected Behavior
The project should use lz4-java version 1.8.1 (patched) instead of 1.8.0 (vulnerable to CVE-2025-12183).
## Actual Behavior
Before this fix, the project was using lz4-java 1.8.0 as a transitive dependency from Kafka 4.0.0, which contains the security vulnerability CVE-2025-12183.

## Steps to Reproduce
1. Run `./gradlew :cruise-control:dependencies --configuration runtimeClasspath | grep lz4`
2. Observe that lz4-java 1.8.0 is upgraded to 1.8.1
3. Verify build passes: `./gradlew clean build`

## Known Workarounds
<!-- if any -->

## Additional evidence
1. **Environment**: Gradle 8.5, Java 17, Kafka 4.0.0
2. **Dependency verification output**:

```
org.lz4:lz4-java:1.8.0 -> 1.8.1
at.yawk.lz4:lz4-java:1.8.1 -> org.lz4:lz4-java:1.8.1
```

3. **Build verification**: `./gradlew clean build -x test` - BUILD SUCCESSFUL
4. **Implementation approach**: 
- Added `lz4JavaVersion=1.8.1` in [`gradle.properties`](gradle.properties:10)
- Added dependency constraint in [`build.gradle`](build.gradle:325-327)
- Added capability resolution in [`build.gradle`](build.gradle:99-107) to resolve org.lz4 vs at.yawk.lz4 conflict

## Categorization
- [ ] documentation
- [ ] bugfix
- [ ] new feature
- [ ] refactor
- [x] security/CVE
- [ ] other

This PR resolves #<Replace-Me-With-The-Issue-Number-Addressed-By-This-PR> if any.
