### PR TITLE
Add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,7 @@ Responsible Disclosure of Security Vulnerabilities
 ==================================================
 
 Please do not file reports on Github for security issues.
-Please review the guidelines on at 
-https://www.linkedin.com/help/linkedin/answer/62924/security-vulnerabilities?lang=en
+See [SECURITY.md](./SECURITY.md) for how to report a vulnerability.
 
 Tips for Getting Your Pull Request (PR) Accepted
 ===========================================

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately through GitHub Security Advisories:
+
+**https://github.com/linkedin/cruise-control/security/advisories/new**
+
+Do not report security issues through public GitHub issues, pull requests, or
+discussions.
+
+We will acknowledge your report, work with you to understand and validate the
+issue, and keep you informed as we prepare and release a fix.


### PR DESCRIPTION
## Summary

Adds a `SECURITY.md` so that security researchers have a clear, standard place to report vulnerabilities, and updates `CONTRIBUTING.md` to point to it.

## Changes
- **`SECURITY.md`** (new): A minimal security policy directing reporters to file vulnerabilities privately through GitHub Security Advisories (`/security/advisories/new`), and asking them not to use public issues/PRs/discussions.
- **`CONTRIBUTING.md`**: The responsible-disclosure section now links to `SECURITY.md` instead of an external page, keeping a single source of truth.

GitHub automatically surfaces a repo-root `SECURITY.md` via the "Report a vulnerability" button and the Security tab.