### PR TITLE
Fix InaccessibleObjectException in OperationFuture.get() on Java 17

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/OperationFuture.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/OperationFuture.java
@@ -6,8 +6,8 @@ package com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable;
 
 import com.linkedin.cruisecontrol.servlet.response.CruiseControlResponse;
 import com.linkedin.kafka.cruisecontrol.async.progress.OperationProgress;
-import java.lang.reflect.Field;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -45,19 +45,29 @@ public class OperationFuture extends CompletableFuture<CruiseControlResponse> {
 
   @Override
   public CruiseControlResponse get() throws InterruptedException, ExecutionException {
+    // Annotate failures with the operation context by rethrowing a new exception instance. Mutating the
+    // original exception's detailMessage via reflection is not possible on Java 9+ without --add-opens
+    // and threw InaccessibleObjectException at runtime on Java 17.
     try {
       return super.get();
-    } catch (Throwable t) {
-      try {
-        Field f = Throwable.class.getDeclaredField("detailMessage");
-        f.setAccessible(true);
-        f.set(t, String.format("Operation '%s' received exception. ", _operation)
-                 + (t.getMessage() == null ? "" : t.getMessage()));
-      } catch (IllegalAccessException | NoSuchFieldException e) {
-        // let it go
-      }
-      throw t;
+    } catch (ExecutionException ee) {
+      ExecutionException annotated = new ExecutionException(annotatedMessage(ee), ee.getCause());
+      annotated.setStackTrace(ee.getStackTrace());
+      throw annotated;
+    } catch (CancellationException ce) {
+      CancellationException annotated = new CancellationException(annotatedMessage(ce));
+      annotated.initCause(ce);
+      annotated.setStackTrace(ce.getStackTrace());
+      throw annotated;
+    } catch (InterruptedException ie) {
+      InterruptedException annotated = new InterruptedException(annotatedMessage(ie));
+      annotated.setStackTrace(ie.getStackTrace());
+      throw annotated;
     }
+  }
+
+  private String annotatedMessage(Throwable t) {
+    return String.format("Operation '%s' received exception. ", _operation) + (t.getMessage() == null ? "" : t.getMessage());
   }
 
   /**

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/OperationFutureTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/OperationFutureTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 
 public class OperationFutureTest {
@@ -60,6 +61,20 @@ public class OperationFutureTest {
     assertEquals(DEFAULT_RESULT, t.result());
     assertThat(t.exception(), instanceOf(ExecutionException.class));
     assertEquals(cause, t.exception().getCause());
+  }
+
+  @Test
+  public void testGetFailedAnnotatesMessageWithOperation() throws InterruptedException {
+    OperationFuture future = new OperationFuture("testGetFailedAnnotatesMessageWithOperation");
+    future.completeExceptionally(new Exception("original failure"));
+    try {
+      future.get();
+      fail("Expected ExecutionException");
+    } catch (ExecutionException ee) {
+      assertTrue(ee.getMessage().contains("Operation 'testGetFailedAnnotatesMessageWithOperation' received exception."));
+      assertTrue(ee.getMessage().contains("original failure"));
+      assertEquals("original failure", ee.getCause().getMessage());
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary
1. Why: `OperationFuture.get()` annotates failures by mutating `Throwable.detailMessage` via `setAccessible(true)` reflection. On Java 9+ this requires `--add-opens=java.base/java.lang=ALL-UNNAMED`; without it, `setAccessible` throws `InaccessibleObjectException` — a `RuntimeException` that escapes the existing `IllegalAccessException | NoSuchFieldException` catch and propagates to the caller.
2. What: Rethrow new `ExecutionException` / `CancellationException` / `InterruptedException` instances that carry the operation context in the message, preserving the original cause and stack trace. No reflection, so it works on any JVM without `--add-opens`. Semantics are preserved for callers: `get()` still throws the same exception types, `ExecutionException.getCause()` still returns the original failure, and cancel/timeout behavior is unchanged (existing `OperationFutureTest` passes unmodified).

## Expected Behavior
`/user_tasks?fetch_completed_task=true` returns the stored error for a task that completed with an exception, with the operation context prepended to the message.

## Actual Behavior
On a stock Java 17 runtime (e.g. the Strimzi Kafka images) the endpoint returns a 500 with `InaccessibleObjectException` whenever the fetched task completed with an error — the reflection path only runs when the future holds an exception, so the endpoint fails exactly when the stored error is needed most.

## Steps to Reproduce
1. Run Cruise Control on Java 17 without `--add-opens=java.base/java.lang=ALL-UNNAMED` (any stock JVM; the bundled unit tests don't catch this because `build.gradle` adds the `--add-opens` flag to test JVMs).
2. Trigger any operation that completes with an error (e.g. a rebalance that fails).
3. Fetch it via `GET /kafkacruisecontrol/user_tasks?fetch_completed_task=true` — the request returns a 500 with `InaccessibleObjectException` instead of the task's stored error.

## Known Workarounds
Add `--add-opens=java.base/java.lang=ALL-UNNAMED` to the Cruise Control JVM options.

## Additional evidence
1. Environment: Cruise Control on a stock Java 17 runtime (Strimzi Kafka images), hit in production while debugging a failed rebalance on a 232-broker / ~110K-partition cluster; the failed task's exception was unretrievable.
2. Testing: new regression test `testGetFailedAnnotatesMessageWithOperation` asserts the message annotation and that the original cause is preserved; existing `OperationFutureTest` passes unmodified; `checkstyleMain` / `checkstyleTest` clean.
3. Verified in production: `/user_tasks?fetch_completed_task=true` now returns failed-task errors instead of crashing.

## Categorization
- [ ] documentation
- [x] bugfix
- [ ] new feature
- [ ] refactor
- [ ] security/CVE
- [ ] other