### PR TITLE
Add missing EasyMock.verify calls in unit tests

### DIFF
--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ReplicationThrottleHelperTest.java
@@ -503,6 +503,7 @@ public class ReplicationThrottleHelperTest extends CCKafkaIntegrationTestHarness
     )));
 
     // Case 2: queue a single result and call checkConfigs with matching configs, so it succeeds
+    EasyMock.verify(mockAdminClient);
     EasyMock.reset(mockAdminClient);
     expectDescribeTopicConfigs(mockAdminClient, TOPIC0, EMPTY_CONFIG, true);
     EasyMock.replay(mockAdminClient);

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletEndpointTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletEndpointTest.java
@@ -235,6 +235,7 @@ public class KafkaCruiseControlServletEndpointTest {
     List<UserTaskManager.UserTaskInfo> result5 = userTaskState2.prepareResultList(parameters5);
     // Test Case 5 result
     Assert.assertEquals(1, result5.size());
+    EasyMock.verify(MOCK_UUID_GENERATOR, MOCK_HTTP_SESSION, MOCK_HTTP_SERVLET_RESPONSE);
     EasyMock.reset(MOCK_UUID_GENERATOR, MOCK_HTTP_SESSION, MOCK_HTTP_SERVLET_RESPONSE);
 
   }


### PR DESCRIPTION
## Description

This PR adds missing `EasyMock.verify()` calls in unit tests as mentioned in issue #1408.

### Changes Made

1. **ReplicationThrottleHelperTest.java:506**
   - Added `EasyMock.verify(mockAdminClient)` before `EasyMock.reset()` in `testWaitForConfigs` method
   - This ensures the mock is verified before being reset for the next test case

2. **KafkaCruiseControlServletEndpointTest.java:238**
   - Added `EasyMock.verify(MOCK_UUID_GENERATOR, MOCK_HTTP_SESSION, MOCK_HTTP_SERVLET_RESPONSE)` at the end of `testUserTaskParameters` method
   - This verifies all mocked interactions before the test ends

### Why These Changes Are Important

Without `EasyMock.verify()`, tests may pass even if mocked objects are not called as expected. The verify call ensures:
- All expected method invocations occurred
- Mocked objects were used correctly
- Test behavior matches the intended design

### Testing

- All existing tests pass with these changes
- The changes are minimal and focused on test quality

Fixes #1408
