### PR TITLE
GHA: artifactory publish workflow: set artifactory key from secrets

### DIFF
--- a/.github/workflows/artifactory.yaml
+++ b/.github/workflows/artifactory.yaml
@@ -21,5 +21,8 @@ jobs:
           cache: gradle
       - uses: gradle/actions/setup-gradle@v4 # v4.0.0
       - name: publish
+        env:
+          ARTIFACTORY_USER: cruise-control-ci
+          ARTIFACTORY_KEY: ${{ secrets.ARTIFACTORY_KEY }}
         run: |
           ./gradlew :artifactoryPublish :cruise-control:artifactoryPublish :cruise-control-core:artifactoryPublish :cruise-control-metrics-reporter:artifactoryPublish


### PR DESCRIPTION
## Summary
1. Why: artifactory artifacts publishing is currently broken due to invalid credentials.
2. What: updates artifactory publish workflow to use secret token.

## Expected Behavior
- publish workflow works 

## Actual Behavior
- publish workflow [fails](https://github.com/linkedin/cruise-control/actions/runs/26465576063/job/77924797384)

## Known Workarounds
- n/a

## Additional evidence
```
$ TOKEN=**** curl -H "Authorization: Bearer $TOKEN" -X GET "https://linkedin.jfrog.io/artifactory/api/system/ping"
OK
```

## Categorization
- [ ] documentation
- [ ] bugfix
- [ ] new feature
- [ ] refactor
- [x] security/CVE
- [ ] other