### PR TITLE
Batch AdminClient config RPCs in ReplicationThrottleHelper

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
@@ -85,18 +85,19 @@ class ReplicationThrottleHelper {
       LOG.info("Setting rebalance throttle of {} bytes/sec on {} brokers for {} topics ({} replica movements)",
           _throttleRate, participatingBrokers.size(), throttledReplicas.size(), replicaMovementProposals.size());
 
-      // Batch set broker throttle rates
+      // Batch set broker throttle rates. Reads are chunked like every other AdminClient call in
+      // this class; each future is resolved eagerly and any failure is rethrown, preserving the
+      // fail-fast semantics of the previous .all() call.
       if (!participatingBrokers.isEmpty()) {
         List<ConfigResource> brokerResources = participatingBrokers.stream()
             .map(id -> new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(id)))
             .collect(Collectors.toList());
-        Map<ConfigResource, Config> brokerConfigs = _adminClient.describeConfigs(brokerResources)
-            .all().get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        Map<ConfigResource, KafkaFuture<Config>> brokerFutures = describeConfigsInChunks(brokerResources);
 
         Map<ConfigResource, Collection<AlterConfigOp>> brokerOps = new HashMap<>();
         for (int brokerId : participatingBrokers) {
           ConfigResource cf = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(brokerId));
-          Config config = brokerConfigs.get(cf);
+          Config config = brokerFutures.get(cf).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
           List<AlterConfigOp> ops = buildSetThrottleRateOps(config, brokerId);
           if (!ops.isEmpty()) {
             brokerOps.put(cf, ops);
@@ -463,6 +464,11 @@ class ReplicationThrottleHelper {
           return false;
         }
         Map<ConfigResource, KafkaFuture<Config>> futures = describeConfigsInChunks(new ArrayList<>(pendingByResource.keySet()));
+        // Existing topic names, fetched lazily and at most once per verification attempt, shared
+        // by all topics that fail verification in this attempt. Remains null if the listing fails,
+        // in which case topics are conservatively treated as still existing and kept pending.
+        Set<String> existingTopics = null;
+        boolean topicListFetchAttempted = false;
         Iterator<Map.Entry<ConfigResource, Map<String, String>>> pendingIter = pendingByResource.entrySet().iterator();
         while (pendingIter.hasNext()) {
           Map.Entry<ConfigResource, Map<String, String>> entry = pendingIter.next();
@@ -473,7 +479,11 @@ class ReplicationThrottleHelper {
               pendingIter.remove();
             }
           } catch (ExecutionException | TimeoutException e) {
-            if (cf.type() == ConfigResource.Type.TOPIC && topicNoLongerExists(cf.name())) {
+            if (cf.type() == ConfigResource.Type.TOPIC && !topicListFetchAttempted) {
+              topicListFetchAttempted = true;
+              existingTopics = tryListTopicNames();
+            }
+            if (cf.type() == ConfigResource.Type.TOPIC && existingTopics != null && !existingTopics.contains(cf.name())) {
               LOG.debug("Skipping config verification for topic {} since it no longer exists", cf.name());
               pendingIter.remove();
             } else {
@@ -497,20 +507,20 @@ class ReplicationThrottleHelper {
   }
 
   /**
-   * Best-effort existence check used during verification. A failure to check is treated as
-   * "the topic still exists" so that verification keeps retrying instead of passing unverified.
+   * Best-effort topic listing used during verification. A failure to list is surfaced as
+   * {@code null} so that callers conservatively treat topics as still existing and keep
+   * retrying instead of passing unverified.
    *
-   * @param topic the topic to check
-   * @return {@code true} if the topic is confirmed to no longer exist, {@code false} otherwise
+   * @return the set of existing topic names, or {@code null} if the listing failed
    */
-  private boolean topicNoLongerExists(String topic) {
+  private Set<String> tryListTopicNames() {
     try {
-      return !topicExists(topic);
+      return listTopicNames();
     } catch (ExecutionException | TimeoutException e) {
-      return false;
+      return null;
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      return false;
+      return null;
     }
   }
 
@@ -588,10 +598,6 @@ class ReplicationThrottleHelper {
       LOG.error("Unable to list topics due to {}", e.getMessage());
       throw e;
     }
-  }
-
-  boolean topicExists(String topic) throws InterruptedException, TimeoutException, ExecutionException {
-    return listTopicNames().contains(topic);
   }
 
   static String removeReplicasFromConfig(String throttleConfig, Set<String> replicas) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -43,6 +44,10 @@ class ReplicationThrottleHelper {
   static final String FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG = "follower.replication.throttled.replicas";
   public static final long CLIENT_REQUEST_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
   static final int RETRIES = 30;
+  // Cap on the number of resources packed into a single AdminClient config request. Requests for
+  // TOPIC resources are routed to a single broker, so an unbounded batch could produce an
+  // oversized request on clusters with a very large number of topics.
+  static final int MAX_RESOURCES_PER_ADMIN_REQUEST = 500;
 
   private final AdminClient _adminClient;
   private final Long _throttleRate;
@@ -187,19 +192,26 @@ class ReplicationThrottleHelper {
       LOG.info("Removing replica movement throttles from {} brokers in the cluster: {}",
           brokersToRemoveThrottlesFrom.size(), brokersToRemoveThrottlesFrom);
 
-      // Batch remove broker throttle rates
+      // Batch remove broker throttle rates. Read configs via per-broker futures so that a broker
+      // which became unreachable mid-execution only skips throttle removal for itself; throttles
+      // on the remaining brokers are still cleared.
       if (!brokersToRemoveThrottlesFrom.isEmpty()) {
         List<ConfigResource> brokerResources = brokersToRemoveThrottlesFrom.stream()
             .map(id -> new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(id)))
             .collect(Collectors.toList());
-        Map<ConfigResource, Config> brokerConfigs = _adminClient.describeConfigs(brokerResources)
-            .all().get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        Map<ConfigResource, KafkaFuture<Config>> brokerFutures = describeConfigsInChunks(brokerResources);
 
         Map<ConfigResource, Collection<AlterConfigOp>> brokerOps = new HashMap<>();
-        for (int brokerId : brokersToRemoveThrottlesFrom) {
-          ConfigResource cf = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(brokerId));
-          Config config = brokerConfigs.get(cf);
-          List<AlterConfigOp> ops = buildRemoveThrottleRateOps(config, brokerId);
+        for (ConfigResource cf : brokerResources) {
+          Config config;
+          try {
+            config = brokerFutures.get(cf).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+          } catch (ExecutionException | TimeoutException e) {
+            LOG.warn("Failed to read configs for broker {} while clearing throttles. Skipping throttle removal for it.",
+                cf.name(), e);
+            continue;
+          }
+          List<AlterConfigOp> ops = buildRemoveThrottleRateOps(config, Integer.parseInt(cf.name()));
           if (!ops.isEmpty()) {
             brokerOps.put(cf, ops);
           }
@@ -348,19 +360,23 @@ class ReplicationThrottleHelper {
         .map(t -> new ConfigResource(ConfigResource.Type.TOPIC, t))
         .collect(Collectors.toList());
 
-    Map<ConfigResource, KafkaFuture<Config>> futures = _adminClient.describeConfigs(resources).values();
+    Map<ConfigResource, KafkaFuture<Config>> futures = describeConfigsInChunks(resources);
     Map<String, Config> result = new HashMap<>();
+    // Fetched lazily and at most once, to resolve failures without issuing one listTopics per topic.
+    Set<String> existingTopics = null;
 
-    for (Map.Entry<ConfigResource, KafkaFuture<Config>> entry : futures.entrySet()) {
-      String topic = entry.getKey().name();
+    for (ConfigResource cf : resources) {
+      String topic = cf.name();
       try {
-        result.put(topic, entry.getValue().get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        result.put(topic, futures.get(cf).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS));
       } catch (ExecutionException e) {
-        if (!topicExists(topic)) {
-          result.put(topic, new Config(Collections.emptyList()));
-        } else {
+        if (existingTopics == null) {
+          existingTopics = listTopicNames();
+        }
+        if (existingTopics.contains(topic)) {
           throw e;
         }
+        result.put(topic, new Config(Collections.emptyList()));
       }
     }
     return result;
@@ -377,8 +393,10 @@ class ReplicationThrottleHelper {
    */
   private void batchAlterBrokerConfigs(Map<ConfigResource, Collection<AlterConfigOp>> ops)
   throws ExecutionException, InterruptedException, TimeoutException {
-    _adminClient.incrementalAlterConfigs(ops)
-        .all().get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    for (Map<ConfigResource, Collection<AlterConfigOp>> chunkOps : partitionOps(ops)) {
+      _adminClient.incrementalAlterConfigs(chunkOps)
+          .all().get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
     waitForBatchConfigs(ops);
   }
 
@@ -390,8 +408,13 @@ class ReplicationThrottleHelper {
    */
   private void batchAlterTopicConfigs(Map<ConfigResource, Collection<AlterConfigOp>> ops)
   throws ExecutionException, InterruptedException, TimeoutException {
-    Map<ConfigResource, KafkaFuture<Void>> futures = _adminClient.incrementalAlterConfigs(ops).values();
+    Map<ConfigResource, KafkaFuture<Void>> futures = new HashMap<>(ops.size());
+    for (Map<ConfigResource, Collection<AlterConfigOp>> chunkOps : partitionOps(ops)) {
+      futures.putAll(_adminClient.incrementalAlterConfigs(chunkOps).values());
+    }
     Map<ConfigResource, Collection<AlterConfigOp>> successfulOps = new HashMap<>();
+    // Fetched lazily and at most once, to resolve failures without issuing one listTopics per topic.
+    Set<String> existingTopics = null;
 
     for (Map.Entry<ConfigResource, KafkaFuture<Void>> entry : futures.entrySet()) {
       String topic = entry.getKey().name();
@@ -399,11 +422,13 @@ class ReplicationThrottleHelper {
         entry.getValue().get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         successfulOps.put(entry.getKey(), ops.get(entry.getKey()));
       } catch (ExecutionException e) {
-        if (!topicExists(topic)) {
-          LOG.debug("Failed to change configs for topic {} since it does not exist", topic);
-        } else {
+        if (existingTopics == null) {
+          existingTopics = listTopicNames();
+        }
+        if (existingTopics.contains(topic)) {
           throw e;
         }
+        LOG.debug("Failed to change configs for topic {} since it does not exist", topic);
       }
     }
 
@@ -414,50 +439,118 @@ class ReplicationThrottleHelper {
 
   /**
    * Batch verify configs by polling describeConfigs until all resources match expected values.
-   * Uses per-resource futures via values() so that a failure for one resource (e.g. a deleted topic)
-   * does not skip verification for the entire batch.
+   * Uses per-resource futures via values() so that verification of one resource does not depend on
+   * the others. A topic that is confirmed deleted mid-verification is dropped from verification;
+   * any other per-resource failure (e.g. a transient network error, or a broker read failure)
+   * keeps the resource pending so that it is retried instead of silently passing unverified.
    *
    * @param allOps the map of config resources to their expected alter operations
    */
   void waitForBatchConfigs(Map<ConfigResource, Collection<AlterConfigOp>> allOps) {
-    Map<ConfigResource, Map<String, String>> expectedByResource = new HashMap<>();
+    // Resources that still await verification. Verified resources and confirmed-deleted topics are
+    // removed as verification progresses.
+    Map<ConfigResource, Map<String, String>> pendingByResource = new HashMap<>();
     for (Map.Entry<ConfigResource, Collection<AlterConfigOp>> entry : allOps.entrySet()) {
       // Use HashMap::new instead of Collectors.toMap to allow inserting null values
       Map<String, String> expected = entry.getValue().stream()
           .collect(HashMap::new, (m, o) -> m.put(o.configEntry().name(), o.configEntry().value()), HashMap::putAll);
-      expectedByResource.put(entry.getKey(), expected);
+      pendingByResource.put(entry.getKey(), expected);
     }
 
-    List<ConfigResource> resources = new ArrayList<>(allOps.keySet());
-    boolean retryResponse = CruiseControlMetricsUtils.retry(() -> {
+    boolean verified = CruiseControlMetricsUtils.retry(() -> {
       try {
-        Map<ConfigResource, KafkaFuture<Config>> futures = _adminClient.describeConfigs(resources).values();
-        for (Map.Entry<ConfigResource, Map<String, String>> entry : expectedByResource.entrySet()) {
+        if (pendingByResource.isEmpty()) {
+          return false;
+        }
+        Map<ConfigResource, KafkaFuture<Config>> futures = describeConfigsInChunks(new ArrayList<>(pendingByResource.keySet()));
+        Iterator<Map.Entry<ConfigResource, Map<String, String>>> pendingIter = pendingByResource.entrySet().iterator();
+        while (pendingIter.hasNext()) {
+          Map.Entry<ConfigResource, Map<String, String>> entry = pendingIter.next();
+          ConfigResource cf = entry.getKey();
           try {
-            Config config = futures.get(entry.getKey()).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-            if (!configsEqual(config, entry.getValue())) {
-              return true;
+            Config config = futures.get(cf).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            if (configsEqual(config, entry.getValue())) {
+              pendingIter.remove();
             }
           } catch (ExecutionException | TimeoutException e) {
-            // Per-resource failure (e.g. topic deleted or network blip during verification).
-            // Skip verification for this resource only; other resources continue.
-            LOG.warn("Failed to verify config for {}, skipping verification for this resource", entry.getKey(), e);
+            if (cf.type() == ConfigResource.Type.TOPIC && topicNoLongerExists(cf.name())) {
+              LOG.debug("Skipping config verification for topic {} since it no longer exists", cf.name());
+              pendingIter.remove();
+            } else {
+              // Keep the resource pending: a transient failure must not let an unverified
+              // (potentially unthrottled) config pass silently.
+              LOG.warn("Failed to verify config for {}; will retry", cf, e);
+            }
           }
         }
-        return false;
+        return !pendingByResource.isEmpty();
       } catch (InterruptedException e) {
-        LOG.warn("Interrupted during batch config verification for {} resources, skipping verification", resources.size(), e);
+        LOG.warn("Interrupted during batch config verification for {} resources, skipping verification",
+            pendingByResource.size(), e);
         Thread.currentThread().interrupt();
         return false;
       }
     }, _retries);
-    if (!retryResponse) {
-      throw new IllegalStateException("Could not verify that configs were applied to " + allOps.keySet().size()
-          + " resources within the time limit");
+    if (!verified) {
+      throw new IllegalStateException("The following configs were not applied within the time limit: " + pendingByResource);
     }
   }
 
-  // --- Existing methods kept for backward compatibility and test setup ---
+  /**
+   * Best-effort existence check used during verification. A failure to check is treated as
+   * "the topic still exists" so that verification keeps retrying instead of passing unverified.
+   *
+   * @param topic the topic to check
+   * @return {@code true} if the topic is confirmed to no longer exist, {@code false} otherwise
+   */
+  private boolean topicNoLongerExists(String topic) {
+    try {
+      return !topicExists(topic);
+    } catch (ExecutionException | TimeoutException e) {
+      return false;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+
+  /**
+   * Issue describeConfigs in chunks of at most {@link #MAX_RESOURCES_PER_ADMIN_REQUEST} resources
+   * and return the per-resource futures from all chunks.
+   *
+   * @param resources the config resources to describe
+   * @return a map from each resource to its config future
+   */
+  private Map<ConfigResource, KafkaFuture<Config>> describeConfigsInChunks(List<ConfigResource> resources) {
+    Map<ConfigResource, KafkaFuture<Config>> futures = new HashMap<>(resources.size());
+    for (int i = 0; i < resources.size(); i += MAX_RESOURCES_PER_ADMIN_REQUEST) {
+      List<ConfigResource> chunk = resources.subList(i, Math.min(resources.size(), i + MAX_RESOURCES_PER_ADMIN_REQUEST));
+      futures.putAll(_adminClient.describeConfigs(chunk).values());
+    }
+    return futures;
+  }
+
+  /**
+   * Partition an alter-config request into chunks of at most {@link #MAX_RESOURCES_PER_ADMIN_REQUEST} resources.
+   *
+   * @param ops the full map of config resources to their alter operations
+   * @return the input split into chunks, each holding at most {@link #MAX_RESOURCES_PER_ADMIN_REQUEST} resources
+   */
+  private static List<Map<ConfigResource, Collection<AlterConfigOp>>> partitionOps(Map<ConfigResource, Collection<AlterConfigOp>> ops) {
+    List<Map<ConfigResource, Collection<AlterConfigOp>>> chunks = new ArrayList<>();
+    Map<ConfigResource, Collection<AlterConfigOp>> currentChunk = new HashMap<>();
+    for (Map.Entry<ConfigResource, Collection<AlterConfigOp>> entry : ops.entrySet()) {
+      if (currentChunk.size() == MAX_RESOURCES_PER_ADMIN_REQUEST) {
+        chunks.add(currentChunk);
+        currentChunk = new HashMap<>();
+      }
+      currentChunk.put(entry.getKey(), entry.getValue());
+    }
+    if (!currentChunk.isEmpty()) {
+      chunks.add(currentChunk);
+    }
+    return chunks;
+  }
 
   private boolean throttlingEnabled() {
     return _throttleRate != null;
@@ -488,68 +581,23 @@ class ReplicationThrottleHelper {
     return throttledReplicasByTopic;
   }
 
-  private Config getEntityConfigs(ConfigResource cf) throws ExecutionException, InterruptedException, TimeoutException {
-    Map<ConfigResource, Config> configs = _adminClient.describeConfigs(Collections.singletonList(cf)).all()
-        .get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-    return configs.get(cf);
-  }
-
-  void changeTopicConfigs(String topic, Collection<AlterConfigOp> ops)
-  throws ExecutionException, InterruptedException, TimeoutException {
-    ConfigResource cf = new ConfigResource(ConfigResource.Type.TOPIC, topic);
-    Map<ConfigResource, Collection<AlterConfigOp>> configs = Collections.singletonMap(cf, ops);
+  private Set<String> listTopicNames() throws InterruptedException, TimeoutException, ExecutionException {
     try {
-      _adminClient.incrementalAlterConfigs(configs).all()
-          .get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-      waitForConfigs(cf, ops);
-    } catch (Exception e) {
-      if (!topicExists(topic)) {
-        LOG.debug("Failed to change configs for topic {} since it does not exist", topic);
-        return;
-      }
+      return _adminClient.listTopics().names().get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    } catch (ExecutionException | InterruptedException | TimeoutException e) {
+      LOG.error("Unable to list topics due to {}", e.getMessage());
       throw e;
     }
-  }
-
-  void changeBrokerConfigs(int brokerId, Collection<AlterConfigOp> ops)
-  throws ExecutionException, InterruptedException, TimeoutException {
-    ConfigResource cf = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(brokerId));
-    Map<ConfigResource, Collection<AlterConfigOp>> configs = Collections.singletonMap(cf, ops);
-    _adminClient.incrementalAlterConfigs(configs).all()
-        .get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-    waitForConfigs(cf, ops);
   }
 
   boolean topicExists(String topic) throws InterruptedException, TimeoutException, ExecutionException {
-    try {
-      return _adminClient.listTopics().names().get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS).contains(topic);
-    } catch (ExecutionException | InterruptedException | TimeoutException e) {
-      LOG.error("Unable to check if topic {} exists due to {}", topic, e.getMessage());
-      throw e;
-    }
+    return listTopicNames().contains(topic);
   }
 
   static String removeReplicasFromConfig(String throttleConfig, Set<String> replicas) {
     List<String> throttles = new ArrayList<>(Arrays.asList(throttleConfig.split(",")));
     throttles.removeIf(replicas::contains);
     return String.join(",", throttles);
-  }
-
-  // Retries until we can read the configs changes we just wrote
-  void waitForConfigs(ConfigResource cf, Collection<AlterConfigOp> ops) {
-    // Use HashMap::new instead of Collectors.toMap to allow inserting null values
-    Map<String, String> expectedConfigs = ops.stream()
-            .collect(HashMap::new, (m, o) -> m.put(o.configEntry().name(), o.configEntry().value()), HashMap::putAll);
-    boolean retryResponse = CruiseControlMetricsUtils.retry(() -> {
-      try {
-        return !configsEqual(getEntityConfigs(cf), expectedConfigs);
-      } catch (ExecutionException | InterruptedException | TimeoutException e) {
-        return false;
-      }
-    }, _retries);
-    if (!retryResponse) {
-      throw new IllegalStateException("The following configs " + ops + " were not applied to " + cf + " within the time limit");
-    }
   }
 
   static boolean configsEqual(Config configs, Map<String, String> expectedValues) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
@@ -10,6 +10,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.config.ConfigResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,15 +75,63 @@ class ReplicationThrottleHelper {
   void setThrottles(List<ExecutionProposal> replicaMovementProposals)
   throws ExecutionException, InterruptedException, TimeoutException {
     if (throttlingEnabled()) {
-      LOG.info("Setting a rebalance throttle of {} bytes/sec", _throttleRate);
       Set<Integer> participatingBrokers = getParticipatingBrokers(replicaMovementProposals);
       Map<String, Set<String>> throttledReplicas = getThrottledReplicasByTopic(replicaMovementProposals);
-      for (int broker : participatingBrokers) {
-        setThrottledRateIfNecessary(broker);
+      LOG.info("Setting rebalance throttle of {} bytes/sec on {} brokers for {} topics ({} replica movements)",
+          _throttleRate, participatingBrokers.size(), throttledReplicas.size(), replicaMovementProposals.size());
+
+      // Batch set broker throttle rates
+      if (!participatingBrokers.isEmpty()) {
+        List<ConfigResource> brokerResources = participatingBrokers.stream()
+            .map(id -> new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(id)))
+            .collect(Collectors.toList());
+        Map<ConfigResource, Config> brokerConfigs = _adminClient.describeConfigs(brokerResources)
+            .all().get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        Map<ConfigResource, Collection<AlterConfigOp>> brokerOps = new HashMap<>();
+        for (int brokerId : participatingBrokers) {
+          ConfigResource cf = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(brokerId));
+          Config config = brokerConfigs.get(cf);
+          List<AlterConfigOp> ops = buildSetThrottleRateOps(config, brokerId);
+          if (!ops.isEmpty()) {
+            brokerOps.put(cf, ops);
+          }
+        }
+
+        if (!brokerOps.isEmpty()) {
+          LOG.info("Updating throttle rate on {} out of {} brokers", brokerOps.size(), participatingBrokers.size());
+          batchAlterBrokerConfigs(brokerOps);
+        }
       }
-      for (Map.Entry<String, Set<String>> entry : throttledReplicas.entrySet()) {
-        setThrottledReplicas(entry.getKey(), entry.getValue());
+
+      // Batch set topic throttled replicas.
+      // Note: batching widens the read-modify-write window compared to the old per-topic approach.
+      // This assumes Cruise Control is the sole writer of throttle configs during an operation.
+      if (!throttledReplicas.isEmpty()) {
+        Map<String, Config> topicConfigs = batchGetTopicConfigs(throttledReplicas.keySet());
+
+        Map<ConfigResource, Collection<AlterConfigOp>> topicOps = new HashMap<>();
+        for (Map.Entry<String, Set<String>> entry : throttledReplicas.entrySet()) {
+          String topic = entry.getKey();
+          Config config = topicConfigs.get(topic);
+          if (config == null) {
+            LOG.warn("Skip setting throttled replicas for topic {} since no configs can be read", topic);
+            continue;
+          }
+          List<AlterConfigOp> ops = buildSetThrottledReplicasOps(config, entry.getValue());
+          if (!ops.isEmpty()) {
+            topicOps.put(new ConfigResource(ConfigResource.Type.TOPIC, topic), ops);
+          }
+        }
+
+        if (!topicOps.isEmpty()) {
+          LOG.info("Setting throttled replicas on {} out of {} topics", topicOps.size(), throttledReplicas.size());
+          batchAlterTopicConfigs(topicOps);
+        }
       }
+
+      LOG.info("Throttle setup complete for {} brokers and {} topics",
+          participatingBrokers.size(), throttledReplicas.size());
     }
   }
 
@@ -135,17 +184,275 @@ class ReplicationThrottleHelper {
       Set<Integer> brokersToRemoveThrottlesFrom = new TreeSet<>(participatingBrokers);
       brokersToRemoveThrottlesFrom.removeAll(brokersWithInProgressTasks);
 
-      LOG.info("Removing replica movement throttles from brokers in the cluster: {}", brokersToRemoveThrottlesFrom);
-      for (int broker : brokersToRemoveThrottlesFrom) {
-        removeThrottledRateFromBroker(broker);
+      LOG.info("Removing replica movement throttles from {} brokers in the cluster: {}",
+          brokersToRemoveThrottlesFrom.size(), brokersToRemoveThrottlesFrom);
+
+      // Batch remove broker throttle rates
+      if (!brokersToRemoveThrottlesFrom.isEmpty()) {
+        List<ConfigResource> brokerResources = brokersToRemoveThrottlesFrom.stream()
+            .map(id -> new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(id)))
+            .collect(Collectors.toList());
+        Map<ConfigResource, Config> brokerConfigs = _adminClient.describeConfigs(brokerResources)
+            .all().get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        Map<ConfigResource, Collection<AlterConfigOp>> brokerOps = new HashMap<>();
+        for (int brokerId : brokersToRemoveThrottlesFrom) {
+          ConfigResource cf = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(brokerId));
+          Config config = brokerConfigs.get(cf);
+          List<AlterConfigOp> ops = buildRemoveThrottleRateOps(config, brokerId);
+          if (!ops.isEmpty()) {
+            brokerOps.put(cf, ops);
+          }
+        }
+
+        if (!brokerOps.isEmpty()) {
+          batchAlterBrokerConfigs(brokerOps);
+        }
       }
 
+      // Batch remove topic throttled replicas
       Map<String, Set<String>> throttledReplicas = getThrottledReplicasByTopic(completedProposals);
-      for (Map.Entry<String, Set<String>> entry : throttledReplicas.entrySet()) {
-        removeThrottledReplicasFromTopic(entry.getKey(), entry.getValue());
+      if (!throttledReplicas.isEmpty()) {
+        Map<String, Config> topicConfigs = batchGetTopicConfigs(throttledReplicas.keySet());
+
+        Map<ConfigResource, Collection<AlterConfigOp>> topicOps = new HashMap<>();
+        for (Map.Entry<String, Set<String>> entry : throttledReplicas.entrySet()) {
+          String topic = entry.getKey();
+          Config config = topicConfigs.get(topic);
+          if (config == null) {
+            LOG.debug("Skip removing throttled replicas {} from topic {} since no configs can be read",
+                String.join(",", entry.getValue()), topic);
+            continue;
+          }
+          List<AlterConfigOp> ops = buildRemoveThrottledReplicasOps(config, topic, entry.getValue());
+          if (!ops.isEmpty()) {
+            topicOps.put(new ConfigResource(ConfigResource.Type.TOPIC, topic), ops);
+          }
+        }
+
+        if (!topicOps.isEmpty()) {
+          batchAlterTopicConfigs(topicOps);
+        }
       }
     }
   }
+
+  // --- Ops builders extracted from the old single-resource methods ---
+
+  private List<AlterConfigOp> buildSetThrottleRateOps(Config brokerConfigs, int brokerId) {
+    if (_throttleRate == null) {
+      throw new IllegalStateException("Throttle rate cannot be null");
+    }
+    List<AlterConfigOp> ops = new ArrayList<>();
+    for (String replicaThrottleRateConfigKey : Arrays.asList(LEADER_REPLICATION_THROTTLED_RATE_CONFIG,
+            FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG)) {
+      ConfigEntry currThrottleRate = brokerConfigs.get(replicaThrottleRateConfigKey);
+      if (currThrottleRate == null || !currThrottleRate.value().equals(String.valueOf(_throttleRate))) {
+        LOG.debug("Setting {} to {} bytes/second for broker {}", replicaThrottleRateConfigKey, _throttleRate, brokerId);
+        ops.add(new AlterConfigOp(new ConfigEntry(replicaThrottleRateConfigKey, String.valueOf(_throttleRate)), AlterConfigOp.OpType.SET));
+      }
+    }
+    return ops;
+  }
+
+  private List<AlterConfigOp> buildSetThrottledReplicasOps(Config topicConfigs, Set<String> replicas) {
+    List<AlterConfigOp> ops = new ArrayList<>();
+    for (String replicaThrottleConfigKey : Arrays.asList(LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG,
+            FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG)) {
+      ConfigEntry currThrottledReplicas = topicConfigs.get(replicaThrottleConfigKey);
+      if (currThrottledReplicas != null && currThrottledReplicas.value().trim().equals(WILDCARD_ASTERISK)) {
+        // The existing setup throttles all replica. So, nothing needs to be changed.
+        continue;
+      }
+
+      // Merge new throttled replicas with existing configuration values.
+      Set<String> newThrottledReplicas = new TreeSet<>(replicas);
+      if (currThrottledReplicas != null && !currThrottledReplicas.value().equals("")) {
+        newThrottledReplicas.addAll(Arrays.asList(currThrottledReplicas.value().split(",")));
+      }
+      ops.add(new AlterConfigOp(new ConfigEntry(replicaThrottleConfigKey, String.join(",", newThrottledReplicas)), AlterConfigOp.OpType.SET));
+    }
+    return ops;
+  }
+
+  private List<AlterConfigOp> buildRemoveThrottleRateOps(Config brokerConfigs, int brokerId) {
+    List<AlterConfigOp> ops = new ArrayList<>();
+    ConfigEntry currLeaderThrottle = brokerConfigs.get(LEADER_REPLICATION_THROTTLED_RATE_CONFIG);
+    if (currLeaderThrottle != null) {
+      if (currLeaderThrottle.source().equals(ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG)) {
+        LOG.debug("Skipping removal for static leader throttle rate: {} on broker {}", currLeaderThrottle, brokerId);
+      } else {
+        LOG.debug("Removing leader throttle rate: {} on broker {}", currLeaderThrottle, brokerId);
+        ops.add(new AlterConfigOp(new ConfigEntry(LEADER_REPLICATION_THROTTLED_RATE_CONFIG, null), AlterConfigOp.OpType.DELETE));
+      }
+    }
+    ConfigEntry currFollowerThrottle = brokerConfigs.get(FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG);
+    if (currFollowerThrottle != null) {
+      if (currFollowerThrottle.source().equals(ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG)) {
+        LOG.debug("Skipping removal for static follower throttle rate: {} on broker {}", currFollowerThrottle, brokerId);
+      } else {
+        LOG.debug("Removing follower throttle rate: {} on broker {}", currFollowerThrottle, brokerId);
+        ops.add(new AlterConfigOp(new ConfigEntry(FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, null), AlterConfigOp.OpType.DELETE));
+      }
+    }
+    return ops;
+  }
+
+  private List<AlterConfigOp> buildRemoveThrottledReplicasOps(Config topicConfigs, String topic, Set<String> replicas) {
+    List<AlterConfigOp> ops = new ArrayList<>();
+    ConfigEntry currentLeaderThrottledReplicas = topicConfigs.get(LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG);
+    if (currentLeaderThrottledReplicas != null) {
+      if (currentLeaderThrottledReplicas.value().equals(WILDCARD_ASTERISK)) {
+        LOG.debug("Existing config throttles all leader replicas. So, do not remove any leader replica throttle for topic {}", topic);
+      } else {
+        replicas.forEach(r -> LOG.debug("Removing leader throttles for topic {} and replica {}", topic, r));
+        String newThrottledReplicas = removeReplicasFromConfig(currentLeaderThrottledReplicas.value(), replicas);
+        if (newThrottledReplicas.isEmpty()) {
+          ops.add(new AlterConfigOp(new ConfigEntry(LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG, null), AlterConfigOp.OpType.DELETE));
+        } else {
+          ops.add(new AlterConfigOp(new ConfigEntry(LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG, newThrottledReplicas), AlterConfigOp.OpType.SET));
+        }
+      }
+    }
+    ConfigEntry currentFollowerThrottledReplicas = topicConfigs.get(FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG);
+    if (currentFollowerThrottledReplicas != null) {
+      if (currentFollowerThrottledReplicas.value().equals(WILDCARD_ASTERISK)) {
+        LOG.debug("Existing config throttles all follower replicas. So, do not remove any follower replica throttle for topic {}", topic);
+      } else {
+        replicas.forEach(r -> LOG.debug("Removing follower throttles for topic {} and replica {}", topic, r));
+        String newThrottledReplicas = removeReplicasFromConfig(currentFollowerThrottledReplicas.value(), replicas);
+        if (newThrottledReplicas.isEmpty()) {
+          ops.add(new AlterConfigOp(new ConfigEntry(FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, null), AlterConfigOp.OpType.DELETE));
+        } else {
+          ops.add(new AlterConfigOp(new ConfigEntry(FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, newThrottledReplicas), AlterConfigOp.OpType.SET));
+        }
+      }
+    }
+    return ops;
+  }
+
+  // --- Batch AdminClient helpers ---
+
+  /**
+   * Batch-read topic configs, gracefully handling non-existent topics by returning empty configs.
+   * Uses describeConfigs().values() for per-topic error handling.
+   *
+   * @param topics the set of topic names to read configs for
+   * @return a map from topic name to its config, with empty configs for non-existent topics
+   */
+  private Map<String, Config> batchGetTopicConfigs(Set<String> topics)
+  throws ExecutionException, InterruptedException, TimeoutException {
+    // Sort topic names for deterministic ordering in logs and diagnostics
+    List<ConfigResource> resources = topics.stream()
+        .sorted()
+        .map(t -> new ConfigResource(ConfigResource.Type.TOPIC, t))
+        .collect(Collectors.toList());
+
+    Map<ConfigResource, KafkaFuture<Config>> futures = _adminClient.describeConfigs(resources).values();
+    Map<String, Config> result = new HashMap<>();
+
+    for (Map.Entry<ConfigResource, KafkaFuture<Config>> entry : futures.entrySet()) {
+      String topic = entry.getKey().name();
+      try {
+        result.put(topic, entry.getValue().get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      } catch (ExecutionException e) {
+        if (!topicExists(topic)) {
+          result.put(topic, new Config(Collections.emptyList()));
+        } else {
+          throw e;
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Batch-write broker configs and wait for verification.
+   *
+   * @param ops the map of broker config resources to their alter operations
+   */
+  private void batchAlterBrokerConfigs(Map<ConfigResource, Collection<AlterConfigOp>> ops)
+  throws ExecutionException, InterruptedException, TimeoutException {
+    _adminClient.incrementalAlterConfigs(ops)
+        .all().get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    waitForBatchConfigs(ops);
+  }
+
+  /**
+   * Batch-write topic configs using values() for per-topic error handling, then wait for
+   * verification on successfully written topics.
+   *
+   * @param ops the map of topic config resources to their alter operations
+   */
+  private void batchAlterTopicConfigs(Map<ConfigResource, Collection<AlterConfigOp>> ops)
+  throws ExecutionException, InterruptedException, TimeoutException {
+    Map<ConfigResource, KafkaFuture<Void>> futures = _adminClient.incrementalAlterConfigs(ops).values();
+    Map<ConfigResource, Collection<AlterConfigOp>> successfulOps = new HashMap<>();
+
+    for (Map.Entry<ConfigResource, KafkaFuture<Void>> entry : futures.entrySet()) {
+      String topic = entry.getKey().name();
+      try {
+        entry.getValue().get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        successfulOps.put(entry.getKey(), ops.get(entry.getKey()));
+      } catch (ExecutionException e) {
+        if (!topicExists(topic)) {
+          LOG.debug("Failed to change configs for topic {} since it does not exist", topic);
+        } else {
+          throw e;
+        }
+      }
+    }
+
+    if (!successfulOps.isEmpty()) {
+      waitForBatchConfigs(successfulOps);
+    }
+  }
+
+  /**
+   * Batch verify configs by polling describeConfigs until all resources match expected values.
+   * Uses per-resource futures via values() so that a failure for one resource (e.g. a deleted topic)
+   * does not skip verification for the entire batch.
+   *
+   * @param allOps the map of config resources to their expected alter operations
+   */
+  void waitForBatchConfigs(Map<ConfigResource, Collection<AlterConfigOp>> allOps) {
+    Map<ConfigResource, Map<String, String>> expectedByResource = new HashMap<>();
+    for (Map.Entry<ConfigResource, Collection<AlterConfigOp>> entry : allOps.entrySet()) {
+      // Use HashMap::new instead of Collectors.toMap to allow inserting null values
+      Map<String, String> expected = entry.getValue().stream()
+          .collect(HashMap::new, (m, o) -> m.put(o.configEntry().name(), o.configEntry().value()), HashMap::putAll);
+      expectedByResource.put(entry.getKey(), expected);
+    }
+
+    List<ConfigResource> resources = new ArrayList<>(allOps.keySet());
+    boolean retryResponse = CruiseControlMetricsUtils.retry(() -> {
+      try {
+        Map<ConfigResource, KafkaFuture<Config>> futures = _adminClient.describeConfigs(resources).values();
+        for (Map.Entry<ConfigResource, Map<String, String>> entry : expectedByResource.entrySet()) {
+          try {
+            Config config = futures.get(entry.getKey()).get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            if (!configsEqual(config, entry.getValue())) {
+              return true;
+            }
+          } catch (ExecutionException e) {
+            // Per-resource failure (e.g. topic deleted during verification).
+            // Skip verification for this resource only; other resources continue.
+            LOG.warn("Failed to verify config for {}, skipping verification for this resource", entry.getKey(), e);
+          }
+        }
+        return false;
+      } catch (InterruptedException | TimeoutException e) {
+        LOG.warn("Error during batch config verification for {} resources, skipping verification", resources.size(), e);
+        return false;
+      }
+    }, _retries);
+    if (!retryResponse) {
+      throw new IllegalStateException("Could not verify that configs were applied to " + allOps.keySet().size()
+          + " resources within the time limit");
+    }
+  }
+
+  // --- Existing methods kept for backward compatibility and test setup ---
 
   private boolean throttlingEnabled() {
     return _throttleRate != null;
@@ -176,67 +483,10 @@ class ReplicationThrottleHelper {
     return throttledReplicasByTopic;
   }
 
-  private void setThrottledRateIfNecessary(int brokerId) throws ExecutionException, InterruptedException, TimeoutException {
-    if (_throttleRate == null) {
-      throw new IllegalStateException("Throttle rate cannot be null");
-    }
-    Config brokerConfigs = getBrokerConfigs(brokerId);
-    List<AlterConfigOp> ops = new ArrayList<>();
-    for (String replicaThrottleRateConfigKey : Arrays.asList(LEADER_REPLICATION_THROTTLED_RATE_CONFIG, FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG)) {
-      ConfigEntry currThrottleRate = brokerConfigs.get(replicaThrottleRateConfigKey);
-      if (currThrottleRate == null || !currThrottleRate.value().equals(String.valueOf(_throttleRate))) {
-        LOG.debug("Setting {} to {} bytes/second for broker {}", replicaThrottleRateConfigKey, _throttleRate, brokerId);
-        ops.add(new AlterConfigOp(new ConfigEntry(replicaThrottleRateConfigKey, String.valueOf(_throttleRate)), AlterConfigOp.OpType.SET));
-      }
-    }
-    if (!ops.isEmpty()) {
-      changeBrokerConfigs(brokerId, ops);
-    }
-  }
-
-  private Config getTopicConfigs(String topic) throws ExecutionException, InterruptedException, TimeoutException {
-    try {
-      return getEntityConfigs(new ConfigResource(ConfigResource.Type.TOPIC, topic));
-    } catch (Exception e) {
-      if (!topicExists(topic)) {
-        return new Config(Collections.emptyList());
-      }
-      throw e;
-    }
-  }
-
-  private Config getBrokerConfigs(int brokerId) throws ExecutionException, InterruptedException, TimeoutException {
-    return getEntityConfigs(new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(brokerId)));
-  }
-
   private Config getEntityConfigs(ConfigResource cf) throws ExecutionException, InterruptedException, TimeoutException {
     Map<ConfigResource, Config> configs = _adminClient.describeConfigs(Collections.singletonList(cf)).all()
         .get(CLIENT_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     return configs.get(cf);
-  }
-
-  private void setThrottledReplicas(String topic, Set<String> replicas)
-  throws ExecutionException, InterruptedException, TimeoutException {
-    Config topicConfigs = getTopicConfigs(topic);
-    List<AlterConfigOp> ops = new ArrayList<>();
-    for (String replicaThrottleConfigKey : Arrays.asList(LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG,
-            FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG)) {
-      ConfigEntry currThrottledReplicas = topicConfigs.get(replicaThrottleConfigKey);
-      if (currThrottledReplicas != null && currThrottledReplicas.value().trim().equals(WILDCARD_ASTERISK)) {
-        // The existing setup throttles all replica. So, nothing needs to be changed.
-        continue;
-      }
-
-      // Merge new throttled replicas with existing configuration values.
-      Set<String> newThrottledReplicas = new TreeSet<>(replicas);
-      if (currThrottledReplicas != null && !currThrottledReplicas.value().equals("")) {
-        newThrottledReplicas.addAll(Arrays.asList(currThrottledReplicas.value().split(",")));
-      }
-      ops.add(new AlterConfigOp(new ConfigEntry(replicaThrottleConfigKey, String.join(",", newThrottledReplicas)), AlterConfigOp.OpType.SET));
-    }
-    if (!ops.isEmpty()) {
-      changeTopicConfigs(topic, ops);
-    }
   }
 
   void changeTopicConfigs(String topic, Collection<AlterConfigOp> ops)
@@ -278,83 +528,6 @@ class ReplicationThrottleHelper {
     List<String> throttles = new ArrayList<>(Arrays.asList(throttleConfig.split(",")));
     throttles.removeIf(replicas::contains);
     return String.join(",", throttles);
-  }
-
-  /**
-   * It gets whether there is any throttled replica specified in the configuration property. If there is and the
-   * specified throttled replica does not equal to "*", it modifies the configuration property by removing a
-   * given set of replicas from the set of throttled replicas
-   *
-   * @param topic name of topic which contains <code>replicas</code>
-   * @param replicas replicas to remove from the configuration properties
-   */
-  private void removeThrottledReplicasFromTopic(String topic, Set<String> replicas)
-  throws ExecutionException, InterruptedException, TimeoutException {
-    Config topicConfigs = getTopicConfigs(topic);
-    if (topicConfigs == null) {
-      LOG.debug("Skip removing throttled replicas {} from topic {} since no configs can be read", String.join(",", replicas), topic);
-      return;
-    }
-    List<AlterConfigOp> ops = new ArrayList<>();
-
-    ConfigEntry currentLeaderThrottledReplicas = topicConfigs.get(LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG);
-    if (currentLeaderThrottledReplicas != null) {
-      if (currentLeaderThrottledReplicas.value().equals(WILDCARD_ASTERISK)) {
-        LOG.debug("Existing config throttles all leader replicas. So, do not remove any leader replica throttle");
-      } else {
-        replicas.forEach(r -> LOG.debug("Removing leader throttles for topic {} and replica {}", topic, r));
-        String newThrottledReplicas = removeReplicasFromConfig(currentLeaderThrottledReplicas.value(), replicas);
-        if (newThrottledReplicas.isEmpty()) {
-          ops.add(new AlterConfigOp(new ConfigEntry(LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG, null), AlterConfigOp.OpType.DELETE));
-        } else {
-          ops.add(new AlterConfigOp(new ConfigEntry(LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG, newThrottledReplicas), AlterConfigOp.OpType.SET));
-        }
-      }
-    }
-    ConfigEntry currentFollowerThrottledReplicas = topicConfigs.get(FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG);
-    if (currentFollowerThrottledReplicas != null) {
-      if (currentFollowerThrottledReplicas.value().equals(WILDCARD_ASTERISK)) {
-        LOG.debug("Existing config throttles all follower replicas. So, do not remove any follower replica throttle");
-      } else {
-        replicas.forEach(r -> LOG.debug("Removing follower throttles for topic {} and replica {}", topic, r));
-        String newThrottledReplicas = removeReplicasFromConfig(currentFollowerThrottledReplicas.value(), replicas);
-        if (newThrottledReplicas.isEmpty()) {
-          ops.add(new AlterConfigOp(new ConfigEntry(FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, null), AlterConfigOp.OpType.DELETE));
-        } else {
-          ops.add(new AlterConfigOp(new ConfigEntry(FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, newThrottledReplicas), AlterConfigOp.OpType.SET));
-        }
-      }
-    }
-    if (!ops.isEmpty()) {
-      changeTopicConfigs(topic, ops);
-    }
-  }
-
-  private void removeThrottledRateFromBroker(Integer brokerId)
-  throws ExecutionException, InterruptedException, TimeoutException {
-    Config brokerConfigs = getBrokerConfigs(brokerId);
-    ConfigEntry currLeaderThrottle = brokerConfigs.get(LEADER_REPLICATION_THROTTLED_RATE_CONFIG);
-    ConfigEntry currFollowerThrottle = brokerConfigs.get(FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG);
-    List<AlterConfigOp> ops = new ArrayList<>();
-    if (currLeaderThrottle != null) {
-      if (currLeaderThrottle.source().equals(ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG)) {
-        LOG.debug("Skipping removal for static leader throttle rate: {}", currFollowerThrottle);
-      } else {
-        LOG.debug("Removing leader throttle rate: {} on broker {}", currLeaderThrottle, brokerId);
-        ops.add(new AlterConfigOp(new ConfigEntry(LEADER_REPLICATION_THROTTLED_RATE_CONFIG, null), AlterConfigOp.OpType.DELETE));
-      }
-    }
-    if (currFollowerThrottle != null) {
-      if (currFollowerThrottle.source().equals(ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG)) {
-        LOG.debug("Skipping removal for static follower throttle rate: {}", currFollowerThrottle);
-      } else {
-        LOG.debug("Removing follower throttle rate: {} on broker {}", currFollowerThrottle, brokerId);
-        ops.add(new AlterConfigOp(new ConfigEntry(FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, null), AlterConfigOp.OpType.DELETE));
-      }
-    }
-    if (!ops.isEmpty()) {
-      changeBrokerConfigs(brokerId, ops);
-    }
   }
 
   // Retries until we can read the configs changes we just wrote

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
@@ -368,6 +368,10 @@ class ReplicationThrottleHelper {
 
   /**
    * Batch-write broker configs and wait for verification.
+   * Uses .all() (fail-fast) rather than .values() (per-resource) because broker config failures are
+   * not expected during normal operation -- unlike topics, brokers are not deleted mid-operation.
+   * A broker failure here indicates a serious infrastructure issue that should fail the entire
+   * throttle setup rather than partially applying configs.
    *
    * @param ops the map of broker config resources to their alter operations
    */
@@ -434,15 +438,16 @@ class ReplicationThrottleHelper {
             if (!configsEqual(config, entry.getValue())) {
               return true;
             }
-          } catch (ExecutionException e) {
-            // Per-resource failure (e.g. topic deleted during verification).
+          } catch (ExecutionException | TimeoutException e) {
+            // Per-resource failure (e.g. topic deleted or network blip during verification).
             // Skip verification for this resource only; other resources continue.
             LOG.warn("Failed to verify config for {}, skipping verification for this resource", entry.getKey(), e);
           }
         }
         return false;
-      } catch (InterruptedException | TimeoutException e) {
-        LOG.warn("Error during batch config verification for {} resources, skipping verification", resources.size(), e);
+      } catch (InterruptedException e) {
+        LOG.warn("Interrupted during batch config verification for {} resources, skipping verification", resources.size(), e);
+        Thread.currentThread().interrupt();
         return false;
       }
     }, _retries);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
@@ -88,14 +88,28 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     )).all().get();
   }
 
-  private static void setWildcardThrottleReplicaForTopic(ReplicationThrottleHelper helper, String topicName) throws Exception {
+  private void setWildcardThrottleReplicaForTopic(ReplicationThrottleHelper helper, String topicName) throws Exception {
     for (String replicaThrottleProp : Arrays.asList(ReplicationThrottleHelper.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG,
                                                     ReplicationThrottleHelper.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG)) {
       Collection<AlterConfigOp> configs = Collections.singletonList(
               new AlterConfigOp(new ConfigEntry(replicaThrottleProp, ReplicationThrottleHelper.WILDCARD_ASTERISK), AlterConfigOp.OpType.SET)
       );
-      helper.changeTopicConfigs(topicName, configs);
+      changeTopicConfigs(helper, topicName, configs);
     }
+  }
+
+  // Applies topic configs directly via the admin client and waits until they are readable.
+  private void changeTopicConfigs(ReplicationThrottleHelper helper, String topic, Collection<AlterConfigOp> ops) throws Exception {
+    ConfigResource cf = new ConfigResource(ConfigResource.Type.TOPIC, topic);
+    _adminClient.incrementalAlterConfigs(Collections.singletonMap(cf, ops)).all().get();
+    helper.waitForBatchConfigs(Collections.singletonMap(cf, ops));
+  }
+
+  // Applies broker configs directly via the admin client and waits until they are readable.
+  private void changeBrokerConfigs(ReplicationThrottleHelper helper, int brokerId, Collection<AlterConfigOp> ops) throws Exception {
+    ConfigResource cf = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(brokerId));
+    _adminClient.incrementalAlterConfigs(Collections.singletonMap(cf, ops)).all().get();
+    helper.waitForBatchConfigs(Collections.singletonMap(cf, ops));
   }
 
   private ExecutionTask inProgressTaskForProposal(long id, ExecutionProposal proposal) {
@@ -164,8 +178,9 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
             mockConfigEntry(ReplicationThrottleHelper.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, "300",
                     ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG))
     );
-    // Expect batched calls: one batch read, one batch write, one batch verify (via values()), then topic read fails
-    expectBatchDescribeBrokerConfigs(mockAdminClient, brokers, brokerConfig);
+    // Expect batched calls: one batch read (via values()), one batch write, one batch verify (via values()),
+    // then topic read fails
+    expectBatchDescribeBrokerConfigsViaValues(mockAdminClient, brokers, brokerConfig);
     expectBatchIncrementalBrokerConfigs(mockAdminClient);
     expectBatchDescribeBrokerConfigsViaValues(mockAdminClient, brokers, brokerConfig2);
     expectBatchDescribeTopicConfigsViaValues(mockAdminClient, TOPIC0, EMPTY_CONFIG, false);
@@ -178,7 +193,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
 
     // Case 2: a situation where Topic0 gets deleted after its configs were read.
     EasyMock.reset(mockAdminClient);
-    expectBatchDescribeBrokerConfigs(mockAdminClient, brokers);
+    expectBatchDescribeBrokerConfigsViaValues(mockAdminClient, brokers);
     expectBatchIncrementalBrokerConfigs(mockAdminClient);
     expectBatchDescribeBrokerConfigsViaValues(mockAdminClient, brokers, EMPTY_CONFIG);
     String throttledReplicas = brokerId0 + "," + brokerId1;
@@ -356,7 +371,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
               new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, String.valueOf(throttleRate)),
               AlterConfigOp.OpType.SET)
     );
-    throttleHelper.changeBrokerConfigs(0, broker0Configs);
+    changeBrokerConfigs(throttleHelper, 0, broker0Configs);
 
     // Partition 1 (which is not involved in any execution proposal) has pre-existing throttled
     // replicas (on both leaders and followers); we expect these configurations to be merged
@@ -367,7 +382,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
       new AlterConfigOp(new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "1:0,1:1"),
               AlterConfigOp.OpType.SET)
     );
-    throttleHelper.changeTopicConfigs(TOPIC0, topic0Configs);
+    changeTopicConfigs(throttleHelper, TOPIC0, topic0Configs);
 
     // Topic 1 is not involved in any execution proposal. It has pre-existing throttled replicas.
     List<AlterConfigOp> topic1Config = Arrays.asList(
@@ -376,7 +391,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
       new AlterConfigOp(new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "1:1"),
               AlterConfigOp.OpType.SET)
     );
-    throttleHelper.changeTopicConfigs(TOPIC1, topic1Config);
+    changeTopicConfigs(throttleHelper, TOPIC1, topic1Config);
 
     throttleHelper.setThrottles(Collections.singletonList(proposal));
 
@@ -545,28 +560,6 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
   }
 
   @Test
-  public void testWaitForConfigs() throws Exception {
-    AdminClient mockAdminClient = EasyMock.strictMock(AdminClient.class);
-    int retries = 3;
-    // Case 1: queue more responses than RETRIES and expect checkConfigs to throw
-    for (int i = 0; i < retries + 1; i++) {
-      expectDescribeTopicConfigs(mockAdminClient, TOPIC0, EMPTY_CONFIG, true);
-    }
-    EasyMock.replay(mockAdminClient);
-    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, 100L, retries);
-    ConfigResource cf = new ConfigResource(ConfigResource.Type.TOPIC, TOPIC0);
-    assertThrows(IllegalStateException.class, () -> throttleHelper.waitForConfigs(cf, Collections.singletonList(
-            new AlterConfigOp(new ConfigEntry("k", "v"), AlterConfigOp.OpType.SET)
-    )));
-
-    // Case 2: queue a single result and call checkConfigs with matching configs, so it succeeds
-    EasyMock.reset(mockAdminClient);
-    expectDescribeTopicConfigs(mockAdminClient, TOPIC0, EMPTY_CONFIG, true);
-    EasyMock.replay(mockAdminClient);
-    throttleHelper.waitForConfigs(cf, Collections.emptyList());
-  }
-
-  @Test
   public void testWaitForBatchConfigs() throws Exception {
     AdminClient mockAdminClient = EasyMock.mock(AdminClient.class);
     int retries = 3;
@@ -615,21 +608,40 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     EasyMock.replay(mockAdminClient);
     throttleHelper.waitForBatchConfigs(allOps);
 
-    // Case 4: one resource throws ExecutionException during verification, other matches.
-    // Verification should succeed (failed resource is skipped, matching resource passes).
+    // Case 4: a topic resource fails during verification and the topic is confirmed deleted.
+    // Verification should succeed (deleted topic is dropped, matching resource passes).
+    ConfigResource topicCf = new ConfigResource(ConfigResource.Type.TOPIC, TOPIC0);
+    Map<ConfigResource, Collection<AlterConfigOp>> opsWithTopic = new HashMap<>();
+    opsWithTopic.put(brokerCf0, setOps);
+    opsWithTopic.put(topicCf, setOps);
     EasyMock.reset(mockAdminClient);
     expectBatchDescribeConfigsViaValuesWithFailure(mockAdminClient, brokerCf0, matchingConfig,
-        brokerCf1, new ExecutionException(new UnknownTopicOrPartitionException()));
+        topicCf, new ExecutionException(new UnknownTopicOrPartitionException()));
+    // The topic is confirmed deleted, so its verification is skipped.
+    expectListTopics(mockAdminClient, Collections.emptySet());
     EasyMock.replay(mockAdminClient);
-    throttleHelper.waitForBatchConfigs(allOps);
+    throttleHelper.waitForBatchConfigs(opsWithTopic);
 
-    // Case 5: one resource throws TimeoutException during verification, other matches.
-    // Verification should succeed (timed-out resource is skipped, matching resource passes).
+    // Case 5: a topic resource fails transiently during verification while the topic still exists.
+    // The resource stays pending and is verified on the next attempt.
     EasyMock.reset(mockAdminClient);
     expectBatchDescribeConfigsViaValuesWithFailure(mockAdminClient, brokerCf0, matchingConfig,
-        brokerCf1, new TimeoutException("simulated timeout"));
+        topicCf, new TimeoutException("simulated timeout"));
+    // The topic still exists, so verification retries instead of skipping.
+    expectListTopics(mockAdminClient, Collections.singleton(TOPIC0));
+    expectBatchDescribeConfigsViaValues(mockAdminClient, Collections.singletonMap(topicCf, matchingConfig));
     EasyMock.replay(mockAdminClient);
-    throttleHelper.waitForBatchConfigs(allOps);
+    throttleHelper.waitForBatchConfigs(opsWithTopic);
+
+    // Case 6: a broker resource keeps failing during verification. It must not pass silently:
+    // verification retries until attempts are exhausted and then throws.
+    EasyMock.reset(mockAdminClient);
+    for (int i = 0; i < retries + 1; i++) {
+      expectBatchDescribeConfigsViaValuesWithFailure(mockAdminClient, brokerCf0, matchingConfig,
+          brokerCf1, new TimeoutException("simulated timeout"));
+    }
+    EasyMock.replay(mockAdminClient);
+    assertThrows(IllegalStateException.class, () -> throttleHelper.waitForBatchConfigs(allOps));
   }
 
   @Test
@@ -681,25 +693,6 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     EasyMock.expect(configEntry.source()).andReturn(configSource).atLeastOnce();
     EasyMock.replay(configEntry);
     return configEntry;
-  }
-
-  // --- Single-resource mock helpers (used by testWaitForConfigs and other tests that call single-resource methods) ---
-
-  private void expectDescribeTopicConfigs(AdminClient adminClient, String topic, Config topicConfig, boolean topicExists)
-  throws ExecutionException, InterruptedException, TimeoutException {
-    ConfigResource cf = new ConfigResource(ConfigResource.Type.TOPIC, topic);
-    Map<ConfigResource, Config> topicConfigs = Collections.singletonMap(cf, topicConfig);
-    DescribeConfigsResult mockDescribeConfigsResult = EasyMock.mock(DescribeConfigsResult.class);
-    KafkaFuture<Map<ConfigResource, Config>> mockFuture = EasyMock.mock(KafkaFuture.class);
-    if (topicExists) {
-      EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject())).andReturn(topicConfigs);
-    } else {
-      EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject()))
-              .andThrow(new ExecutionException(new UnknownTopicOrPartitionException()));
-    }
-    EasyMock.expect(mockDescribeConfigsResult.all()).andReturn(mockFuture);
-    EasyMock.expect(adminClient.describeConfigs(Collections.singletonList(cf))).andReturn(mockDescribeConfigsResult);
-    EasyMock.replay(mockDescribeConfigsResult, mockFuture);
   }
 
   private void expectListTopics(AdminClient adminClient, Set<String> topics)
@@ -838,7 +831,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
   }
 
   // Expects a single batched describeConfigs call for brokers returning per-resource futures via values().
-  // Used for waitForBatchConfigs verification steps.
+  // Used for the clearThrottles broker config read and for waitForBatchConfigs verification steps.
   private void expectBatchDescribeBrokerConfigsViaValues(AdminClient adminClient, List<Integer> brokers, Config brokerConfig)
   throws ExecutionException, InterruptedException, TimeoutException {
     Map<ConfigResource, Config> configMap = new HashMap<>();
@@ -846,6 +839,15 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
       configMap.put(new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(id)), brokerConfig);
     }
     expectBatchDescribeConfigsViaValues(adminClient, configMap);
+  }
+
+  // Same as above, with all brokers already at the default throttle rate (rate=100).
+  private void expectBatchDescribeBrokerConfigsViaValues(AdminClient adminClient, List<Integer> brokers)
+  throws ExecutionException, InterruptedException, TimeoutException {
+    Config brokerConfig = new Config(Arrays.asList(
+      new ConfigEntry(ReplicationThrottleHelper.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, "100"),
+      new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, "100")));
+    expectBatchDescribeBrokerConfigsViaValues(adminClient, brokers, brokerConfig);
   }
 
   // Expects a single batched describeConfigs call returning per-resource futures via values().

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
@@ -231,7 +231,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
 
     // Case 1: a situation where Topic0 does not exist. Hence no property is returned upon read.
     // Batch read brokers (rates already match 100L, so no broker writes)
-    expectBatchDescribeBrokerConfigs(mockAdminClient, brokers);
+    expectBatchDescribeBrokerConfigsViaValues(mockAdminClient, brokers);
     // Batch read topic configs (topic doesn't exist)
     expectBatchDescribeTopicConfigsViaValues(mockAdminClient, TOPIC0, EMPTY_CONFIG, false);
     expectListTopics(mockAdminClient, Collections.emptySet());
@@ -246,7 +246,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     // Case 2: a situation where Topic0 gets deleted after its configs were read. Change configs should not fail.
     EasyMock.reset(mockAdminClient);
     // Batch read brokers (rates already match)
-    expectBatchDescribeBrokerConfigs(mockAdminClient, brokers);
+    expectBatchDescribeBrokerConfigsViaValues(mockAdminClient, brokers);
     String throttledReplicas = brokerId0 + "," + brokerId1;
     Config topicConfigs = new Config(Arrays.asList(
       new ConfigEntry(ReplicationThrottleHelper.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG, throttledReplicas),
@@ -284,7 +284,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, throttleRate);
 
     // Batch read brokers — rates already match, no writes needed
-    expectBatchDescribeBrokerConfigs(mockAdminClient, brokers);
+    expectBatchDescribeBrokerConfigsViaValues(mockAdminClient, brokers);
 
     // Batch read topic configs via values() — TOPIC0 succeeds, TOPIC1 fails
     String existingReplicas = "1:0,1:1";
@@ -706,31 +706,6 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
   }
 
   // --- Batch mock helpers (used by testSetThrottleOnNonExistentTopic and testClearThrottleOnNonExistentTopic) ---
-
-  // Expects a single batched describeConfigs call for all brokers, returning configs via all().
-  private void expectBatchDescribeBrokerConfigs(AdminClient adminClient, List<Integer> brokers, Config brokerConfig)
-  throws ExecutionException, InterruptedException, TimeoutException {
-    Map<ConfigResource, Config> configMap = new HashMap<>();
-    for (int id : brokers) {
-      configMap.put(new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(id)), brokerConfig);
-    }
-    DescribeConfigsResult mockDescribeConfigsResult = EasyMock.mock(DescribeConfigsResult.class);
-    KafkaFuture<Map<ConfigResource, Config>> mockFuture = EasyMock.mock(KafkaFuture.class);
-    EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject())).andReturn(configMap);
-    EasyMock.expect(mockDescribeConfigsResult.all()).andReturn(mockFuture);
-    EasyMock.expect(adminClient.describeConfigs(EasyMock.anyObject())).andReturn(mockDescribeConfigsResult);
-    EasyMock.replay(mockDescribeConfigsResult, mockFuture);
-  }
-
-  // Expects a single batched describeConfigs call for all brokers with default throttle rate configs (rate=100).
-  private void expectBatchDescribeBrokerConfigs(AdminClient adminClient, List<Integer> brokers)
-  throws ExecutionException, InterruptedException, TimeoutException {
-    // All participating brokers have throttled rate set already
-    Config brokerConfig = new Config(Arrays.asList(
-      new ConfigEntry(ReplicationThrottleHelper.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, "100"),
-      new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, "100")));
-    expectBatchDescribeBrokerConfigs(adminClient, brokers, brokerConfig);
-  }
 
   // Expects a single batched incrementalAlterConfigs call for brokers, succeeding via all().
   private void expectBatchIncrementalBrokerConfigs(AdminClient adminClient)

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
@@ -164,11 +164,11 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
             mockConfigEntry(ReplicationThrottleHelper.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, "300",
                     ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG))
     );
-    // Expect that only the dynamic throttle rate configs are removed when clearing throttles
-    expectDescribeBrokerConfigs(mockAdminClient, brokers, brokerConfig);
-    expectIncrementalBrokerConfigs(mockAdminClient, brokers);
-    expectDescribeBrokerConfigs(mockAdminClient, brokers, brokerConfig2);
-    expectDescribeTopicConfigs(mockAdminClient, TOPIC0, EMPTY_CONFIG, false);
+    // Expect batched calls: one batch read, one batch write, one batch verify (via values()), then topic read fails
+    expectBatchDescribeBrokerConfigs(mockAdminClient, brokers, brokerConfig);
+    expectBatchIncrementalBrokerConfigs(mockAdminClient);
+    expectBatchDescribeBrokerConfigsViaValues(mockAdminClient, brokers, brokerConfig2);
+    expectBatchDescribeTopicConfigsViaValues(mockAdminClient, TOPIC0, EMPTY_CONFIG, false);
     expectListTopics(mockAdminClient, Collections.emptySet());
     ExecutionTask mockCompleteTask = prepareMockCompleteTask(proposal);
     EasyMock.replay(mockAdminClient);
@@ -178,15 +178,15 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
 
     // Case 2: a situation where Topic0 gets deleted after its configs were read.
     EasyMock.reset(mockAdminClient);
-    expectDescribeBrokerConfigs(mockAdminClient, brokers);
-    expectIncrementalBrokerConfigs(mockAdminClient, brokers);
-    expectDescribeBrokerConfigs(mockAdminClient, brokers, EMPTY_CONFIG);
+    expectBatchDescribeBrokerConfigs(mockAdminClient, brokers);
+    expectBatchIncrementalBrokerConfigs(mockAdminClient);
+    expectBatchDescribeBrokerConfigsViaValues(mockAdminClient, brokers, EMPTY_CONFIG);
     String throttledReplicas = brokerId0 + "," + brokerId1;
     Config topicConfigProps = new Config(Arrays.asList(
             new ConfigEntry(ReplicationThrottleHelper.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG, throttledReplicas),
             new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, throttledReplicas)));
-    expectDescribeTopicConfigs(mockAdminClient, TOPIC0, topicConfigProps, true);
-    expectIncrementalTopicConfigs(mockAdminClient, TOPIC0, false);
+    expectBatchDescribeTopicConfigsViaValues(mockAdminClient, TOPIC0, topicConfigProps, true);
+    expectBatchIncrementalTopicConfigsViaValues(mockAdminClient, TOPIC0, false);
     expectListTopics(mockAdminClient, Collections.emptySet());
     mockCompleteTask = prepareMockCompleteTask(proposal);
     EasyMock.replay(mockAdminClient);
@@ -215,10 +215,13 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, throttleRate);
 
     // Case 1: a situation where Topic0 does not exist. Hence no property is returned upon read.
-    expectDescribeBrokerConfigs(mockAdminClient, brokers);
-    expectDescribeTopicConfigs(mockAdminClient, TOPIC0, EMPTY_CONFIG, false);
+    // Batch read brokers (rates already match 100L, so no broker writes)
+    expectBatchDescribeBrokerConfigs(mockAdminClient, brokers);
+    // Batch read topic configs (topic doesn't exist)
+    expectBatchDescribeTopicConfigsViaValues(mockAdminClient, TOPIC0, EMPTY_CONFIG, false);
     expectListTopics(mockAdminClient, Collections.emptySet());
-    expectIncrementalTopicConfigs(mockAdminClient, TOPIC0, false);
+    // Batch write topic configs (topic doesn't exist, write fails)
+    expectBatchIncrementalTopicConfigsViaValues(mockAdminClient, TOPIC0, false);
     expectListTopics(mockAdminClient, Collections.emptySet());
     EasyMock.replay(mockAdminClient);
     // Expect no exception
@@ -227,13 +230,16 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
 
     // Case 2: a situation where Topic0 gets deleted after its configs were read. Change configs should not fail.
     EasyMock.reset(mockAdminClient);
-    expectDescribeBrokerConfigs(mockAdminClient, brokers);
+    // Batch read brokers (rates already match)
+    expectBatchDescribeBrokerConfigs(mockAdminClient, brokers);
     String throttledReplicas = brokerId0 + "," + brokerId1;
     Config topicConfigs = new Config(Arrays.asList(
       new ConfigEntry(ReplicationThrottleHelper.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG, throttledReplicas),
       new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, throttledReplicas)));
-    expectDescribeTopicConfigs(mockAdminClient, TOPIC0, topicConfigs, true);
-    expectIncrementalTopicConfigs(mockAdminClient, TOPIC0, false);
+    // Batch read topic configs (topic exists at read time)
+    expectBatchDescribeTopicConfigsViaValues(mockAdminClient, TOPIC0, topicConfigs, true);
+    // Batch write topic configs (topic gets deleted, write fails)
+    expectBatchIncrementalTopicConfigsViaValues(mockAdminClient, TOPIC0, false);
     expectListTopics(mockAdminClient, Collections.emptySet());
     EasyMock.replay(mockAdminClient);
     // Expect no exception
@@ -510,6 +516,56 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
   }
 
   @Test
+  public void testWaitForBatchConfigs() throws Exception {
+    AdminClient mockAdminClient = EasyMock.mock(AdminClient.class);
+    int retries = 3;
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, 100L, retries);
+
+    ConfigResource brokerCf0 = new ConfigResource(ConfigResource.Type.BROKER, "0");
+    ConfigResource brokerCf1 = new ConfigResource(ConfigResource.Type.BROKER, "1");
+
+    Collection<AlterConfigOp> setOps = Collections.singletonList(
+        new AlterConfigOp(
+            new ConfigEntry(ReplicationThrottleHelper.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, "100"),
+            AlterConfigOp.OpType.SET));
+    Map<ConfigResource, Collection<AlterConfigOp>> allOps = new HashMap<>();
+    allOps.put(brokerCf0, setOps);
+    allOps.put(brokerCf1, setOps);
+
+    Config matchingConfig = new Config(Collections.singletonList(
+        new ConfigEntry(ReplicationThrottleHelper.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, "100")));
+
+    // Case 1: retries exhaust with configs never matching, expect IllegalStateException
+    Map<ConfigResource, Config> mismatchMap = new HashMap<>();
+    mismatchMap.put(brokerCf0, EMPTY_CONFIG);
+    mismatchMap.put(brokerCf1, EMPTY_CONFIG);
+    for (int i = 0; i < retries + 1; i++) {
+      expectBatchDescribeConfigsViaValues(mockAdminClient, mismatchMap);
+    }
+    EasyMock.replay(mockAdminClient);
+    assertThrows(IllegalStateException.class, () -> throttleHelper.waitForBatchConfigs(allOps));
+
+    // Case 2: configs match on first attempt
+    EasyMock.reset(mockAdminClient);
+    Map<ConfigResource, Config> matchMap = new HashMap<>();
+    matchMap.put(brokerCf0, matchingConfig);
+    matchMap.put(brokerCf1, matchingConfig);
+    expectBatchDescribeConfigsViaValues(mockAdminClient, matchMap);
+    EasyMock.replay(mockAdminClient);
+    throttleHelper.waitForBatchConfigs(allOps);
+
+    // Case 3: partial match — one broker matches, the other doesn't, then both match
+    EasyMock.reset(mockAdminClient);
+    Map<ConfigResource, Config> partialMap = new HashMap<>();
+    partialMap.put(brokerCf0, matchingConfig);
+    partialMap.put(brokerCf1, EMPTY_CONFIG);
+    expectBatchDescribeConfigsViaValues(mockAdminClient, partialMap);
+    expectBatchDescribeConfigsViaValues(mockAdminClient, matchMap);
+    EasyMock.replay(mockAdminClient);
+    throttleHelper.waitForBatchConfigs(allOps);
+  }
+
+  @Test
   public void testConfigsEqual() {
     Map<String, String> expectedConfigs = new HashMap<>();
     List<ConfigEntry> entries = new ArrayList<>();
@@ -560,6 +616,8 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     return configEntry;
   }
 
+  // --- Single-resource mock helpers (used by testWaitForConfigs and other tests that call single-resource methods) ---
+
   private void expectDescribeTopicConfigs(AdminClient adminClient, String topic, Config topicConfig, boolean topicExists)
   throws ExecutionException, InterruptedException, TimeoutException {
     ConfigResource cf = new ConfigResource(ConfigResource.Type.TOPIC, topic);
@@ -577,22 +635,6 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     EasyMock.replay(mockDescribeConfigsResult, mockFuture);
   }
 
-  private void expectIncrementalTopicConfigs(AdminClient adminClient, String topic, boolean topicExists)
-  throws ExecutionException, InterruptedException, TimeoutException {
-    ConfigResource cf = new ConfigResource(ConfigResource.Type.TOPIC, topic);
-    AlterConfigsResult mockAlterConfigsResult = EasyMock.mock(AlterConfigsResult.class);
-    KafkaFuture<Void> mockFuture = EasyMock.mock(KafkaFuture.class);
-    EasyMock.expect(mockAlterConfigsResult.all()).andReturn(mockFuture);
-    if (topicExists) {
-      EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject())).andReturn(null);
-    } else {
-      EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject()))
-              .andThrow(new ExecutionException(new UnknownTopicOrPartitionException()));
-    }
-    EasyMock.expect(adminClient.incrementalAlterConfigs(Collections.singletonMap(cf, EasyMock.anyObject()))).andReturn(mockAlterConfigsResult);
-    EasyMock.replay(mockAlterConfigsResult, mockFuture);
-  }
-
   private void expectListTopics(AdminClient adminClient, Set<String> topics)
   throws ExecutionException, InterruptedException, TimeoutException {
     ListTopicsResult mockListTopicsResult = EasyMock.mock(ListTopicsResult.class);
@@ -603,41 +645,115 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     EasyMock.replay(mockListTopicsResult, mockFuture);
   }
 
-  private void expectDescribeBrokerConfigs(AdminClient adminClient, List<Integer> brokers)
+  // --- Batch mock helpers (used by testSetThrottleOnNonExistentTopic and testClearThrottleOnNonExistentTopic) ---
+
+  // Expects a single batched describeConfigs call for all brokers, returning configs via all().
+  private void expectBatchDescribeBrokerConfigs(AdminClient adminClient, List<Integer> brokers, Config brokerConfig)
+  throws ExecutionException, InterruptedException, TimeoutException {
+    Map<ConfigResource, Config> configMap = new HashMap<>();
+    for (int id : brokers) {
+      configMap.put(new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(id)), brokerConfig);
+    }
+    DescribeConfigsResult mockDescribeConfigsResult = EasyMock.mock(DescribeConfigsResult.class);
+    KafkaFuture<Map<ConfigResource, Config>> mockFuture = EasyMock.mock(KafkaFuture.class);
+    EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject())).andReturn(configMap);
+    EasyMock.expect(mockDescribeConfigsResult.all()).andReturn(mockFuture);
+    EasyMock.expect(adminClient.describeConfigs(EasyMock.anyObject())).andReturn(mockDescribeConfigsResult);
+    EasyMock.replay(mockDescribeConfigsResult, mockFuture);
+  }
+
+  // Expects a single batched describeConfigs call for all brokers with default throttle rate configs (rate=100).
+  private void expectBatchDescribeBrokerConfigs(AdminClient adminClient, List<Integer> brokers)
   throws ExecutionException, InterruptedException, TimeoutException {
     // All participating brokers have throttled rate set already
     Config brokerConfig = new Config(Arrays.asList(
       new ConfigEntry(ReplicationThrottleHelper.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, "100"),
       new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, "100")));
-    expectDescribeBrokerConfigs(adminClient, brokers, brokerConfig);
+    expectBatchDescribeBrokerConfigs(adminClient, brokers, brokerConfig);
   }
 
-  private void expectDescribeBrokerConfigs(AdminClient adminClient, List<Integer> brokers, Config brokerConfig)
+  // Expects a single batched incrementalAlterConfigs call for brokers, succeeding via all().
+  private void expectBatchIncrementalBrokerConfigs(AdminClient adminClient)
   throws ExecutionException, InterruptedException, TimeoutException {
-    for (int i : brokers) {
-      ConfigResource cf = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(i));
-      Map<ConfigResource, Config> brokerConfigs = Collections.singletonMap(cf, brokerConfig);
-      DescribeConfigsResult mockDescribeConfigsResult = EasyMock.mock(DescribeConfigsResult.class);
-      KafkaFuture<Map<ConfigResource, Config>> mockFuture = EasyMock.mock(KafkaFuture.class);
-      EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject())).andReturn(brokerConfigs);
-      EasyMock.expect(mockDescribeConfigsResult.all()).andReturn(mockFuture);
-      EasyMock.expect(adminClient.describeConfigs(Collections.singletonList(cf))).andReturn(mockDescribeConfigsResult);
-      EasyMock.replay(mockDescribeConfigsResult, mockFuture);
+    AlterConfigsResult mockAlterConfigsResult = EasyMock.mock(AlterConfigsResult.class);
+    KafkaFuture<Void> mockFuture = EasyMock.mock(KafkaFuture.class);
+    EasyMock.expect(mockAlterConfigsResult.all()).andReturn(mockFuture);
+    EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject())).andReturn(null);
+    EasyMock.expect(adminClient.incrementalAlterConfigs(EasyMock.anyObject())).andReturn(mockAlterConfigsResult);
+    EasyMock.replay(mockAlterConfigsResult, mockFuture);
+  }
+
+  // Expects a single batched describeConfigs call for a topic, returning per-topic futures via values().
+  // If topicExists is false, the topic's future will throw ExecutionException(UnknownTopicOrPartitionException).
+  private void expectBatchDescribeTopicConfigsViaValues(AdminClient adminClient, String topic, Config topicConfig, boolean topicExists)
+  throws ExecutionException, InterruptedException, TimeoutException {
+    ConfigResource cf = new ConfigResource(ConfigResource.Type.TOPIC, topic);
+    DescribeConfigsResult mockDescribeConfigsResult = EasyMock.mock(DescribeConfigsResult.class);
+    KafkaFuture<Config> mockFuture = EasyMock.mock(KafkaFuture.class);
+    if (topicExists) {
+      EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject())).andReturn(topicConfig);
+    } else {
+      EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject()))
+              .andThrow(new ExecutionException(new UnknownTopicOrPartitionException()));
     }
+    Map<ConfigResource, KafkaFuture<Config>> futureMap = Collections.singletonMap(cf, mockFuture);
+    EasyMock.expect(mockDescribeConfigsResult.values()).andReturn(futureMap);
+    EasyMock.expect(adminClient.describeConfigs(EasyMock.anyObject())).andReturn(mockDescribeConfigsResult);
+    EasyMock.replay(mockDescribeConfigsResult, mockFuture);
   }
 
-  private void expectIncrementalBrokerConfigs(AdminClient adminClient, List<Integer> brokers)
+  // Expects a single batched incrementalAlterConfigs call for a topic, returning per-topic futures via values().
+  // If topicExists is false, the topic's future will throw ExecutionException(UnknownTopicOrPartitionException).
+  private void expectBatchIncrementalTopicConfigsViaValues(AdminClient adminClient, String topic, boolean topicExists)
   throws ExecutionException, InterruptedException, TimeoutException {
-    for (int brokerId : brokers) {
-      ConfigResource cf = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(brokerId));
-      AlterConfigsResult mockAlterConfigsResult = EasyMock.mock(AlterConfigsResult.class);
-      KafkaFuture<Void> mockFuture = EasyMock.mock(KafkaFuture.class);
-      EasyMock.expect(mockAlterConfigsResult.all()).andReturn(mockFuture);
+    ConfigResource cf = new ConfigResource(ConfigResource.Type.TOPIC, topic);
+    AlterConfigsResult mockAlterConfigsResult = EasyMock.mock(AlterConfigsResult.class);
+    KafkaFuture<Void> mockFuture = EasyMock.mock(KafkaFuture.class);
+    if (topicExists) {
       EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject())).andReturn(null);
-      EasyMock.expect(adminClient.incrementalAlterConfigs(Collections.singletonMap(cf, EasyMock.anyObject()))).andReturn(mockAlterConfigsResult);
-      EasyMock.replay(mockAlterConfigsResult, mockFuture);
+    } else {
+      EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject()))
+              .andThrow(new ExecutionException(new UnknownTopicOrPartitionException()));
     }
+    Map<ConfigResource, KafkaFuture<Void>> futureMap = Collections.singletonMap(cf, mockFuture);
+    EasyMock.expect(mockAlterConfigsResult.values()).andReturn(futureMap);
+    EasyMock.expect(adminClient.incrementalAlterConfigs(EasyMock.anyObject())).andReturn(mockAlterConfigsResult);
+    EasyMock.replay(mockAlterConfigsResult, mockFuture);
   }
+
+  // Expects a single batched describeConfigs call for brokers returning per-resource futures via values().
+  // Used for waitForBatchConfigs verification steps.
+  private void expectBatchDescribeBrokerConfigsViaValues(AdminClient adminClient, List<Integer> brokers, Config brokerConfig)
+  throws ExecutionException, InterruptedException, TimeoutException {
+    Map<ConfigResource, Config> configMap = new HashMap<>();
+    for (int id : brokers) {
+      configMap.put(new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(id)), brokerConfig);
+    }
+    expectBatchDescribeConfigsViaValues(adminClient, configMap);
+  }
+
+  // Expects a single batched describeConfigs call returning per-resource futures via values().
+  // Used by testWaitForBatchConfigs to test multi-resource verification.
+  private void expectBatchDescribeConfigsViaValues(AdminClient adminClient, Map<ConfigResource, Config> configMap)
+  throws ExecutionException, InterruptedException, TimeoutException {
+    DescribeConfigsResult mockDescribeConfigsResult = EasyMock.mock(DescribeConfigsResult.class);
+    Map<ConfigResource, KafkaFuture<Config>> futureMap = new HashMap<>();
+    List<Object> mocksToReplay = new ArrayList<>();
+    mocksToReplay.add(mockDescribeConfigsResult);
+
+    for (Map.Entry<ConfigResource, Config> entry : configMap.entrySet()) {
+      KafkaFuture<Config> mockFuture = EasyMock.mock(KafkaFuture.class);
+      EasyMock.expect(mockFuture.get(EasyMock.anyLong(), EasyMock.anyObject())).andReturn(entry.getValue());
+      futureMap.put(entry.getKey(), mockFuture);
+      mocksToReplay.add(mockFuture);
+    }
+
+    EasyMock.expect(mockDescribeConfigsResult.values()).andReturn(futureMap);
+    EasyMock.expect(adminClient.describeConfigs(EasyMock.anyObject())).andReturn(mockDescribeConfigsResult);
+    EasyMock.replay(mocksToReplay.toArray());
+  }
+
+  // --- Assertion helpers ---
 
   private void assertExpectedThrottledRateForBroker(int brokerId, Long expectedRate) throws ExecutionException, InterruptedException {
     ConfigResource cf = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(brokerId));

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
@@ -248,6 +248,57 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
   }
 
   @Test
+  public void testSetThrottleOnMixedTopicExistence() throws Exception {
+    final long throttleRate = 100L;
+    final int brokerId0 = 0;
+    final int brokerId1 = 1;
+    final int brokerId2 = 2;
+    final List<Integer> brokers = Arrays.asList(brokerId0, brokerId1, brokerId2);
+
+    // Two proposals on different topics: TOPIC0 exists, TOPIC1 does not
+    ExecutionProposal proposal0 = new ExecutionProposal(new TopicPartition(TOPIC0, 0),
+        100, new ReplicaPlacementInfo(brokerId0),
+        Arrays.asList(new ReplicaPlacementInfo(brokerId0), new ReplicaPlacementInfo(brokerId1)),
+        Arrays.asList(new ReplicaPlacementInfo(brokerId0), new ReplicaPlacementInfo(brokerId2)));
+    ExecutionProposal proposal1 = new ExecutionProposal(new TopicPartition(TOPIC1, 0),
+        100, new ReplicaPlacementInfo(brokerId0),
+        Arrays.asList(new ReplicaPlacementInfo(brokerId0), new ReplicaPlacementInfo(brokerId1)),
+        Arrays.asList(new ReplicaPlacementInfo(brokerId0), new ReplicaPlacementInfo(brokerId2)));
+
+    AdminClient mockAdminClient = EasyMock.mock(AdminClient.class);
+    ReplicationThrottleHelper throttleHelper = new ReplicationThrottleHelper(mockAdminClient, throttleRate);
+
+    // Batch read brokers — rates already match, no writes needed
+    expectBatchDescribeBrokerConfigs(mockAdminClient, brokers);
+
+    // Batch read topic configs via values() — TOPIC0 succeeds, TOPIC1 fails
+    String existingReplicas = "1:0,1:1";
+    Config topic0Config = new Config(Arrays.asList(
+        new ConfigEntry(ReplicationThrottleHelper.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG, existingReplicas),
+        new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, existingReplicas)));
+    expectBatchDescribeTopicConfigsMixed(mockAdminClient, TOPIC0, topic0Config, TOPIC1);
+    // listTopics for TOPIC1 non-existence check
+    expectListTopics(mockAdminClient, Collections.emptySet());
+
+    // Batch write topic configs via values() — TOPIC0 succeeds, TOPIC1 fails
+    expectBatchIncrementalTopicConfigsMixed(mockAdminClient, TOPIC0, TOPIC1);
+    // listTopics for TOPIC1 non-existence check during write
+    expectListTopics(mockAdminClient, Collections.emptySet());
+
+    // Verification for TOPIC0 only (TOPIC1 was filtered out as unsuccessful)
+    ConfigResource topic0Cf = new ConfigResource(ConfigResource.Type.TOPIC, TOPIC0);
+    Config verifyConfig = new Config(Arrays.asList(
+        new ConfigEntry(ReplicationThrottleHelper.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "0:0,0:1,0:2,1:0,1:1"),
+        new ConfigEntry(ReplicationThrottleHelper.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "0:0,0:1,0:2,1:0,1:1")));
+    expectBatchDescribeConfigsViaValues(mockAdminClient, Collections.singletonMap(topic0Cf, verifyConfig));
+
+    EasyMock.replay(mockAdminClient);
+    // Expect no exception — TOPIC0 throttle is applied, TOPIC1 is gracefully skipped
+    throttleHelper.setThrottles(Arrays.asList(proposal0, proposal1));
+    EasyMock.verify(mockAdminClient);
+  }
+
+  @Test
   public void testAddingThrottlesWithNoPreExistingThrottles() throws Exception {
     createTopics();
 
@@ -563,6 +614,22 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     expectBatchDescribeConfigsViaValues(mockAdminClient, matchMap);
     EasyMock.replay(mockAdminClient);
     throttleHelper.waitForBatchConfigs(allOps);
+
+    // Case 4: one resource throws ExecutionException during verification, other matches.
+    // Verification should succeed (failed resource is skipped, matching resource passes).
+    EasyMock.reset(mockAdminClient);
+    expectBatchDescribeConfigsViaValuesWithFailure(mockAdminClient, brokerCf0, matchingConfig,
+        brokerCf1, new ExecutionException(new UnknownTopicOrPartitionException()));
+    EasyMock.replay(mockAdminClient);
+    throttleHelper.waitForBatchConfigs(allOps);
+
+    // Case 5: one resource throws TimeoutException during verification, other matches.
+    // Verification should succeed (timed-out resource is skipped, matching resource passes).
+    EasyMock.reset(mockAdminClient);
+    expectBatchDescribeConfigsViaValuesWithFailure(mockAdminClient, brokerCf0, matchingConfig,
+        brokerCf1, new TimeoutException("simulated timeout"));
+    EasyMock.replay(mockAdminClient);
+    throttleHelper.waitForBatchConfigs(allOps);
   }
 
   @Test
@@ -721,6 +788,55 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     EasyMock.replay(mockAlterConfigsResult, mockFuture);
   }
 
+  // Expects a batched describeConfigs via values() for two topics: one existing, one non-existing.
+  // The existing topic returns its config; the non-existing one throws ExecutionException.
+  private void expectBatchDescribeTopicConfigsMixed(
+      AdminClient adminClient, String existingTopic, Config existingConfig, String missingTopic)
+  throws ExecutionException, InterruptedException, TimeoutException {
+    ConfigResource existingCf = new ConfigResource(ConfigResource.Type.TOPIC, existingTopic);
+    ConfigResource missingCf = new ConfigResource(ConfigResource.Type.TOPIC, missingTopic);
+    DescribeConfigsResult mockResult = EasyMock.mock(DescribeConfigsResult.class);
+
+    KafkaFuture<Config> existingFuture = EasyMock.mock(KafkaFuture.class);
+    EasyMock.expect(existingFuture.get(EasyMock.anyLong(), EasyMock.anyObject())).andReturn(existingConfig);
+
+    KafkaFuture<Config> missingFuture = EasyMock.mock(KafkaFuture.class);
+    EasyMock.expect(missingFuture.get(EasyMock.anyLong(), EasyMock.anyObject()))
+        .andThrow(new ExecutionException(new UnknownTopicOrPartitionException()));
+
+    Map<ConfigResource, KafkaFuture<Config>> futureMap = new HashMap<>();
+    futureMap.put(existingCf, existingFuture);
+    futureMap.put(missingCf, missingFuture);
+
+    EasyMock.expect(mockResult.values()).andReturn(futureMap);
+    EasyMock.expect(adminClient.describeConfigs(EasyMock.anyObject())).andReturn(mockResult);
+    EasyMock.replay(mockResult, existingFuture, missingFuture);
+  }
+
+  // Expects a batched incrementalAlterConfigs via values() for two topics: one succeeds, one fails.
+  private void expectBatchIncrementalTopicConfigsMixed(
+      AdminClient adminClient, String existingTopic, String missingTopic)
+  throws ExecutionException, InterruptedException, TimeoutException {
+    ConfigResource existingCf = new ConfigResource(ConfigResource.Type.TOPIC, existingTopic);
+    ConfigResource missingCf = new ConfigResource(ConfigResource.Type.TOPIC, missingTopic);
+    AlterConfigsResult mockResult = EasyMock.mock(AlterConfigsResult.class);
+
+    KafkaFuture<Void> existingFuture = EasyMock.mock(KafkaFuture.class);
+    EasyMock.expect(existingFuture.get(EasyMock.anyLong(), EasyMock.anyObject())).andReturn(null);
+
+    KafkaFuture<Void> missingFuture = EasyMock.mock(KafkaFuture.class);
+    EasyMock.expect(missingFuture.get(EasyMock.anyLong(), EasyMock.anyObject()))
+        .andThrow(new ExecutionException(new UnknownTopicOrPartitionException()));
+
+    Map<ConfigResource, KafkaFuture<Void>> futureMap = new HashMap<>();
+    futureMap.put(existingCf, existingFuture);
+    futureMap.put(missingCf, missingFuture);
+
+    EasyMock.expect(mockResult.values()).andReturn(futureMap);
+    EasyMock.expect(adminClient.incrementalAlterConfigs(EasyMock.anyObject())).andReturn(mockResult);
+    EasyMock.replay(mockResult, existingFuture, missingFuture);
+  }
+
   // Expects a single batched describeConfigs call for brokers returning per-resource futures via values().
   // Used for waitForBatchConfigs verification steps.
   private void expectBatchDescribeBrokerConfigsViaValues(AdminClient adminClient, List<Integer> brokers, Config brokerConfig)
@@ -751,6 +867,28 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     EasyMock.expect(mockDescribeConfigsResult.values()).andReturn(futureMap);
     EasyMock.expect(adminClient.describeConfigs(EasyMock.anyObject())).andReturn(mockDescribeConfigsResult);
     EasyMock.replay(mocksToReplay.toArray());
+  }
+
+  // Expects a single batched describeConfigs call where one resource succeeds and another throws.
+  // Used to test per-resource error handling in waitForBatchConfigs.
+  private void expectBatchDescribeConfigsViaValuesWithFailure(
+      AdminClient adminClient, ConfigResource successResource, Config successConfig,
+      ConfigResource failResource, Exception failException)
+  throws ExecutionException, InterruptedException, TimeoutException {
+    DescribeConfigsResult mockDescribeConfigsResult = EasyMock.mock(DescribeConfigsResult.class);
+    Map<ConfigResource, KafkaFuture<Config>> futureMap = new HashMap<>();
+
+    KafkaFuture<Config> successFuture = EasyMock.mock(KafkaFuture.class);
+    EasyMock.expect(successFuture.get(EasyMock.anyLong(), EasyMock.anyObject())).andReturn(successConfig);
+    futureMap.put(successResource, successFuture);
+
+    KafkaFuture<Config> failFuture = EasyMock.mock(KafkaFuture.class);
+    EasyMock.expect(failFuture.get(EasyMock.anyLong(), EasyMock.anyObject())).andThrow(failException);
+    futureMap.put(failResource, failFuture);
+
+    EasyMock.expect(mockDescribeConfigsResult.values()).andReturn(futureMap);
+    EasyMock.expect(adminClient.describeConfigs(EasyMock.anyObject())).andReturn(mockDescribeConfigsResult);
+    EasyMock.replay(mockDescribeConfigsResult, successFuture, failFuture);
   }
 
   // --- Assertion helpers ---


### PR DESCRIPTION
## Summary
1. Why: `setThrottles()` and `clearThrottles()` in `ReplicationThrottleHelper` make sequential, blocking AdminClient RPCs — one `describeConfigs` + one `incrementalAlterConfigs` per broker, then per topic. For a 250-broker cluster with ~100 topics and 1250-movement batches, this produces 600+ synchronous RPCs taking 30+ minutes before any data movement begins. Every call passes `Collections.singletonMap()` / `Collections.singletonList()` with exactly one `ConfigResource`, despite the AdminClient API supporting multi-resource operations.
2. What: Batch all `describeConfigs` and `incrementalAlterConfigs` calls across brokers and topics into single multi-resource AdminClient calls (chunked at 500 resources per request), and verify all configs in one batched polling loop:

| Operation | Before | After |
|---|---|---|
| `setThrottles()` broker rates | B x describeConfigs + B x incrementalAlterConfigs | 1 batch describeConfigs + 1 batch incrementalAlterConfigs |
| `setThrottles()` topic replicas | T x describeConfigs + T x incrementalAlterConfigs | 1 batch describeConfigs + 1 batch incrementalAlterConfigs |
| `clearThrottles()` | Same sequential pattern | Same batching |
| `waitForConfigs()` verification | (B+T) x polling loops | 1 batch polling loop |

Design decisions:
- Broker set-path configs use `.all()` (brokers always exist, atomic batch); topic configs and the per-broker clear path use `.values()` so a topic deleted mid-operation or a broker that became unreachable only skips itself instead of failing the whole batch.
- `waitForBatchConfigs` drops a topic from verification only after confirming via a single lazily-fetched `listTopics` that it was really deleted; any other failure keeps the resource pending and retries, so an unverified throttle can never pass silently.
- Requests are chunked at 500 resources per call, since topic config requests are routed to a single broker and unbounded batches could get oversized on clusters with many topics.
- Same 30-second `CLIENT_REQUEST_TIMEOUT_MS` per call; the per-call timeout does not scale linearly with resource count.
- Read-modify-write window trade-off documented in code: the batch version reads all configs first, then writes all — a wider window than the sequential approach, acceptable given the performance gain and the assumption that CC is the sole writer of throttle configs during an operation.
- No semantic changes and no new configs — same set/clear points as today, just batched. The now-unused single-resource methods (`changeTopicConfigs`, `changeBrokerConfigs`, `waitForConfigs`, `getEntityConfigs`) are removed.

## Expected Behavior
Throttle setup and removal for an execution completes in seconds regardless of cluster size, and replica movements begin promptly after the proposal is computed.

## Actual Behavior
On large clusters, the executor spends 30+ minutes issuing sequential throttle config RPCs before the first replica movement starts, and again when clearing throttles between batches.

## Steps to Reproduce
1. Run Cruise Control against a large cluster (hundreds of brokers, ~100 topics with moving replicas).
2. Trigger an execution that moves replicas with a replication throttle configured (e.g. `rebalance?dryrun=false`).
3. Observe the delay between proposal computation and the first replica movement: one `describeConfigs` + one `incrementalAlterConfigs` round-trip per broker and per topic.

## Known Workarounds
None within Cruise Control. Related PRs (#2214, #2304) reduce how often the helper is invoked at the Executor layer, which is complementary but does not remove the per-resource RPC pattern inside the helper.

## Additional evidence
1. Environment: verified on a production cluster (hundreds of brokers, ~100K partitions), deployed via Strimzi with the patched cruise-control jar, running a full rebalance with tens of thousands of replica movements.
2. Timeline from the trigger on that cluster: proposal computed at ~75s; throttle rate described + altered on every broker in ~1s (single batched call); broker + topic configs verified with throttle setup complete in ~23s (nearly all of it the two fixed 10s verification backoff sleeps); first replica movements finished at ~100s. Previously this cluster showed the familiar ~30-minute stall before any movement began. Details in [this comment](https://github.com/linkedin/cruise-control/pull/2367#issuecomment-4883915627).
3. Testing: all `ReplicationThrottleHelperTest` tests pass (unit + embedded-Kafka integration), including new `testWaitForBatchConfigs` cases (retry exhaustion, immediate match, partial match with retries, ExecutionException/TimeoutException during verification, deleted-topic skip, transient-failure retry, persistent-broker-failure exhaustion) and `testSetThrottleOnMixedTopicExistence`; checkstyle clean.

## Categorization
- [ ] documentation
- [ ] bugfix
- [ ] new feature
- [x] refactor
- [ ] security/CVE
- [ ] other

