### PR TITLE
Fix throttle removal verification hang when a default replication throttle is set

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelper.java
@@ -42,6 +42,20 @@ class ReplicationThrottleHelper {
   static final String FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG = "follower.replication.throttled.replicas";
   public static final long CLIENT_REQUEST_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
   static final int RETRIES = 30;
+  // Backoff parameters for the config verification retry loop. The sleep between attempts is
+  // scale * base^attempt, capped at MAX_RETRY_SLEEP_MS so that a slow-to-verify config cannot
+  // park the executor thread for an unbounded exponential sleep.
+  static final long RETRY_BACKOFF_SCALE_MS = TimeUnit.SECONDS.toMillis(5);
+  static final int RETRY_BACKOFF_BASE = 2;
+  static final int MAX_RETRY_SLEEP_MS = (int) TimeUnit.SECONDS.toMillis(30);
+  // Config sources that a config entry can resolve from after a successful per-entity DELETE.
+  // Seeing one of these during verification means the delete itself worked; the value is
+  // inherited from a lower-precedence layer that CC does not manage.
+  private static final Set<ConfigEntry.ConfigSource> CONFIG_SOURCES_INHERITED_AFTER_DELETE = Collections.unmodifiableSet(
+      new HashSet<>(Arrays.asList(
+          ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG,
+          ConfigEntry.ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG,
+          ConfigEntry.ConfigSource.DEFAULT_CONFIG)));
 
   private final AdminClient _adminClient;
   private final Long _throttleRate;
@@ -368,7 +382,7 @@ class ReplicationThrottleHelper {
       } catch (ExecutionException | InterruptedException | TimeoutException e) {
         return false;
       }
-    }, _retries);
+    }, RETRY_BACKOFF_SCALE_MS, RETRY_BACKOFF_BASE, _retries, MAX_RETRY_SLEEP_MS);
     if (!retryResponse) {
       throw new IllegalStateException("The following configs " + ops + " were not applied to " + cf + " within the time limit");
     }
@@ -381,8 +395,13 @@ class ReplicationThrottleHelper {
         if (entry.getValue() != null) {
           return false;
         }
-      } else if (configEntry.source().equals(ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG) && entry.getValue() == null) {
-        LOG.debug("Found static broker config: {}, skipping comparison", configEntry);
+      } else if (entry.getValue() == null && CONFIG_SOURCES_INHERITED_AFTER_DELETE.contains(configEntry.source())) {
+        // A deleted per-entity config can still resolve to a value inherited from a
+        // lower-precedence layer (static broker config, cluster-wide dynamic default, or the
+        // Kafka default). The deletion itself succeeded, so skip the comparison; otherwise
+        // verification of the delete would never converge (e.g. when a cluster-wide default
+        // replication throttle is set via kafka-configs --entity-default).
+        LOG.debug("Config {} resolves from {} after deletion, skipping comparison", configEntry, configEntry.source());
       } else if (!Objects.equals(entry.getValue(), configEntry.value())) {
         return false;
       }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
@@ -540,6 +540,28 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     entries.add(mockStaticConfig);
     assertTrue(ReplicationThrottleHelper.configsEqual(new Config(entries), expectedConfigs));
     EasyMock.verify(mockStaticConfig);
+
+    // A deleted per-broker config that resolves to a cluster-wide dynamic default
+    // (kafka-configs --entity-default) is also considered applied
+    ConfigEntry mockDynamicDefaultConfig = mockConfigEntry("name6", "value6", ConfigEntry.ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG);
+    expectedConfigs.put("name6", null);
+    entries.add(mockDynamicDefaultConfig);
+    assertTrue(ReplicationThrottleHelper.configsEqual(new Config(entries), expectedConfigs));
+    EasyMock.verify(mockDynamicDefaultConfig);
+
+    // A deleted config that resolves to the Kafka default is also considered applied
+    ConfigEntry mockDefaultConfig = mockConfigEntry("name7", "value7", ConfigEntry.ConfigSource.DEFAULT_CONFIG);
+    expectedConfigs.put("name7", null);
+    entries.add(mockDefaultConfig);
+    assertTrue(ReplicationThrottleHelper.configsEqual(new Config(entries), expectedConfigs));
+    EasyMock.verify(mockDefaultConfig);
+
+    // A non-null expected value must still match even when the source is a default layer
+    expectedConfigs.put("name6", "value6");
+    assertTrue(ReplicationThrottleHelper.configsEqual(new Config(entries), expectedConfigs));
+    expectedConfigs.put("name6", "other-value");
+    assertFalse(ReplicationThrottleHelper.configsEqual(new Config(entries), expectedConfigs));
+    expectedConfigs.put("name6", null);
   }
 
   private ExecutionTask prepareMockCompleteTask(ExecutionProposal proposal) {


### PR DESCRIPTION
## Summary
1. Why: When clearing throttles after replica movements, `ReplicationThrottleHelper` deletes the per-broker `leader/follower.replication.throttled.rate` configs and then polls `describeConfigs` until the configs read back as absent. If a cluster-wide dynamic default throttle exists (set via `kafka-configs --alter --entity-type brokers --entity-default`), the deleted per-broker config resolves to the default value, so `describeConfigs` keeps returning a non-null entry, `configsEqual` keeps returning false, and verification never converges. Worse, the retry helper (`CruiseControlMetricsUtils.retry`) doubles the sleep between attempts with no cap (`5s * 2^n`), so the executor thread ends up parked in exponentially growing sleeps — attempt 13 alone sleeps ~11 hours; exhausting 30 retries would take centuries.
2. What: (a) `configsEqual` already skipped the comparison when a deleted config resolves to `STATIC_BROKER_CONFIG`; extend the same treatment to `DYNAMIC_DEFAULT_BROKER_CONFIG` and `DEFAULT_CONFIG` — seeing a value from one of these sources after a DELETE means the per-entity delete itself succeeded and the remaining value is inherited from a layer Cruise Control does not manage. (b) Cap the verification retry backoff at 30s per attempt, so a genuinely failing verification exhausts its 30 retries in ~15 minutes and fails loudly with the existing `IllegalStateException` instead of parking the executor for hours/days.

## Expected Behavior
After a movement batch completes, throttle removal verification converges and the execution proceeds to the next batch, regardless of whether a cluster-wide default replication throttle is set.

## Actual Behavior
Throttle removal verification never converges when an `--entity-default` replication throttle exists. The executor thread parks in exponentially growing sleeps inside `waitForConfigs`, the execution appears hung (no further movements dispatched), and new executions are rejected with `Cannot start a new execution while there is an ongoing execution`.

## Steps to Reproduce
1. Set a cluster-wide default replication throttle: `kafka-configs --alter --entity-type brokers --entity-default --add-config leader.replication.throttled.rate=...,follower.replication.throttled.rate=...`
2. Trigger a Cruise Control execution that moves replicas (e.g. `rebalance?dryrun=false`).
3. After the first movement batch completes, `clearThrottles` deletes the per-broker rates, and verification loops forever because the deleted configs resolve to the dynamic default layer.

## Known Workarounds
Remove the `--entity-default` replication throttle before running an execution, or restart Cruise Control to abort the stuck execution.

## Additional evidence
1. Environment: observed in production on a 200+ broker cluster — the executor finished its first batch of movements, then made no progress for hours.
2. Thread dump of the stuck executor:

```
"ProposalExecutor-0" TIMED_WAITING (sleeping)
    at java.lang.Thread.sleep
    at com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsUtils.retry
    at com.linkedin.kafka.cruisecontrol.executor.ReplicationThrottleHelper.waitForConfigs
    ...
    at com.linkedin.kafka.cruisecontrol.executor.ReplicationThrottleHelper.clearThrottles
    at com.linkedin.kafka.cruisecontrol.executor.Executor$ProposalExecutionRunnable.interBrokerMoveReplicas
```

3. Broker configs showing the deleted per-broker rate resolving to the `--entity-default` layer:

```
leader.replication.throttled.rate=... synonyms={DYNAMIC_DEFAULT_BROKER_CONFIG:leader.replication.throttled.rate=...}
```

4. Testing: extended `testConfigsEqual` with cases for `DYNAMIC_DEFAULT_BROKER_CONFIG` and `DEFAULT_CONFIG` sources (deleted configs treated as applied; non-null expected values still compared); full `ReplicationThrottleHelperTest` suite (unit + embedded-Kafka integration) passes; checkstyle clean.
5. Note: this bug is independent of (and pre-dates) the batching work in #2367 — it was uncovered while testing that branch on a real cluster, since the strict batched verification surfaced the hang clearly. The same fix applies to both code paths.

## Categorization
- [ ] documentation
- [x] bugfix
- [ ] new feature
- [ ] refactor
- [ ] security/CVE
- [ ] other