### PR TITLE
GHA: artifactory publish workflow: set artifactory key from secrets

### DIFF
--- a/.github/workflows/artifactory.yaml
+++ b/.github/workflows/artifactory.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4 # v4.0.0
       - name: publish
         env:
-          ARTIFACTORY_USER: cruise-control-ci
+          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           ARTIFACTORY_KEY: ${{ secrets.ARTIFACTORY_KEY }}
         run: |
           ./gradlew :artifactoryPublish :cruise-control:artifactoryPublish :cruise-control-core:artifactoryPublish :cruise-control-metrics-reporter:artifactoryPublish


### PR DESCRIPTION
## Summary
1. Why: artifactory publishing is still broken, due to invalid username
2. What: username is required and must be a valid one: use 

## Expected Behavior
- artifactory publishing is working

## Actual Behavior
- artifactory publishing is [broken](https://github.com/linkedin/cruise-control/actions/runs/26468260356)

```
Execution failed for task ':artifactoryDeploy'.
> java.io.IOException: JFrog service failed. Received 401: {
    "errors" : [ {
      "status" : 401,
      "message" : "Unauthorized"
    } ]
  }
```

## Steps to Reproduce
https://github.com/linkedin/cruise-control/actions/runs/26468260356

## Known Workarounds
- n/a

## Categorization
- [ ] documentation
- [ ] bugfix
- [ ] new feature
- [ ] refactor
- [x] security/CVE
- [ ] other

This PR resolves #<Replace-Me-With-The-Issue-Number-Addressed-By-This-PR> if any.
